### PR TITLE
Stop shed roof mapgen tripping on z=1 items

### DIFF
--- a/data/json/mapgen/nested/house_nested.json
+++ b/data/json/mapgen/nested/house_nested.json
@@ -2063,6 +2063,7 @@
         "-....-",
         "------"
       ],
+      "flags": [ "ERASE_ITEMS_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "roof_palette" ]
     }
   },


### PR DESCRIPTION
#### Summary
Bugfixes "Stop shed_6x6_roof mapgen tripping debugmsgs over z=1 items"

#### Purpose of change
Recurring CI noise: `shed_6x6_junk` places `shed_6x6_roof` at z=1, gutter tiles overwrite t_open_air where items sometimes already exist.

#### Describe the solution
Add `ERASE_ITEMS_BEFORE_PLACING_TERRAIN`.

#### Describe alternatives you've considered
N/A

#### Testing
N/A, JSON flag.

#### Additional context
N/A