### PR TITLE
[ Xedra Evolved ] Eliminate classless Dream Magick Spells and begin working through adjustments to Spell learning artifacts

### DIFF
--- a/data/mods/Xedra_Evolved/eocs/eoc_conditions.json
+++ b/data/mods/Xedra_Evolved/eocs/eoc_conditions.json
@@ -206,7 +206,7 @@
     "id": "EOC_DREAM_CLASS_XP",
     "condition": { "one_in_chance": 2 },
     "effect": [ { "run_eocs": "EOC_DREAM_CRAFTS", "time_in_future": 1 } ],
-    "false_effect": [ { "run_eocs": "EOC_DREAM_SPELLS", "time_in_future": 1 } ]
+    "false_effect": [ { "run_eocs": "EOC_XE_GOT_A_SPELL_LVL", "time_in_future": 1 } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/eocs/eoc_conditions.json
+++ b/data/mods/Xedra_Evolved/eocs/eoc_conditions.json
@@ -211,7 +211,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_DREAM_CRAFTS",
-    "condition":  { "or": [ { "u_has_trait": "DREAMSMITH" }, { "u_has_trait": "INVENTOR" } ] },
+    "condition": { "or": [ { "u_has_trait": "DREAMSMITH" }, { "u_has_trait": "INVENTOR" } ] },
     "effect": [ { "run_eocs": "EOC_DREAMSMITHS_SCORE_TRAIN", "time_in_future": 1 } ],
     "false_effect": [ { "run_eocs": "EOC_XE_GOT_A_SPELL_LVL", "time_in_future": 1 } ]
   }

--- a/data/mods/Xedra_Evolved/eocs/eoc_conditions.json
+++ b/data/mods/Xedra_Evolved/eocs/eoc_conditions.json
@@ -200,5 +200,19 @@
       { "math": [ "dream_counter = 1" ] },
       { "run_eocs": "EOC_RESET_DREAM_COUNTER", "time_in_future": 1 }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DREAM_CLASS_XP",
+    "condition": { "one_in_chance": 2 },
+    "effect": [ { "run_eocs": "EOC_DREAM_CRAFTS", "time_in_future": 1 } ],
+    "false_effect": [ { "run_eocs": "EOC_DREAM_SPELLS", "time_in_future": 1 } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DREAM_CRAFTS",
+    "condition":  { "or": [ { "u_has_trait": "DREAMSMITH" }, { "u_has_trait": "INVENTOR" } ] },
+    "effect": [ { "run_eocs": "EOC_DREAMSMITHS_SCORE_TRAIN", "time_in_future": 1 } ],
+    "false_effect": [ { "run_eocs": "EOC_XE_GOT_A_SPELL_LVL", "time_in_future": 1 } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
@@ -36,7 +36,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_MAGICIANS_HAT2",
-    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } } ], [ { "math": [ "u_magicians_hat_xp = 1" ] } ] ] },
+    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } } ], [ { "math": [ "u_magicians_hat_xp = 1" ] } ] } ] },
     "effect": [ { "run_eocs": "EOC_DREAM_CLASS_XP" } ],
     "false_effect": { "u_message": "You've learned as much as you can from this item." }
   },

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
@@ -13,7 +13,28 @@
     "material": [ "forged_dreamstuff" ],
     "symbol": "0",
     "color": "green",
