### PR TITLE
fix to setting age dialog

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3459,7 +3459,7 @@ bool character_creator_ui::handle_action( const std::string &action )
         you.name = popup.query();
     } else if( action == "CHANGE_AGE" ) {
         const int age_current = you.base_age();
-        number_input_popup<int> age_query( 0, age_current,
+        number_input_popup<int> age_query( 48, age_current,
                                            string_format( _( "Enter age in years.  Minimum %d, maximum %d" ),
                                                    CHARACTER_AGE_MIN, CHARACTER_AGE_MAX ) );
         int age_result = age_query.query();


### PR DESCRIPTION
The dialog currently cuts off.  This fixes it.

#### Summary
Bugfixes "Fix dialog for changing age"

#### Purpose of change

In the new character section, if you try to set your age the dialog gets cut off.

This makes the dialog long enough to look as it should.

#### Describe the solution

Make a new character.  Change the age.  Pretty basic.

Code wise, the function number_input_popup had a '0' for a field that controlled width.  So the width is way too narrow.  There should be text about choosing an age from 16-65, but instead you get 'Enter age in years.  Minimum 1X' where the X is the 'close dialog' icon.

upping that 0 makes the dialog work as expected.


#### Describe alternatives you've considered

Not fixing it.

Different numbers.  Honestly once I found one that looked decent, I stopped looking.  It is likely not perfect, but a vast improvement.

#### Testing

Make a new character.  Hit 'a' to change the age.  Read.

I checked both Custom and Random characters.

#### Additional context

