### PR TITLE
Fix screen flashing during activities

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -250,6 +250,8 @@ RGBTuple color_loader<RGBTuple>::from_rgb( const int r, const int g, const int b
 #include <imgui/imgui_impl_sdl2.h>
 #include <imgui/imgui_impl_sdlrenderer2.h>
 
+static bool clear_screen = false;
+
 ImVec4 cataimgui::imvec4_from_color( const nc_color &color )
 {
     SDL_Color c = curses_color_to_SDL( color );
@@ -589,6 +591,11 @@ void cataimgui::client::new_frame()
         ImGui_ImplSDLRenderer2_CreateDeviceObjects();
     }
 #endif
+    if( clear_screen )
+    {
+        clear_screen = false;
+        clear_sdl_window();
+    }
     ImGui_ImplSDLRenderer2_NewFrame();
     ImGui_ImplSDL2_NewFrame();
 
@@ -607,6 +614,11 @@ void cataimgui::client::end_frame()
         io.AddKeyEvent( cata_key_to_imgui( code ), false );
     }
     cata_input_trail.clear();
+}
+
+bool cataimgui::clear_pending()
+{
+    return clear_screen;
 }
 
 void cataimgui::client::process_input( void *input )
@@ -902,7 +914,7 @@ cataimgui::window::~window()
             GImGui->InputEventsQueue.resize( 0 );
 #ifdef TILES
             // Removes leftover ImGui artifacts
-            clear_sdl_window();
+            clear_screen = true;
 #endif
         }
     }

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -591,8 +591,7 @@ void cataimgui::client::new_frame()
         ImGui_ImplSDLRenderer2_CreateDeviceObjects();
     }
 #endif
-    if( clear_screen )
-    {
+    if( clear_screen ) {
         clear_screen = false;
         clear_sdl_window();
     }

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -113,6 +113,9 @@ void set_scroll( scroll &s );
 void draw_colored_text( const std::string &original_text, const nc_color &color,
                         float wrap_width = 0.0F, bool *is_selected = nullptr,
                         bool *is_focused = nullptr, bool *is_hovered = nullptr );
+#ifndef TUI
+bool clear_pending();
+#endif
 void draw_colored_text( const std::string &original_text, nc_color &color,
                         float wrap_width = 0.0F, bool *is_selected = nullptr,
                         bool *is_focused = nullptr, bool *is_hovered = nullptr );

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -62,7 +62,6 @@
 #include "player_activity.h"
 #include "point.h"
 #include "popup.h"
-
 #include "rng.h"
 #include "scent_map.h"
 #include "sdlsound.h"

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -23,6 +23,9 @@
 #include "bionics.h"
 #include "cached_options.h"
 #include "calendar.h"
+#ifdef TILES
+#include "cata_imgui.h"
+#endif
 #include "cata_variant.h"
 #include "clzones.h"
 #include "coordinates.h"
@@ -59,9 +62,7 @@
 #include "player_activity.h"
 #include "point.h"
 #include "popup.h"
-#ifdef TILES
-#include "cata_imgui.h"
-#endif
+
 #include "rng.h"
 #include "scent_map.h"
 #include "sdlsound.h"

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -59,6 +59,9 @@
 #include "player_activity.h"
 #include "point.h"
 #include "popup.h"
+#ifdef TILES
+#include "cata_imgui.h"
+#endif
 #include "rng.h"
 #include "scent_map.h"
 #include "sdlsound.h"
@@ -731,6 +734,13 @@ bool do_turn()
             }
 
             // Avoid redrawing the main UI every time due to invalidation
+#ifdef TILES
+            // If an ImGui window just closed and cleared the buffer, do a full
+            // redraw now before blocking UIs below.
+            if( cataimgui::clear_pending() ) {
+                ui_manager::redraw();
+            }
+#endif
             ui_adaptor dummy( ui_adaptor::disable_uis_below {} );
             if( !g->wait_popup ) {
                 g->wait_popup = std::make_unique<static_popup>();


### PR DESCRIPTION
#### Summary
Bugfixes "Fix screen flashing during activities"

#### Purpose of change
Fixes #86762

#### Describe the solution
- Perform a screen clear on a new frame before any of the game world is drawn, instead of after an ImGui window has been closed.
- In the activity wait loop, check if a screen clear is pending.  If so, perform a full redraw first so the game world is fully rendered before UI rendering is locked to the popup activity only.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled in Windows.
Started the game and verified artifacts were not present when closing ImGui menus
Verified the screen did not flash during activities
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
