### PR TITLE
Reimplementation of Clear SDL artifacts when closing ImGui Menus

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -900,6 +900,10 @@ cataimgui::window::~window()
         if( !ui_adaptor::has_imgui() ) {
             ImGui::GetIO().ClearInputKeys();
             GImGui->InputEventsQueue.resize( 0 );
+#ifdef TILES
+            // Removes leftover ImGui artifacts
+            clear_sdl_window();
+#endif
         }
     }
 }

--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -232,7 +232,8 @@ void loading_ui::done()
 {
     if( gLUI != nullptr ) {
 #ifdef TILES
-        gLUI->chosen_load_img = cata_path();
+        // Need to manually clear the screen due to using direct ImGui calls
+        clear_sdl_window();
 #endif
         delete gLUI->ui;
         delete gLUI->bg;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -168,6 +168,11 @@ static void ClearScreen()
     RenderClear( renderer );
 }
 
+void clear_sdl_window()
+{
+    ClearScreen();
+}
+
 static void InitSDL()
 {
     int init_flags = SDL_INIT_VIDEO | SDL_INIT_TIMER;

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -64,6 +64,8 @@ window_dimensions get_window_dimensions( const catacurses::window &win );
 window_dimensions get_window_dimensions( const point &pos, const point &size );
 
 const SDL_Renderer_Ptr &get_sdl_renderer();
+// Clears the SDL renderer to black
+void clear_sdl_window();
 // Returns the main game window. Needed by text input wrappers and other
 // SDL3 APIs that require an explicit window parameter.
 SDL_Window *get_sdl_window();


### PR DESCRIPTION
#### Summary
Bugfixes "Reimplementation of Clear SDL artifacts when closing ImGui Menus"

#### Purpose of change
When exiting ImGui menus, it is possible for leftover artifacts to appear on the sides of the screen in certain resolution/scaling settings.

#### Describe the solution
Clear the SDL renderer anytime the last open ImGui window is closed.  
Loading screen is using raw ImGui input, so add a clear call there as well.

#### Describe alternatives you've considered
Call clear inside every ImGui menu implementation upon closing - inefficient and not as future-proof.

#### Testing
Compiled in Windows
Loaded a game and verified menu artifacts were not leftover from: New Character, Crafting, Overmap, Keybinds, Surroundings menus.

#### Additional context

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
