### PR TITLE
Add decaying zombie upgrades

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -5692,5 +5692,23 @@
     "name": [ "" ],
     "desc": [ "" ],
     "max_duration": "2 minutes"
+  },
+  {
+    "id": "nauseating_smell",
+    "type": "effect_type",
+    "name": [ "Nauseating Stench" ],
+    "desc": [ "Something smells unbelievably foul." ],
+    "apply_message": "Your are assaulted by one of the most vile smells you've ever smelled.",
+    "remove_message": "The last traces of the foul stench leave your nostrils.",
+    "rating": "bad",
+    "max_duration": 120,
+    "base_mods": {
+      "str_mod": [ -1 ],
+      "dex_mod": [ -1 ],
+      "speed_mod": [ -10 ],
+      "cough_chance": [ 3 ],
+      "vomit_chance": [ 15 ],
+      "vomit_tick": [ 10 ]
+    }
   }
 ]

--- a/data/json/emit.json
+++ b/data/json/emit.json
@@ -473,5 +473,12 @@
     "field": "fd_nm_monster_gas_2",
     "intensity": 3,
     "chance": 10
+  },
+  {
+    "id": "emit_nauseating_smell",
+    "type": "emit",
+    "field": "fd_nauseating_smell",
+    "intensity": 1,
+    "qty": 20
   }
 ]

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -2372,5 +2372,38 @@
     "display_items": true,
     "display_field": true,
     "looks_like": "fd_fatigue"
+  },
+  {
+    "id": "fd_nauseating_smell",
+    "type": "field_type",
+    "intensity_levels": [
+      {
+        "name": "nauseating stench",
+        "effects": [
+          {
+            "effect_id": "nauseating_smell",
+            "min_duration": "15 seconds",
+            "max_duration": "45 seconds",
+            "intensity": 1,
+            "immune_in_vehicle": false,
+            "is_environmental": true
+          }
+        ]
+      },
+      { "//": "repeat last entry" },
+      { "//": "repeat last entry" }
+    ],
+    "decay_amount_factor": 5,
+    "gas_absorption_factor": "80m",
+    "percent_spread": 25,
+    "dirty_transparency_cache": true,
+    "has_fume": true,
+    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
+    "priority": 8,
+    "half_life": "2 minutes",
+    "phase": "gas",
+    "display_items": true,
+    "display_field": true,
+    "looks_like": "fd_nuke_gas"
   }
 ]

--- a/data/json/monstergroups/zombie_upgrades.json
+++ b/data/json/monstergroups/zombie_upgrades.json
@@ -31,6 +31,17 @@
   },
   {
     "type": "monstergroup",
+    "id": "GROUP_ZOMBIE_DECAYED_UPGRADE",
+    "default": "mon_zombie_rot",
+    "//": "decayed zombie upgrades",
+    "monsters": [
+      { "monster": "mon_zombie_rot", "weight": 250 },
+      { "monster": "mon_zombie_rot_grabber", "weight": 350 },
+      { "monster": "mon_devourer", "weight": 150 }
+    ]
+  },
+  {
+    "type": "monstergroup",
     "id": "GROUP_ZOMBIE_DEVOURER_UPGRADE",
     "default": "mon_devourer",
     "//": "devourer zombie upgrades",

--- a/data/json/monstergroups/zombie_upgrades.json
+++ b/data/json/monstergroups/zombie_upgrades.json
@@ -37,6 +37,7 @@
     "monsters": [
       { "monster": "mon_zombie_rot", "weight": 250 },
       { "monster": "mon_zombie_rot_grabber", "weight": 350 },
+      { "monster": "mon_zombie_rot_diseased", "weight": 200 },
       { "monster": "mon_devourer", "weight": 150 }
     ]
   },

--- a/data/json/monsters/zed-classic.json
+++ b/data/json/monsters/zed-classic.json
@@ -192,7 +192,7 @@
     "melee_dice_sides": 2,
     "grab_strength": 15,
     "fungalize_into": "mon_zombie_rot_dusted",
