### PR TITLE
Direct route autodrive pathfinding

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1558,6 +1558,16 @@
   },
   {
     "type": "keybinding",
+    "id": "CHOOSE_DESTINATION_DIRECT",
+    "name": "Choose destination (direct path)",
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "T" },
+      { "input_method": "keyboard_code", "key": "T", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_S" }
+    ]
+  },
+  {
+    "type": "keybinding",
     "id": "GO_TO_DESTINATION",
     "name": "Go to destination",
     "bindings": [ { "input_method": "keyboard_any", "key": "g" }, { "input_method": "gamepad", "key": "L_RADIAL_NE" } ]

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -358,6 +358,7 @@ enum class oter_travel_cost_type : int {
 
 template<>
 struct enum_traits<oter_travel_cost_type> {
+    static constexpr oter_travel_cost_type first = static_cast<oter_travel_cost_type>( 0 );
     static constexpr oter_travel_cost_type last = oter_travel_cost_type::last;
 };
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -276,9 +276,11 @@ void overmap_sidebar::draw_settings_info()
 void overmap_sidebar::draw_quick_reference()
 {
     draw_sidebar_text( _( "Use movement keys to pan." ), c_magenta );
-    draw_sidebar_text( string_format( _( "Press %s to preview route." ),
+    draw_sidebar_text( string_format( _( "Press %s to preview efficient route." ),
                                       ictxt.get_desc( "CHOOSE_DESTINATION" ) ), c_magenta );
-    draw_sidebar_text( _( "Press again to confirm." ), c_magenta );
+    draw_sidebar_text( string_format( _( "Press %s to preview direct route." ),
+                                      ictxt.get_desc( "CHOOSE_DESTINATION_DIRECT" ) ), c_magenta );
+    draw_sidebar_text( _( "Press route button again to confirm." ), c_magenta );
     print_hint( "LEVEL_UP" );
     print_hint( "LEVEL_DOWN" );
     print_hint( "look" );
@@ -1929,7 +1931,7 @@ static void modify_horde_func( tripoint_abs_omt &curs )
 }
 
 static std::vector<tripoint_abs_omt> get_overmap_path_to( const tripoint_abs_omt &dest,
-        bool driving )
+        bool driving, bool direct_travel = false )
 {
     if( overmap_buffer.seen( dest ) == om_vision_level::unseen ) {
         return {};
@@ -1975,6 +1977,10 @@ static std::vector<tripoint_abs_omt> get_overmap_path_to( const tripoint_abs_omt
             params.set_cost( oter_travel_cost_type::air, 8 );
         }
     }
+
+    if( direct_travel ) {
+        params = overmap_path_params::flatten_pathfinding_costs( params );
+    }
     // literal "edge" case: the vehicle may be in a different OMT than the player
     const tripoint_abs_omt start_omt_pos = driving ? player_veh->pos_abs_omt() : player_omt_pos;
     if( dest == player_omt_pos || dest == start_omt_pos ) {
@@ -1987,8 +1993,13 @@ static std::vector<tripoint_abs_omt> get_overmap_path_to( const tripoint_abs_omt
 static bool try_travel_to_destination( avatar &player_character, const tripoint_abs_omt curs,
                                        const tripoint_abs_omt dest, const bool driving )
 {
-    std::vector<tripoint_abs_omt> path = get_overmap_path_to( dest, driving );
+    std::vector<tripoint_abs_omt> path = player_character.omt_path;
+    // No existing path or path does not contain our destination, get a new one!
+    if( path.empty() || std::find( path.begin(), path.end(), dest ) == path.end() ) {
+        path = get_overmap_path_to( dest, driving );
+    }
 
+    // Still empty, we just don't know how to get there.
     if( path.empty() ) {
         std::string popupmsg;
         if( dest.z() == player_character.posz() ) {
@@ -2111,6 +2122,7 @@ static tripoint_abs_omt display()
     ictxt.register_action( "MOUSE_MOVE" );
     ictxt.register_action( "SELECT" );
     ictxt.register_action( "CHOOSE_DESTINATION" );
+    ictxt.register_action( "CHOOSE_DESTINATION_DIRECT" );
     ictxt.register_action( "CENTER_ON_DESTINATION" );
     ictxt.register_action( "GO_TO_DESTINATION" );
 
@@ -2288,10 +2300,11 @@ static tripoint_abs_omt display()
                 curs.x() = p.x();
                 curs.y() = p.y();
             }
-        } else if( action == "CHOOSE_DESTINATION" ) {
+        } else if( action == "CHOOSE_DESTINATION" || action == "CHOOSE_DESTINATION_DIRECT" ) {
             avatar &player_character = get_avatar();
             const bool driving = player_character.in_vehicle && player_character.controlling_vehicle;
-            std::vector<tripoint_abs_omt> path = get_overmap_path_to( curs, driving );
+            bool direct = action == "CHOOSE_DESTINATION_DIRECT";
+            std::vector<tripoint_abs_omt> path = get_overmap_path_to( curs, driving, direct );
             bool same_path_selected = false;
             if( path == player_character.omt_path ) {
                 same_path_selected = true;

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -10,6 +10,7 @@
 #include <optional>
 #include <string>
 #include <tuple>
+#include <type_traits>
 
 #include "basecamp.h"
 #include "calendar.h"
@@ -1059,6 +1060,33 @@ overmap_path_params overmap_path_params::for_aircraft()
     overmap_path_params ret;
     ret.set_cost( oter_travel_cost_type::air, 8 ); // limited by vehicle autodrive speed
     ret.allow_diagonal = false;
+    return ret;
+}
+
+// For the for-loop in the below function.
+using enum_traits_int = std::underlying_type_t<oter_travel_cost_type>;
+static constexpr enum_traits_int max = static_cast<enum_traits_int>
+                                       ( enum_traits<oter_travel_cost_type>::last );
+overmap_path_params overmap_path_params::flatten_pathfinding_costs( overmap_path_params orig )
+{
+    overmap_path_params ret = std::move( orig );
+
+    for( enum_traits_int i = 0; i < max; ++i ) {
+        // In order to make a more direct path we take the logarithm (base 2) of the existing travel cost.
+        // This allows the pathfinding to consider most passable terrains as 'close enough', while still
+        // avoiding any really bad routes, and never pathing into impassable terrains.
+
+        oter_travel_cost_type checked = static_cast<oter_travel_cost_type>( i );
+
+        if( ret.travel_cost_per_type.find( checked ) == ret.travel_cost_per_type.end() ) {
+            continue; // Value doesn't already exist in the map, skip.
+        }
+        if( ret.travel_cost_per_type[checked] < 1 ) {
+            continue; // Impassable, skip.
+        }
+        ret.travel_cost_per_type[checked] = log2( ret.travel_cost_per_type[checked] );
+    }
+
     return ret;
 }
 

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -69,6 +69,7 @@ struct overmap_path_params {
     static overmap_path_params for_land_vehicle( float offroad_coeff, bool tiny, bool amphibious );
     static overmap_path_params for_watercraft();
     static overmap_path_params for_aircraft();
+    static overmap_path_params flatten_pathfinding_costs( overmap_path_params orig );
 };
 
 struct radio_tower_reference {


### PR DESCRIPTION
#### Summary
Features "Direct route autodrive pathfinding"

#### Purpose of change
<img width="604" height="410" alt="image" src="https://github.com/user-attachments/assets/b6409a2c-360b-4a58-836a-a71d4982d9ab" />

"This seems really inefficient" (it is)

#### Describe the solution
A new hotkey for setting destination which tells it, basically, "Go directly there (as direct as is reasonable)!". The existing `W` hotkey remains, and instead sets an 'efficient' route. So both do the same thing, you just press one or the other depending on your needs.

The way this is accomplished is by 'flattening' all travel type costs, replacing them with their base-2 logarithm. Impassable tiles are skipped, remaining impassable. But something like a few tiles of fields is not the same cost as dozens of road tiles (unless your vehicle really can't offroad!). This allows the pathfinding to consider most passable terrains as 'close enough', while still avoiding any really bad routes, and never pathing into impassable terrains.


#### Describe alternatives you've considered
-The obvious alternative would be to change the travel type costs directly, so that direct routes are always preferred. But there's a good and valuable dichotomy between *efficient* and *direct*, which I think is simple enough to expose intuitively to the user.

-log2 was chosen because it doesn't flatten quite as much as log10. Other logarithms could be used, or something like square root. I'm not invested in the exact math, it can be tweaked to our needs. The important part is that it is not a linear reduction.

#### Testing
"Direct" route through a city avoids plowing through houses
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/9d11a72f-a08e-484d-a560-9a4013527a04" />

Efficient vs direct route around a city
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/3f338b4e-66a3-4ae4-a9b9-5e75c7ff445e" />
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/73caa9eb-1c48-40f0-8105-c343b87b3376" />


#### Additional context
I think this idea or something like it was originally mentioned by Kevin Granade on the discord, but I don't remember. It's been bouncing around in the back of my head for a while now, and it's finally time for it to come out.