-    "use_action": { "type": "learn_spell", "spells": [ "damage_transfer" ] }
+    "use_action": { "type": "effect_on_conditions", "description": "You play with your %s.", "effect_on_conditions": [ "EOC_MAGICIANS_HAT" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MAGICIANS_HAT",
+    "condition": { "math": [ "u_magicians_hat_xp = 0" ] },
+    "effect": [
+      { "math": [ "u_magicians_hat_xp ++" ] },
+      { "math": [ "magic_potential++" ] },
+          {
+            "u_message": "Got magic potential from Frosty's hat, magic_potential: <global_val:magic_potential>",
+            "type": "debug"
+          }
+    ],
+    "false_effects": [ { "run_eocs": "EOC_MAGICIANS_HAT2" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MAGICIANS_HAT2",
+    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, [ { "math": [ "u_magicians_hat_xp = 1" ] } ] ] },
+    "effect": [ { "run_eocs": "EOC_DREAM_CLASS_XP" } ],
+    "false_effect": { "u_message": "You've learned as much as you can from this item."} 
   },
   {
     "id": "fire_ball",
@@ -29,6 +50,27 @@
     "material": [ "forged_dreamstuff" ],
     "symbol": "o",
     "color": "red",
-    "use_action": { "type": "learn_spell", "spells": [ "fire_teleport" ] }
+    "use_action": { "type": "effect_on_conditions", "description": "You play with your %s.", "effect_on_conditions": [ "EOC_FIRE_BALL" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_FIRE_BALL",
+    "condition": { "math": [ "u_fire_ball_xp = 0" ] },
+    "effect": [
+      { "math": [ "u_fire_ball_xp ++" ] },
+      { "math": [ "magic_potential++" ] },
+          {
+            "u_message": "Got magic potential from the dragonball, magic_potential: <global_val:magic_potential>",
+            "type": "debug"
+          }
+    ],
+    "false_effects": [ { "run_eocs": "EOC_FIRE_BALL2" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_FIRE_BALL2",
+    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, [ { "math": [ "u_magicians_hat_xp = 1" ] } ] ] },
+    "effect": [ { "run_eocs": "EOC_DREAM_CLASS_XP" } ],
+    "false_effect": { "u_message": "You've learned as much as you can from this item."} 
   }
 ]

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
@@ -22,7 +22,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_MAGICIANS_HAT",
-    "condition": { "math": [ "u_magicians_hat_xp = 0" ] },
+    "condition": { "math": [ "u_magicians_hat_xp == 0" ] },
     "effect": [
       { "math": [ "u_magicians_hat_xp ++" ] },
       { "math": [ "magic_potential++" ] },
@@ -59,7 +59,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_FIRE_BALL",
-    "condition": { "math": [ "u_fire_ball_xp = 0" ] },
+    "condition": { "math": [ "u_fire_ball_xp == 0" ] },
     "effect": [
       { "math": [ "u_fire_ball_xp ++" ] },
       { "math": [ "magic_potential++" ] },

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
@@ -36,7 +36,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_MAGICIANS_HAT2",
-    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }. { "math": [ "u_magicians_hat_xp = 1" ] } ] } ] },
+    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, { "math": [ "u_magicians_hat_xp = 1" ] } ] } ] },
     "effect": [ { "run_eocs": "EOC_DREAM_CLASS_XP" } ],
     "false_effect": { "u_message": "You've learned as much as you can from this item." }
   },

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
@@ -36,7 +36,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_MAGICIANS_HAT2",
-    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, { "math": [ "u_magicians_hat_xp = 1" ] } ] } ] },
+   "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, [ { "math": [ "u_magicians_hat_xp = 1" ] } ] ] },
     "effect": [ { "run_eocs": "EOC_DREAM_CLASS_XP" } ],
     "false_effect": { "u_message": "You've learned as much as you can from this item." }
   },

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
@@ -26,6 +26,7 @@
     "effect": [
       { "math": [ "u_magicians_hat_xp ++" ] },
       { "math": [ "magic_potential++" ] },
+      { "u_message": "You do some extemperaneous magic tricks with the hat and somehow feel as though something inside of you has changed." },
       {
         "u_message": "Got magic potential from Frosty's hat, magic_potential: <global_val:magic_potential>",
         "type": "debug"
@@ -63,6 +64,7 @@
     "effect": [
       { "math": [ "u_fire_ball_xp ++" ] },
       { "math": [ "magic_potential++" ] },
+      { "u_message": "Did you know how to do contact juggling before the cataclysm or only just now this moment?" },
       {
         "u_message": "Got magic potential from the dragonball, magic_potential: <global_val:magic_potential>",
         "type": "debug"

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
@@ -36,7 +36,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_MAGICIANS_HAT2",
-   "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, [ { "math": [ "u_magicians_hat_xp = 1" ] } ] ] },
+    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, [ { "math": [ "u_magicians_hat_xp = 1" ] } ] ] },
     "effect": [ { "run_eocs": "EOC_DREAM_CLASS_XP" } ],
     "false_effect": { "u_message": "You've learned as much as you can from this item." }
   },

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
@@ -36,7 +36,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_MAGICIANS_HAT2",
-   "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, [ { "math": [ "u_magicians_hat_xp = 1" ] } ] ] },
+   "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, [ { "math": [ "u_magicians_hat_xp == 1" ] } ] ] },
     "effect": [ { "run_eocs": "EOC_DREAM_CLASS_XP" } ],
     "false_effect": { "u_message": "You've learned as much as you can from this item." }
   },
