### PR TITLE
Lithium battery disassembly

### DIFF
--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -1920,6 +1920,8 @@
     "material": [ "acid" ],
     "volume": "400 ml",
     "weight": "700 g",
+    "count": 1,
+    "stack_size": 1,
     "phase": "liquid"
   }
 ]

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -1910,8 +1910,15 @@
     "symbol": ","
   },
   {
+    "type": "ammunition_type",
+    "id": "electrolyte_slurry",
+    "name": "electrolyte slurry",
+    "default": "waste_electrolyte_slurry"
+  },
+  {
     "type": "ITEM",
     "id": "waste_electrolyte_slurry",
+    "subtypes": [ "AMMO" ],
     "category": "other",
     "name": { "str_sp": "Electrolyte Slurry" },
     "symbol": "o",
@@ -1920,7 +1927,7 @@
     "material": [ "acid" ],
     "volume": "400 ml",
     "weight": "700 g",
-    "stackable": true,
+    "ammo_type": "electrolyte_slurry",
     "count": 1,
     "stack_size": 1,
     "phase": "liquid"

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -1920,7 +1920,7 @@
     "material": [ "acid" ],
     "volume": "400 ml",
     "weight": "700 g",
-    "phase": "liquid"
+    "phase": "liquid",
     "freezing_point": -30
   }
 ]

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -1908,5 +1908,19 @@
     "description": "A handful of dry leaves(?) from an alien plant.  Despite their otherworldly origin, they have very few uses and are thus (almost) only good for burning.",
     "color": "red",
     "symbol": ","
+  },
+  {
+    "type": "ITEM",
+    "id": "waste_electrolyte_slurry",
+    "category": "other",
+    "name": { "str_sp": "Electrolyte Slurry" },
+    "symbol": "o",
+    "color": "cyan",
+    "description": "The leftover remnants of what was inside of a lithium-ion battery. It has a rainbow sheen, almost like oil resting on water.",
+    "material": [ "acid" ],
+    "volume": "400 ml",
+    "weight": "700 g",
+    "phase": "liquid"
+    "freezing_point": -30
   }
 ]

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -1912,6 +1912,7 @@
   {
     "type": "ITEM",
     "id": "waste_electrolyte_slurry",
+    "subtypes": [ "AMMO" ],
     "category": "other",
     "name": { "str_sp": "Electrolyte Slurry" },
     "symbol": "o",

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -1912,7 +1912,6 @@
   {
     "type": "ITEM",
     "id": "waste_electrolyte_slurry",
-    "subtypes": [ "AMMO" ],
     "category": "other",
     "name": { "str_sp": "Electrolyte Slurry" },
     "symbol": "o",
@@ -1921,6 +1920,7 @@
     "material": [ "acid" ],
     "volume": "400 ml",
     "weight": "700 g",
+    "stackable": true,
     "count": 1,
     "stack_size": 1,
     "phase": "liquid"

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -1916,11 +1916,10 @@
     "name": { "str_sp": "Electrolyte Slurry" },
     "symbol": "o",
     "color": "cyan",
-    "description": "The leftover remnants of what was inside of a lithium-ion battery. It has a rainbow sheen, almost like oil resting on water.",
+    "description": "The leftover remnants of what was inside of a lithium-ion battery.  It has a rainbow sheen, almost like oil resting on water.",
     "material": [ "acid" ],
     "volume": "400 ml",
     "weight": "700 g",
-    "phase": "liquid",
-    "freezing_point": -30
+    "phase": "liquid"
   }
 ]

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -1910,15 +1910,8 @@
     "symbol": ","
   },
   {
-    "type": "ammunition_type",
-    "id": "electrolyte_slurry",
-    "name": "electrolyte slurry",
-    "default": "waste_electrolyte_slurry"
-  },
-  {
     "type": "ITEM",
     "id": "waste_electrolyte_slurry",
-    "subtypes": [ "AMMO" ],
     "category": "other",
     "name": { "str_sp": "Electrolyte Slurry" },
     "symbol": "o",
@@ -1927,9 +1920,7 @@
     "material": [ "acid" ],
     "volume": "400 ml",
     "weight": "700 g",
-    "ammo_type": "electrolyte_slurry",
-    "count": 1,
-    "stack_size": 1,
+    "stackable": true,
     "phase": "liquid"
   }
 ]

