### PR TITLE
Labyrinth turrets shoot phase goo

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -502,5 +502,11 @@
     "type": "ammo_effect",
     "always_cast_spell": true,
     "spell_data": [ { "id": "nl_destruction_ray" } ]
+  },
+  {
+    "id": "NL_PHASE_GOO",
+    "type": "ammo_effect",
+    "always_cast_spell": true,
+    "spell_data": [ { "id": "nl_phase_goo" } ]
   }
 ]

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -5728,5 +5728,27 @@
       "vomit_chance": [ 15 ],
       "vomit_tick": [ 10 ]
     }
+  },
+  {
+    "type": "effect_type",
+    "id": "nl_phase_goo",
+    "name": [ "Out of phase" ],
+    "desc": [
+      "Your body is partially out of phase with reality.  You move much more slowly, but you might be able to phase through some obstacles with ease."
+    ],
+    "apply_message": "You're coated in out-of-phase goo!",
+    "remove_message": "Your body returns to its normal phase.",
+    "rating": "bad",
+    "max_intensity": 1,
+    "enchantments": [
+      {
+        "values": [
+          { "value": "MOVE_COST", "multiply": 0.75 },
+          { "value": "MOVECOST_OBSTACLE_MOD", "multiply": -1 },
+          { "value": "PHASE_DISTANCE", "add": 1 }
+        ]
+      }
+    ],
+    "show_in_info": true
   }
 ]

--- a/data/json/faults/fault_fixes_armor.json
+++ b/data/json/faults/fault_fixes_armor.json
@@ -316,5 +316,13 @@
     "faults_removed": [ "fault_denim_hole" ],
     "copy-from": "mend_armor_cotton_tear_stitch",
     "requirements": [ [ "tailoring_denim_small_simple", 1 ] ]
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_armor_nl_phase_goo",
+    "name": "Wipe off the out-of-phase goo",
+    "faults_removed": [ "fault_nl_phase_goo" ],
+    "success_msg": "You wipe off the goo.",
+    "time": "120 s"
   }
 ]

--- a/data/json/faults/faults_armor.json
+++ b/data/json/faults/faults_armor.json
@@ -161,5 +161,20 @@
     "name": { "str": "Hole" },
     "description": "There's a big hole in the fabric.",
     "copy-from": "fault_cotton_hole"
+  },
+  {
+    "type": "fault",
+    "id": "fault_nl_phase_goo",
+    "name": { "str": "Out of phase" },
+    "description": "The object is covered in dimensionally-altered goo, lowering its protective value.  You think you could mend the problem by just wiping it off.",
+    "item_prefix": "out-of-phase",
+    "message": "Out-of-phase goo sticks to the %s!",
+    "degradation_mod": 0,
+    "price_modifier": 0,
+    "armor_mod": [
+      { "damage_id": "bash", "multiply": 0.5 },
+      { "damage_id": "cut", "multiply": 0.5 },
+      { "damage_id": "stab", "multiply": 0.5 }
+    ]
   }
 ]

--- a/data/json/monster_special_attacks/monster_gun.json
+++ b/data/json/monster_special_attacks/monster_gun.json
@@ -437,5 +437,16 @@
     "dispersion": 2000,
     "ranged_damage": { "damage_type": "acid", "amount": 6, "armor_penetration": 0 },
     "flags": [ "PSEUDO", "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "NO_TURRET" ]
+  },
+  {
+    "id": "nl_turret_phase_goo_thrower",
+    "copy-from": "v29",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "phase alternator", "//~": "NO_I18N" },
+    "energy_drain": "0 kJ",
+    "ammo_effects": [ "NL_PHASE_GOO" ],
+    "ranged_damage": { "damage_type": "pure", "amount": 1, "armor_penetration": 0 },
+    "flags": [ "PSEUDO", "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "NO_TURRET" ]
   }
 ]

--- a/data/json/monster_special_attacks/netherum_labyrinth.json
+++ b/data/json/monster_special_attacks/netherum_labyrinth.json
@@ -14,5 +14,40 @@
     "max_aoe": 1,
     "min_range": 20,
     "max_range": 20