@@ -73,7 +73,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_FIRE_BALL2",
-    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, [ { "math": [ "u_fire_ball_xp = 1" ] } ] ] },
+    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, [ { "math": [ "u_fire_ball_xp == 1" ] } ] ] },
     "effect": [ { "run_eocs": "EOC_DREAM_CLASS_XP" } ],
     "false_effect": { "u_message": "You've learned as much as you can from this item." }
   }

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
@@ -69,7 +69,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_FIRE_BALL2",
-    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, [ { "math": [ "u_magicians_hat_xp = 1" ] } ] ] },
+    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, [ { "math": [ "u_fire_ball_xp = 1" ] } ] ] },
     "effect": [ { "run_eocs": "EOC_DREAM_CLASS_XP" } ],
     "false_effect": { "u_message": "You've learned as much as you can from this item."} 
   }

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
@@ -26,7 +26,9 @@
     "effect": [
       { "math": [ "u_magicians_hat_xp ++" ] },
       { "math": [ "magic_potential++" ] },
-      { "u_message": "You do some extemperaneous magic tricks with the hat and somehow feel as though something inside of you has changed." },
+      {
+        "u_message": "You do some extemperaneous magic tricks with the hat and somehow feel as though something inside of you has changed."
+      },
       {
         "u_message": "Got magic potential from Frosty's hat, magic_potential: <global_val:magic_potential>",
         "type": "debug"

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
@@ -31,12 +31,12 @@
         "type": "debug"
       }
     ],
-    "false_effects": [ { "run_eocs": "EOC_MAGICIANS_HAT2" } ]
+    "false_effect": [ { "run_eocs": "EOC_MAGICIANS_HAT2" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_MAGICIANS_HAT2",
-    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, [ { "math": [ "u_magicians_hat_xp = 1" ] } ] ] },
+    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } } ], [ { "math": [ "u_magicians_hat_xp = 1" ] } ] ] },
     "effect": [ { "run_eocs": "EOC_DREAM_CLASS_XP" } ],
     "false_effect": { "u_message": "You've learned as much as you can from this item." }
   },

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
@@ -36,7 +36,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_MAGICIANS_HAT2",
-    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } } ], [ { "math": [ "u_magicians_hat_xp = 1" ] } ] } ] },
+    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }. { "math": [ "u_magicians_hat_xp = 1" ] } ] } ] },
     "effect": [ { "run_eocs": "EOC_DREAM_CLASS_XP" } ],
     "false_effect": { "u_message": "You've learned as much as you can from this item." }
   },

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
@@ -13,7 +13,11 @@
     "material": [ "forged_dreamstuff" ],
     "symbol": "0",
     "color": "green",
