### PR TITLE
[Magiclysm] Diviner updates and maintenance

### DIFF
--- a/data/mods/Magiclysm/npc/TALK_FORGE_DIVINER.json
+++ b/data/mods/Magiclysm/npc/TALK_FORGE_DIVINER.json
@@ -390,7 +390,7 @@
     "dynamic_line": "Have you seen mi-go architecture?  They make these living, organic structures out of resin.  Kind of cool.  And disturbing, I guess.  Of course, they'll cut you to pieces if you gawk at it too long.  I'll mark the location of one of these places on your map for one denarius.  I heard a story, not sure if it was true, but allegedly one guy tried to use the mi-go building resin as armor.  Apparently, it bore into the poor guy's flesh!  Like lichen!  His friends tried to tear it off, but it wouldn't bulge.  He was in so much pain they decided to put him out of his misery.  But they couldn't do it, because the armor was too good!  So I guess that in a sense it worked.  Heh.  The mental image still keeps me awake at night, occasionally.  And now you have it too.  You're welcome.",
     "responses": [
       {
-        "text": "Uh sure.  Thanks?  It's a deal.",
+        "text": "Uh, sure.  Thanks?  It's a deal.",
         "topic": "TALK_DONE",
         "condition": { "u_has_item": "denarius" },
         "effect": [ { "assign_mission": "MISSION_FORGE_DIVINER_MI_GO_ENCAMPMENT" }, { "u_consume_item": "denarius" } ]
@@ -407,7 +407,7 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER_MI_GO_TOWER",
     "type": "talk_topic",
-    "dynamic_line": "The mi-go seem to abduct humans and animals for some alien purpose, and then build these towers for their spaceships to dock with to move the prisoners of-world.  Did I mention they have space ships?  Well, I've never actually seen one dock with a tower, but still.  I'll mark such a tower on your map for one denarius.",
+    "dynamic_line": "The mi-go seem to abduct humans and animals for some alien purpose, and then build these towers for their spaceships to dock with to move the prisoners off-world.  Did I mention they have space ships?  Well, I've never actually seen one dock with a tower, but still.  I'll mark such a tower on your map for one denarius.",
     "responses": [
       {
         "text": "It's a deal.",
@@ -882,7 +882,7 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER_GOD",
     "type": "talk_topic",
-    "dynamic_line": "Valzain is over at the entrance of the forge, selling overpriced magical knick-knacks.  Or perhaps there was something else you had in mind?",
+    "dynamic_line": "Valzain is in the back, down in the vault, selling overpriced magical knick-knacks.  Or perhaps there was something else you had in mind?",
     "responses": [
       { "text": "Another forge?", "topic": "TALK_FORGE_LORD_DIVINER_OTHER_FORGE" },
       { "text": "A Lovecraftian horror.", "topic": "TALK_FORGE_LORD_DIVINER_LOVECRAFTIAN" },
@@ -894,20 +894,33 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER_OTHER_FORGE",
     "type": "talk_topic",
-    "dynamic_line": "There is only one Forge of Wonders, it's not like this is a multidimensional franchise opportunity.",
+    "dynamic_line": "There is only one Forge of Wonders.  It's not like this is a multidimensional franchise opportunity.",
     "responses": [ { "text": "About something else…", "topic": "TALK_NONE" }, { "text": "Nevermind.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_FORGE_LORD_DIVINER_LOVECRAFTIAN",
     "type": "talk_topic",
-    "dynamic_line": "There are these city-sized creatures called Void Leviathans that lives in the vast nether regions between realities.  Sometimes they used to wash up onto Earths that had recently had a Cataclysm.  Caused all kinds of trouble, they did, so Valzain made it so they would spawn underground instead.  But I haven't seen any of them in quite a while.  Perhaps they retreated deeper into the empty parts of the nether?  Sorry, I haven't seen any in this reality yet.  I can't help you.",
-    "//": "This is for if nether_monster_corpse gets implemented.",
-    "responses": [ { "text": "About something else…", "topic": "TALK_NONE" }, { "text": "Nevermind.", "topic": "TALK_DONE" } ]
+    "dynamic_line": "There are these city-sized creatures called Void Leviathans that lives in the vast nether regions between realities.  Sometimes they used to wash up onto Earths that had recently had a Cataclysm.  Caused all kinds of trouble, they did, so Valzain made it so they would spawn underground instead.  I can mark the marooned corpse of one such creature on your map for one denarius.",
+    "responses": [
+      {
+        "text": "It's a deal.",
+        "topic": "TALK_DONE",
+        "condition": { "u_has_item": "denarius" },
+        "effect": [ { "assign_mission": "MISSION_FORGE_DIVINER_LOVECRAFTIAN" }, { "u_consume_item": "denarius" } ]
+      },
+      {
+        "text": "I can't afford that right now.",
+        "topic": "TALK_FORGE_LORD_DIVINER_GET_MONEY",
+        "condition": { "not": { "u_has_item": "denarius" } }
+      },
+      { "text": "About something else…", "topic": "TALK_NONE" },
+      { "text": "Nevermind.", "topic": "TALK_DONE" }
+    ]
   },
   {
     "id": "TALK_FORGE_LORD_DIVINER_MALIGNANCE",
     "type": "talk_topic",
-    "dynamic_line": "The Malignance is the cause for much of our woes.  It is the force animating the zombies.  It is responsible for the portal storms, and it seems to be absolutely bursting with hate.  Valzain theorizes that it used to be a fundamental force of nature or perhaps a school of magic that somehow grew conscious, or perhaps had a consciousness imposed on it. Allegedly, the Mi-Go speak of a time before it existed, or perhaps a time in which it wasn't so dangerous.  By now, it is everywhere on Earth.  As far as I can tell, it builds no structures and has no bases of operation, so there is no place I can point you towards.  Sorry.",
+    "dynamic_line": "The Malignance is the cause for much of our woes.  It is the force animating the zombies.  It is responsible for the portal storms, and it seems to be absolutely bursting with hate.  Valzain theorizes that it used to be a fundamental force of nature or perhaps a school of magic that somehow grew conscious, or perhaps had a consciousness imposed on it.  Allegedly, the Mi-Go speak of a time before it existed, or perhaps a time in which it wasn't so dangerous.  By now, it is everywhere on Earth.  As far as I can tell, it builds no structures and has no bases of operation, so there is no place I can point you towards.  Sorry.",
     "responses": [ { "text": "About something else…", "topic": "TALK_NONE" }, { "text": "Nevermind.", "topic": "TALK_DONE" } ]
   }
 ]

--- a/data/mods/Magiclysm/npc/TALK_FORGE_DIVINER.json
+++ b/data/mods/Magiclysm/npc/TALK_FORGE_DIVINER.json
@@ -900,7 +900,7 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER_LOVECRAFTIAN",
     "type": "talk_topic",
-    "dynamic_line": "There are these city-sized creatures called Void Leviathans that lives in the vast nether regions between realities.  Sometimes they used to wash up onto Earths that had recently had a Cataclysm.  Caused all kinds of trouble, they did, so Valzain made it so they would spawn underground instead.  I can mark the marooned corpse of one such creature on your map for one denarius.",
+    "dynamic_line": "There are these city-sized creatures called Void Leviathans that live in the vast nether regions between realities.  Sometimes they used to wash up onto Earths that had recently had a Cataclysm.  Caused all kinds of trouble, they did, so Valzain made it so they would spawn underground instead.  I can mark the marooned corpse of one such creature on your map for one denarius.",
     "responses": [
       {
         "text": "It's a deal.",

--- a/data/mods/Magiclysm/npc/forge_diviner_missions.json
+++ b/data/mods/Magiclysm/npc/forge_diviner_missions.json
@@ -418,5 +418,18 @@
     "start": {
       "assign_mission_target": { "om_terrain": "magic_field_a1", "om_special": "magic_field", "reveal_radius": 3, "cant_see": true }
     }
+  },
+  {
+    "id": "MISSION_FORGE_DIVINER_LOVECRAFTIAN",
+    "type": "mission_definition",
+    "name": { "str": "Visit the Lovecraftian horror" },
+    "goal": "MGOAL_GO_TO_TYPE",
+    "difficulty": 0,
+    "value": 0,
+    "description": "The diviner told you that there would be the corpse of a Lovecraftian horror here.",
+    "destination": "corpse_surface",
+    "start": {
+      "assign_mission_target": { "om_terrain": "corpse_surface", "om_special": "nether_monster_corpse", "reveal_radius": 2, "cant_see": true }
+    }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "Update diviner"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Updates to diviner:
- Valzain is now in the back, not at the entrance.
- nether_monster_corpse was implemented, so you can now expect the diviner to point to one such location.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Copied the nether corpse mission from Pat, worked like a charm. Otherwise just minor dialogue changes.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Copied the files to my local copy and made a new world.
Teleported to Forge and asked for Lovecraftian horror.
Got the mission and completed it (with debug teleport).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
