### PR TITLE
[Magiclysm] Goldbrew and dragonfire fixes (+some minor changes)

### DIFF
--- a/data/mods/Magiclysm/harvest.json
+++ b/data/mods/Magiclysm/harvest.json
@@ -254,7 +254,7 @@
     "id": "zombie_ravenfolk",
     "type": "harvest",
     "copy-from": "zombie_humanoid",
-    "//": "removes 66% of their featers due to most being unusable due to being from an undead corpse.",
+    "//": "removes 66% of their feathers due to most being unusable due to being from an undead corpse.",
     "delete": { "entries": [ { "drop": "skull_human_tainted", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] },
     "extend": {
       "entries": [
@@ -384,6 +384,7 @@
   {
     "id": "sojourners_palm_harv",
     "type": "harvest",
+    "message": "As you harvest the flowers from the tree, it vanishes into thin air.",
     "entries": [ { "drop": "sojourners_flower", "base_num": [ 1, 5 ] } ]
   },
   {

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -1856,5 +1856,23 @@
     "extend": {
       "entries": [ { "group": "spellbook_restricted_loot_0", "prob": 4 }, { "group": "spellbook_restricted_loot_1", "prob": 1 } ]
     }
+  },
+  {
+    "type": "item_group",
+    "id": "table_wine",
+    "copy-from": "table_wine",
+    "subtype": "distribution",
+    "//": "This way goldbrew spawns more often in places where you'd expect fancy alcohols",
+    "extend": { "items": [ { "item": "goldbrew", "prob": 20 } ] }
+  },
+  {
+    "type": "item_group",
+    "id": "liquor_and_spirits",
+    "copy-from": "liquor_and_spirits",
+    "subtype": "distribution",
+    "//": "Goldbrew - rarity as single malt whiskey, dragonfire - rarity as vodka.",
+    "extend": {
+      "entries": [ { "item": "dragonfire", "prob": 20 }, { "item": "goldbrew", "prob": 2 } ]
+    }
   }
 ]

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -1871,8 +1871,6 @@
     "copy-from": "liquor_and_spirits",
     "subtype": "distribution",
     "//": "Goldbrew - rarity as single malt whiskey, dragonfire - rarity as vodka.",
-    "extend": {
-      "entries": [ { "item": "dragonfire", "prob": 20 }, { "item": "goldbrew", "prob": 2 } ]
-    }
+    "extend": { "entries": [ { "item": "dragonfire", "prob": 20 }, { "item": "goldbrew", "prob": 2 } ] }
   }
 ]

--- a/data/mods/Magiclysm/items/spell_scrolls.json
+++ b/data/mods/Magiclysm/items/spell_scrolls.json
@@ -2256,7 +2256,7 @@
     "id": "spell_scroll_earthshaper_repair_metal_stone",
     "//": "Earthshaper spell",
     "name": { "str": "Scroll of Fault-Mending Chant", "str_pl": "Scrolls of Fault-Mending Chant" },
-    "description": "With some earth and stone and a song, repair and item made of natural stone or metal.",
+    "description": "With some earth and stone and a song, repair an item made of natural stone or metal.",
     "use_action": { "type": "learn_spell", "spells": [ "earthshaper_repair_metal_stone" ] }
   },
   {

--- a/data/mods/Magiclysm/recipes/alcohol.json
+++ b/data/mods/Magiclysm/recipes/alcohol.json
@@ -124,6 +124,7 @@
     "time": "30 m",
     "batch_time_factors": [ 50, 4 ],
     "autolearn": [ [ "cooking", 7 ] ],
+    "book_learn": [ [ "distilling_cookbook", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_fermenting" }, { "proficiency": "prof_brewing" } ],
     "qualities": [ { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 6, "LIST" ] ] ],
@@ -142,6 +143,7 @@
     "time": "30 m",
     "batch_time_factors": [ 50, 4 ],
     "autolearn": [ [ "cooking", 7 ] ],
+    "book_learn": [ [ "distilling_cookbook", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_fermenting" }, { "proficiency": "prof_brewing" } ],
     "qualities": [ { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 6, "LIST" ] ] ],
@@ -160,7 +162,7 @@
     "difficulty": 5,
     "time": "30 m",
     "batch_time_factors": [ 50, 4 ],
-    "autolearn": true,
+    "book_learn": [ [ "distilling_cookbook", 4 ] ],
     "qualities": [ { "id": "BOIL", "level": 2 }, { "id": "DISTILL", "level": 2 } ],
     "tools": [ [ [ "water_boiling_heat", 21, "LIST" ] ] ],
     "components": [ [ [ "wash_dragonfire", 21 ] ] ]
@@ -176,7 +178,7 @@
     "difficulty": 5,
     "time": "30 m",
     "batch_time_factors": [ 50, 4 ],
-    "autolearn": true,
+    "book_learn": [ [ "distilling_cookbook", 4 ] ],
     "qualities": [ { "id": "BOIL", "level": 2 }, { "id": "DISTILL", "level": 2 } ],
     "tools": [ [ [ "water_boiling_heat", 21, "LIST" ] ] ],
     "components": [ [ [ "wash_goldbrew", 21 ] ] ]

--- a/data/mods/Magiclysm/recipes/alcohol.json
+++ b/data/mods/Magiclysm/recipes/alcohol.json
@@ -124,7 +124,7 @@
     "time": "30 m",
     "batch_time_factors": [ 50, 4 ],
     "autolearn": [ [ "cooking", 7 ] ],
-    "book_learn": [ [ "distilling_cookbook", 3 ] ],
+    "book_learn": [ [ "distilling_cookbook", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_fermenting" }, { "proficiency": "prof_brewing" } ],
     "qualities": [ { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 6, "LIST" ] ] ],

--- a/data/mods/Magiclysm/requirements/cooking_components.json
+++ b/data/mods/Magiclysm/requirements/cooking_components.json
@@ -8,5 +8,15 @@
     "id": "meat_red_raw",
     "type": "requirement",
     "extend": { "components": [ [ [ "purified_meat", 1 ] ] ] }
+  },
+  {
+    "id": "hard_liquor_unmixed",
+    "type": "requirement",
+    "extend": { "components": [ [ [ "dragonfire", 1 ], [ "goldbrew", 1 ] ] ] }
+  },
+  {
+    "id": "wash_liquor",
+    "type": "requirement",
+    "extend": { "components": [ [ [ "wash_dragonfire", 1 ], [ "wash_goldbrew", 1 ] ] ] }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "Add ways for dragonfire and goldbrew to spawn in the world, and the recipe to an existing book."

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

My previous PR included the alcohols but not ways for them to spawn or the player to craft them, so this fixes that.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Item group extends.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Did not test yet.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Also added a line for sojourner palm harvesting because the whole tree disappears when you harvest it. Feel free to dispute this, I kind of just left it in because I worked 10+ hours today and was too lazy to remove it after accidentally committing it.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