-    "use_action": { "type": "effect_on_conditions", "description": "You play with your %s.", "effect_on_conditions": [ "EOC_MAGICIANS_HAT" ] }
+    "use_action": {
+      "type": "effect_on_conditions",
+      "description": "You play with your %s.",
+      "effect_on_conditions": [ "EOC_MAGICIANS_HAT" ]
+    }
   },
   {
     "type": "effect_on_condition",
@@ -22,10 +26,10 @@
     "effect": [
       { "math": [ "u_magicians_hat_xp ++" ] },
       { "math": [ "magic_potential++" ] },
-          {
-            "u_message": "Got magic potential from Frosty's hat, magic_potential: <global_val:magic_potential>",
-            "type": "debug"
-          }
+      {
+        "u_message": "Got magic potential from Frosty's hat, magic_potential: <global_val:magic_potential>",
+        "type": "debug"
+      }
     ],
     "false_effects": [ { "run_eocs": "EOC_MAGICIANS_HAT2" } ]
   },
@@ -34,7 +38,7 @@
     "id": "EOC_MAGICIANS_HAT2",
     "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, [ { "math": [ "u_magicians_hat_xp = 1" ] } ] ] },
     "effect": [ { "run_eocs": "EOC_DREAM_CLASS_XP" } ],
-    "false_effect": { "u_message": "You've learned as much as you can from this item."} 
+    "false_effect": { "u_message": "You've learned as much as you can from this item." }
   },
   {
     "id": "fire_ball",
@@ -59,10 +63,10 @@
     "effect": [
       { "math": [ "u_fire_ball_xp ++" ] },
       { "math": [ "magic_potential++" ] },
-          {
-            "u_message": "Got magic potential from the dragonball, magic_potential: <global_val:magic_potential>",
-            "type": "debug"
-          }
+      {
+        "u_message": "Got magic potential from the dragonball, magic_potential: <global_val:magic_potential>",
+        "type": "debug"
+      }
     ],
     "false_effects": [ { "run_eocs": "EOC_FIRE_BALL2" } ]
   },
@@ -71,6 +75,6 @@
     "id": "EOC_FIRE_BALL2",
     "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, [ { "math": [ "u_magicians_hat_xp = 1" ] } ] ] },
     "effect": [ { "run_eocs": "EOC_DREAM_CLASS_XP" } ],
-    "false_effect": { "u_message": "You've learned as much as you can from this item."} 
+    "false_effect": { "u_message": "You've learned as much as you can from this item." }
   }
 ]

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
@@ -68,7 +68,7 @@
         "type": "debug"
       }
     ],
-    "false_effects": [ { "run_eocs": "EOC_FIRE_BALL2" } ]
+    "false_effect": [ { "run_eocs": "EOC_FIRE_BALL2" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_classless.json
@@ -36,7 +36,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_MAGICIANS_HAT2",
-    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, [ { "math": [ "u_magicians_hat_xp == 1" ] } ] ] },
+    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, { "math": [ "u_magicians_hat_xp == 1" ] } ] },
     "effect": [ { "run_eocs": "EOC_DREAM_CLASS_XP" } ],
     "false_effect": { "u_message": "You've learned as much as you can from this item." }
   },
@@ -73,7 +73,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_FIRE_BALL2",
-    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, [ { "math": [ "u_fire_ball_xp == 1" ] } ] ] },
+    "condition": { "and": [ { "not": { "u_has_trait": "VAMPIRE" } }, { "math": [ "u_fire_ball_xp == 1" ] } ] },
     "effect": [ { "run_eocs": "EOC_DREAM_CLASS_XP" } ],
     "false_effect": { "u_message": "You've learned as much as you can from this item." }
   }

--- a/data/mods/Xedra_Evolved/procgen/dreamer_procgen.json
+++ b/data/mods/Xedra_Evolved/procgen/dreamer_procgen.json
@@ -27,6 +27,8 @@
       { "weight": 40, "spell_id": "XAEA_line", "base_power": 250 },
       { "weight": 40, "spell_id": "XAEA_hologram_summon", "base_power": 250 },
       { "weight": 40, "spell_id": "XAEA_electric_emit", "base_power": 250 },
