### PR TITLE
More clothing faults (denim)

### DIFF
--- a/data/json/faults/fault_fixes_armor.json
+++ b/data/json/faults/fault_fixes_armor.json
@@ -312,7 +312,7 @@
   {
     "type": "fault_fix",
     "id": "mend_armor_denim_hole_close",
-    "name": "Stitch the fabric back together",
+    "name": "Patch the hole",
     "faults_removed": [ "fault_denim_hole" ],
     "copy-from": "mend_armor_cotton_tear_stitch",
     "requirements": [ [ "tailoring_denim_small_simple", 1 ] ]

--- a/data/json/faults/fault_fixes_armor.json
+++ b/data/json/faults/fault_fixes_armor.json
@@ -300,6 +300,21 @@
     "mod_degradation": -25,
     "time": "20 m",
     "skills": { "tailor": 1 },
-    "requirements": [ [ "filament", 3 ], [ "fabric_standard_small", 1 ], { "qualities": [ { "id": "SEW", "level": 1 } ] } ]
+    "requirements": [ [ "tailoring_cotton_small_simple", 1 ] ]
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_armor_denim_tear_stitch",
+    "name": "Stitch the fabric back together",
+    "faults_removed": [ "fault_denim_torn" ],
+    "copy-from": "mend_armor_cotton_tear_stitch"
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_armor_denim_tear_stitch",
+    "name": "Stitch the fabric back together",
+    "faults_removed": [ "fault_denim_torn" ],
+    "copy-from": "mend_armor_cotton_tear_stitch",
+    "requirements": [ [ "tailoring_denim_small_simple", 1 ] ]
   }
 ]

--- a/data/json/faults/fault_fixes_armor.json
+++ b/data/json/faults/fault_fixes_armor.json
@@ -311,9 +311,9 @@
   },
   {
     "type": "fault_fix",
-    "id": "mend_armor_denim_tear_stitch",
+    "id": "mend_armor_denim_hole_close",
     "name": "Stitch the fabric back together",
-    "faults_removed": [ "fault_denim_torn" ],
+    "faults_removed": [ "fault_denim_hole" ],
     "copy-from": "mend_armor_cotton_tear_stitch",
     "requirements": [ [ "tailoring_denim_small_simple", 1 ] ]
   }

--- a/data/json/faults/fault_groups_armor.json
+++ b/data/json/faults/fault_groups_armor.json
@@ -28,5 +28,10 @@
     "type": "fault_group",
     "id": "fabric_cotton",
     "group": [ { "fault": "fault_cotton_torn", "weight": 100 }, { "fault": "fault_cotton_hole", "weight": 75 } ]
+  },
+  {
+    "type": "fault_group",
+    "id": "fabric_denim",
+    "group": [ { "fault": "fault_denim_torn", "weight": 100 }, { "fault": "fault_denim_hole", "weight": 75 } ]
   }
 ]

--- a/data/json/faults/faults_armor.json
+++ b/data/json/faults/faults_armor.json
@@ -147,5 +147,17 @@
       { "damage_id": "cut", "multiply": 0.85 },
       { "damage_id": "stab", "multiply": 0.85 }
     ]
+  },
+  {
+    "type": "fault",
+    "id": "fault_denim_torn",
+    "name": { "str": "Torn denim" },
+    "copy-from": "fault_cotton_torn"
+  },
+  {
+    "type": "fault",
+    "id": "fault_denim_hole",
+    "name": { "str": "Hole" },
+    "copy-from": "fault_denim_hole"
   }
 ]

--- a/data/json/faults/faults_armor.json
+++ b/data/json/faults/faults_armor.json
@@ -158,6 +158,6 @@
     "type": "fault",
     "id": "fault_denim_hole",
     "name": { "str": "Hole" },
-    "copy-from": "fault_denim_hole"
+    "copy-from": "fault_cotton_hole"
   }
 ]

--- a/data/json/faults/faults_armor.json
+++ b/data/json/faults/faults_armor.json
@@ -152,12 +152,14 @@
     "type": "fault",
     "id": "fault_denim_torn",
     "name": { "str": "Torn denim" },