+  },
+  {
+    "id": "nl_phase_goo",
+    "type": "SPELL",
+    "name": "Nether Phase Goo",
+    "description": "Phase Goo effect in labyrinthine structures.",
+    "valid_targets": [ "hostile" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_NL_PHASE_GOO",
+    "shape": "blast",
+    "min_damage": 0,
+    "max_damage": 0,
+    "min_aoe": 1,
+    "max_aoe": 1,
+    "min_range": 0,
+    "max_range": 25
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NL_PHASE_GOO",
+    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, "u_is_character" ] },
+    "effect": [
+      { "u_add_effect": "nl_phase_goo", "duration": "30 seconds" },
+      {
+        "u_run_inv_eocs": "all",
+        "search_data": [ { "worn_only": true } ],
+        "true_eocs": [
+          {
+            "id": "EOC_NL_PHASE_GOO_PHASED_FAULT",
+            "condition": { "one_in_chance": 4 },
+            "effect": { "npc_set_fault": "fault_nl_phase_goo", "force": true, "message": true }
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/data/json/monsters/netherum/labyrinth_monsters.json
+++ b/data/json/monsters/netherum/labyrinth_monsters.json
@@ -107,15 +107,20 @@
     "special_attacks": [
       {
         "type": "gun",
-        "cooldown": 5,
-        "move_cost": 100,
-        "gun_type": "feral_human_thrown_rock",
-        "ammo_type": "bone_dart",
-        "fake_skills": [ [ "throw", 5 ] ],
-        "fake_str": 20,
-        "require_targeting_player": false,
-        "ranges": [ [ 0, 12, "DEFAULT" ] ],
-        "description": "The turret launches a bony dart at you!"
+        "cooldown": 20,
+        "move_cost": 400,
+        "gun_type": "nl_turret_phase_goo_thrower",
+        "fake_skills": [ [ "gun", 5 ] ],
+        "fake_dex": 12,
+        "ranges": [ [ 0, 25, "DEFAULT" ] ],
+        "require_targeting_npc": true,
+        "require_targeting_monster": true,
+        "target_moving_vehicles": true,
+        "laser_lock": false,
+        "targeting_sound": "clacking bone and cracking sinew.",
+        "targeting_volume": 50,
+        "targeting_cost": 800,
+        "targeting_timeout_extend": -10
       }
     ],
     "special_when_hit": [ "RETURN_FIRE", 100 ],

--- a/tools/json_tools/generic_guns_validator.py
+++ b/tools/json_tools/generic_guns_validator.py
@@ -52,6 +52,7 @@ ID_WHITELIST = {
     'bone_dart_launcher',
     'nl_destruction_ray',
     'nl_turret_chem_thrower',
+    'nl_turret_phase_goo_thrower',
     'coilgun',
     'slamfire_shotgun',
     'slamfire_shotgun_d',


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Labyrinth turrets that shoot phase goo"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Final piece of reviving #84045.  I-am-Erik designed the flesh turrets to shoot a "phase goo," that serves more to bring armored characters down a notch, than to hurt all characters equally.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Phase goo has some weird effects.  Firstly, if hit, the player always gets 1 pure damage, and goes vaguely, but not completely, incorporeal.  They are significantly slowed, but their ability to clear obstacles increases, and they can actually phase through 1-tile walls.

However, there's a chance a piece of equipment worn will get a fault called `out-of-phase`.  This reduces its protective values by half.  It can be mended by just wiping it off, but it takes 2 minutes, so will likely have to be done after combat.  This makes the turrets odd and deadly, but indirectly so.

If you are dimensionally anchored, it does not affect you.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Turning on an anchor mends the fault.  I think should still be on the table for future PR.
Needing materials to mends the fault, like methanol/ethanol.
Having AltarOS teach you how to mend the fault.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Got shot, got out of phase, got equipment gooped, cleaned it off.  Repeated with an anchor, and no goo.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Idea to use a fault came from GuardianDll

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
