### PR TITLE
Give glass shiv `PUNCTURE_VEHICLE_WHEELS` flag

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -797,7 +797,7 @@
     "volume": "82 ml",
     "longest_side": "15 cm",
     "to_hit": { "grip": "none", "length": "hand", "surface": "line", "balance": "good" },
-    "flags": [ "SHEATH_KNIFE", "CONDUCTIVE", "FRAGILE_MELEE", "ALLOWS_BODY_BLOCK" ],
+    "flags": [ "SHEATH_KNIFE", "CONDUCTIVE", "FRAGILE_MELEE", "ALLOWS_BODY_BLOCK", "PUNCTURE_VEHICLE_WHEELS" ],
     "weapon_category": [ "SHIVS" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -18 ] ],
     "melee_damage": { "cut": 6 }


### PR DESCRIPTION


#### Summary
None

#### Purpose of change

Since glass shiv is basically just a safe to wield glass shard, i give it the PUNCTURE_VEHICLE_WHEELS flag.

#### Describe the solution

Give the PUNCTURE_VEHICLE_WHEELS flag to the glass shiv.

#### Describe alternatives you've considered

Not doing it?
#### Testing
I ran over 10 glass shivs.
<img width="848" height="299" alt="Screenshot_20260426_214037" src="https://github.com/user-attachments/assets/59ee7dbe-b5b5-4942-a4e1-875cd4ad73cf" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
