### PR TITLE
Revert "Fix SDL render artifacts when closing ImGui UIs"

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -900,9 +900,6 @@ cataimgui::window::~window()
         if( !ui_adaptor::has_imgui() ) {
             ImGui::GetIO().ClearInputKeys();
             GImGui->InputEventsQueue.resize( 0 );
-#if defined(TILES)
-            clear_sdl_screen();
-#endif
         }
     }
 }

--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -233,7 +233,9 @@ void loading_ui::done()
     if( gLUI != nullptr ) {
 #ifdef TILES
         gLUI->chosen_load_img = cata_path();
-        clear_sdl_screen();
+        // Clear the message that was drawn on top of the loading image
+        SetRenderDrawColor( get_sdl_renderer(), 0, 0, 0, 255 );
+        RenderClear( get_sdl_renderer() );
 #endif
         delete gLUI->ui;
         delete gLUI->bg;

--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -233,9 +233,6 @@ void loading_ui::done()
     if( gLUI != nullptr ) {
 #ifdef TILES
         gLUI->chosen_load_img = cata_path();
-        // Clear the message that was drawn on top of the loading image
-        SetRenderDrawColor( get_sdl_renderer(), 0, 0, 0, 255 );
-        RenderClear( get_sdl_renderer() );
 #endif
         delete gLUI->ui;
         delete gLUI->bg;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -168,11 +168,6 @@ static void ClearScreen()
     RenderClear( renderer );
 }
 
-void clear_sdl_screen()
-{
-    ClearScreen();
-}
-
 static void InitSDL()
 {
     int init_flags = SDL_INIT_VIDEO | SDL_INIT_TIMER;

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -67,9 +67,6 @@ const SDL_Renderer_Ptr &get_sdl_renderer();
 // Returns the main game window. Needed by text input wrappers and other
 // SDL3 APIs that require an explicit window parameter.
 SDL_Window *get_sdl_window();
-// Clears the SDL renderer to black. Call this when closing an ImGui UI to
-// avoid leaving stale render artifacts visible before the next game frame.
-void clear_sdl_screen();
 
 #endif // TILES
 


### PR DESCRIPTION
#### Summary
None 

#### Purpose of change
Both #86704 and #86694 were made with help of copilot, which violates our license, see https://github.com/CleverRaven/Cataclysm-DDA/blob/1a40cf080972142cf03975456619add70d9e9854/CONTRIBUTING.md#licensing-and-authorship

<img width="1304" height="309" alt="image" src="https://github.com/user-attachments/assets/0589d4c7-8e93-4c4f-9dd7-eaa196862b78" />

#### Describe the solution
Revert