### PR TITLE
animal weakpoints include vital organs

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3132,6 +3132,24 @@
   },
   {
     "type": "effect_type",
+    "id": "lung_collapse",
+    "name": [ "Lung Collapse" ],
+    "desc": [ "Your have difficulties breathing!" ],
+    "rating": "bad",
+    "max_intensity": 2,
+    "//": "intensity 1 - one of two lungs is collapsed; intensity 2 - both lungs are collapsed",
+    "base_mods": { "hurt_amount": [ 1 ], "hurt_tick": [ 4 ] },
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [ { "value": "SPEED", "multiply": { "math": [ "u_effect_intensity('lung_collapse') * -0.25" ] } } ]
+      }
+    ],
+    "chance_kill": [ [ 0, 1 ], [ 1, 120 ] ],
+    "show_in_info": true
+  },
+  {
+    "type": "effect_type",
     "id": "revived_marker",
     "//COMMENT": "Hardcoded dummy effect to track a monster as revived. Applied and checked in C++ only.",
     "name": [ "Revived" ],

--- a/data/json/monster_weakpoints/quadruped_weakpoints_animal.json
+++ b/data/json/monster_weakpoints/quadruped_weakpoints_animal.json
@@ -5,6 +5,7 @@
     "weakpoints": [
       {
         "name": "the head",
+        "id": "head",
         "is_head": true,
         "armor_mult": { "physical": 0.75 },
         "crit_mult": { "all": 1.1 },
@@ -37,7 +38,24 @@
         ]
       },
       {
+        "name": "the head",
+        "id": "brain",
+        "armor_mult": { "physical": 0.45 },
+        "difficulty": { "melee": 4, "ranged": 7 },
+        "damage_mult": { "physical": 2 },
+        "coverage_mult": { "melee": 0 },
+        "coverage": 0.5,
+        "is_head": true,
+        "effects": [
+          {
+            "instant_death_chance": 100,
+            "message": "With a clean attack to the head, %s drops dead like a puppet with strings cut."
+          }
+        ]
+      },
+      {
         "name": "the eye",
+        "id": "eye",
         "is_head": true,
         "armor_mult": { "physical": 0 },
         "coverage": 1,
@@ -57,47 +75,68 @@
       },
       {
         "name": "the chest",
+        "id": "chest",
         "armor_mult": { "bash": 2 },
         "difficulty": { "melee": 2, "ranged": 1 },
         "damage_mult": { "stab": 1.25, "bullet": 1.33 },
         "coverage": 18
       },
       {
-        "name": "the vitals",
+        "name": "the chest",
+        "id": "heart",
+        "armor_mult": { "bullet": 2.5, "cut": 1.5, "stab": 2, "bash": 0 },
+        "difficulty": { "ranged": 4 },
+        "damage_mult": { "physical": 2 },
+        "coverage_mult": { "melee": 0 },
+        "coverage": 0.3,
+        "effects": [ { "effect": "bleed", "intensity": [ 25, 40 ], "permanent": true, "damage_required": [ 1, 100 ] } ]
+      },
+      {
+        "name": "the chest",
+        "id": "lungs",
         "armor_mult": { "physical": 0.45 },
         "difficulty": { "ranged": 4 },
         "damage_mult": { "physical": 2 },
         "coverage_mult": { "melee": 0 },
-        "coverage": 7,
+        "coverage": 6,
+        "effects": [ { "effect": "lung_collapse", "intensity": [ 1, 2 ], "permanent": true, "damage_required": [ 1, 100 ] } ]
+      },
+      {
+        "name": "the chest",
+        "id": "heart_and_lungs",
+        "//": "since both heart and lungs are generally close to each other, you can hit both in the same attack",
+        "armor_mult": { "bullet": 2.5, "cut": 1.5, "stab": 2, "bash": 0 },
+        "difficulty": { "ranged": 4 },
+        "damage_mult": { "physical": 2 },
+        "coverage_mult": { "melee": 0 },
+        "coverage": 0.1,
+        "effects": [
+          { "effect": "bleed", "intensity": [ 25, 40 ], "permanent": true, "damage_required": [ 1, 100 ] },
+          { "effect": "lung_collapse", "intensity": [ 1, 2 ], "permanent": true, "damage_required": [ 1, 100 ] }
+        ]
+      },
+      {
+        "name": "the vitals",
+        "id": "vitals",
+        "//": "rest of internal organs, that would make monster die, but not as fast; liver and similar",
+        "armor_mult": { "physical": 0.45 },
+        "difficulty": { "ranged": 4 },
+        "damage_mult": { "physical": 2 },
+        "coverage_mult": { "melee": 0 },
+        "coverage": 3,
         "effects": [
           {
             "effect": "bleed",
-            "intensity": [ 10, 15 ],
-            "duration": [ 10, 20 ],
-            "chance": 75,
+            "intensity": [ 10, 22 ],
+            "permanent": true,
             "message": "The %s is shot in the vitals!",
-            "damage_required": [ 1, 10 ]
-          },
-          {
-            "effect": "bleed",
-            "intensity": [ 20, 30 ],
-            "duration": [ 20, 30 ],
-            "chance": 85,
-            "message": "The %s is shot in the vitals!",
-            "damage_required": [ 11, 50 ]
-          },
-          {
-            "effect": "bleed",
-            "intensity": [ 30, 40 ],
-            "duration": [ 30, 40 ],
-            "chance": 95,
-            "message": "The %s is shot in the vitals!",
-            "damage_required": [ 51, 100 ]
+            "damage_required": [ 1, 100 ]
           }
         ]
       },
       {
         "name": "the leg",
+        "id": "leg",
         "difficulty": { "melee": 1, "ranged": 2 },
         "coverage_mult": { "point": 0.75 },
         "effects": [

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3466,8 +3466,6 @@ void monster::process_one_effect( effect &it, bool is_new )
         effect_cache[VISION_IMPAIRED] = true;
     } else if( ( id == effect_bleed || id == effect_dripping_mechanical_fluid ) &&
                x_in_y( it.get_intensity(), it.get_max_intensity() ) ) {
-        // this is for balance only
-        it.mod_duration( -rng( 1_turns, it.get_int_dur_factor() / 2 ) );
         bleed( here );
         if( id == effect_bleed ) {
             // monsters are simplified so they just take damage from bleeding


### PR DESCRIPTION
#### Summary
Features "Animal weakpoints include vital organs, deadly if hit"
#### Purpose of change
From what i saw, lot of hunting relies on hunter hitting the head of creature, killing it instantly, or hitting any of internal organs, bleeding the animal to death. Also i in general would like to put down bows relying on 10x crits in order to deal with enemies, and make it rely on what is actually happening - target getting hit in a spot that either kills it instantly, or makes it bleed heavily
#### Describe the solution
- Expand quadruped weakpoints with brain (instant death), heart (massive, **permanent** bleeding), lungs (lung collapse, decreases moving speed), and vitals (less massive but still permanent bleeding)
- Remove the bit of code that forced the bleeding to end prematurely, by decreasing it's duration by duration factor, "for balance reason", resulting in bleeding being removed even if it is permanent

#### Describe alternatives you've considered
Move specific effects away from quadruped weakpoints into some generic "internal organs"

#### Testing
Shooting modified pig that has 10 times more HP, confirmed weakpoints are being hit, 
I made a test (i am thinking how to include it, it doesn't test anything, more of a report) that prints the result of 10000 weakpoint selections depending on skill, item etc, and here is how current distribution looks like for
<img width="2013" height="627" alt="image" src="https://github.com/user-attachments/assets/f3d37423-7f73-42f3-8935-61ca2bba640b" />

#### Additional context
I would like to extend it later to human monsters (civilians, ferals) and, ultimately, zombies as well, the generic mainly - they are warm and bleed, if they still rely on biology at this point, turning the biology off is a reasonable countermeasure against them