### PR TITLE
[XEDRA Evolved] Give the `human` butchery result omnivore stomach

### DIFF
--- a/data/mods/Xedra_Evolved/harvest_monster_hunter_gracken.json
+++ b/data/mods/Xedra_Evolved/harvest_monster_hunter_gracken.json
@@ -174,6 +174,13 @@
     "extend": { "entries": [ { "drop": "ant_stomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" } ] }
   },
   {
+    "id": "human",
+    "type": "harvest",
+    "copy-from": "human",
+    "delete": { "entries": [ { "drop": "hstomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" } ] },
+    "extend": { "entries": [ { "drop": "omnivore_stomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" } ] }
+  },
+  {
     "id": "zombie_child",
     "//": "your child sized humanoid zombie",
     "type": "harvest",


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Human are omnivore, so why dont they drop omnivore stomach?

#### Describe the solution
Adds the json thing to the `human` butchery results

#### Describe alternatives you've considered

Make up some reason for why the gracken cant take advantage of human stomach specifically.

#### Testing
 butchered a feral prepper
<img width="654" height="388" alt="Screenshot_20260430_002044" src="https://github.com/user-attachments/assets/9d3274dc-5449-41b6-a2c8-2752727b891e" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