--- a/data/json/items/resources/misc.json
+++ b/data/json/items/resources/misc.json
@@ -314,7 +314,7 @@
     "name": { "str": "discharging lithium-ion battery" },
     "symbol": "=",
     "color": "dark_gray",
-    "description": "A lithium-ion battery that is soaking in saltwater. After about a day, it should have short-circuited and discharged its energy, leaving it safe to handle... ideally.",
+    "description": "A lithium-ion battery that is soaking in saltwater.  After about a day, it should have short-circuited and discharged its energy, leaving it safe to handle… ideally.",
     "material": [ "plastic", "steel" ],
     "weight": "1500 g",
     "volume": "500 ml",
@@ -335,11 +335,10 @@
     "name": { "str": "discharged lithium-ion battery" },
     "symbol": "=",
     "color": "dark_gray",
-    "description": "A lithium-ion battery that has been shorted and discharged using saltwater. At least, you hope it is.",
+    "description": "A lithium-ion battery that has been shorted and discharged using saltwater.  At least, you hope it is.",
     "material": [ "plastic", "steel" ],
     "weight": "1500 g",
     "volume": "500 ml",
     "category": "other"
-   }
+  }
 ]
-

--- a/data/json/items/resources/misc.json
+++ b/data/json/items/resources/misc.json
@@ -324,9 +324,9 @@
       "msg": "You dump the colorful saltwater and dry the battery.",
       "moves": 1000,
       "type": "delayed_transform",
-      "transform_age": 86400,
+      "transform_age": 172800,
       "not_ready_msg": "The battery is still discharging.",
-      "//": "24 hours"
+      "//": "48 hours"
     }
   },
   {

--- a/data/json/items/resources/misc.json
+++ b/data/json/items/resources/misc.json
@@ -307,5 +307,39 @@
     "price_postapoc": "10 cent",
     "volume": "250 ml",
     "flags": [ "UNRECOVERABLE" ]
-  }
+  },
+  {
+    "type": "ITEM",
+    "id": "discharging_battery",
+    "name": { "str": "discharging lithium-ion battery" },
+    "symbol": "=",
+    "color": "dark_gray",
+    "description": "A lithium-ion battery that is soaking in saltwater. After about a day, it should have short-circuited and discharged its energy, leaving it safe to handle... ideally.",
+    "material": [ "plastic", "steel" ],
+    "weight": "1500 g",
+    "volume": "500 ml",
+    "category": "other",
+    "use_action": {
+      "target": "discharged_storage_battery",
+      "msg": "You dump the colorful saltwater and dry the battery.",
+      "moves": 1000,
+      "type": "delayed_transform",
+      "transform_age": 86400,
+      "not_ready_msg": "The battery is still discharging.",
+      "//": "24 hours"
+    }
+  },
+  {
+    "type": "ITEM",
+    "id": "discharged_storage_battery",
+    "name": { "str": "discharged lithium-ion battery" },
+    "symbol": "=",
+    "color": "dark_gray",
+    "description": "A lithium-ion battery that has been shorted and discharged using saltwater. At least, you hope it is.",
+    "material": [ "plastic", "steel" ],
+    "weight": "1500 g",
+    "volume": "500 ml",
+    "category": "other"
+   }
 ]
+

--- a/data/json/items/resources/misc.json
+++ b/data/json/items/resources/misc.json
@@ -311,7 +311,7 @@
   {
     "type": "ITEM",
     "id": "discharging_battery",
-    "name": { "str": "discharging lithium-ion battery" },
+    "name": { "str": "discharging lithium-ion battery", "str_pl": "discharging lithium-ion batteries" },
     "symbol": "=",
     "color": "dark_gray",
     "description": "A lithium-ion battery that is soaking in saltwater.  After about a day, it should have short-circuited and discharged its energy, leaving it safe to handle… ideally.",
@@ -332,7 +332,7 @@
   {
     "type": "ITEM",
     "id": "discharged_storage_battery",
-    "name": { "str": "discharged lithium-ion battery" },
+    "name": { "str": "discharged lithium-ion battery", "str_pl": "discharged lithium-ion batteries" },
     "symbol": "=",
     "color": "dark_gray",
     "description": "A lithium-ion battery that has been shorted and discharged using saltwater.  At least, you hope it is.",

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -3487,9 +3487,6 @@
     "time": "1 m",
     "autolearn": true,
     "qualities": [ { "id": "CHEM", "level": 1 } ],
-    "components": [
-      [ [ "small_storage_battery", 1 ] ],
-      [ [ "salt_water", 2 ] ] 
-    ]
-   }
+    "components": [ [ [ "small_storage_battery", 1 ] ], [ [ "salt_water", 2 ] ] ]
+  }
 ]

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -3475,5 +3475,21 @@
     "reversible": false,
     "autolearn": true,
     "components": [ [ [ "razor_blade", 1 ] ], [ [ "duct_tape", 5 ], [ "medical_tape", 10 ] ] ]
