### PR TITLE
Acid Blood mutation overrides your blood type

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -258,6 +258,7 @@ enum class blood_type {
     blood_A,
     blood_B,
     blood_AB,
+    blood_acid,
     num_bt
 };
 

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -241,6 +241,7 @@ std::string enum_to_string<blood_type>( blood_type data )
         case blood_type::blood_A: return "A";
         case blood_type::blood_B: return "B";
         case blood_type::blood_AB: return "AB";
+        case blood_type::blood_acid: return "Acid";
             // *INDENT-ON*
         case blood_type::num_bt:
             break;

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -582,7 +582,7 @@ void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_
     }
 
     if( mut == trait_ACIDBLOOD ) {
-        my_blood_type = blood_acid;
+        my_blood_type = blood_type::blood_acid;
     }
 
     if( mut == trait_GLASSJAW ) {
@@ -678,7 +678,7 @@ void Character::mutation_loss_effect( const trait_id &mut )
 
     // give the player a random new blood type, regardless of what it was before
     if( mut == trait_ACIDBLOOD ) {
-        my_blood_type = randomize_blood();
+        randomize_blood();
     }
 
     if( mut == trait_GLASSJAW ) {

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -581,7 +581,6 @@ void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_
         return;
     }
 
-    // give the player a random new blood type, regardless of what it was before
     if( mut = trait_ACIDBLOOD ) {
         you.my_blood_type = blood_acid;
     }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -581,8 +581,8 @@ void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_
         return;
     }
 
-    if( mut = trait_ACIDBLOOD ) {
-        you.my_blood_type = blood_acid;
+    if( mut == trait_ACIDBLOOD ) {
+        my_blood_type = blood_acid;
     }
 
     if( mut == trait_GLASSJAW ) {
@@ -677,8 +677,8 @@ void Character::mutation_loss_effect( const trait_id &mut )
     }
 
     // give the player a random new blood type, regardless of what it was before
-    if( mut = trait_ACIDBLOOD ) {
-        you.my_blood_type = randomize_blood();
+    if( mut == trait_ACIDBLOOD ) {
+        my_blood_type = randomize_blood();
     }
 
     if( mut == trait_GLASSJAW ) {

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -81,6 +81,7 @@ static const mtype_id mon_player_blob( "mon_player_blob" );
 
 static const mutation_category_id mutation_category_ANY( "ANY" );
 
+static const trait_id trait_ACIDBLOOD( "ACIDBLOOD" );
 static const trait_id trait_ARVORE_FOREST_MAPPING( "ARVORE_FOREST_MAPPING" );
 static const trait_id trait_BURROW( "BURROW" );
 static const trait_id trait_BURROWLARGE( "BURROWLARGE" );
@@ -579,6 +580,12 @@ void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_
     if( mut.obj().vanity ) {
         return;
     }
+
+    // give the player a random new blood type, regardless of what it was before
+    if( mut = trait_ACIDBLOOD ) {
+        you.my_blood_type = blood_acid;
+    }
+
     if( mut == trait_GLASSJAW ) {
         recalc_hp();
     }
@@ -668,6 +675,11 @@ void Character::mutation_loss_effect( const trait_id &mut )
 {
     if( mut.obj().vanity ) {
         return;
+    }
+
+    // give the player a random new blood type, regardless of what it was before
+    if( mut = trait_ACIDBLOOD ) {
+        you.my_blood_type = randomize_blood();
     }
 
     if( mut == trait_GLASSJAW ) {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3483,7 +3483,7 @@ bool character_creator_ui::handle_action( const std::string &action )
         if( !you.blood_rh_factor ) {
             you.blood_rh_factor = true;
         } else {
-            if( static_cast<blood_type>( static_cast<int>( you.my_blood_type ) + 1 ) != blood_type::num_bt ) {
+            if( static_cast<blood_type>( static_cast<int>( you.my_blood_type ) + 1 ) < blood_type::blood_acid ) {
                 you.my_blood_type = static_cast<blood_type>( static_cast<int>( you.my_blood_type ) + 1 );
                 you.blood_rh_factor = false;
             } else {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3483,7 +3483,8 @@ bool character_creator_ui::handle_action( const std::string &action )
         if( !you.blood_rh_factor ) {
             you.blood_rh_factor = true;
         } else {
-            if( static_cast<blood_type>( static_cast<int>( you.my_blood_type ) + 1 ) < blood_type::blood_acid ) {
+            if( static_cast<blood_type>( static_cast<int>( you.my_blood_type ) + 1 ) <
+                blood_type::blood_acid ) {
                 you.my_blood_type = static_cast<blood_type>( static_cast<int>( you.my_blood_type ) + 1 );
                 you.blood_rh_factor = false;
             } else {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Mutating acid blood means you're no longer type AB/O/etc"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
You could have acid blood that melts the blood draw kit that you used to draw it but you were still type O or whatever. I wanted to change that.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added another blood type, blood_acid, to the blood_type enum. You gain this blood type when you mutate acid blood. If you ever lose it, your blood becomes a random human type.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Don't do this. It has no effect on gameplay, it's purely visual, but eventually we may track these for the purposes of blood transfusions, so it may matter someday. And I do like the "body horror" of no longer having human blood on your character sheet.
Make having acid blood override your RH factor. You still have an RH factor with your acid blood. I think this is a little funny and probably fine. It would be cool to have blood transfusions between acid-blooded mutants failing due to incompatible RH factor.
Adding more strange blood types as side effects of mutating, like medical mutants having a "C" blood type or plants having some other unknown blood type.
Check for having a flag (ACIDBLOOD flag or something) and update your blood type that way instead of directly via the mutation.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Confirmed that you can only cycle between human blood types during character creation.
Mutating acid blood via debug menu changes my blood type to "acid".
Removing the mutation gives me a random blood type again.
"Acid" blood type displays properly in the @ menu.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<img width="329" height="132" alt="image" src="https://github.com/user-attachments/assets/cc0520eb-a34f-4d20-9b2f-dbaa44fb85a1" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
