### PR TITLE
Cephalopod Eyes are a bodypart

### DIFF
--- a/data/json/mutations/limbs_body_parts.json
+++ b/data/json/mutations/limbs_body_parts.json
@@ -59,6 +59,22 @@
     "flags": [ "HIGH_GLARE", "HYPEROPIC", "LIMB_UPPER" ]
   },
   {
+    "type": "body_part",
+    "id": "eyes_ceph",
+    "//": "Same size as bulging, plus high glare and eye membrane",
+    "name": "cephalopod eyes",
+    "accusative": { "ctxt": "bodypart_accusative", "str": "cephalopod eyes" },
+    "heading": "eyes",
+    "heading_multiple": "eyes",
+    "copy-from": "eyes_bulging",
+    "opposite_part": "eyes_ceph",
+    "limb_scores": [ [ "vision", 0.7 ], [ "night_vis", 5.0 ], [ "reaction", 0.8 ] ],
+    "wet_morale": 5,
+    "sub_parts": [ "eyes_ceph_left", "eyes_ceph_right" ],
+    "similar_bodypart": "eyes",
+    "flags": [ "IGNORE_TEMP", "HIGH_GLARE", "LIMB_UPPER", "EYE_MEMBRANE" ]
+  },
+  {
     "id": "muzzle",
     "//": "Used as a default for similar_bodypart to work for armor.",
     "type": "body_part",

--- a/data/json/mutations/limbs_sublimbs.json
+++ b/data/json/mutations/limbs_sublimbs.json
@@ -88,6 +88,28 @@
     "similar_bodypart": "eyes_right"
   },
   {
+    "id": "eyes_ceph_left",
+    "type": "sub_body_part",
+    "max_coverage": 50,
+    "parent": "eyes_ceph",
+    "side": "left",
+    "opposite": "eyes_ceph_right",
+    "name_multiple": "eyes",
+    "name": "left eye",
+    "similar_bodypart": "eyes_left"
+  },
+  {
+    "id": "eyes_ceph_right",
+    "type": "sub_body_part",
+    "max_coverage": 50,
+    "parent": "eyes_ceph",
+    "side": "right",
+    "opposite": "eyes_ceph_left",
+    "name_multiple": "eyes",
+    "name": "right eye",
+    "similar_bodypart": "eyes_right"
+  },
+  {
     "id": "muzzle_lips",
     "type": "sub_body_part",
     "max_coverage": 25,

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5725,7 +5725,7 @@
     "active": true,
     "starts_active": true,
     "vitamin_cost": 160,
-    "flags": [ "HIGH_GLARE" ]
+    "enchantments": [ { "condition": "ALWAYS", "modified_bodyparts": [ { "lose": "eyes" }, { "gain": "eyes_ceph" } ] } ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -860,7 +860,7 @@
     "active": true,
     "starts_active": true,
     "vitamin_cost": 210,
-    "cancels": [ "ELFA_NV", "ELFA_FNV" ]
+    "cancels": [ "ELFA_NV", "ELFA_FNV", "FEL_NV", "CEPH_VISION" ]
   },
   {
     "type": "mutation",
@@ -875,7 +875,7 @@
     "active": true,
     "starts_active": true,
     "vitamin_cost": 190,
-    "cancels": [ "ELFA_NV", "ELFA_FNV" ]
+    "cancels": [ "ELFA_NV", "ELFA_FNV", "FEL_NV", "CEPH_VISION" ]
   },
   {
     "type": "mutation",
@@ -890,7 +890,7 @@
     "active": true,
     "starts_active": true,
     "vitamin_cost": 210,
-    "cancels": [ "ELFA_NV", "ELFA_FNV" ]
+    "cancels": [ "ELFA_NV", "ELFA_FNV", "FEL_NV", "CEPH_VISION" ]
   },
   {
     "type": "mutation",
@@ -5725,7 +5725,8 @@
     "active": true,
     "starts_active": true,
     "vitamin_cost": 160,
-    "enchantments": [ { "condition": "ALWAYS", "modified_bodyparts": [ { "lose": "eyes" }, { "gain": "eyes_ceph" } ] } ]
+    "enchantments": [ { "condition": "ALWAYS", "modified_bodyparts": [ { "lose": "eyes" }, { "gain": "eyes_ceph" } ] } ],
+    "cancels": [ "NIGHTVISION", "NIGHTVISION2", "NIGHTVISION3" ]
   },
   {
     "type": "mutation",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -326,7 +326,6 @@ static const species_id species_HUMAN( "HUMAN" );
 static const start_location_id start_location_sloc_shelter_safe( "sloc_shelter_safe" );
 
 static const trait_id trait_BIRD_EYE( "BIRD_EYE" );
-static const trait_id trait_CEPH_VISION( "CEPH_VISION" );
 static const trait_id trait_CF_HAIR( "CF_HAIR" );
 static const trait_id trait_CHLOROMORPH( "CHLOROMORPH" );
 static const trait_id trait_CLUMSY( "CLUMSY" );
@@ -2474,9 +2473,6 @@ void Character::recalc_sight_limits()
         ( is_mounted() && mounted_creature->has_flag( mon_flag_MECH_RECON_VISION ) ) ) {
         vision_mode_cache.set( NIGHTVISION_3 );
     }
-    if( has_active_mutation( trait_CEPH_VISION ) ) {
-        vision_mode_cache.set( CEPH_VISION );
-    }
     if( has_active_mutation( trait_NIGHTVISION2 ) ) {
         vision_mode_cache.set( NIGHTVISION_2 );
     }
@@ -2518,7 +2514,7 @@ float Character::get_vision_threshold( float light_level ) const
                                      ( LIGHT_AMBIENT_LIT - LIGHT_AMBIENT_MINIMAL ) );
 
     float range = get_per() / 3.0f;
-    if( vision_mode_cache[NIGHTVISION_3] || vision_mode_cache[CEPH_VISION] ) {
+    if( vision_mode_cache[NIGHTVISION_3] ) {
         range += 10;
     } else if( vision_mode_cache[NIGHTVISION_2] || vision_mode_cache[URSINE_VISION] ) {
         range += 4.5;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Cephalopod Eyes are a bodypart"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Continued limbifying

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Cephalopod Eyes are now limbs. They're the same size as bulging eyes, have slightly worse vision in light (and the same glare problem as feline eyes), but excellent night vision. 

Remove hardcoded Cephalopod Eyes vision mode checking. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Mutated cephalopod eyes, had eyes. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
