### PR TITLE
Cache item category pointer on inventory_entry

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -657,13 +657,18 @@ void inventory_entry::cache_denial( inventory_selector_preset const &preset ) co
 
 const item_category *inventory_entry::get_category_ptr() const
 {
+    if( cached_category_ptr != nullptr ) {
+        return cached_category_ptr;
+    }
     if( custom_category != nullptr ) {
-        return custom_category;
+        cached_category_ptr = custom_category;
+        return cached_category_ptr;
     }
     if( !is_item() ) {
         return nullptr;
     }
-    return &any_item()->get_category_of_contents();
+    cached_category_ptr = &any_item()->get_category_of_contents();
+    return cached_category_ptr;
 }
 
 inventory_column::inventory_column( const inventory_selector_preset &preset ) :
@@ -1346,15 +1351,16 @@ inventory_entry *inventory_column::add_entry( const inventory_entry &entry )
     paging_is_valid = false;
     if( entry.is_item() ) {
         item_location entry_item = entry.locations.front();
+        item_category const *entry_cat_ptr = entry.get_category_ptr();
 
         auto entry_with_loc = std::find_if( dest.begin(),
-        dest.end(), [&entry, &entry_item, this]( const inventory_entry & e ) {
+        dest.end(), [&entry_item, entry_cat_ptr, this]( const inventory_entry & e ) {
             if( !e.is_item() ) {
                 return false;
             }
             item_location found_entry_item = e.locations.front();
             return !e.is_collated() &&
-                   e.get_category_ptr() == entry.get_category_ptr() &&
+                   e.get_category_ptr() == entry_cat_ptr &&
                    entry_item.where() == found_entry_item.where() &&
                    entry_item.pos_abs() == found_entry_item.pos_abs() &&
                    entry_item.parent_item() == found_entry_item.parent_item() &&

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -97,6 +97,7 @@ class inventory_entry
         inventory_entry( const inventory_entry &entry, const item_category *custom_category ) :
             inventory_entry( entry ) {
             this->custom_category = custom_category;
+            this->cached_category_ptr = nullptr;
         }
 
         explicit inventory_entry( const std::vector<item_location> &locations,
@@ -201,6 +202,7 @@ class inventory_entry
 
         void set_custom_category( const item_category *category ) {
             custom_category = category;
+            cached_category_ptr = nullptr;
         }
 
         void reset_collation() {
@@ -222,6 +224,7 @@ class inventory_entry
 
     private:
         mutable item_category const *custom_category = nullptr;
+        mutable item_category const *cached_category_ptr = nullptr;
     protected:
         // indents the entry if it is contained in an item
         bool _indent = true;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3832,6 +3832,9 @@ const item_category &item::get_category_of_contents( int depth, int maxdepth ) c
             cached_category = { cat.get_id(), calendar::turn };
             return cat;
         }
+        item_category const &cat = this->get_category_shallow();
+        cached_category = { cat.get_id(), calendar::turn };
+        return cat;
     }
     return this->get_category_shallow();
 }


### PR DESCRIPTION
#### Summary
Performance "Cache item category pointer on inventory_entry"

#### Purpose of change

Follow-up to #86695 and #86708. Inventory still lagged scrolling around the dimensional bag from #86690, and my shelf-of-everything save took about five seconds to open the Grab selector. `inventory_column::add_entry` runs two linear scans over existing entries, each comparison calling `get_category_ptr` which walks the container's contents. Same categories recomputed thousands of times per open.

#### Describe the solution

Lazy-memoize `inventory_entry::get_category_ptr` into a `cached_category_ptr` field. Reset on `set_custom_category` and the copy-with-new-category constructor. Hoist the new entry's category lookup out of `add_entry`'s merge lambda.

Also caches the negative path in `item::get_category_of_contents`. When `aggregated_contents` returned empty, the shallow fallback wasn't cached, so the next call this turn re-walked every pocket.

#### Describe alternatives you've considered

Memoizing `aggregated_contents` directly would be heavier and needs invalidation on every pocket mutation. The entry-layer cache takes it off the hot path, so this can wait.

#### Testing

Existing item tests pass. Verified in-game: dimensional bag from #86690 scrolls smoothly, and the Grab selector on my big shelf save opens almost instantly instead of taking five seconds.

#### Additional context

N/A