### PR TITLE
fixes devourers not dropping cbms

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3189,10 +3189,9 @@ void monster::die( map *here, Creature *nkiller )
         }
     }
 
-    if( death_drops) {
-        if (!no_extra_death_drops)
-        {
-            drop_items_on_death(here, corpse.get_item());
+    if( death_drops ) {
+        if( !no_extra_death_drops ) {
+            drop_items_on_death( here, corpse.get_item() );
         }
         spawn_dissectables_on_death( corpse.get_item() );
     }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3189,8 +3189,11 @@ void monster::die( map *here, Creature *nkiller )
         }
     }
 
-    if( death_drops && !no_extra_death_drops ) {
-        drop_items_on_death( here, corpse.get_item() );
+    if( death_drops) {
+        if (!no_extra_death_drops)
+        {
+            drop_items_on_death(here, corpse.get_item());
+        }
         spawn_dissectables_on_death( corpse.get_item() );
     }
     if( death_drops && !is_hallucination() ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Fixes naturally evolved Zomborg Devourers not dropping CBMs"

#### Purpose of change

They should drop CBMs given theyre still cyborgs. Closes #86669

#### Describe the solution

Implemented solution proposed by @PatrikLundell 

#### Testing

Spawned zombie master and had it evolve zomborgs and then dissected them. 
Started with Winter scenario and found naturally generated zomborg devourers and dissected them.
Dissected other zombies and critters to see if I broke anything.

#### Additional context

<img width="349" height="511" alt="image" src="https://github.com/user-attachments/assets/713c451e-ee69-4a45-aab3-d11bbc0861a9" />

<img width="386" height="498" alt="image" src="https://github.com/user-attachments/assets/53959fc1-72f2-40fb-b2a4-b32c00f6718a" />