-  }
+  },
+  {
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "result": "discharging_battery",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_OTHER",
+    "skill_used": "electronics",
+    "difficulty": 2,
+    "time": "1 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CHEM", "level": 1 } ],
+    "components": [
+      [ [ "small_storage_battery", 1 ] ],
+      [ [ "salt_water", 2 ] ] 
+    ]
+   }
 ]

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -394,8 +394,7 @@
       [ [ "scrap", 7 ] ],
       [ [ "copper", 13 ] ],
       [ [ "aluminum_foil", 400 ] ],
-      [ [ "graphite", 4900 ] ],
-      [ [ "chem_nickel_powder", 2000 ] ]
+      [ [ "graphite", 4900 ] ]
     ]
   }
 ]

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -394,7 +394,8 @@
       [ [ "scrap", 7 ] ],
       [ [ "copper", 13 ] ],
       [ [ "aluminum_foil", 400 ] ],
-      [ [ "graphite", 4900 ] ]
+      [ [ "graphite", 4900 ] ],
+      [ [ "waste_electrolyte_slurry", 1 ] ]
     ]
   }
 ]

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -389,6 +389,13 @@
     "skill_used": "electronics",
     "time": "20 m",
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "CUT_FINE", "level": 2 } ],
-    "components": [ [ [ "plastic_chunk", 2 ] ], [ [ "scrap", 7 ] ], [ [ "copper", 13 ] ], [ [ "aluminum_foil", 400 ] ], [ [ "graphite", 4900 ] ], [ [ "chem_nickel_powder", 2000 ] ] ]
+    "components": [
+      [ [ "plastic_chunk", 2 ] ],
+      [ [ "scrap", 7 ] ],
+      [ [ "copper", 13 ] ],
+      [ [ "aluminum_foil", 400 ] ],
+      [ [ "graphite", 4900 ] ],
+      [ [ "chem_nickel_powder", 2000 ] ]
+    ]
   }
 ]

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -381,5 +381,14 @@
     "time": "3 m",
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
     "components": [ [ [ "scrap_aluminum", 3 ] ], [ [ "sheet_canvas", 1 ] ] ]
+  },
+  {
+    "result": "discharged_storage_battery",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "skill_used": "electronics",
+    "time": "20 m",
+    "qualities": [ { "id": "CUT", "level": 2 }, { "id": "CUT_FINE", "level": 2 } ],
+    "components": [ [ [ "plastic_chunk", 2 ] ], [ [ "scrap", 7 ] ], [ [ "copper", 13 ] ], [ [ "aluminum_foil", 400 ] ], [ [ "graphite", 4900 ] ], [ [ "chem_nickel_powder", 2000 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Added small storage battery disassembly."

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I was a bit bummed out to discover how comparatively difficult it is to get to metalworking from what it was before, particularly in regards to the Clay Crucible. I found that graphite could be annoyingly rare to find sometimes, and wanted to find a potential alternative a crafty person could use.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
After doing some research, I discovered that a very common use for graphite in the modern day is in lithium-ion batteries, which are explicitly referenced with the storage batteries. After digging into that I also discovered a (at least mostly) safe way to discharge lithium-ion batteries to disassemble them without explosions or combustion. I figured this could be a good way to introduce another source of graphite a dedicated player could use to reach metalworking.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Making the graphite within pencils harvestable.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Opened fresh world, verified crafting recipe, used debug to spawn discharging battery, waited 24 hours to act and transform into discharged battery.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I did quite a lot of math using the games weight values for all the individual resources I think (with some research) would be at the least closest to the materials for a lithium-ion battery, and did my best to estimate the amount of resources by weight distribution.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
