### PR TITLE
Aim local cache structures are not optional

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -898,7 +898,7 @@ aim_mods_cache Character::gen_aim_mods_cache( const item &gun )const
 
 double Character::fastest_aiming_method_speed( const item &gun, double recoil,
         const Target_attributes &target_attributes,
-        const std::optional<std::reference_wrapper<const parallax_cache>> parallax_cache ) const
+        const parallax_cache &parallaxes ) const
 {
     // Get fastest aiming method that can be used to improve aim further below @ref recoil.
 
@@ -934,13 +934,7 @@ double Character::fastest_aiming_method_speed( const item &gun, double recoil,
     const float light_limit = 120.0f;
     bool laser_light_available = target_attributes.range <= ( base_distance + get_per() ) * std::max(
                                      1.0f - target_attributes.light / light_limit, 0.0f ) && target_attributes.visible;
-    // There are only two kinds of parallaxes, one with zoom and one without. So cache them.
-    std::vector<std::optional<int>> parallaxes;
-    parallaxes.resize( 2 );
-    if( parallax_cache.has_value() ) {
-        parallaxes[0].emplace( parallax_cache.value().get().parallax_without_zoom );
-        parallaxes[1].emplace( parallax_cache.value().get().parallax_with_zoom );
-    }
+
     for( const item *e : gun.gunmods() ) {
         const islot_gunmod &mod = *e->type->gunmod;
         if( mod.sight_dispersion < 0 || mod.field_of_view <= 0 ) {
@@ -949,12 +943,11 @@ double Character::fastest_aiming_method_speed( const item &gun, double recoil,
         if( e->has_flag( flag_LASER_SIGHT ) && !laser_light_available ) {
             continue;
         }
-        bool zoom = e->has_flag( flag_ZOOM );
-        // zoom==true will access parallaxes[1], zoom==false will access parallaxes[0].
-        int parallax = parallaxes[static_cast<int>( zoom )].has_value() ? parallaxes[static_cast<int>
-                       ( zoom )].value() : get_character_parallax( zoom );
-        parallaxes[static_cast<int>( zoom )].emplace( parallax );
-        // Maunal expansion of effective_dispersion() for performance.
+
+        int parallax = e->has_flag( flag_ZOOM ) ? parallaxes.parallax_with_zoom :
+                       parallaxes.parallax_without_zoom;
+
+        // Manual expansion of effective_dispersion() for performance.
         double e_effective_dispersion = parallax + mod.sight_dispersion;
 
         // The character can hardly get the aiming speed bonus from a non-magnifier sight when aiming at a target that is too far or too small
@@ -1056,7 +1049,7 @@ double Character::aim_per_move( const item &gun, double recoil,
         return 0.0;
     }
     const double sight_speed_modifier = fastest_aiming_method_speed( gun, recoil, target_attributes,
-                                        std::make_optional( std::ref( aim_cache.parallaxes ) ) );
+                                        aim_cache.parallaxes );
     const int limit = aim_cache.limit;
     if( sight_speed_modifier == INT_MIN ) {
         // No suitable sights (already at maximum aim).

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1043,17 +1043,21 @@ double Character::aim_factor_from_length( const item &gun ) const
 }
 
 double Character::aim_per_move( const item &gun, double recoil,
+                                const Target_attributes &target_attributes ) const
+{
+    return aim_per_move( gun, recoil, target_attributes, gen_aim_mods_cache( gun ) );
+}
+
+double Character::aim_per_move( const item &gun, double recoil,
                                 const Target_attributes &target_attributes,
-                                std::optional<std::reference_wrapper<const aim_mods_cache>> aim_cache ) const
+                                const aim_mods_cache &aim_cache ) const
 {
     if( !gun.is_gun() ) {
         return 0.0;
     }
-    bool use_cache = aim_cache.has_value();
-    double sight_speed_modifier = fastest_aiming_method_speed( gun, recoil, target_attributes,
-                                  use_cache ? std::make_optional( std::ref( aim_cache.value().get().parallaxes ) ) : std::nullopt );
-    int limit = use_cache ? aim_cache.value().get().limit :
-                most_accurate_aiming_method_limit( gun );
+    const double sight_speed_modifier = fastest_aiming_method_speed( gun, recoil, target_attributes,
+                                        std::make_optional( std::ref( aim_cache.parallaxes ) ) );
+    const int limit = aim_cache.limit;
     if( sight_speed_modifier == INT_MIN ) {
         // No suitable sights (already at maximum aim).
         return 0;
@@ -1065,26 +1069,18 @@ double Character::aim_per_move( const item &gun, double recoil,
     // Base speed is non-zero to prevent extreme rate changes as aim speed approaches 0.
     double aim_speed = 10.0;
 
-    skill_id gun_skill = gun.gun_skill();
+    const skill_id gun_skill = gun.gun_skill();
 
     aim_speed += sight_speed_modifier;
 
-    if( !use_cache ) {
-        // Ranges [-1.5 - 3.5] for archery Ranges [0 - 2.5] for others
-        aim_speed += get_modifier( character_modifier_aim_speed_skill_mod, gun_skill );
+    // Ranges [-1.5 - 3.5] for archery Ranges [0 - 2.5] for others
+    aim_speed += aim_cache.aim_speed_skill_mod;
 
-        /** @EFFECT_DEX increases aiming speed */
-        // every DEX increases 0.5 aim_speed
-        aim_speed += get_modifier( character_modifier_aim_speed_dex_mod );
+    /** @EFFECT_DEX increases aiming speed */
+    // every DEX increases 0.5 aim_speed
+    aim_speed += aim_cache.aim_speed_dex_mod;
 
-        aim_speed *= get_modifier( character_modifier_aim_speed_mod );
-    } else {
-        aim_speed += aim_cache.value().get().aim_speed_skill_mod;
-
-        aim_speed += aim_cache.value().get().aim_speed_dex_mod;
-
-        aim_speed *= aim_cache.value().get().aim_speed_mod;
-    }
+    aim_speed *= aim_cache.aim_speed_mod;
 
     // finally multiply everything by a harsh function that is eliminated by 7.5 gunskill
     aim_speed /= std::max( 1.0, 2.5 - 0.2 * get_skill_level( gun_skill ) );
@@ -1092,24 +1088,19 @@ double Character::aim_per_move( const item &gun, double recoil,
     aim_speed *= std::max( recoil / MAX_RECOIL, 1 - logarithmic_range( 0, MAX_RECOIL, recoil ) );
 
     // add 4 max aim speed per skill up to 5 skill, then 1 per skill for skill 5-10
-    double base_aim_speed_cap = 5.0 +  1.0 * get_skill_level( gun_skill ) + std::max( 10.0,
-                                3.0 * get_skill_level( gun_skill ) );
-    if( !use_cache ) {
-        // This upper limit usually only affects the first half of the aiming process
-        // Pistols have a much higher aiming speed limit
-        aim_speed = std::min( aim_speed, base_aim_speed_cap * aim_factor_from_volume( gun ) );
+    const double base_aim_speed_cap = 5.0
+                                      + 1.0 * get_skill_level( gun_skill )
+                                      + std::max( 10.0, 3.0 * get_skill_level( gun_skill ) );
 
-        // When the character is in an open area, it will not be affected by the length of the weapon.
-        // This upper limit usually only affects the first half of the aiming process
-        // Weapons shorter than carbine are usually not affected by it
-        aim_speed = std::min( aim_speed, base_aim_speed_cap * aim_factor_from_length( gun ) );
-    } else {
-        aim_speed = std::min( aim_speed,
-                              base_aim_speed_cap * aim_cache.value().get().aim_factor_from_volume );
+    // This upper limit usually only affects the first half of the aiming process
+    // Pistols have a much higher aiming speed limit
+    aim_speed = std::min( aim_speed, base_aim_speed_cap * aim_cache.aim_factor_from_volume );
 
-        aim_speed = std::min( aim_speed,
-                              base_aim_speed_cap * aim_cache.value().get().aim_factor_from_length );
-    }
+    // When the character is in an open area, it will not be affected by the length of the weapon.
+    // This upper limit usually only affects the first half of the aiming process
+    // Weapons shorter than carbine are usually not affected by it
+    aim_speed = std::min( aim_speed, base_aim_speed_cap * aim_cache.aim_factor_from_length );
+
     // Just a raw scaling factor.
     aim_speed *= 2.4;
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1036,12 +1036,6 @@ double Character::aim_factor_from_length( const item &gun ) const
 }
 
 double Character::aim_per_move( const item &gun, double recoil,
-                                const Target_attributes &target_attributes ) const
-{
-    return aim_per_move( gun, recoil, target_attributes, gen_aim_mods_cache( gun ) );
-}
-
-double Character::aim_per_move( const item &gun, double recoil,
                                 const Target_attributes &target_attributes,
                                 const aim_mods_cache &aim_cache ) const
 {

--- a/src/character.h
+++ b/src/character.h
@@ -778,8 +778,8 @@ class Character : public Creature, public visitable
         std::vector<aim_type> get_aim_types( const item &gun ) const;
         int point_shooting_limit( const item &gun ) const;
         double fastest_aiming_method_speed( const item &gun, double recoil,
-                                            const Target_attributes &target_attributes = Target_attributes(),
-                                            std::optional<std::reference_wrapper<const parallax_cache>> parallax_cache = std::nullopt ) const;
+                                            const Target_attributes &target_attributes,
+                                            const parallax_cache &parallaxes ) const;
         int most_accurate_aiming_method_limit( const item &gun ) const;
         double aim_factor_from_volume( const item &gun ) const;
         double aim_factor_from_length( const item &gun ) const;

--- a/src/character.h
+++ b/src/character.h
@@ -801,8 +801,10 @@ class Character : public Creature, public visitable
         * Use a struct to avoid repeatedly calculate some modifiers that are actually persistent for aiming UI drawing.
         */
         double aim_per_move( const item &gun, double recoil,
-                             const Target_attributes &target_attributes = Target_attributes(),
-                             std::optional<std::reference_wrapper<const aim_mods_cache>> aim_cache = std::nullopt ) const;
+                             const Target_attributes &target_attributes = Target_attributes() ) const;
+        double aim_per_move( const item &gun, double recoil,
+                             const Target_attributes &target_attributes,
+                             const aim_mods_cache &aim_cache ) const;
 
         int get_dodges_left() const;
         void set_dodges_left( int dodges );

--- a/src/character.h
+++ b/src/character.h
@@ -801,8 +801,6 @@ class Character : public Creature, public visitable
         * Use a struct to avoid repeatedly calculate some modifiers that are actually persistent for aiming UI drawing.
         */
         double aim_per_move( const item &gun, double recoil,
-                             const Target_attributes &target_attributes ) const;
-        double aim_per_move( const item &gun, double recoil,
                              const Target_attributes &target_attributes,
                              const aim_mods_cache &aim_cache ) const;
 

--- a/src/character.h
+++ b/src/character.h
@@ -801,7 +801,7 @@ class Character : public Creature, public visitable
         * Use a struct to avoid repeatedly calculate some modifiers that are actually persistent for aiming UI drawing.
         */
         double aim_per_move( const item &gun, double recoil,
-                             const Target_attributes &target_attributes = Target_attributes() ) const;
+                             const Target_attributes &target_attributes ) const;
         double aim_per_move( const item &gun, double recoil,
                              const Target_attributes &target_attributes,
                              const aim_mods_cache &aim_cache ) const;

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -475,12 +475,12 @@ void npc_attack_gun::use( npc &source, const tripoint_bub_ms &location ) const
         return;
     }
 
-    const int dist = rl_dist( source.pos_bub(), location );
+    const Target_attributes target( source.pos_bub(), location );
 
     // Only aim if we aren't in risk of being hit
     // TODO: Get distance to closest enemy
-    if( dist > 1 && source.aim_per_move( gun, source.recoil ) > 0 &&
-        source.confident_gun_mode_range( gunmode, source.recoil ) < dist ) {
+    if( target.range > 1 && source.aim_per_move( gun, source.recoil, target ) > 0 &&
+        source.confident_gun_mode_range( gunmode, source.recoil ) < target.range ) {
         add_msg_debug( debugmode::debug_filter::DF_NPC, "%s is aiming", source.disp_name() );
         source.aim( Target_attributes( source.pos_bub(), location ) );
     } else {

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -476,10 +476,11 @@ void npc_attack_gun::use( npc &source, const tripoint_bub_ms &location ) const
     }
 
     const Target_attributes target( source.pos_bub(), location );
+    const aim_mods_cache aim_cache = source.gen_aim_mods_cache( gun );
 
     // Only aim if we aren't in risk of being hit
     // TODO: Get distance to closest enemy
-    if( target.range > 1 && source.aim_per_move( gun, source.recoil, target ) > 0 &&
+    if( target.range > 1 && source.aim_per_move( gun, source.recoil, target, aim_cache ) > 0 &&
         source.confident_gun_mode_range( gunmode, source.recoil ) < target.range ) {
         add_msg_debug( debugmode::debug_filter::DF_NPC, "%s is aiming", source.disp_name() );
         source.aim( Target_attributes( source.pos_bub(), location ) );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3537,15 +3537,16 @@ bool npc::enough_time_to_reload( const item &gun ) const
 void npc::aim( const Target_attributes &target_attributes )
 {
     const item_location weapon = get_wielded_item();
-    double aim_amount = weapon ? aim_per_move( *weapon, recoil ) : 0.0;
     const aim_mods_cache aim_cache = gen_aim_mods_cache( *weapon );
     int hold_moves = moves;
     double hold_recoil = recoil;
-    while( aim_amount > 0 && recoil > 0 && moves > 0 ) {
+    while( recoil > 0 && moves > 0 ) {
+        const double aim_amount = aim_per_move( *weapon, recoil, target_attributes, aim_cache );
+        if( aim_amount <= MIN_RECOIL_IMPROVEMENT ) {
+            break;
+        }
         moves--;
-        recoil -= aim_amount;
-        recoil = std::max( 0.0, recoil );
-        aim_amount = aim_per_move( *weapon, recoil, target_attributes, aim_cache );
+        recoil = std::max( 0.0, recoil - aim_amount );
     }
     add_msg_debug( debugmode::debug_filter::DF_NPC_COMBATAI,
                    "%s reduced recoil from %f to %f in %d moves",

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3545,7 +3545,7 @@ void npc::aim( const Target_attributes &target_attributes )
         moves--;
         recoil -= aim_amount;
         recoil = std::max( 0.0, recoil );
-        aim_amount = aim_per_move( *weapon, recoil, target_attributes, { std::ref( aim_cache ) } );
+        aim_amount = aim_per_move( *weapon, recoil, target_attributes, aim_cache );
     }
     add_msg_debug( debugmode::debug_filter::DF_NPC_COMBATAI,
                    "%s reduced recoil from %f to %f in %d moves",

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1816,7 +1816,8 @@ static void mod_stamina_archery( Character &you, const item &relevant )
 static void do_aim( Character &you, const item &relevant, const Target_attributes &target,
                     const double min_recoil )
 {
-    const double aim_amount = you.aim_per_move( relevant, you.recoil, target );
+    const aim_mods_cache aim_cache = you.gen_aim_mods_cache( relevant );
+    const double aim_amount = you.aim_per_move( relevant, you.recoil, target, aim_cache );
     if( aim_amount > 0 && you.recoil > min_recoil ) {
         // Increase aim at the cost of moves
         you.mod_moves( -1 );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -683,7 +683,7 @@ int Character::gun_engagement_moves( const item &gun, int target, int start,
     double penalty = start;
     const aim_mods_cache aim_cache = gen_aim_mods_cache( gun );
     while( penalty > target ) {
-        const double adj = aim_per_move( gun, penalty, attributes, { std::ref( aim_cache ) } );
+        const double adj = aim_per_move( gun, penalty, attributes, aim_cache );
         if( adj <= MIN_RECOIL_IMPROVEMENT ) {
             break;
         }
@@ -1969,10 +1969,9 @@ static recoil_prediction predict_recoil( const Character &you, const item &weapo
     double predicted_recoil = start_recoil;
     int predicted_delay = 0;
     const aim_mods_cache &aim_cache = you.gen_aim_mods_cache( weapon );
-    auto aim_cache_opt = std::make_optional( std::ref( aim_cache ) );
     // next loop simulates aiming until either aim mode threshold or sight_dispersion is reached
     do {
-        const double aim_amount = you.aim_per_move( weapon, predicted_recoil, target, aim_cache_opt );
+        const double aim_amount = you.aim_per_move( weapon, predicted_recoil, target, aim_cache );
         if( aim_amount <= MIN_RECOIL_IMPROVEMENT ) {
             break;
         }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1813,9 +1813,10 @@ static void mod_stamina_archery( Character &you, const item &relevant )
                    stamina_cost, str_ratio, skill_modifier );
 }
 
-static void do_aim( Character &you, const item &relevant, const double min_recoil )
+static void do_aim( Character &you, const item &relevant, const Target_attributes &target,
+                    const double min_recoil )
 {
-    const double aim_amount = you.aim_per_move( relevant, you.recoil );
+    const double aim_amount = you.aim_per_move( relevant, you.recoil, target );
     if( aim_amount > 0 && you.recoil > min_recoil ) {
         // Increase aim at the cost of moves
         you.mod_moves( -1 );
@@ -3895,10 +3896,11 @@ bool target_ui::action_aim()
 {
     set_last_target();
     apply_aim_turning_penalty();
+    const Target_attributes target( src, dst );
     const double min_recoil = calculate_aim_cap( *you, dst );
     double hold_recoil = you->recoil;
     for( int i = 0; i < 10; ++i ) {
-        do_aim( *you, *relevant, min_recoil );
+        do_aim( *you, *relevant, target, min_recoil );
     }
     add_msg_debug( debugmode::debug_filter::DF_BALLISTIC,
                    "you reduced recoil from %f to %f in 10 moves",
@@ -3934,9 +3936,10 @@ bool target_ui::action_aim_and_shoot( const std::string &action )
     int aim_threshold = it->threshold;
     set_last_target();
     apply_aim_turning_penalty();
+    const Target_attributes target( src, dst );
     const double min_recoil = calculate_aim_cap( *you, dst );
     do {
-        do_aim( *you, relevant ? *relevant : null_item_reference(), min_recoil );
+        do_aim( *you, relevant ? *relevant : null_item_reference(), target, min_recoil );
     } while( you->get_moves() > 0 && you->recoil > aim_threshold &&
              you->recoil - sight_dispersion > min_recoil );
 

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -15,6 +15,7 @@
 #include "calendar.h"
 #include "cata_catch.h"
 #include "cata_utility.h"
+#include "character.h"
 #include "character_attire.h"
 #include "coordinates.h"
 #include "creature.h"
@@ -193,6 +194,7 @@ static void test_shooting_scenario( npc &shooter, const int min_quickdraw_range,
                                     const int min_good_range, const int max_good_range )
 {
     {
+        aim_mods_cache aim_cache = shooter.gen_aim_mods_cache( *shooter.get_wielded_item() );
         const Target_attributes target;
         const dispersion_sources dispersion = get_dispersion( shooter, 0, min_quickdraw_range );
         std::vector<firing_statistics> minimum_stats = firing_test( dispersion, min_quickdraw_range, {
@@ -201,8 +203,10 @@ static void test_shooting_scenario( npc &shooter, const int min_quickdraw_range,
         } );
         INFO( dispersion );
         INFO( "Range: " << min_quickdraw_range );
-        INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL, target ) );
-        INFO( "Min aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), shooter.recoil, target ) );
+        INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL, target,
+                aim_cache ) );
+        INFO( "Min aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), shooter.recoil,
+                target, aim_cache ) );
         CAPTURE( shooter.get_modifier( character_modifier_ranged_dispersion_manip_mod ) );
         CAPTURE( minimum_stats[0].n() );
         CAPTURE( minimum_stats[0].margin_of_error() );
@@ -212,28 +216,34 @@ static void test_shooting_scenario( npc &shooter, const int min_quickdraw_range,
         CHECK( minimum_stats[1].avg() < 0.1 );
     }
     {
+        aim_mods_cache aim_cache = shooter.gen_aim_mods_cache( *shooter.get_wielded_item() );
         const Target_attributes target;
         const dispersion_sources dispersion = get_dispersion( shooter, 300, min_good_range );
         firing_statistics good_stats = firing_test( dispersion, min_good_range, Threshold( accuracy_goodhit,
                                        0.5 ) );
         INFO( dispersion );
         INFO( "Range: " << min_good_range );
-        INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL, target ) );
-        INFO( "Min aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), shooter.recoil, target ) );
+        INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL, target,
+                aim_cache ) );
+        INFO( "Min aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), shooter.recoil,
+                target, aim_cache ) );
         CAPTURE( shooter.get_modifier( character_modifier_ranged_dispersion_manip_mod ) );
         CAPTURE( good_stats.n() );
         CAPTURE( good_stats.margin_of_error() );
         CHECK( good_stats.avg() > 0.0 );
     }
     {
+        aim_mods_cache aim_cache = shooter.gen_aim_mods_cache( *shooter.get_wielded_item() );
         const Target_attributes target;
         const dispersion_sources dispersion = get_dispersion( shooter, 500, max_good_range );
         firing_statistics good_stats = firing_test( dispersion, max_good_range, Threshold( accuracy_goodhit,
                                        0.1 ) );
         INFO( dispersion );
         INFO( "Range: " << max_good_range );
-        INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL, target ) );
-        INFO( "Min aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), shooter.recoil, target ) );
+        INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL, target,
+                aim_cache ) );
+        INFO( "Min aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), shooter.recoil,
+                target, aim_cache ) );
         CAPTURE( shooter.get_modifier( character_modifier_ranged_dispersion_manip_mod ) );
         CAPTURE( good_stats.n() );
         CAPTURE( good_stats.margin_of_error() );
@@ -243,6 +253,7 @@ static void test_shooting_scenario( npc &shooter, const int min_quickdraw_range,
 
 static void test_fast_shooting( npc &shooter, const int moves, float hit_rate )
 {
+    aim_mods_cache aim_cache = shooter.gen_aim_mods_cache( *shooter.get_wielded_item() );
     const Target_attributes target;
     const int fast_shooting_range = 3;
     const float hit_rate_cap = hit_rate + 0.5f;
@@ -253,8 +264,10 @@ static void test_fast_shooting( npc &shooter, const int moves, float hit_rate )
                                          Threshold( accuracy_standard, hit_rate_cap ) );
     INFO( dispersion );
     INFO( "Range: " << fast_shooting_range );
-    INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL, target ) );
-    INFO( "Min aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), shooter.recoil, target ) );
+    INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL, target,
+            aim_cache ) );
+    INFO( "Min aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), shooter.recoil,
+            target, aim_cache ) );
     CAPTURE( shooter.get_modifier( character_modifier_ranged_dispersion_manip_mod ) );
     CAPTURE( shooter.get_wielded_item()->gun_skill().str() );
     CAPTURE( shooter.get_skill_level( shooter.get_wielded_item()->gun_skill() ) );

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -193,6 +193,7 @@ static void test_shooting_scenario( npc &shooter, const int min_quickdraw_range,
                                     const int min_good_range, const int max_good_range )
 {
     {
+        const Target_attributes target;
         const dispersion_sources dispersion = get_dispersion( shooter, 0, min_quickdraw_range );
         std::vector<firing_statistics> minimum_stats = firing_test( dispersion, min_quickdraw_range, {
             Threshold( accuracy_grazing, 0.2 ),
@@ -200,8 +201,8 @@ static void test_shooting_scenario( npc &shooter, const int min_quickdraw_range,
         } );
         INFO( dispersion );
         INFO( "Range: " << min_quickdraw_range );
-        INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL ) );
-        INFO( "Min aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), shooter.recoil ) );
+        INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL, target ) );
+        INFO( "Min aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), shooter.recoil, target ) );
         CAPTURE( shooter.get_modifier( character_modifier_ranged_dispersion_manip_mod ) );
         CAPTURE( minimum_stats[0].n() );
         CAPTURE( minimum_stats[0].margin_of_error() );
@@ -211,26 +212,28 @@ static void test_shooting_scenario( npc &shooter, const int min_quickdraw_range,
         CHECK( minimum_stats[1].avg() < 0.1 );
     }
     {
+        const Target_attributes target;
         const dispersion_sources dispersion = get_dispersion( shooter, 300, min_good_range );
         firing_statistics good_stats = firing_test( dispersion, min_good_range, Threshold( accuracy_goodhit,
                                        0.5 ) );
         INFO( dispersion );
         INFO( "Range: " << min_good_range );
-        INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL ) );
-        INFO( "Min aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), shooter.recoil ) );
+        INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL, target ) );
+        INFO( "Min aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), shooter.recoil, target ) );
         CAPTURE( shooter.get_modifier( character_modifier_ranged_dispersion_manip_mod ) );
         CAPTURE( good_stats.n() );
         CAPTURE( good_stats.margin_of_error() );
         CHECK( good_stats.avg() > 0.0 );
     }
     {
+        const Target_attributes target;
         const dispersion_sources dispersion = get_dispersion( shooter, 500, max_good_range );
         firing_statistics good_stats = firing_test( dispersion, max_good_range, Threshold( accuracy_goodhit,
                                        0.1 ) );
         INFO( dispersion );
         INFO( "Range: " << max_good_range );
-        INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL ) );
-        INFO( "Min aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), shooter.recoil ) );
+        INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL, target ) );
+        INFO( "Min aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), shooter.recoil, target ) );
         CAPTURE( shooter.get_modifier( character_modifier_ranged_dispersion_manip_mod ) );
         CAPTURE( good_stats.n() );
         CAPTURE( good_stats.margin_of_error() );
@@ -240,6 +243,7 @@ static void test_shooting_scenario( npc &shooter, const int min_quickdraw_range,
 
 static void test_fast_shooting( npc &shooter, const int moves, float hit_rate )
 {
+    const Target_attributes target;
     const int fast_shooting_range = 3;
     const float hit_rate_cap = hit_rate + 0.5f;
     const dispersion_sources dispersion = get_dispersion( shooter, moves, fast_shooting_range );
@@ -249,8 +253,8 @@ static void test_fast_shooting( npc &shooter, const int moves, float hit_rate )
                                          Threshold( accuracy_standard, hit_rate_cap ) );
     INFO( dispersion );
     INFO( "Range: " << fast_shooting_range );
-    INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL ) );
-    INFO( "Min aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), shooter.recoil ) );
+    INFO( "Max aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), MAX_RECOIL, target ) );
+    INFO( "Min aim speed: " << shooter.aim_per_move( *shooter.get_wielded_item(), shooter.recoil, target ) );
     CAPTURE( shooter.get_modifier( character_modifier_ranged_dispersion_manip_mod ) );
     CAPTURE( shooter.get_wielded_item()->gun_skill().str() );
     CAPTURE( shooter.get_skill_level( shooter.get_wielded_item()->gun_skill() ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Aim local cache structures are not optional"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

To solve #66709, two structs were introduced as a way to "cache" values that remain stable during various aiming loops that use `Character::aim_per_move`. To avoid touching all callsites, I suppose, those caches were introduced as `std::optional`. While not a problem per-se - optional values are cool! - those caches are not a great candidate to this pattern, as code get duplicated (on cache generation and on cache miss), and the result is a bit hard to follow compared to the code before that change.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Structs are maintained, but `std::optional` were removed. So now, each and every callsite is required to build a `aim_cache` via `gen_aim_mods_cache`. Most already did, so little changes required on that. During this process, I've removed default parameters from those functions as all, so as I touched each call site of `aim_per_move`, every parameter is not explicitly sourced. Takeways:

- Removed lots of redundant branching from both `aim_per_move` and `fastest_aiming_method_speed`, primary goal of this patch.
- Some loops didn't use the build cache for the first `aim_per_move` call, namely `do_aim` and `npc::aim`. Now they do.
- Some call-sites didn't supplied `Target_attributes`, even thought they have all data required to create such struct. With current implementation that's a minor thing, as it's only used for laser sights. By following the implementation, I do believe that means NPCs do not benefit from laser-sight guns, and this patch should fix that
- Did a bit extra refactoring on `npc::aim`, so now code sorta follows the pattern of other `aim_per_move` callers. Not enough to deduplicate everything, but a step on that direction, if possible.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
- Not doing, to avoid churn as functionally code is the same. Supposedly some minor bug is fixed, and code is IMO easier to follow to be worth.
- Rename structs and functions, merge `parallax_cache` with `aim_cache` and other small bits here and there. May do in future PR, if that's sensible, but avoided here to keep changes to a bare minimum.
- Move this aim code somewhere else, even to a `character_aim.cpp` following a pattern I saw with other use-cases. Same as above, but I'm also not sure what's the criteria for splitting files anyway so not my call.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Played the game. Aimed with few guns, namely a revolver (so point-shooting + iron-sight) and HWP (point-shooting + holo + ACOG zoom + laser). Eyeballing numbers everything looks same (which is expected). 

I'm not well versed in unit testing with C++ and this repo libraries. Assuming there are unit tests already, the beviour should be not require any changes (I doubt  the NPC laser issue was covered though).

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

For quite a while I'm dancing around surfacing sights on target UI, which I'm working on right now. Also may experiment with sight-related proficiencies. This refactoring was the first step and felt worth anyway so here we are :)

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