+      { "weight": 4, "spell_id": "damage_transfer", "base_power": 500 },
+      { "weight": 3, "spell_id": "fire_teleport", "base_power": 750 },
       { "weight": 30, "spell_id": "XAEA_mod_moves", "base_power": 250 },
       { "weight": 20, "spell_id": "XAEA_motion_vision", "base_power": 250 }
     ],

--- a/data/mods/Xedra_Evolved/spells/classless_spells.json
+++ b/data/mods/Xedra_Evolved/spells/classless_spells.json
@@ -16,26 +16,6 @@
     "max_book_level": 0
   },
   {
-    "id": "night_sight",
-    "type": "SPELL",
-    "name": "Night Sight",
-    "description": "Gives you the power to see in the dark.",
-    "message": "Your eyes glow lavender for a moment.  Now your sight can pierce the darkest shadows.",
-    "valid_targets": [ "self" ],
-    "effect": "attack",
-    "effect_str": "night_sight",
-    "skill": "deduction",
-    "shape": "blast",
-    "base_casting_time": 2000,
-    "base_energy_cost": 1200,
-    "magic_type": "xedra_magic_generic",
-    "difficulty": 6,
-    "max_level": 20,
-    "min_duration": { "math": [ "spell_time(time(' 3 m'))" ] },
-    "max_duration": { "math": [ "spell_time(time(' 3 h'))" ] },
-    "duration_increment": { "math": [ "spell_time(time(' 3 m'))" ] }
-  },
-  {
     "id": "dread_weight",
     "type": "SPELL",
     "name": "Weight of Dread",

--- a/data/mods/Xedra_Evolved/spells/classless_spells.json
+++ b/data/mods/Xedra_Evolved/spells/classless_spells.json
@@ -15,7 +15,7 @@
     "failure_exp_percent": 1,
     "max_book_level": 0
   },
-   {
+  {
     "id": "night_sight",
     "type": "SPELL",
     "name": "Night Sight",

--- a/data/mods/Xedra_Evolved/spells/classless_spells.json
+++ b/data/mods/Xedra_Evolved/spells/classless_spells.json
@@ -15,6 +15,26 @@
     "failure_exp_percent": 1,
     "max_book_level": 0
   },
+   {
+    "id": "night_sight",
+    "type": "SPELL",
+    "name": "Night Sight",
+    "description": "Gives you the power to see in the dark.",
+    "message": "Your eyes glow lavender for a moment.  Now your sight can pierce the darkest shadows.",
+    "valid_targets": [ "self" ],
+    "effect": "attack",
+    "effect_str": "night_sight",
+    "skill": "deduction",
+    "shape": "blast",
+    "base_casting_time": 2000,
+    "base_energy_cost": 1200,
+    "magic_type": "xedra_magic_generic",
+    "difficulty": 6,
+    "max_level": 20,
+    "min_duration": { "math": [ "spell_time(time(' 3 m'))" ] },
+    "max_duration": { "math": [ "spell_time(time(' 3 h'))" ] },
+    "duration_increment": { "math": [ "spell_time(time(' 3 m'))" ] }
+  },
   {
     "id": "dread_weight",
     "type": "SPELL",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "Rework Spell Learning for Dream Magick Part Uno reverse"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I love the idea of the spell learning artifacts.  I hated that you could continue studying them after they taught you the initial spell.  I hated the weird bugs we could experience from them allowing workarounds to other limiting features.  I also hated making the mapgen to find them which meant that they never stopped being everywhere but also being useless.  And also you couldn't ever count on finding the spell you wanted.  Finally there shouldn't be any classless dream magick.  
This attempts to start working on all of these issues.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Removes spell learning ability from some artifiacts but adds in spell learning eoc adjustments.  Makes the classless spells now procgen artifact spells.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
More individualized EOCs
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
TBD
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