+    "description": "There's a tear in the fabric.",
     "copy-from": "fault_cotton_torn"
   },
   {
     "type": "fault",
     "id": "fault_denim_hole",
     "name": { "str": "Hole" },
+    "description": "There's a big hole in the fabric.",
     "copy-from": "fault_cotton_hole"
   }
 ]

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -409,6 +409,7 @@
     "symbol": "[",
     "looks_like": "pants",
     "color": "light_blue",
+    "faults": [ { "fault_group": "fabric_denim" } ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -465,6 +466,7 @@
     "symbol": "[",
     "looks_like": "jeans",
     "color": "light_blue",
+    "faults": [ { "fault_group": "fabric_denim" } ],
     "armor": [
       {
         "encumbrance": [ 7, 11 ],
@@ -527,6 +529,7 @@
     "symbol": "[",
     "looks_like": "jeans",
     "color": "light_blue",
+    "faults": [ { "fault_group": "fabric_denim" } ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -595,6 +598,7 @@
     "symbol": "[",
     "looks_like": "jeans",
     "color": "light_blue",
+    "faults": [ { "fault_group": "fabric_denim" } ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -1877,6 +1881,7 @@
     "symbol": "[",
     "looks_like": "shorts",
     "color": "light_blue",
+    "faults": [ { "fault_group": "fabric_denim" } ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -1933,6 +1938,7 @@
     "symbol": "[",
     "looks_like": "skirt",
     "color": "blue",
+    "faults": [ { "fault_group": "fabric_denim" } ],
     "warmth": 7,
     "armor": [
       { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] },

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -957,6 +957,7 @@
     "looks_like": "dress_shirt",
     "symbol": "[",
     "color": "light_blue",
+    "faults": [ { "fault_group": "fabric_denim" } ],
     "flags": [ "VARSIZE" ],
     "armor": [
       { "covers": [ "torso" ], "coverage": 95, "encumbrance": [ 4, 5 ] },

--- a/data/json/requirements/tailoring.json
+++ b/data/json/requirements/tailoring.json
@@ -296,6 +296,13 @@
     "components": [ [ [ "denim_patch", 1 ] ], [ [ "filament", 5, "LIST" ] ] ]
   },
   {
+    "id": "tailoring_denim_small_simple",
+    "type": "requirement",
+    "//": "14g per unit. Crafting possibly-patchwork denim items, adjusted for tailoring rework. Time needed is usually 20 minutes per unit if hand-stitching.  excessive weight of material is wasted, possibly producing denim scraps.",
+    "qualities": [ { "id": "SEW", "level": 2 }, { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "denim_patch", 1 ] ], [ [ "filament", 5, "LIST" ] ] ]
+  },
+  {
     "id": "tailoring_canvas",
     "type": "requirement",
     "//": "85g per unit. Crafting canvas items, adjusted for tailoring rework. 7g+excessive weight of material is wasted, producing patches or scraps. Time needed is usually 40 minutes per unit if hand-stitching. This uses roughly 50 inches of thread to account for waste.",


### PR DESCRIPTION

#### Summary
Features "Added and applied the fault group 'fabric_denim' to denim leg and torso clothes"

#### Purpose of change
Working further on issue #80881 for general armor faults. There is still a lot of faults for clothing and armor to be added, so I'm going over some of the materials one at a time.

#### Describe the solution

Added two faults for denim clothing, which are their equivalent to the cotton clothing faults. Also changed the requirements for fixing the cotton hole fault to tailoring_cotton_small_simple and added the tailoring_denim_small_simple requirement to use in the denim fix. (Reason for adding denim_small_simple: I don't think you really need a specialised tool to cut fabric in order to patch up a hole, regular cutting should suffice)

After adding the faults, I added them to leg and torso clothing made from denim

#### Describe alternatives you've considered

Not add the faults, not add another requirement for denim and use a pre-existing one, add different faults for denim than for cotton

#### Testing

Spawned in some denim clothing and equipped it. Set health to 99999 and let zombies hit my character until the clothes got damaged and got a fault. Also confirmed whether the mending options were there.

#### Additional context

<img width="645" height="415" alt="image" src="https://github.com/user-attachments/assets/26699f87-e63f-4b45-a196-1c74d42e6875" />

<img width="652" height="194" alt="image" src="https://github.com/user-attachments/assets/3af70323-0a26-4771-b21f-b15da266884e" />