-    "upgrades": { "half_life": 172, "into": "mon_devourer" },
+    "upgrades": { "half_life": 172, "into_group": "GROUP_ZOMBIE_DECAYED_UPGRADE" },
     "extend": { "flags": [ "GEN_DORMANT", "CLUMSY_ATTACKS" ] }
   },
   {

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -1041,5 +1041,34 @@
     "death_drops": { "subtype": "collection", "groups": [ [ "default_zombie_clothes", 100 ], [ "zombie_fursuits", 100 ] ] },
     "armor": { "bash": 5, "cut": 5, "bullet": 1, "electric": 1 },
     "//": "The torn fursuit offers slightly more protection."
+  },
+  {
+    "id": "mon_zombie_rot_grabber",
+    "type": "MONSTER",
+    "name": { "str": "decayed grasper" },
+    "description": "A once-dead human corpse, moving despite seeming like it could fall apart into putrescence at any moment.  It slowly crawls along the ground with an eerily-fluid motion.",
+    "copy-from": "mon_zombie_base",
+    "hp": 55,
+    "speed": 30,
+    "color": "light_green_yellow",
+    "melee_skill": 1,
+    "melee_dice_sides": 2,
+    "grab_strength": 50,
+    "fungalize_into": "mon_zombie_rot_dusted",
+    "upgrades": false,
+    "extend": {
+      "flags": [ "GEN_DORMANT" ],
+      "special_attacks": [
+        {
+          "id": "grab",
+          "accuracy": 4,
+          "move_cost": 25,
+          "cooldown": 7,
+          "attack_upper": false,
+          "hit_dmg_u": "%1$s winds its limbs around your %2$s!",
+          "hit_dmg_npc": "%1$s winds its limbs around <npcname>'s %2$s!"
+        }
+      ]
+    }
   }
 ]

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -1056,19 +1056,42 @@
     "grab_strength": 50,
     "fungalize_into": "mon_zombie_rot_dusted",
     "upgrades": false,
-    "extend": {
-      "flags": [ "GEN_DORMANT" ],
-      "special_attacks": [
-        {
-          "id": "grab",
-          "accuracy": 4,
-          "move_cost": 25,
-          "cooldown": 7,
-          "attack_upper": false,
-          "hit_dmg_u": "%1$s winds its limbs around your %2$s!",
-          "hit_dmg_npc": "%1$s winds its limbs around <npcname>'s %2$s!"
-        }
-      ]
-    }
+    "//": "No PARROT is deliberate, it's in no condition to speak",
+    "special_attacks": [
+      { "id": "bite_humanoid", "cooldown": 5 },
+      { "id": "scratch_humanoid" },
+      {
+        "id": "grab",
+        "accuracy": 4,
+        "move_cost": 25,
+        "cooldown": 2,
+        "attack_upper": false,
+        "hit_dmg_u": "%1$s winds its limbs around your %2$s!",
+        "hit_dmg_npc": "%1$s winds its limbs around <npcname>'s %2$s!"
+      }
+    ],
+    "extend": { "flags": [ "GEN_DORMANT" ] }
+  },
+  {
+    "id": "mon_zombie_rot_diseased",
+    "type": "MONSTER",
+    "name": { "str": "zombie plaguebearer" },
+    "description": "The skin of this walking corpses glistens with disturbing fluids.  Even at a distance, the smell nearly makes you gag.",
+    "copy-from": "mon_zombie_base",
+    "hp": 65,
+    "speed": 70,
+    "color": "light_green_yellow",
+    "melee_skill": 3,
+    "melee_dice_sides": 2,
+    "grab_strength": 50,
+    "attack_effs": [ { "id": "pre_flu", "duration": 432000, "chance": 2 }, { "id": "rat_bite_fever", "duration": 345600, "chance": 3 } ],
+    "fungalize_into": "mon_zombie_rot_dusted",
+    "emit_fields": [ { "emit_id": "emit_nauseating_smell", "delay": "1 s" } ],
+    "upgrades": false,
+    "special_attacks": [
+      { "id": "bite_humanoid", "cooldown": 5, "infection_chance": 95 },
+      { "id": "grab", "cooldown": 2 },
+      { "id": "scratch_humanoid" }
+    ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Add decaying zombie upgrades"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Currently all decaying zombies become devourers. This wasn't a problem when devourers were much weaker than they are now, but now that devourers can be extremely strong, we should throw some other upgrades in there. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add more upgrades:

- Decaying Grasper: A kind of "undead trap." Can barely move but will grab you if you come nearby with a strong grasp. 
- Zombie Plaguebearer: Decayed zombie but one absolutely filled with diseases. Their bite guarantees infection and even their normal attacks can cause problems if they damage you.  It also smells indescribably foul--maybe wear a gas mask.

I'll just do two for now.

At the moment, neither upgrade, but there's room for upgrade paths for them. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Plaguebearer is infectious. Nauseating stench works, a gas mask protects you. Continued "gagging" (coughing) while nearby when not using a gas mask. 
Decayed grasper: Works. Very slow, grabs you. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
