### PR TITLE
Add more wells

### DIFF
--- a/data/mods/TEST_DATA/itemgroups.json
+++ b/data/mods/TEST_DATA/itemgroups.json
@@ -134,5 +134,13 @@
     "id": "test_bottle_water",
     "subtype": "collection",
     "entries": [ { "item": "water_clean", "charges": 1, "container-item": "bottle_plastic", "sealed": false } ]
+  },
+  {
+    "type": "item_group",
+    "id": "test_multimag_full_load",
+    "subtype": "collection",
+    "ammo": 100,
+    "magazine": 100,
+    "entries": [ { "item": "test_multimag_gun", "prob": 100 } ]
   }
 ]

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5707,5 +5707,29 @@
       { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] },
       { "magazine_well": "500 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "stanag30" ] }
     ]
+  },
+  {
+    "id": "test_multimag_gun_same_type",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "test same-type multimag gun" },
+    "description": "Test gun with two wells restricted to the same magazine type, used to verify pocket-targeted reload disambiguates between identical wells.",
+    "weight": "1000 g",
+    "volume": "1500 ml",
+    "longest_side": "400 mm",
+    "material": [ "steel" ],
+    "symbol": "(",
+    "color": "light_gray",
+    "ammo": [ "9mm" ],
+    "skill": "pistol",
+    "range": 10,
+    "ranged_damage": { "damage_type": "bullet", "amount": 10 },
+    "dispersion": 480,
+    "durability": 10,
+    "flags": [ "NO_TURRET" ],
+    "pocket_data": [
+      { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] },
+      { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] }
+    ]
   }
 ]

--- a/doc/JSON/ITEM_SPAWN.md
+++ b/doc/JSON/ITEM_SPAWN.md
@@ -196,6 +196,13 @@ be specified for guns and magazines in the entries array to use a non-default am
 
 *  Use `charges` in the entries array.  A default magazine will be added for you if needed.
 
+#### Multi-well items
+
+Items with more than one `MAGAZINE_WELL` pocket follow two extra rules:
+
+* `charges` on the entry is ambiguous (no rule says how to split the count across pockets) and is rejected with a debugmsg.  The wells stay empty.
+* `ammo` and `magazine` are still single rolls per item, but the outcome is applied to every empty well.  When `magazine` rolls true, each well's default magazine is installed; when `ammo` also rolls true, each inserted magazine is filled with its own default ammo.  Wells already holding a magazine are skipped except for an empty mag, which is topped up when the `ammo` roll succeeds.
+
 ## Shortcuts
 
 This:

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4946,6 +4946,8 @@ bool target_practice_activity_actor::check_weapon_valid( Character &who )
 
 bool target_practice_activity_actor::attempt_reload( Character &who )
 {
+    // TODO(multimag): pocket_index defaults to -1; target practice cannot
+    // pick a specific well on multi-well guns yet.
     item *gun = gun_loc.get_item();
 
     std::vector<item_location> ammo_locs;
@@ -7784,6 +7786,7 @@ reload_activity_actor::reload_activity_actor( item::reload_option &&opt, int ext
 {
     moves_total = opt.moves() + extra_moves;
     quantity = opt.qty();
+    pocket_index = opt.pocket_index;
     target_loc = std::move( opt.target );
     ammo_loc = std::move( opt.ammo );
     seconds_per_round = opt.qty() ? std::min( 1, moves_total / quantity ) : 0;
@@ -7860,7 +7863,7 @@ void reload_activity_actor::reload( player_activity &act, Character &who, int lo
     const std::string reloadable_name = reloadable.tname();
     const bool ammo_is_filthy = ammo.is_filthy();
 
-    if( !reloadable.reload( who, ammo_loc, qty ) ) {
+    if( !reloadable.reload( who, ammo_loc, qty, pocket_index ) ) {
         return;
     }
 
@@ -7973,6 +7976,7 @@ void reload_activity_actor::serialize( JsonOut &jsout ) const
 
     jsout.member( "moves_total", moves_total );
     jsout.member( "qty", quantity );
+    jsout.member( "pocket_index", pocket_index );
     jsout.member( "target_loc", target_loc );
     jsout.member( "ammo_loc", ammo_loc );
     jsout.member( "seconds_per_round", seconds_per_round );
@@ -7989,6 +7993,10 @@ std::unique_ptr<activity_actor> reload_activity_actor::deserialize( JsonValue &j
 
     data.read( "moves_total", actor.moves_total );
     data.read( "qty", actor.quantity );
+    // Saves missing the key route through the first-compatible-well path.
+    // TODO(multimag): backwards-compat default; remove after a stable release.
+    actor.pocket_index = -1;
+    data.read( "pocket_index", actor.pocket_index );
     data.read( "target_loc", actor.target_loc );
     data.read( "ammo_loc", actor.ammo_loc );
     data.read( "seconds_per_round", actor.seconds_per_round );

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -2245,6 +2245,9 @@ class reload_activity_actor : public activity_actor
         int quantity = 0;
         int seconds_per_round = 0;
         int already_loaded = 0;
+        // MAGAZINE_WELL pocket index in target_loc->contents. Negative =
+        // first-compatible-well fallback.
+        int pocket_index = -1;
         // cache ammo because reloading deletes the location
         itype_id ammo_id; // NOLINT(cata-serialize)
         item_location target_loc;

--- a/src/character.h
+++ b/src/character.h
@@ -1916,8 +1916,19 @@ class Character : public Creature, public visitable
          */
         void mend_item( item_location &&obj, bool interactive = true );
 
+        /**
+         * Build the list of reload_option entries for selecting reload ammo
+         * for `base`. With `per_well_targets` false the function emits one
+         * option per item (base and each gunmod) plus one per loaded
+         * magazine, all carrying reload_option::pocket_index = -1, which
+         * routes execution through the first-compatible-well selection
+         * inside item::reload. With `per_well_targets` true it additionally
+         * walks every MAGAZINE_WELL pocket on the base item and on each
+         * gunmod, emitting per-well reload targets whose pocket_index
+         * identifies the specific well in target->contents.
+         */
         bool list_ammo( const item_location &base, std::vector<item::reload_option> &ammo_list,
-                        bool empty = true ) const;
+                        bool empty = true, bool per_well_targets = false ) const;
         /**
          * Select suitable ammo with which to reload the item
          * @param base Item to select ammo for

--- a/src/character_ammo.cpp
+++ b/src/character_ammo.cpp
@@ -217,13 +217,14 @@ hint_rating Character::rate_action_unload( const item &it ) const
         return hint_rating::cant;
     }
 
-    if( it.magazine_current() ) {
+    if( !it.magazines_current().empty() ) {
         return hint_rating::good;
     }
 
     for( const item *e : it.gunmods() ) {
         if( ( e->is_gun() && !e->has_flag( flag_NO_UNLOAD ) &&
-              ( e->magazine_current() || e->ammo_remaining( ) > 0 || e->casings_count() > 0 ) ) ||
+              ( !e->magazines_current().empty() || e->ammo_remaining( ) > 0 ||
+                e->casings_count() > 0 ) ) ||
             ( e->has_flag( flag_BRASS_CATCHER ) && !e->is_container_empty() ) ) {
             return hint_rating::good;
         }

--- a/src/character_ammo.cpp
+++ b/src/character_ammo.cpp
@@ -15,7 +15,9 @@
 #include "flag.h"
 #include "item.h"
 #include "item_location.h"
+#include "item_pocket.h"
 #include "itype.h"
+#include "pocket_type.h"
 #include "type_id.h"
 #include "units.h"
 #include "value_ptr.h"
@@ -82,30 +84,68 @@ bool Character::can_reload( const item &it, const item *ammo ) const
 }
 
 bool Character::list_ammo( const item_location &base, std::vector<item::reload_option> &ammo_list,
-                           bool empty ) const
+                           bool empty, bool per_well_targets ) const
 {
-    // Associate the destination with "parent"
-    // Useful for handling gun mods with magazines
-    std::vector<item_location> opts;
-    opts.emplace_back( base );
+    // pocket_index < 0 -> first-compatible-well fallback in item::reload.
+    struct opt_entry {
+        item_location loc;
+        int pocket_index;
+    };
+    std::vector<opt_entry> opts;
 
-    if( base->magazine_current() ) {
-        opts.emplace_back( base, const_cast<item *>( base->magazine_current() ) );
-    }
+    auto append_owner_options = [&opts, per_well_targets]( const item_location & owner ) {
+        opts.push_back( { owner, -1 } );
+        if( per_well_targets ) {
+            int idx = 0;
+            for( const item_pocket *p : owner->get_pockets(
+            []( const item_pocket & ) {
+            return true;
+        } ) ) {
+                if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                    opts.push_back( { owner, idx } );
+                    if( const item *mag = p->magazine_current() ) {
+                        opts.push_back( { item_location( owner, const_cast<item *>( mag ) ), -1 } );
+                    }
+                }
+                ++idx;
+            }
+        } else if( owner->magazine_current() ) {
+            opts.push_back( { item_location( owner, const_cast<item *>( owner->magazine_current() ) ), -1 } );
+        }
+    };
 
+    append_owner_options( base );
     for( const item *mod : base->gunmods() ) {
         item_location mod_loc( base, const_cast<item *>( mod ) );
-        opts.emplace_back( mod_loc );
-        if( mod->magazine_current() ) {
-            opts.emplace_back( mod_loc, const_cast<item *>( mod->magazine_current() ) );
-        }
+        append_owner_options( mod_loc );
     }
 
     bool ammo_match_found = false;
     int ammo_search_range = is_mounted() ? -1 : 1;
-    for( item_location &p : opts ) {
+    for( opt_entry &entry : opts ) {
+        item_location &p = entry.loc;
+        // For per-well entries, filter compatibility against that specific
+        // pocket so magazines that fit a sibling well do not leak through.
+        const item_pocket *targeted_well = nullptr;
+        if( entry.pocket_index >= 0 ) {
+            int idx = 0;
+            for( const item_pocket *pp : p->get_pockets( []( const item_pocket & ) {
+            return true;
+        } ) ) {
+                if( idx == entry.pocket_index ) {
+                    if( pp->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                        targeted_well = pp;
+                    }
+                    break;
+                }
+                ++idx;
+            }
+        }
         for( item_location &ammo : find_ammo( *p, empty, ammo_search_range ) ) {
-            if( p.can_reload_with( ammo, false ) ) {
+            const bool well_accepts = targeted_well != nullptr
+                                      ? targeted_well->can_reload_with( *ammo, false )
+                                      : p.can_reload_with( ammo, false );
+            if( well_accepts ) {
                 // Record that there's a matching ammo type,
                 // even if something is preventing reloading at the moment.
                 ammo_match_found = true;
@@ -115,8 +155,11 @@ bool Character::list_ammo( const item_location &base, std::vector<item::reload_o
                 // Again, this is "are they compatible", later check handles "can we do it now".
                 ammo_match_found = p.can_reload_with( ammo, false );
             }
-            if( can_reload( *p, ammo.get_item() ) ) {
-                ammo_list.emplace_back( this, p, std::move( ammo ) );
+            const bool emit = targeted_well != nullptr
+                              ? targeted_well->can_reload_with( *ammo, true )
+                              : can_reload( *p, ammo.get_item() );
+            if( emit ) {
+                ammo_list.emplace_back( this, p, std::move( ammo ), entry.pocket_index );
             }
         }
     }

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -1604,6 +1604,8 @@ std::string Character::weapname_mode() const
 
 std::string Character::weapname_ammo() const
 {
+    // TODO(multimag): HUD '(empty)' indicator and ammo count summarize the
+    // first MAGAZINE_WELL only. Multi-well guns need a per-well summary.
     if( weapon.is_gun() ) {
         gun_mode current_mode = weapon.gun_current_mode();
         const bool no_mode = !current_mode.target;
@@ -2347,7 +2349,10 @@ bool Character::add_or_drop_with_msg( item &it, const bool /*unloading*/, const 
                 break;
             }
         }
-        const bool allow_wield = !wielded_has_it && weapon.magazine_current() != &it;
+        const std::vector<item *> wielded_mags = weapon.magazines_current();
+        const bool wielded_mag_collision = std::find( wielded_mags.begin(), wielded_mags.end(),
+                                           &it ) != wielded_mags.end();
+        const bool allow_wield = !wielded_has_it && !wielded_mag_collision;
         const int prev_charges = it.charges;
         item_location ni = i_add( it, true, avoid,
                                   original_inventory_item, /*allow_drop=*/false, /*allow_wield=*/allow_wield );
@@ -2497,17 +2502,37 @@ bool Character::unload( item_location &loc, bool bypass_activity,
         }
         return true;
 
-    } else if( target->magazine_current() ) {
-        if( !this->add_or_drop_with_msg( *target->magazine_current(), true, nullptr,
-                                         target->magazine_current() ) ) {
-            return false;
+    } else if( !target->magazines_current().empty() ) {
+        // Snapshot the loaded magazine pointers up front; the vector will shift
+        // as we remove magazines from the wells.
+        std::vector<item *> mags_to_eject = target->magazines_current();
+        if( !bypass_activity && mags_to_eject.size() > 1 ) {
+            std::vector<std::string> mag_msgs;
+            mag_msgs.reserve( mags_to_eject.size() + 1 );
+            for( const item *mag : mags_to_eject ) {
+                mag_msgs.emplace_back( mag->tname() );
+            }
+            mag_msgs.emplace_back( _( "All" ) );
+            const int ret = uilist( _( "Unload which magazine?" ), mag_msgs );
+            if( ret < 0 ) {
+                return false;
+            }
+            if( ret < static_cast<int>( mags_to_eject.size() ) ) {
+                item *picked = mags_to_eject[ret];
+                mags_to_eject = { picked };
+            }
         }
-        // Eject magazine consuming half as much time as required to insert it
-        this->mod_moves( -this->item_reload_cost( *target, *target->magazine_current(), -1 ) / 2 );
+        for( item *mag : mags_to_eject ) {
+            if( !this->add_or_drop_with_msg( *mag, true, nullptr, mag ) ) {
+                return false;
+            }
+            // Eject magazine consuming half as much time as required to insert it
+            this->mod_moves( -this->item_reload_cost( *target, *mag, -1 ) / 2 );
 
-        target->remove_items_with( [&target]( const item & e ) {
-            return target->magazine_current() == &e;
-        } );
+            target->remove_items_with( [mag]( const item & e ) {
+                return &e == mag;
+            } );
+        }
 
     } else if( target->ammo_remaining( ) ) {
         int qty = target->ammo_remaining( );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6995,6 +6995,9 @@ void game::butcher( const std::optional<tripoint_bub_ms> &p )
 static item::reload_option favorite_ammo_or_select( avatar &u, item_location &loc, bool empty,
         bool prompt )
 {
+    // TODO(multimag): favorite-ammo fast path uses list_ammo() with the
+    // legacy first-compatible-well fallback. A second well that accepts the
+    // same ammo type is not offered without an explicit menu step.
     if( u.ammo_location ) {
         std::vector<item::reload_option> ammo_list;
         if( u.list_ammo( loc, ammo_list, false ) ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7033,6 +7033,9 @@ void game::reload( item_location &loc, bool prompt, bool empty )
 
     switch( u.rate_action_reload( *loc ) ) {
         case hint_rating::iffy:
+            // TODO(multimag): remaining_ammo_capacity() is a first-loaded-mag
+            // fallback; multi-well items will report "already fully loaded"
+            // when only the first well is full.
             if( ( loc->is_ammo_container() || loc->is_magazine() ) && loc->ammo_remaining( ) > 0 &&
                 loc->remaining_ammo_capacity() == 0 ) {
                 add_msg( m_info, _( "The %s is already fully loaded!" ), loc->tname() );
@@ -7172,6 +7175,8 @@ void game::reload_weapon( bool try_everything )
             return a->is_gun();
         }
         // Finally sort by speed to reload.
+        // TODO(multimag): aggregate remaining_ammo_capacity() falls back to
+        // the first MAGAZINE_WELL; multi-well items rank by first-well only.
         return ( a->get_reload_time() * a->remaining_ammo_capacity() ) <
                ( b->get_reload_time() * b->remaining_ammo_capacity() );
     } );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -3,6 +3,7 @@
 #include <imgui/imgui.h>
 #include <algorithm>
 #include <bitset>
+#include <climits>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -70,6 +71,7 @@
 #include "translations.h"
 #include "type_id.h"
 #include "ui_manager.h"
+#include "uilist.h"
 #include "uistate.h"
 #include "units.h"
 #include "units_utility.h"
@@ -3088,15 +3090,16 @@ class select_ammo_inventory_preset : public inventory_selector_preset
             }, _( "LOCATION" ) );
 
             append_cell( [&you, target]( const item_location & loc ) {
-                for( const item_location &opt : get_possible_reload_targets( target ) ) {
-                    if( opt.can_reload_with( loc, true ) ) {
-                        if( opt == target ) {
-                            return std::string();
-                        }
-                        return string_format( _( "%s, %s" ), opt->type_name(), opt.describe( &you ) );
-                    }
+                const std::vector<reload_target> targets = get_possible_reload_targets( target );
+                const reload_target *match = find_matching_reload_target( targets, loc );
+                if( match == nullptr ) {
+                    return std::string();
                 }
-                return std::string();
+                if( match->target == target ) {
+                    return std::string();
+                }
+                return string_format( _( "%s, %s" ), match->target->type_name(),
+                                      match->target.describe( &you ) );
             }, _( "DESTINATION" ) );
 
             append_cell( []( const inventory_entry & entry ) {
@@ -3155,21 +3158,17 @@ class select_ammo_inventory_preset : public inventory_selector_preset
                 return false;
             }
 
-            std::vector<item_location> opts = get_possible_reload_targets( target );
-
-            for( item_location &p : opts ) {
-                if( ( loc->has_flag( flag_SPEEDLOADER ) && p->allows_speedloader( loc->typeId() ) &&
-                      loc->ammo_remaining( ) > 1 && p->ammo_remaining( ) < 1 ) &&
-                    p.can_reload_with( loc, true ) ) {
-                    return true;
-                }
-
-                if( p.can_reload_with( loc, true ) ) {
+            const std::vector<reload_target> targets = get_possible_reload_targets( target );
+            for( const reload_target &rt : targets ) {
+                // Speedloader compatibility is queried on the owner gun, not
+                // on a specific well pocket.
+                if( loc->has_flag( flag_SPEEDLOADER ) && rt.target->allows_speedloader( loc->typeId() ) &&
+                    loc->ammo_remaining() > 1 && rt.target->ammo_remaining() < 1 &&
+                    rt.target.can_reload_with( loc, true ) ) {
                     return true;
                 }
             }
-
-            return false;
+            return find_matching_reload_target( targets, loc ) != nullptr;
         }
 
         // sort in order of move cost (ascending), then remaining ammo (descending) with empty magazines always last
@@ -3231,16 +3230,90 @@ item::reload_option game_menus::inv::select_ammo( Character &you, const item_loc
         return item::reload_option();
     }
 
-    item_location target_loc;
-    for( const item_location &opt : get_possible_reload_targets( loc ) ) {
-        if( opt.can_reload_with( selected.first, true ) ) {
-            target_loc = opt;
-            break;
-        }
+    // The selector lists one entry per ammo source. When the picked source
+    // matches multiple reload targets (sibling wells, multiple loaded mags
+    // of the same type), disambiguate via a follow-up uilist instead of
+    // duplicating selector entries per (source, target) pair.
+    const std::vector<reload_target> targets = get_possible_reload_targets( loc );
+    const std::vector<const reload_target *> matches =
+        find_all_matching_reload_targets( targets, selected.first );
+    if( matches.empty() ) {
+        return item::reload_option();
     }
 
-    item::reload_option opt( &you, target_loc, selected.first );
-    opt.qty( selected.second );
+    const reload_target *match = matches.front();
+    bool disambiguated = false;
+    if( matches.size() > 1 ) {
+        // Disambiguate: prompt the player, suffixing labels with (well N) when
+        // labels would otherwise collide on the same owner.
+        std::map<const item *, int> wells_per_owner;
+        std::map<std::pair<const item *, itype_id>, int> mags_per_owner_type;
+        for( const reload_target *rt : matches ) {
+            if( rt->kind == reload_target::kind::well ) {
+                wells_per_owner[rt->owner.get_item()]++;
+            } else {
+                mags_per_owner_type[ {rt->owner.get_item(), rt->target->typeId()}]++;
+            }
+        }
+        std::map<const item *, int> well_counters;
+        std::map<std::pair<const item *, itype_id>, int> mag_counters;
+        uilist menu;
+        menu.text = string_format( _( "Reload which destination on %s?" ),
+                                   loc->display_name() );
+        for( size_t i = 0; i < matches.size(); ++i ) {
+            const reload_target &rt = *matches[i];
+            std::string label;
+            if( rt.kind == reload_target::kind::well ) {
+                int idx = 0;
+                std::string well_desc;
+                for( const item_pocket *p : rt.owner->get_pockets(
+                []( const item_pocket & ) {
+                return true;
+            } ) ) {
+                    if( idx == rt.pocket_index && p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                        const itype_id default_mag = p->magazine_default();
+                        well_desc = default_mag.is_null()
+                                    ? string_format( _( "magazine well %d" ), rt.ui_well_index + 1 )
+                                    : item::find_type( default_mag )->nname( 1 );
+                        break;
+                    }
+                    ++idx;
+                }
+                label = string_format( _( "%s: %s" ), rt.owner->tname(), well_desc );
+                if( wells_per_owner[rt.owner.get_item()] > 1 ) {
+                    const int n = ++well_counters[rt.owner.get_item()];
+                    //~ %1$s is owner+well description, %2$d is 1-indexed well number on that owner
+                    label = string_format( _( "%1$s (well %2$d)" ), label, n );
+                }
+            } else {
+                //~ %1$s is the gun or gunmod that holds the magazine, %2$s is the magazine's tname
+                label = string_format( _( "%1$s: top up %2$s" ), rt.owner->tname(),
+                                       rt.target->tname() );
+                const std::pair<const item *, itype_id> key { rt.owner.get_item(), rt.target->typeId() };
+                if( mags_per_owner_type[key] > 1 ) {
+                    const int n = ++mag_counters[key];
+                    //~ %1$s is "<owner>: top up <mag name>", %2$d is 1-indexed well number on that owner
+                    label = string_format( _( "%1$s (well %2$d)" ), label, n );
+                }
+            }
+            menu.addentry( static_cast<int>( i ), true, MENU_AUTOASSIGN, label );
+        }
+        menu.query();
+        if( menu.ret < 0 || menu.ret >= static_cast<int>( matches.size() ) ) {
+            return item::reload_option();
+        }
+        match = matches[menu.ret];
+        disambiguated = true;
+    }
+
+    item::reload_option opt( &you, match->target, selected.first, match->pocket_index );
+    if( disambiguated && !inv_s.last_choice_count_player_adjusted() ) {
+        // Refill to the chosen target's own capacity when the seeded count
+        // (from a sibling match) came back unmodified.
+        opt.qty( INT_MAX );
+    } else {
+        opt.qty( selected.second );
+    }
 
     return opt;
 }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3963,43 +3963,195 @@ ammo_inventory_selector::ammo_inventory_selector( Character &you,
     force_single_column = true;
 }
 
-std::vector<item_location> get_possible_reload_targets( const item_location &target )
+std::vector<reload_target> get_possible_reload_targets( const item_location &target )
 {
-    std::vector<item_location> opts;
-    opts.emplace_back( target );
+    std::vector<reload_target> opts;
 
-    if( target->magazine_current() ) {
-        opts.emplace_back( target, const_cast<item *>( target->magazine_current() ) );
-    }
+    auto append_owner = [&opts]( const item_location & owner ) {
+        // pocket_index is the position in contents (stable across empty
+        // wells), not the position in magazines_current().
+        int idx = 0;
+        for( const item_pocket *p : owner->get_pockets( []( const item_pocket & ) {
+        return true;
+    } ) ) {
+            if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                reload_target well;
+                well.target = owner;
+                well.owner = owner;
+                well.pocket_index = idx;
+                well.ui_well_index = idx;
+                well.kind = reload_target::kind::well;
+                opts.push_back( well );
 
-    for( const item *mod : target->gunmods() ) {
-        item_location mod_loc( target, const_cast<item *>( mod ) );
-        opts.emplace_back( mod_loc );
-        if( mod->magazine_current() ) {
-            opts.emplace_back( mod_loc, const_cast<item *>( mod->magazine_current() ) );
+                if( const item *mag = p->magazine_current() ) {
+                    reload_target mag_target;
+                    mag_target.target = item_location( owner, const_cast<item *>( mag ) );
+                    mag_target.owner = owner;
+                    mag_target.pocket_index = -1;
+                    mag_target.ui_well_index = idx;
+                    mag_target.kind = reload_target::kind::loaded_mag;
+                    opts.push_back( mag_target );
+                }
+            }
+            ++idx;
         }
+        // No MAGAZINE_WELL (integral mag, watertight container): target the
+        // owner directly so loose ammo discovery has a destination.
+        bool has_well = false;
+        for( const reload_target &rt : opts ) {
+            if( rt.owner == owner ) {
+                has_well = true;
+                break;
+            }
+        }
+        if( !has_well ) {
+            reload_target self;
+            self.target = owner;
+            self.owner = owner;
+            self.pocket_index = -1;
+            self.ui_well_index = -1;
+            self.kind = reload_target::kind::loaded_mag;
+            opts.push_back( self );
+        }
+    };
+
+    append_owner( target );
+    for( const item *mod : target->gunmods() ) {
+        append_owner( item_location( target, const_cast<item *>( mod ) ) );
     }
 
     return opts;
 }
 
+// Well entries require owner-level (gun ammo type) AND pocket-level
+// (item id, fullness) compatibility. Loaded-mag entries delegate to the
+// magazine's own can_reload_with.
+static bool reload_target_accepts( const reload_target &rt, const item_location &ammo )
+{
+    if( rt.kind == reload_target::kind::well ) {
+        if( !rt.owner.can_reload_with( ammo, true ) ) {
+            return false;
+        }
+        int idx = 0;
+        for( const item_pocket *p : rt.owner->get_pockets( []( const item_pocket & ) {
+        return true;
+    } ) ) {
+            if( idx == rt.pocket_index ) {
+                return p->is_type( pocket_type::MAGAZINE_WELL ) &&
+                       p->can_reload_with( *ammo, true );
+            }
+            ++idx;
+        }
+        return false;
+    }
+    return rt.target.can_reload_with( ammo, true );
+}
+
+const reload_target *find_matching_reload_target(
+    const std::vector<reload_target> &targets, const item_location &ammo )
+{
+    for( const reload_target &rt : targets ) {
+        if( reload_target_accepts( rt, ammo ) ) {
+            return &rt;
+        }
+    }
+    return nullptr;
+}
+
+std::vector<const reload_target *> find_all_matching_reload_targets(
+    const std::vector<reload_target> &targets, const item_location &ammo )
+{
+    std::vector<const reload_target *> out;
+    for( const reload_target &rt : targets ) {
+        if( reload_target_accepts( rt, ammo ) ) {
+            out.push_back( &rt );
+        }
+    }
+    return out;
+}
+
 // todo: this should happen when the entries are created, but that's a different refactoring
 void ammo_inventory_selector::set_all_entries_chosen_count()
 {
+    const std::vector<reload_target> targets = get_possible_reload_targets( reload_loc );
+
+    // One synthetic category per (owner, ui_well_index) renders as a header
+    // between groups. Build once per selector lifetime; clearing would dangle
+    // pointers held by inventory_entry::custom_category.
+    std::map<std::pair<const item *, int>, const item_category *> cat_map;
+    const bool wants_separators = targets.size() > 1;
+    if( wants_separators && reload_well_categories.empty() ) {
+        int sort_rank = 0;
+        for( const reload_target &rt : targets ) {
+            const std::pair<const item *, int> key{ rt.owner.get_item(), rt.ui_well_index };
+            if( cat_map.count( key ) ) {
+                continue;
+            }
+            std::string label;
+            if( rt.kind == reload_target::kind::well ) {
+                const item_pocket *well = nullptr;
+                int idx = 0;
+                for( const item_pocket *p : rt.owner->get_pockets( []( const item_pocket & ) {
+                return true;
+            } ) ) {
+                    if( idx == rt.pocket_index ) {
+                        well = p;
+                        break;
+                    }
+                    ++idx;
+                }
+                if( well != nullptr && !well->magazine_default().is_null() ) {
+                    label = string_format( _( "%s well" ), item::nname( well->magazine_default() ) );
+                } else {
+                    label = _( "magazine well" );
+                }
+            } else if( rt.target ) {
+                label = string_format( _( "top up %s" ), rt.target->tname() );
+            }
+            if( rt.owner != reload_loc ) {
+                label = string_format( _( "%s: %s" ), rt.owner->tname(), label );
+            }
+            translation header = no_translation( label );
+            reload_well_categories.emplace_back(
+                item_category_id( "RELOAD_WELL_" + std::to_string( reload_well_categories.size() ) ),
+                header, header, sort_rank++ );
+            cat_map[key] = &reload_well_categories.back();
+        }
+    } else if( wants_separators ) {
+        // Subsequent calls: rebuild the map using existing category pointers.
+        std::set<std::pair<const item *, int>> seen;
+        auto cat_it = reload_well_categories.begin();
+        for( const reload_target &rt : targets ) {
+            const std::pair<const item *, int> key{ rt.owner.get_item(), rt.ui_well_index };
+            if( !seen.insert( key ).second ) {
+                continue;
+            }
+            if( cat_it == reload_well_categories.end() ) {
+                break;
+            }
+            cat_map[key] = &*cat_it;
+            ++cat_it;
+        }
+    }
+
     for( inventory_column *col : columns ) {
         for( inventory_entry *entry : col->get_entries( return_item, true ) ) {
-            for( const item_location &loc : get_possible_reload_targets( reload_loc ) ) {
-                item_location it = entry->any_item();
-                if( loc.can_reload_with( it, true ) ) {
-                    item::reload_option tmp_opt( &u, loc, it );
-                    int count = entry->get_available_count();
-                    if( it->has_flag( flag_SPEEDLOADER ) || it->has_flag( flag_SPEEDLOADER_CLIP ) ) {
-                        count = it->ammo_remaining( );
-                    }
-                    tmp_opt.qty( count );
-                    entry->chosen_count = tmp_opt.qty();
-                    break;
-                }
+            item_location it = entry->any_item();
+            const reload_target *match = find_matching_reload_target( targets, it );
+            if( match == nullptr ) {
+                continue;
+            }
+            item::reload_option tmp_opt( &u, match->target, it, match->pocket_index );
+            int count = entry->get_available_count();
+            if( it->has_flag( flag_SPEEDLOADER ) || it->has_flag( flag_SPEEDLOADER_CLIP ) ) {
+                count = it->ammo_remaining( );
+            }
+            tmp_opt.qty( count );
+            entry->chosen_count = tmp_opt.qty();
+            const std::pair<const item *, int> key{ match->owner.get_item(), match->ui_well_index };
+            const auto cit = cat_map.find( key );
+            if( cit != cat_map.end() ) {
+                entry->set_custom_category( cit->second );
             }
         }
     }
@@ -4010,13 +4162,17 @@ void ammo_inventory_selector::mod_chosen_count( inventory_entry &entry, int valu
     if( !entry.any_item()->is_ammo() ) {
         return;
     }
-    for( const item_location &loc : get_possible_reload_targets( reload_loc ) ) {
-        if( loc.can_reload_with( entry.any_item(), true ) ) {
-            item::reload_option tmp_opt( &u, loc, entry.any_item() );
-            tmp_opt.qty( entry.chosen_count + value );
-            entry.chosen_count = tmp_opt.qty();
-            break;
-        }
+    const std::vector<reload_target> targets = get_possible_reload_targets( reload_loc );
+    const reload_target *match = find_matching_reload_target( targets, entry.any_item() );
+    if( match != nullptr ) {
+        item::reload_option tmp_opt( &u, match->target, entry.any_item(), match->pocket_index );
+        tmp_opt.qty( entry.chosen_count + value );
+        entry.chosen_count = tmp_opt.qty();
+    }
+    const item_location loc = entry.any_item();
+    if( std::find( player_adjusted_ammo_locs.begin(), player_adjusted_ammo_locs.end(), loc ) ==
+        player_adjusted_ammo_locs.end() ) {
+        player_adjusted_ammo_locs.push_back( loc );
     }
 
     entry.make_entry_cell_cache( preset );
@@ -4037,7 +4193,11 @@ drop_location ammo_inventory_selector::execute()
                     ui_manager::redraw();
                 }
             } else if( input.action == "ANY_INPUT" || input.action == "SELECT" ) {
-                return { input.entry->any_item(), static_cast<int>( input.entry->chosen_count ) };
+                const item_location chosen_loc = input.entry->any_item();
+                last_player_adjusted = std::find( player_adjusted_ammo_locs.begin(),
+                                                  player_adjusted_ammo_locs.end(),
+                                                  chosen_loc ) != player_adjusted_ammo_locs.end();
+                return { chosen_loc, static_cast<int>( input.entry->chosen_count ) };
             } else {
                 if( highlight( input.entry->any_item() ) ) {
                     ui_manager::redraw();
@@ -4045,11 +4205,16 @@ drop_location ammo_inventory_selector::execute()
                 on_input( input );
             }
         } else if( input.action == "QUIT" ) {
+            last_player_adjusted = false;
             return drop_location();
         } else if( input.action == "CONFIRM" ) {
             const inventory_entry &highlighted = get_active_column().get_highlighted();
             if( highlighted && highlighted.is_selectable() ) {
-                return { highlighted.any_item(), static_cast<int>( highlighted.chosen_count ) };
+                const item_location chosen_loc = highlighted.any_item();
+                last_player_adjusted = std::find( player_adjusted_ammo_locs.begin(),
+                                                  player_adjusted_ammo_locs.end(),
+                                                  chosen_loc ) != player_adjusted_ammo_locs.end();
+                return { chosen_loc, static_cast<int>( highlighted.chosen_count ) };
             }
         } else if( input.action == "INCREASE_COUNT" ) {
             inventory_entry &highlighted = get_active_column().get_highlighted();

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -26,6 +26,7 @@
 #include "debug.h"
 #include "input_context.h"
 #include "item.h"
+#include "item_category.h"
 #include "item_location.h"
 #include "item_pocket.h"
 #include "memory_fast.h"
@@ -40,7 +41,6 @@ class JsonObject;
 class JsonOut;
 class basecamp;
 class inventory_selector_preset;
-class item_category;
 class item_stack;
 class string_input_popup;
 class tinymap;
@@ -1034,7 +1034,32 @@ class container_inventory_selector : public inventory_pick_selector
         item_location loc;
 };
 
-std::vector<item_location> get_possible_reload_targets( const item_location &target );
+// One reload destination: either a MAGAZINE_WELL slot (kind::well) or an
+// already-loaded magazine accepting loose ammo (kind::loaded_mag). owner is
+// the gun/gunmod containing the well; ui_well_index groups entries in the UI.
+struct reload_target {
+    enum class kind {
+        well,
+        loaded_mag,
+    };
+
+    item_location target;
+    item_location owner;
+    int pocket_index = -1;
+    int ui_well_index = -1;
+    kind kind = kind::well;
+};
+
+std::vector<reload_target> get_possible_reload_targets( const item_location &target );
+
+// First reload_target accepting the given ammo, or nullptr.
+const reload_target *find_matching_reload_target(
+    const std::vector<reload_target> &targets, const item_location &ammo );
+
+// Every reload_target accepting the given ammo. Used to detect ambiguous
+// reloads (multiple matching wells / loaded mags) for disambiguation prompts.
+std::vector<const reload_target *> find_all_matching_reload_targets(
+    const std::vector<reload_target> &targets, const item_location &ammo );
 class ammo_inventory_selector : public inventory_selector
 {
     public:
@@ -1043,9 +1068,21 @@ class ammo_inventory_selector : public inventory_selector
 
         drop_location execute();
         void set_all_entries_chosen_count();
+        // True if the user changed the count for the entry returned by
+        // the most recent execute().
+        bool last_choice_count_player_adjusted() const {
+            return last_player_adjusted;
+        }
     private:
         void mod_chosen_count( inventory_entry &entry, int val );
         const item_location reload_loc;
+        // Keyed on item_location so the signal survives column rebuilds
+        // caused by filtering during the menu session.
+        std::vector<item_location> player_adjusted_ammo_locs;
+        bool last_player_adjusted = false;
+        // Per-well synthetic categories. std::list keeps pointers stable for
+        // inventory_entry::custom_category.
+        std::list<item_category> reload_well_categories;
 };
 
 /**

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1569,20 +1569,99 @@ std::string item::display_name( unsigned int quantity ) const
     int amount = 0;
     int max_amount = 0;
     bool show_amt = false;
+    bool amt_built_for_multimag = false;
     // We should handle infinite charges properly in all cases.
     if( is_book() && get_chapters() > 0 ) {
         // a book which has remaining unread chapters
         amount = get_remaining_chapters( player_character );
-    } else if( magazine_current() ) {
-        show_amt = true;
-        const item *mag = magazine_current();
-        amount = ammo_remaining( );
-        const itype *adata = mag->ammo_data();
-        if( adata ) {
-            max_amount = mag->ammo_capacity( adata->ammo->type );
+    } else if( magazine_current() || get_pockets( []( const item_pocket & p ) {
+    return p.is_type( pocket_type::MAGAZINE_WELL );
+    } ).size() > 1 ) {
+        const std::vector<const item_pocket *> well_pockets = get_pockets(
+        []( const item_pocket & p ) {
+            return p.is_type( pocket_type::MAGAZINE_WELL );
+        } );
+        if( well_pockets.size() > 1 ) {
+            // Multi-well: show every well, loaded or not.
+            const bool show_ammo_name = is_gun() && ammo_required() &&
+                                        get_option<bool>( "AMMO_IN_NAMES" );
+            std::vector<std::string> segments;
+            for( const item_pocket *p : well_pockets ) {
+                const item *mag = p->magazine_current();
+                int well_amount = 0;
+                int well_max = 0;
+                const itype *ammo_for_name = nullptr;
+                itype_id ammo_id_for_name;
+                if( mag != nullptr ) {
+                    well_amount = mag->ammo_remaining();
+                    const itype *adata = mag->ammo_data();
+                    well_max = adata
+                               ? mag->ammo_capacity( adata->ammo->type )
+                               : mag->ammo_capacity( item_controller->find_template(
+                                                         mag->ammo_default() )->ammo->type );
+                    ammo_for_name = adata;
+                    ammo_id_for_name = mag->ammo_current();
+                    if( ammo_id_for_name.is_null() ) {
+                        ammo_id_for_name = mag->ammo_default();
+                    }
+                } else {
+                    const itype_id default_mag = p->magazine_default();
+                    if( !default_mag.is_null() && default_mag->magazine ) {
+                        const itype_id &default_ammo = default_mag->magazine->default_ammo;
+                        if( !default_ammo.is_null() && default_ammo->ammo ) {
+                            well_max = default_mag->magazine->capacity;
+                            ammo_for_name = &*default_ammo;
+                            ammo_id_for_name = default_ammo;
+                        }
+                    }
+                }
+                nc_color color = c_white;
+                if( well_amount == 0 ) {
+                    color = c_light_red;
+                } else if( well_max > 0 && well_amount < well_max ) {
+                    const double ratio = static_cast<double>( well_amount ) /
+                                         static_cast<double>( well_max );
+                    if( ratio < 1.0 / 3.0 ) {
+                        color = c_red;
+                    } else if( ratio < 2.0 / 3.0 ) {
+                        color = c_yellow;
+                    } else {
+                        color = c_light_green;
+                    }
+                }
+                std::string segment = colorize( string_format( "%i/%i", well_amount, well_max ),
+                                                color );
+                if( show_ammo_name && !ammo_id_for_name.is_null() ) {
+                    std::string ammoname = ammo_id_for_name->nname( 1 );
+                    if( ammoname.empty() && ammo_for_name && ammo_for_name->ammo ) {
+                        ammoname = ammo_for_name->ammo->type->name();
+                    }
+                    if( !ammoname.empty() ) {
+                        segment += " " + ammoname;
+                    }
+                }
+                segments.emplace_back( segment );
+            }
+            std::string joined;
+            for( size_t i = 0; i < segments.size(); ++i ) {
+                if( i > 0 ) {
+                    joined += ", ";
+                }
+                joined += segments[i];
+            }
+            amt = " (" + joined + ")";
+            amt_built_for_multimag = true;
         } else {
-            max_amount = mag->ammo_capacity( item_controller->find_template(
-                                                 mag->ammo_default() )->ammo->type );
+            show_amt = true;
+            const item *mag = magazine_current();
+            amount = ammo_remaining( );
+            const itype *adata = mag->ammo_data();
+            if( adata ) {
+                max_amount = mag->ammo_capacity( adata->ammo->type );
+            } else {
+                max_amount = mag->ammo_capacity( item_controller->find_template(
+                                                     mag->ammo_default() )->ammo->type );
+            }
         }
     } else if( is_tool() && has_flag( flag_USES_NEARBY_AMMO ) ) {
         show_amt = true;
@@ -1632,37 +1711,39 @@ std::string item::display_name( unsigned int quantity ) const
         }
     }
 
-    if( ( amount || show_amt ) && !has_flag( flag_PSEUDO ) ) {
-        if( is_money() ) {
-            amt = " " + format_money( amount );
-        } else {
-            if( !ammotext.empty() ) {
-                ammotext = " " + ammotext;
-            }
-
-            if( max_amount != 0 ) {
-                const double ratio = static_cast<double>( amount ) / static_cast<double>( max_amount );
-                nc_color charges_color;
-                if( amount == 0 ) {
-                    charges_color = c_light_red;
-                } else if( amount == max_amount ) {
-                    charges_color = c_white;
-                } else if( ratio < 1.0 / 3.0 ) {
-                    charges_color = c_red;
-                } else if( ratio < 2.0 / 3.0 ) {
-                    charges_color = c_yellow;
-                } else {
-                    charges_color = c_light_green;
-                }
-                amt = string_format( " (%s%s)", colorize( string_format( "%i/%i", amount, max_amount ),
-                                     charges_color ),
-                                     ammotext );
+    if( !amt_built_for_multimag ) {
+        if( ( amount || show_amt ) && !has_flag( flag_PSEUDO ) ) {
+            if( is_money() ) {
+                amt = " " + format_money( amount );
             } else {
-                amt = string_format( " (%i%s)", amount, ammotext );
+                if( !ammotext.empty() ) {
+                    ammotext = " " + ammotext;
+                }
+
+                if( max_amount != 0 ) {
+                    const double ratio = static_cast<double>( amount ) / static_cast<double>( max_amount );
+                    nc_color charges_color;
+                    if( amount == 0 ) {
+                        charges_color = c_light_red;
+                    } else if( amount == max_amount ) {
+                        charges_color = c_white;
+                    } else if( ratio < 1.0 / 3.0 ) {
+                        charges_color = c_red;
+                    } else if( ratio < 2.0 / 3.0 ) {
+                        charges_color = c_yellow;
+                    } else {
+                        charges_color = c_light_green;
+                    }
+                    amt = string_format( " (%s%s)", colorize( string_format( "%i/%i", amount, max_amount ),
+                                         charges_color ),
+                                         ammotext );
+                } else {
+                    amt = string_format( " (%i%s)", amount, ammotext );
+                }
             }
+        } else if( !ammotext.empty() ) {
+            amt = " (" + ammotext + ")";
         }
-    } else if( !ammotext.empty() ) {
-        amt = " (" + ammotext + ")";
     }
 
     if( has_link_data() ) {

--- a/src/item.h
+++ b/src/item.h
@@ -2808,6 +2808,30 @@ class item : public visitable
         itype_id magazine_default( bool conversion = false ) const;
 
         /**
+         * Default magazine of every MAGAZINE_WELL pocket directly on this item.
+         * Wells with no default contribute NULL_ID. Does not walk into gunmods'
+         * own internal pockets; spawn-time and ambiguity checks operate on the
+         * host's own wells (mod-supplied wells are folded in via
+         * update_modified_pockets).
+         */
+        std::vector<itype_id> magazines_default() const;
+
+        /**
+         * Every MAGAZINE_WELL pocket directly on this item. Same scope rule as
+         * magazines_default().
+         */
+        std::vector<item_pocket *> all_magazine_well_pockets();
+        std::vector<const item_pocket *> all_magazine_well_pockets() const;
+
+        /**
+         * Spawn-time dressing for every MAGAZINE_WELL on this item.
+         * Empty wells get the default magazine when insert_default_mag is true;
+         * present-but-empty magazines get default ammo when fill_with_default_ammo
+         * is true; loaded magazines are untouched.
+         */
+        void dress_magazine_wells( bool insert_default_mag, bool fill_with_default_ammo );
+
+        /**
          * Get compatible magazines (if any) for this item.
          * @return magazine compatibility which is always empty if item has integral magazine.
          * @see item::magazine_integral.

--- a/src/item.h
+++ b/src/item.h
@@ -606,11 +606,18 @@ class item : public visitable
                 reload_option &operator=( const reload_option & );
 
                 reload_option( const Character *who, const item_location &target, const item_location &ammo );
+                reload_option( const Character *who, const item_location &target, const item_location &ammo,
+                               int pocket_index );
 
                 const Character *who = nullptr;
                 item_location target;
                 item_location ammo;
                 bool is_reload_one = false;
+                // MAGAZINE_WELL pocket index in target->contents. Negative =
+                // first-compatible-well fallback.
+                // TODO(multimag): drop the default once all callers carry an
+                // explicit pocket_index.
+                int pocket_index = -1;
 
                 int qty() const {
                     return qty_;
@@ -632,8 +639,11 @@ class item : public visitable
          * @param u Player doing the reloading
          * @param ammo Location of ammo to be reloaded
          * @param qty caps reloading to this (or fewer) units
+         * @param pocket_index Optional index in this->contents identifying
+         *        which MAGAZINE_WELL pocket to reload. Negative falls
+         *        through to first-compatible-well selection.
          */
-        bool reload( Character &u, item_location ammo, int qty );
+        bool reload( Character &u, item_location ammo, int qty, int pocket_index = -1 );
         // is this speedloader compatible with this item?
         bool allows_speedloader( const itype_id &speedloader_id ) const;
 
@@ -2652,6 +2662,16 @@ class item : public visitable
          * if this item is not loaded, gives remaining capacity of its default ammo
          */
         int remaining_ammo_capacity() const;
+
+        /**
+         * Per-MAGAZINE_WELL-pocket overloads. The index is the pocket position
+         * in this->contents (insertion order). Out-of-range or non-MAGAZINE_WELL
+         * indices return 0. Use these to ask about a specific well on items
+         * with more than one MAGAZINE_WELL pocket.
+         */
+        int ammo_remaining( int well_idx ) const;
+        int ammo_capacity( int well_idx ) const;
+        int remaining_ammo_capacity( int well_idx ) const;
 
         /** Quantity of ammunition consumed per usage of tool or with each shot of gun */
         int ammo_required() const;

--- a/src/item_container.cpp
+++ b/src/item_container.cpp
@@ -111,16 +111,36 @@ void item::clear_automatic_whitelist()
 
 void item::update_modified_pockets()
 {
-    std::optional<const pocket_data *> mag_or_mag_well;
+    std::vector<const pocket_data *> mag_or_mag_wells;
     std::vector<const pocket_data *> container_pockets;
+
+    // Mods that supply magazine pockets via pocket_mods replace the base
+    // item's mag wells (e.g. battery adapter mods). Without a mag-supplying
+    // mod, the base item's wells are preserved as-is.
+    bool mod_supplies_mag_pockets = false;
+    for( const item *mod : mods() ) {
+        if( mod->type->mod ) {
+            for( const pocket_data &pocket : mod->type->mod->add_pockets ) {
+                if( pocket.type == pocket_type::MAGAZINE ||
+                    pocket.type == pocket_type::MAGAZINE_WELL ) {
+                    mod_supplies_mag_pockets = true;
+                    break;
+                }
+            }
+        }
+        if( mod_supplies_mag_pockets ) {
+            break;
+        }
+    }
 
     // Prevent cleanup of pockets belonging to the item base type
     for( const pocket_data &pocket : type->pockets ) {
         if( pocket.type == pocket_type::CONTAINER ) {
             container_pockets.push_back( &pocket );
-        } else if( pocket.type == pocket_type::MAGAZINE ||
-                   pocket.type == pocket_type::MAGAZINE_WELL ) {
-            mag_or_mag_well = &pocket;
+        } else if( !mod_supplies_mag_pockets &&
+                   ( pocket.type == pocket_type::MAGAZINE ||
+                     pocket.type == pocket_type::MAGAZINE_WELL ) ) {
+            mag_or_mag_wells.push_back( &pocket );
         }
     }
 
@@ -140,13 +160,13 @@ void item::update_modified_pockets()
                     container_pockets.push_back( &pocket );
                 } else if( pocket.type == pocket_type::MAGAZINE ||
                            pocket.type == pocket_type::MAGAZINE_WELL ) {
-                    mag_or_mag_well = &pocket;
+                    mag_or_mag_wells.push_back( &pocket );
                 }
             }
         }
     }
 
-    contents.update_modified_pockets( mag_or_mag_well, container_pockets );
+    contents.update_modified_pockets( std::move( mag_or_mag_wells ), std::move( container_pockets ) );
 }
 
 bool item::same_contents( const item &rhs ) const

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -7,6 +7,7 @@
 #include <iterator>
 #include <map>
 #include <numeric>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <tuple>
@@ -2109,10 +2110,9 @@ std::vector<const item *> item_contents::cables() const
 }
 
 void item_contents::update_modified_pockets(
-    const std::optional<const pocket_data *> &mag_or_mag_well,
+    std::vector<const pocket_data *> mag_or_mag_wells,
     std::vector<const pocket_data *> container_pockets )
 {
-    bool mag_or_well_found = false;
     for( auto pocket_iter = contents.begin(); pocket_iter != contents.end(); ) {
         item_pocket &pocket = *pocket_iter;
         if( pocket.is_type( pocket_type::CONTAINER ) ) {
@@ -2146,19 +2146,21 @@ void item_contents::update_modified_pockets(
 
         } else if( pocket.is_type( pocket_type::MAGAZINE ) ||
                    pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
-            if( mag_or_mag_well ) {
-                if( pocket.get_pocket_data() != *mag_or_mag_well ) {
-                    if( !pocket.empty() ) {
-                        // in case the debugmsg wasn't clear, this should never happen
-                        debugmsg( "Oops!  deleted some items when updating pockets that were added via toolmods" );
-                    }
-                    pocket_iter = contents.erase( pocket_iter );
-                } else {
-                    mag_or_well_found = true;
-                    ++pocket_iter;
+            const pocket_data *current = pocket.get_pocket_data();
+            bool matched = false;
+            for( auto it = mag_or_mag_wells.begin(); it != mag_or_mag_wells.end(); ++it ) {
+                if( *it == current ) {
+                    mag_or_mag_wells.erase( it );
+                    matched = true;
+                    break;
                 }
+            }
+            if( matched ) {
+                ++pocket_iter;
             } else {
-                // no mag or mag well, so it needs to be erased
+                if( !pocket.empty() ) {
+                    debugmsg( "Oops!  deleted some items when updating pockets that were added via toolmods" );
+                }
                 pocket_iter = contents.erase( pocket_iter );
             }
         } else {
@@ -2170,10 +2172,9 @@ void item_contents::update_modified_pockets(
     for( const pocket_data *container_pocket : container_pockets ) {
         contents.emplace_back( container_pocket );
     }
-    if( mag_or_mag_well && !mag_or_well_found ) {
-        contents.emplace_back( *mag_or_mag_well );
+    for( const pocket_data *mw : mag_or_mag_wells ) {
+        contents.emplace_back( mw );
     }
-
 }
 
 std::set<itype_id> item_contents::magazine_compatible() const

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2203,6 +2203,17 @@ itype_id item_contents::magazine_default() const
     return itype_id::NULL_ID();
 }
 
+std::vector<itype_id> item_contents::magazines_default() const
+{
+    std::vector<itype_id> result;
+    for( const item_pocket &pocket : contents ) {
+        if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
+            result.push_back( pocket.magazine_default() );
+        }
+    }
+    return result;
+}
+
 units::mass item_contents::total_container_weight_capacity( const bool unrestricted_pockets_only )
 const
 {

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -5,7 +5,6 @@
 #include <cstddef>
 #include <functional>
 #include <list>
-#include <optional>
 #include <set>
 #include <string>
 #include <utility>
@@ -179,7 +178,7 @@ class item_contents
         std::vector<item *> cables();
         std::vector<const item *> cables() const;
 
-        void update_modified_pockets( const std::optional<const pocket_data *> &mag_or_mag_well,
+        void update_modified_pockets( std::vector<const pocket_data *> mag_or_mag_wells,
                                       std::vector<const pocket_data *> container_pockets );
         // all magazines compatible with any pockets.
         // this only checks MAGAZINE_WELL

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -189,6 +189,11 @@ class item_contents
          */
         itype_id magazine_default() const;
         /**
+         * Default magazine of every directly-owned MAGAZINE_WELL pocket.
+         * Does NOT walk into MOD pockets; use item::magazines_default() for that.
+         */
+        std::vector<itype_id> magazines_default() const;
+        /**
          * This function is to aid migration to using nested containers.
          * The call sites of this function need to be updated to search the
          * pockets of the item, or not assume there is only one pocket or item.

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -611,6 +611,17 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
             new_item.charges = std::max( 1, max_capacity );
         }
 
+        const std::vector<itype_id> well_defaults = new_item.magazines_default();
+        const bool is_multi_well = well_defaults.size() > 1;
+
+        if( ch != -1 && is_multi_well ) {
+            // TODO(multimag): per-well charges JSON keys (e.g. well_charges: [N, M]).
+            debugmsg( "in %s: 'charges' is ambiguous on multi-well item '%s'; "
+                      "use per-well JSON when available",
+                      context, new_item.typeId().str() );
+            ch = -1;
+        }
+
         if( ch != -1 ) {
             if( new_item.count_by_charges() || new_item.made_of( phase_id::LIQUID ) ) {
                 // food, ammo
@@ -663,11 +674,17 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
 
         if( new_item.is_magazine() ||
             new_item.has_pocket_type( pocket_type::MAGAZINE_WELL ) ) {
-            bool spawn_ammo = rng( 0, 99 ) < with_ammo && new_item.ammo_remaining() == 0 && ch == -1;
-            bool spawn_mag = rng( 0, 99 ) < with_magazine && !new_item.magazine_integral() &&
-                             !new_item.magazine_current();
+            bool spawn_ammo = rng( 0, 99 ) < with_ammo && ch == -1;
+            bool spawn_mag = rng( 0, 99 ) < with_magazine && !new_item.magazine_integral();
+            if( !is_multi_well ) {
+                spawn_ammo = spawn_ammo && new_item.ammo_remaining() == 0;
+                spawn_mag = spawn_mag && !new_item.magazine_current();
+            }
 
-            if( spawn_mag ) {
+            if( is_multi_well ) {
+                // TODO(multimag): per-well ammo-chance / magazine-chance JSON keys.
+                new_item.dress_magazine_wells( spawn_mag, spawn_ammo );
+            } else if( spawn_mag ) {
                 item mag( new_item.magazine_default(), new_item.birthday() );
                 if( spawn_ammo && !mag.ammo_default().is_null() ) {
                     mag.ammo_set( mag.ammo_default() );

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -1498,6 +1498,68 @@ int item::remaining_ammo_capacity() const
     return ammo_capacity( loaded_ammo->ammo->type ) - ammo_remaining( );
 }
 
+// Returns the MAGAZINE_WELL pocket at well_idx in contents, or nullptr if
+// out of range or the pocket at that index is not a MAGAZINE_WELL.
+static const item_pocket *well_pocket_at( const item &it, int well_idx )
+{
+    if( well_idx < 0 ) {
+        return nullptr;
+    }
+    const std::vector<const item_pocket *> all = it.get_pockets(
+    []( const item_pocket & ) {
+        return true;
+    } );
+    if( well_idx >= static_cast<int>( all.size() ) ) {
+        return nullptr;
+    }
+    const item_pocket *p = all[well_idx];
+    if( !p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+        return nullptr;
+    }
+    return p;
+}
+
+int item::ammo_remaining( int well_idx ) const
+{
+    const item_pocket *p = well_pocket_at( *this, well_idx );
+    if( p == nullptr ) {
+        return 0;
+    }
+    const item *mag = p->magazine_current();
+    return mag ? mag->ammo_remaining() : 0;
+}
+
+int item::ammo_capacity( int well_idx ) const
+{
+    const item_pocket *p = well_pocket_at( *this, well_idx );
+    if( p == nullptr ) {
+        return 0;
+    }
+    const item *mag = p->magazine_current();
+    if( !mag ) {
+        return 0;
+    }
+    const itype *adata = mag->ammo_data();
+    if( adata ) {
+        return mag->ammo_capacity( adata->ammo->type );
+    }
+    const itype_id default_ammo = mag->ammo_default();
+    if( !default_ammo.is_null() && default_ammo->ammo ) {
+        return mag->ammo_capacity( default_ammo->ammo->type );
+    }
+    return 0;
+}
+
+int item::remaining_ammo_capacity( int well_idx ) const
+{
+    const item_pocket *p = well_pocket_at( *this, well_idx );
+    if( p == nullptr ) {
+        return 0;
+    }
+    const item *mag = p->magazine_current();
+    return mag ? mag->remaining_ammo_capacity() : 0;
+}
+
 int item::ammo_capacity( const ammotype &ammo, bool include_linked ) const
 {
     map &here = get_map();
@@ -2269,7 +2331,11 @@ item::reload_option &item::reload_option::operator=( const reload_option & ) = d
 
 item::reload_option::reload_option( const Character *who, const item_location &target,
                                     const item_location &ammo ) :
-    who( who ), target( target ), ammo( ammo )
+    reload_option( who, target, ammo, -1 ) {}
+
+item::reload_option::reload_option( const Character *who, const item_location &target,
+                                    const item_location &ammo, int pocket_index ) :
+    who( who ), target( target ), ammo( ammo ), pocket_index( pocket_index )
 {
     if( this->target->is_ammo_belt() && this->target->type->magazine->linkage ) {
         max_qty = this->who->charges_of( * this->target->type->magazine->linkage );
@@ -2293,6 +2359,12 @@ int item::reload_option::moves() const
 
 void item::reload_option::qty( int val )
 {
+    // Pocket-targeted reloads swap exactly one magazine.
+    if( pocket_index >= 0 ) {
+        qty_ = 1;
+        return;
+    }
+
     bool ammo_in_container = ammo->is_ammo_container();
     bool ammo_in_liquid_container = ammo->is_watertight_container();
     item &ammo_obj = ( ammo_in_container || ammo_in_liquid_container ) ?
@@ -2353,7 +2425,7 @@ void item::casings_handle( const std::function<bool( item & )> &func )
     contents.casings_handle( func );
 }
 
-bool item::reload( Character &u, item_location ammo, int qty )
+bool item::reload( Character &u, item_location ammo, int qty, int pocket_index )
 {
     if( qty <= 0 ) {
         debugmsg( "Tried to reload zero or less charges" );
@@ -2363,6 +2435,60 @@ bool item::reload( Character &u, item_location ammo, int qty )
     if( !ammo ) {
         debugmsg( "Tried to reload using non-existent ammo" );
         return false;
+    }
+
+    // Swap the magazine in the targeted MAGAZINE_WELL only; other wells untouched.
+    if( pocket_index >= 0 ) {
+        std::vector<item_pocket *> all_pockets = get_pockets(
+        []( const item_pocket & ) {
+            return true;
+        } );
+        if( pocket_index >= static_cast<int>( all_pockets.size() ) ) {
+            debugmsg( "reload: pocket_index %d out of range on %s", pocket_index, tname() );
+            return false;
+        }
+        item_pocket *target_pocket = all_pockets[pocket_index];
+        if( !target_pocket->is_type( pocket_type::MAGAZINE_WELL ) ) {
+            debugmsg( "reload: pocket_index %d on %s is not a MAGAZINE_WELL",
+                      pocket_index, tname() );
+            return false;
+        }
+        if( !target_pocket->can_reload_with( *ammo.get_item(), true ) ) {
+            return false;
+        }
+
+        const bool ammo_from_map = !ammo.held_by( u );
+        if( ammo->has_flag( flag_SPEEDLOADER ) || ammo->has_flag( flag_SPEEDLOADER_CLIP ) ) {
+            ammo = item_location( ammo, &ammo->first_ammo() );
+        }
+
+        item magazine_removed;
+        bool allow_wield = false;
+        if( !target_pocket->empty() ) {
+            item *existing = target_pocket->magazine_current();
+            if( existing != nullptr ) {
+                allow_wield = ( !u.is_wielding( *ammo ) && !u.is_wielding( *this ) );
+                magazine_removed = *existing;
+                target_pocket->remove_item( *existing );
+            }
+        }
+
+        ret_val<item *> ins = target_pocket->insert_item( *ammo );
+        if( !ins.success() ) {
+            // Restore the ejected magazine on failure.
+            if( !magazine_removed.is_null() ) {
+                target_pocket->insert_item( magazine_removed );
+            }
+            return false;
+        }
+        ammo.remove_item();
+        if( ammo_from_map ) {
+            u.invalidate_weight_carried_cache();
+        }
+        if( !magazine_removed.is_null() ) {
+            u.i_add( magazine_removed, true, nullptr, nullptr, true, allow_wield );
+        }
+        return true;
     }
 
     if( !can_reload_with( *ammo.get_item(), true ) ) {

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -36,6 +36,7 @@
 #include "explosion.h"
 #include "faction.h"
 #include "flag.h"
+#include "flat_set.h"
 #include "game.h"
 #include "game_constants.h"
 #include "generic_factory.h"
@@ -971,13 +972,41 @@ bool item::can_reload_with( const item &ammo, bool now ) const
     }
 
     if( now && ammo.is_magazine() && !ammo.empty() ) {
+        const ammotype loaded_at = ammo.contents.first_ammo().ammo_type();
         if( is_tool() ) {
             // Dirty hack because "ammo" on tools is actually completely separate thing from "ammo" on guns and "ammo_types()" works only for guns
-            if( !type->tool->ammo_id.count( ammo.contents.first_ammo().ammo_type() ) ) {
+            if( !type->tool->ammo_id.count( loaded_at ) ) {
                 return false;
             }
-        } else {
-            if( !ammo_types().count( ammo.contents.first_ammo().ammo_type() ) ) {
+        } else if( !ammo_types().count( loaded_at ) ) {
+            // Sibling MAGAZINE_WELLs may take auxiliary ammotypes outside the
+            // gun's primary `ammo` field. Accept if any well's allowed mags
+            // have a MAGAZINE pocket restricted to this ammo type.
+            bool well_match = false;
+            for( const item_pocket *p : contents.get_all_reloadable_pockets() ) {
+                if( !p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                    continue;
+                }
+                for( const itype_id &mag_id : p->item_type_restrictions() ) {
+                    if( !mag_id->magazine ) {
+                        continue;
+                    }
+                    for( const pocket_data &mp : mag_id->pockets ) {
+                        if( mp.type == pocket_type::MAGAZINE &&
+                            mp.ammo_restriction.count( loaded_at ) ) {
+                            well_match = true;
+                            break;
+                        }
+                    }
+                    if( well_match ) {
+                        break;
+                    }
+                }
+                if( well_match ) {
+                    break;
+                }
+            }
+            if( !well_match ) {
                 return false;
             }
         }
@@ -1295,9 +1324,9 @@ int item::ammo_remaining( const map &here, const std::set<ammotype> &ammo, const
 
     int ret = 0;
 
-    // Magazine in the item
-    const item *mag = magazine_current();
-    if( mag ) {
+    // Sum ammo across every loaded MAGAZINE_WELL pocket.
+    // TODO(multimag): aggregate; per-well callers use the indexed overload.
+    for( const item *mag : magazines_current() ) {
         ret += mag->ammo_remaining( );
     }
 
@@ -1328,7 +1357,7 @@ int item::ammo_remaining( const map &here, const std::set<ammotype> &ammo, const
     }
 
     // Handle non-magazines with ammo_restriction in a CONTAINER type pocket (like quivers)
-    if( !( mag || is_magazine() || ammo.empty() ) ) {
+    if( magazines_current().empty() && !is_magazine() && !ammo.empty() ) {
         for( const item *e : contents.all_items_top( pocket_type::CONTAINER ) ) {
             if( e->is_ammo() && ammo.find( e->ammo_type() ) != ammo.end() ) {
                 ret += e->charges;
@@ -1453,6 +1482,12 @@ int item::remaining_ammo_capacity() const
         return 0;
     }
 
+    // First-loaded-mag fallback; per-pocket callers use the dedicated overload.
+    if( const item *mag = magazine_current() ) {
+        return mag->remaining_ammo_capacity();
+    }
+
+    // Integral mag: ammo_remaining() excludes MAGAZINE_WELL here.
     const itype *loaded_ammo = ammo_data();
     if( loaded_ammo == nullptr ) {
         loaded_ammo = item::find_type( ammo_default() );
@@ -3269,6 +3304,8 @@ bool item::is_reloadable() const
                 return true;
             }
         } else if( pocket->is_type( pocket_type::MAGAZINE ) ) {
+            // Parent aggregate stays correct when the integral mag is full
+            // of casings (not counted against ammo_remaining()).
             if( remaining_ammo_capacity() > 0 ) {
                 return true;
             }

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -2069,6 +2069,53 @@ std::set<itype_id> item::magazine_compatible() const
     return contents.magazine_compatible();
 }
 
+std::vector<itype_id> item::magazines_default() const
+{
+    return contents.magazines_default();
+}
+
+std::vector<item_pocket *> item::all_magazine_well_pockets()
+{
+    return get_pockets(
+    []( const item_pocket & p ) {
+        return p.is_type( pocket_type::MAGAZINE_WELL );
+    } );
+}
+
+std::vector<const item_pocket *> item::all_magazine_well_pockets() const
+{
+    return get_pockets(
+    []( const item_pocket & p ) {
+        return p.is_type( pocket_type::MAGAZINE_WELL );
+    } );
+}
+
+void item::dress_magazine_wells( bool insert_default_mag, bool fill_with_default_ammo )
+{
+    for( item_pocket *well : all_magazine_well_pockets() ) {
+        item *current_mag = well->magazine_current();
+        if( current_mag != nullptr ) {
+            if( fill_with_default_ammo && current_mag->ammo_remaining() == 0 &&
+                !current_mag->ammo_default().is_null() ) {
+                current_mag->ammo_set( current_mag->ammo_default() );
+            }
+            continue;
+        }
+        if( !insert_default_mag ) {
+            continue;
+        }
+        const itype_id mag_id = well->magazine_default();
+        if( mag_id.is_null() ) {
+            continue;
+        }
+        item mag( mag_id, birthday() );
+        if( fill_with_default_ammo && !mag.ammo_default().is_null() ) {
+            mag.ammo_set( mag.ammo_default() );
+        }
+        well->insert_item( mag );
+    }
+}
+
 item *item::magazine_current()
 {
     return contents.magazine_current();

--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -1312,11 +1312,19 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
                            "<info>" + skill.name() + "</info>" );
     }
 
-    if( mod->magazine_integral() || mod->magazine_current() ) {
-        if( mod->magazine_current() && parts->test( iteminfo_parts::GUN_MAGAZINE ) ) {
-            info.emplace_back( "GUN", _( "Magazine: " ),
-                               string_format( "<stat>%s</stat>",
-                                              mod->magazine_current()->tname() ) );
+    if( mod->magazine_integral() || !mod->magazines_current().empty() ) {
+        const std::vector<const item *> loaded_mags = mod->magazines_current();
+        if( !loaded_mags.empty() && parts->test( iteminfo_parts::GUN_MAGAZINE ) ) {
+            std::string mag_names;
+            for( size_t i = 0; i < loaded_mags.size(); ++i ) {
+                if( i > 0 ) {
+                    mag_names += ", ";
+                }
+                mag_names += loaded_mags[i]->tname();
+            }
+            info.emplace_back( "GUN",
+                               n_gettext( "Magazine: ", "Magazines: ", loaded_mags.size() ),
+                               string_format( "<stat>%s</stat>", mag_names ) );
         }
         if( !mod->ammo_types().empty() && parts->test( iteminfo_parts::GUN_CAPACITY ) ) {
             for( const ammotype &at : mod->ammo_types() ) {
@@ -2728,9 +2736,18 @@ void item::tool_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
     }
 
     if( !magazine_integral() ) {
-        if( magazine_current() && parts->test( iteminfo_parts::TOOL_MAGAZINE_CURRENT ) ) {
-            info.emplace_back( "TOOL", _( "Magazine: " ),
-                               string_format( "<stat>%s</stat>", magazine_current()->tname() ) );
+        const std::vector<const item *> loaded_mags = magazines_current();
+        if( !loaded_mags.empty() && parts->test( iteminfo_parts::TOOL_MAGAZINE_CURRENT ) ) {
+            std::string mag_names;
+            for( size_t i = 0; i < loaded_mags.size(); ++i ) {
+                if( i > 0 ) {
+                    mag_names += ", ";
+                }
+                mag_names += loaded_mags[i]->tname();
+            }
+            info.emplace_back( "TOOL",
+                               n_gettext( "Magazine: ", "Magazines: ", loaded_mags.size() ),
+                               string_format( "<stat>%s</stat>", mag_names ) );
         }
 
         if( parts->test( iteminfo_parts::TOOL_MAGAZINE_COMPATIBLE ) ) {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6760,12 +6760,23 @@ std::vector<item *> map::place_items(
     }
     for( item *e : res ) {
         if( e->is_tool() || e->is_gun() || e->is_magazine() ) {
-            if( rng( 0, 99 ) < magazine && e->magazine_default() && !e->magazine_integral() &&
-                !e->magazine_current() ) {
-                e->put_in( item( e->magazine_default(), e->birthday() ), pocket_type::MAGAZINE_WELL );
+            const std::vector<itype_id> well_defaults = e->magazines_default();
+            const bool is_multi_well = well_defaults.size() > 1;
+            bool roll_mag = rng( 0, 99 ) < magazine && !e->magazine_integral();
+            if( !is_multi_well ) {
+                roll_mag = roll_mag && !e->magazine_current();
             }
-            if( rng( 0, 99 ) < ammo && e->ammo_default() && e->ammo_remaining( ) == 0 ) {
-                e->ammo_set( e->ammo_default() );
+            const bool roll_ammo = rng( 0, 99 ) < ammo;
+            // TODO(multimag): per-well magazine-chance / ammo-chance keys.
+            if( is_multi_well ) {
+                e->dress_magazine_wells( roll_mag, roll_ammo );
+            } else {
+                if( roll_mag && e->magazine_default() ) {
+                    e->put_in( item( e->magazine_default(), e->birthday() ), pocket_type::MAGAZINE_WELL );
+                }
+                if( roll_ammo && e->ammo_default() && e->ammo_remaining( ) == 0 ) {
+                    e->ammo_set( e->ammo_default() );
+                }
             }
         }
 

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -237,15 +238,26 @@ void mdeath::broken( map *here, monster &z )
                 for( const std::pair<const std::string, mtype_special_attack> &attack : z.type->special_attacks ) {
                     if( attack.second->id == "gun" ) {
                         item gun = item( dynamic_cast<const gun_actor *>( attack.second.get() )->gun_type );
-                        bool same_ammo = false;
-                        if( gun.typeId()->magazine_default.count( item( ammo_entry.first ).ammo_type() ) ) {
-                            same_ammo = true;
+                        const ammotype at = item( ammo_entry.first ).ammo_type();
+                        // TODO(multimag): picks the first well-default whose mag accepts this
+                        // ammo type. Sibling wells with the same ammotype but different default
+                        // magazines collapse to the first match.
+                        itype_id mag_id;
+                        for( const itype_id &well_default : gun.magazines_default() ) {
+                            if( well_default.is_null() ) {
+                                continue;
+                            }
+                            const std::set<ammotype> &mag_types = well_default->magazine->type;
+                            if( mag_types.find( at ) != mag_types.end() ) {
+                                mag_id = well_default;
+                                break;
+                            }
                         }
-                        if( same_ammo && gun.uses_magazine() ) {
+                        if( !mag_id.is_null() && gun.uses_magazine() ) {
                             std::vector<item> mags;
                             int ammo_count = ammo_entry.second;
                             while( ammo_count > 0 ) {
-                                item mag = item( gun.type->magazine_default.find( item( ammo_entry.first ).ammo_type() )->second );
+                                item mag = item( mag_id );
                                 mag.ammo_set( ammo_entry.first,
                                               std::min( ammo_count, mag.type->magazine->capacity ) );
                                 mags.insert( mags.end(), mag );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1003,16 +1003,28 @@ void starting_inv_ammo( npc &who, std::list<item> &res, int multiplier )
     item ammo = item();
     ammo_quantity = rng( 1, 2 ) * multiplier;
     if( weapon && weapon->is_gun() ) {
-        if( !weapon->magazine_default().is_null() ) {
-            ammo = item( weapon->magazine_default() );
-            ammo.ammo_set( ammo.ammo_default() );
+        const std::vector<itype_id> well_defaults = weapon->magazines_default();
+        std::vector<itype_id> non_null_defaults;
+        for( const itype_id &mag_id : well_defaults ) {
+            if( !mag_id.is_null() ) {
+                non_null_defaults.push_back( mag_id );
+            }
+        }
+        if( !non_null_defaults.empty() ) {
+            // One filled mag per well, cycling until count met or no carry space.
+            for( int i = 0; i < ammo_quantity; ++i ) {
+                ammo = item( non_null_defaults[i % non_null_defaults.size()] );
+                ammo.ammo_set( ammo.ammo_default() );
+                if( !who.can_stash( ammo ) ) {
+                    break;
+                }
+                res.push_back( ammo );
+            }
         } else if( !weapon->ammo_default().is_null() ) {
             ammo = item( weapon->ammo_default() );
-        } else {
-            return;
-        }
-        while( ammo_quantity-- != 0 && who.can_stash( ammo ) ) {
-            res.push_back( ammo );
+            while( ammo_quantity-- != 0 && who.can_stash( ammo ) ) {
+                res.push_back( ammo );
+            }
         }
     }
 }
@@ -1311,7 +1323,18 @@ void npc::starting_weapon( const npc_class_id &type )
     item_location weapon = get_wielded_item();
     if( weapon ) {
         if( weapon->is_gun() ) {
-            if( !weapon->magazine_default().is_null() ) {
+            const std::vector<itype_id> well_defaults = weapon->magazines_default();
+            const bool is_multi_well = well_defaults.size() > 1;
+            bool any_well_default = false;
+            for( const itype_id &mag_id : well_defaults ) {
+                if( !mag_id.is_null() ) {
+                    any_well_default = true;
+                    break;
+                }
+            }
+            if( is_multi_well && any_well_default ) {
+                weapon->dress_magazine_wells( /*insert_default_mag=*/true, /*fill_with_default_ammo=*/true );
+            } else if( !weapon->magazine_default().is_null() ) {
                 weapon->ammo_set( weapon->magazine_default()->magazine->default_ammo );
             } else if( !weapon->ammo_default().is_null() ) {
                 weapon->ammo_set( weapon->ammo_default() );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2769,6 +2769,8 @@ item_location npc::find_usable_ammo( const item_location &weap ) const
 
 item::reload_option npc::select_ammo( const item_location &base, bool, bool empty )
 {
+    // TODO(multimag): NPC reload uses the legacy first-compatible-well
+    // fallback (no UI to disambiguate sibling wells).
     if( !base ) {
         return item::reload_option();
     }
@@ -6177,6 +6179,8 @@ void npc::do_reload( const item_location &it )
     int qty = reload_opt.qty();
     int reload_time = item_reload_cost( *it, *usable_ammo, qty );
     // TODO: Consider printing this info to player too
+    // TODO(multimag): pocket_index defaults to -1 (first compatible well).
+    // NPCs cannot pick a specific well on multi-well guns yet.
     const std::string ammo_name = usable_ammo->tname();
     if( !target.reload( *this, std::move( usable_ammo ), qty ) ) {
         debugmsg( "do_reload failed: item %s could not be reloaded with %ld charge(s) of %s",

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6582,11 +6582,19 @@ void vehicle::place_spawn_items( map &here )
                     continue; // we destroyed the item
                 }
                 if( e.is_tool() || e.is_gun() || e.is_magazine() ) {
-                    bool spawn_ammo = rng( 0, 99 ) < spawn.with_ammo && e.ammo_remaining( ) == 0;
-                    bool spawn_mag  = rng( 0, 99 ) < spawn.with_magazine && !e.magazine_integral() &&
-                                      !e.magazine_current();
+                    const std::vector<itype_id> well_defaults = e.magazines_default();
+                    const bool is_multi_well = well_defaults.size() > 1;
+                    bool spawn_ammo = rng( 0, 99 ) < spawn.with_ammo;
+                    bool spawn_mag  = rng( 0, 99 ) < spawn.with_magazine && !e.magazine_integral();
+                    if( !is_multi_well ) {
+                        spawn_ammo = spawn_ammo && e.ammo_remaining( ) == 0;
+                        spawn_mag = spawn_mag && !e.magazine_current();
+                    }
 
-                    if( spawn_mag ) {
+                    if( is_multi_well ) {
+                        // TODO(multimag): per-well chance keys for vehicle gun-mount initial load.
+                        e.dress_magazine_wells( spawn_mag, spawn_ammo );
+                    } else if( spawn_mag ) {
                         item mag( e.magazine_default(), e.birthday() );
                         if( spawn_ammo ) {
                             mag.ammo_set( mag.ammo_default() );

--- a/tests/multimag_test.cpp
+++ b/tests/multimag_test.cpp
@@ -1,12 +1,21 @@
+#include <algorithm>
+#include <cstddef>
 #include <string>
 #include <vector>
 
 #include "calendar.h"
 #include "cata_catch.h"
+#include "character.h"
 #include "coordinates.h"
 #include "item.h"
+#include "item_location.h"
+#include "iteminfo_query.h"
+#include "itype.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "options_helpers.h"
+#include "output.h"
+#include "player_helpers.h"
 #include "pocket_type.h"
 #include "point.h"
 #include "ret_val.h"
@@ -15,8 +24,10 @@
 static const itype_id itype_38_special( "38_special" );
 static const itype_id itype_556( "556" );
 static const itype_id itype_9mm( "9mm" );
+static const itype_id itype_flashlight( "flashlight" );
 static const itype_id itype_glock_19( "glock_19" );
 static const itype_id itype_glockmag( "glockmag" );
+static const itype_id itype_medium_battery_cell( "medium_battery_cell" );
 static const itype_id itype_stanag30( "stanag30" );
 static const itype_id itype_sw_619( "sw_619" );
 static const itype_id itype_test_multimag_gun( "test_multimag_gun" );
@@ -159,4 +170,171 @@ TEST_CASE( "dual_well_magazine_operations", "[multimag]" )
         item gun( itype_test_multimag_gun );
         CHECK( gun.first_ammo().is_null() );
     }
+}
+
+TEST_CASE( "rate_action_unload across wells", "[multimag][hint]" )
+{
+    clear_avatar();
+    Character &you = get_player_character();
+
+    SECTION( "good when only second well has a mag" ) {
+        item gun( itype_test_multimag_gun );
+        // Insert into the stanag (second) well only.
+        gun.put_in( make_loaded_stanag(), pocket_type::MAGAZINE_WELL );
+        REQUIRE( gun.magazines_current().size() == 1 );
+        CHECK( you.rate_action_unload( gun ) == hint_rating::good );
+    }
+
+    SECTION( "good when both wells loaded" ) {
+        item gun = make_dual_well_gun();
+        CHECK( you.rate_action_unload( gun ) == hint_rating::good );
+    }
+
+    SECTION( "iffy when no wells loaded but item has ammo capacity" ) {
+        item gun( itype_test_multimag_gun );
+        CHECK( you.rate_action_unload( gun ) == hint_rating::iffy );
+    }
+}
+
+TEST_CASE( "display_name multi-well per-well counts", "[multimag][display]" )
+{
+    SECTION( "single loaded well prints (amount/max ammo) once" ) {
+        item gun = make_loaded_glock();
+        const std::string name = remove_color_tags( gun.display_name() );
+        CAPTURE( name );
+        CHECK( name.find( "(15/15" ) != std::string::npos );
+    }
+
+    SECTION( "dual loaded wells: per-well counts in single paren" ) {
+        item gun = make_dual_well_gun();
+        const std::string name = remove_color_tags( gun.display_name() );
+        CAPTURE( name );
+        // Both well counts appear, comma-separated, inside one outer paren.
+        const size_t open = name.find( '(' );
+        const size_t close = name.find( ')', open );
+        REQUIRE( open != std::string::npos );
+        REQUIRE( close != std::string::npos );
+        const std::string inner = name.substr( open + 1, close - open - 1 );
+        CAPTURE( inner );
+        CHECK( inner.find( "15/15" ) != std::string::npos );
+        CHECK( inner.find( "30/30" ) != std::string::npos );
+        CHECK( inner.find( "," ) != std::string::npos );
+    }
+
+    SECTION( "one well loaded out of two still emits per-well segments" ) {
+        item gun( itype_test_multimag_gun );
+        gun.put_in( make_loaded_stanag(), pocket_type::MAGAZINE_WELL );
+        const std::string name = remove_color_tags( gun.display_name() );
+        CAPTURE( name );
+        // Loaded stanag well still shows full count; empty glock well shows 0/cap.
+        CHECK( name.find( "30/30" ) != std::string::npos );
+        CHECK( name.find( "0/15" ) != std::string::npos );
+        const size_t open = name.find( '(' );
+        const size_t close = name.find( ')', open );
+        REQUIRE( open != std::string::npos );
+        REQUIRE( close != std::string::npos );
+        const std::string inner = name.substr( open + 1, close - open - 1 );
+        CHECK( inner.find( "," ) != std::string::npos );
+    }
+
+    SECTION( "dual loaded wells use variant ammo names, not generic class names" ) {
+        override_option opt( "AMMO_IN_NAMES", "true" );
+        item gun = make_dual_well_gun();
+        const std::string name = remove_color_tags( gun.display_name() );
+        CAPTURE( name );
+        // Variant nname (e.g. "9x19mm JHP") not generic ammotype name.
+        const std::string variant_9mm = item::find_type( itype_9mm )->nname( 1 );
+        const std::string variant_556 = item::find_type( itype_556 )->nname( 1 );
+        CHECK( name.find( variant_9mm ) != std::string::npos );
+        CHECK( name.find( variant_556 ) != std::string::npos );
+    }
+
+    SECTION( "AMMO_IN_NAMES off: dual wells print counts only, no ammo names" ) {
+        override_option opt( "AMMO_IN_NAMES", "false" );
+        item gun = make_dual_well_gun();
+        const std::string name = remove_color_tags( gun.display_name() );
+        CAPTURE( name );
+        const size_t open = name.find( '(' );
+        const size_t close = name.find( ')', open );
+        REQUIRE( open != std::string::npos );
+        REQUIRE( close != std::string::npos );
+        const std::string inner = name.substr( open + 1, close - open - 1 );
+        // Just "<a>/<b>, <c>/<d>" with no ammo names interleaved.
+        CHECK( inner.find( item::find_type( itype_9mm )->nname( 1 ) ) == std::string::npos );
+        CHECK( inner.find( item::find_type( itype_556 )->nname( 1 ) ) == std::string::npos );
+        CHECK( inner.find( "15/15" ) != std::string::npos );
+        CHECK( inner.find( "30/30" ) != std::string::npos );
+    }
+}
+
+TEST_CASE( "iteminfo Magazine label pluralization", "[multimag][display]" )
+{
+    auto iteminfo_for = []( const item & it ) {
+        std::vector<iteminfo> info_v;
+        const std::vector<iteminfo_parts> parts = {
+            iteminfo_parts::GUN_MAGAZINE,
+            iteminfo_parts::TOOL_MAGAZINE_CURRENT
+        };
+        const iteminfo_query query_v( parts );
+        it.info( info_v, &query_v, 1 );
+        return format_item_info( info_v, {} );
+    };
+
+    SECTION( "single loaded: singular 'Magazine:' label" ) {
+        item gun = make_loaded_glock();
+        const std::string info = iteminfo_for( gun );
+        CAPTURE( info );
+        CHECK( info.find( "Magazine: " ) != std::string::npos );
+        CHECK( info.find( "Magazines: " ) == std::string::npos );
+        // Loaded magazine's tname is interpolated.
+        CHECK( info.find( item( itype_glockmag ).tname() ) != std::string::npos );
+    }
+
+    SECTION( "dual loaded: plural 'Magazines:' label, both names listed" ) {
+        item gun = make_dual_well_gun();
+        const std::string info = iteminfo_for( gun );
+        CAPTURE( info );
+        CHECK( info.find( "Magazines: " ) != std::string::npos );
+        const std::string glock_name = item( itype_glockmag ).tname();
+        const std::string stanag_name = item( itype_stanag30 ).tname();
+        CHECK( info.find( glock_name ) != std::string::npos );
+        CHECK( info.find( stanag_name ) != std::string::npos );
+        // The two names appear comma-separated in the same line.
+        const size_t glock_pos = info.find( glock_name );
+        const size_t stanag_pos = info.find( stanag_name );
+        if( glock_pos != std::string::npos && stanag_pos != std::string::npos ) {
+            const size_t lo = std::min( glock_pos, stanag_pos );
+            const size_t hi = std::max( glock_pos, stanag_pos );
+            CHECK( info.substr( lo, hi - lo ).find( "," ) != std::string::npos );
+        }
+    }
+
+    SECTION( "single loaded tool: tool_info path uses singular 'Magazine:'" ) {
+        item flashlight( itype_flashlight );
+        flashlight.put_in( item( itype_medium_battery_cell ), pocket_type::MAGAZINE_WELL );
+        const std::string info = iteminfo_for( flashlight );
+        CAPTURE( info );
+        CHECK( info.find( "Magazine: " ) != std::string::npos );
+        CHECK( info.find( "Magazines: " ) == std::string::npos );
+        CHECK( info.find( item( itype_medium_battery_cell ).tname() ) != std::string::npos );
+    }
+}
+
+TEST_CASE( "Character::unload ejects every loaded magazine", "[multimag][unload]" )
+{
+    clear_avatar();
+    clear_map();
+    Character &you = get_player_character();
+
+    item gun = make_dual_well_gun();
+    REQUIRE( gun.magazines_current().size() == 2 );
+
+    item_location gun_loc = you.i_add( gun );
+    REQUIRE( gun_loc );
+
+    const bool unloaded = you.unload( gun_loc, /*bypass_activity=*/true );
+    CHECK( unloaded );
+
+    const std::vector<item *> remaining = gun_loc->magazines_current();
+    CHECK( remaining.empty() );
 }

--- a/tests/multimag_test.cpp
+++ b/tests/multimag_test.cpp
@@ -16,6 +16,7 @@
 #include "item.h"
 #include "item_location.h"
 #include "item_pocket.h"
+#include "inventory_ui.h"
 #include "iteminfo_query.h"
 #include "itype.h"
 #include "json.h"
@@ -41,6 +42,7 @@ static const itype_id itype_medium_battery_cell( "medium_battery_cell" );
 static const itype_id itype_stanag30( "stanag30" );
 static const itype_id itype_sw_619( "sw_619" );
 static const itype_id itype_test_multimag_gun( "test_multimag_gun" );
+static const itype_id itype_test_multimag_gun_same_type( "test_multimag_gun_same_type" );
 
 static item make_loaded_glock()
 {
@@ -661,6 +663,214 @@ TEST_CASE( "reload_option::qty forces 1 for pocket-targeted (class a) reloads",
     opt.pocket_index = glock_idx;
     opt.qty( 1000 );
     CHECK( opt.qty() == 1 );
+}
+
+TEST_CASE( "get_possible_reload_targets emits per-well reload_target entries",
+           "[multimag][reload]" )
+{
+    clear_avatar();
+    Character &you = get_player_character();
+    you.wear_item( item( itype_backpack ) );
+
+    SECTION( "multi-well gun: one well entry per MAGAZINE_WELL plus loaded-mag entry" ) {
+        item gun = make_dual_well_gun();
+        item_location gun_loc = you.i_add( gun );
+        REQUIRE( gun_loc );
+
+        const std::vector<reload_target> targets = get_possible_reload_targets( gun_loc );
+        std::set<int> well_indices;
+        int loaded_mag_count = 0;
+        for( const reload_target &rt : targets ) {
+            if( rt.kind == reload_target::kind::well && rt.owner == gun_loc ) {
+                well_indices.insert( rt.pocket_index );
+            } else if( rt.kind == reload_target::kind::loaded_mag && rt.owner == gun_loc ) {
+                loaded_mag_count++;
+            }
+        }
+        // Both wells appear with their actual contents indices, and each
+        // loaded magazine produces its own loaded-mag entry.
+        CHECK( well_indices.size() == 2 );
+        CHECK( loaded_mag_count == 2 );
+    }
+
+    SECTION( "integral-mag gun emits a fallback loaded-mag entry on the gun itself" ) {
+        item revolver( itype_sw_619 );
+        item_location revolver_loc = you.i_add( revolver );
+        REQUIRE( revolver_loc );
+
+        const std::vector<reload_target> targets = get_possible_reload_targets( revolver_loc );
+        bool found_fallback = false;
+        for( const reload_target &rt : targets ) {
+            if( rt.kind == reload_target::kind::loaded_mag && rt.target == revolver_loc &&
+                rt.pocket_index < 0 ) {
+                found_fallback = true;
+            }
+        }
+        CHECK( found_fallback );
+    }
+}
+
+TEST_CASE( "find_matching_reload_target routes ammo to the correct well",
+           "[multimag][reload]" )
+{
+    clear_avatar();
+    Character &you = get_player_character();
+    you.wear_item( item( itype_backpack ) );
+
+    item gun( itype_test_multimag_gun );
+    item_location gun_loc = you.i_add( gun );
+    REQUIRE( gun_loc );
+
+    const std::vector<reload_target> targets = get_possible_reload_targets( gun_loc );
+
+    // Find each well's contents index in gun_loc.
+    int glock_well_idx = -1;
+    int stanag_well_idx = -1;
+    {
+        int idx = 0;
+        for( const item_pocket *p : gun_loc->get_pockets( []( const item_pocket & ) {
+        return true;
+    } ) ) {
+            if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                if( glock_well_idx < 0 ) {
+                    glock_well_idx = idx;
+                } else if( stanag_well_idx < 0 ) {
+                    stanag_well_idx = idx;
+                }
+            }
+            ++idx;
+        }
+    }
+    REQUIRE( glock_well_idx >= 0 );
+    REQUIRE( stanag_well_idx >= 0 );
+
+    SECTION( "glock magazine routes to the glockmag-restricted well" ) {
+        item glock_mag( itype_glockmag );
+        glock_mag.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+        item_location glock_loc = you.i_add( glock_mag );
+        REQUIRE( glock_loc );
+
+        const reload_target *match = find_matching_reload_target( targets, glock_loc );
+        REQUIRE( match != nullptr );
+        CHECK( match->kind == reload_target::kind::well );
+        CHECK( match->pocket_index == glock_well_idx );
+    }
+
+    SECTION( "stanag magazine routes to the stanag30-restricted well" ) {
+        item stanag_mag( itype_stanag30 );
+        stanag_mag.put_in( item( itype_556, calendar::turn, 30 ), pocket_type::MAGAZINE );
+        item_location stanag_loc = you.i_add( stanag_mag );
+        REQUIRE( stanag_loc );
+
+        const reload_target *match = find_matching_reload_target( targets, stanag_loc );
+        REQUIRE( match != nullptr );
+        CHECK( match->kind == reload_target::kind::well );
+        CHECK( match->pocket_index == stanag_well_idx );
+    }
+
+    SECTION( "same-type dual-well: find_all_matching emits one entry per accepting well" ) {
+        item same_type_gun( itype_test_multimag_gun_same_type );
+        item_location same_loc = you.i_add( same_type_gun );
+        REQUIRE( same_loc );
+        const std::vector<reload_target> same_targets = get_possible_reload_targets( same_loc );
+
+        item glock_mag( itype_glockmag );
+        glock_mag.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+        item_location glock_loc = you.i_add( glock_mag );
+        REQUIRE( glock_loc );
+
+        const std::vector<const reload_target *> matches =
+            find_all_matching_reload_targets( same_targets, glock_loc );
+        REQUIRE( matches.size() == 2 );
+        // Class-(a) well entries with distinct pocket_index for disambiguation.
+        std::set<int> seen_pocket_indices;
+        for( const reload_target *rt : matches ) {
+            CHECK( rt->kind == reload_target::kind::well );
+            seen_pocket_indices.insert( rt->pocket_index );
+        }
+        CHECK( seen_pocket_indices.size() == 2 );
+    }
+
+    SECTION( "same-type loaded mags: loose ammo matches every loaded mag for class-(b) top-up" ) {
+        // Both wells loaded with glockmag; one half-full, one nearly empty.
+        // Direct-insert into each well by walking pockets; put_in finds only
+        // the first matching pocket and would route both magazines into well
+        // 1 here.
+        item gun_two( itype_test_multimag_gun_same_type );
+        item glock_a( itype_glockmag );
+        glock_a.put_in( item( itype_9mm, calendar::turn, 5 ), pocket_type::MAGAZINE );
+        item glock_b( itype_glockmag );
+        glock_b.put_in( item( itype_9mm, calendar::turn, 1 ), pocket_type::MAGAZINE );
+        std::vector<item_pocket *> wells;
+        for( item_pocket *p : gun_two.get_pockets( []( const item_pocket & pp ) {
+        return pp.is_type( pocket_type::MAGAZINE_WELL );
+        } ) ) {
+            wells.push_back( p );
+        }
+        REQUIRE( wells.size() == 2 );
+        REQUIRE( wells[0]->insert_item( glock_a ).success() );
+        REQUIRE( wells[1]->insert_item( glock_b ).success() );
+        REQUIRE( gun_two.magazines_current().size() == 2 );
+
+        item_location two_loc = you.i_add( gun_two );
+        REQUIRE( two_loc );
+        REQUIRE( two_loc->magazines_current().size() == 2 );
+
+        const std::vector<reload_target> two_targets = get_possible_reload_targets( two_loc );
+
+        item loose_9mm( itype_9mm, calendar::turn, 30 );
+        item_location loose_loc = you.i_add( loose_9mm );
+        REQUIRE( loose_loc );
+
+        const std::vector<const reload_target *> matches =
+            find_all_matching_reload_targets( two_targets, loose_loc );
+        // Both loaded magazines accept loose 9mm; the helper must surface
+        // both so the disambiguation menu can offer a real choice.
+        int loaded_mag_matches = 0;
+        std::vector<int> loaded_remaining;
+        for( const reload_target *rt : matches ) {
+            if( rt->kind == reload_target::kind::loaded_mag ) {
+                loaded_mag_matches++;
+                loaded_remaining.push_back( rt->target->ammo_remaining() );
+            }
+        }
+        CHECK( loaded_mag_matches == 2 );
+
+        // Picking the less-full mag must let qty() refill toward its own
+        // remaining capacity, not stay capped by the more-full mag.
+        const reload_target *small_mag_target = nullptr;
+        for( const reload_target *rt : matches ) {
+            if( rt->kind == reload_target::kind::loaded_mag &&
+                rt->target->ammo_remaining() == 1 ) {
+                small_mag_target = rt;
+                break;
+            }
+        }
+        REQUIRE( small_mag_target != nullptr );
+        item::reload_option opt( &you, small_mag_target->target, loose_loc,
+                                 small_mag_target->pocket_index );
+        // glockmag capacity 15, mag has 1 round, room for 14.
+        CHECK( opt.qty() == 14 );
+
+        // Player picked a partial count below either mag's remaining capacity;
+        // disambiguation must preserve it.
+        item::reload_option opt_partial( &you, small_mag_target->target, loose_loc,
+                                         small_mag_target->pocket_index );
+        opt_partial.qty( 3 );
+        CHECK( opt_partial.qty() == 3 );
+    }
+
+    SECTION( "magazine compatible with no well returns nullptr" ) {
+        // 38_special is loose ammo for the integral revolver fixture and is
+        // not compatible with either of test_multimag_gun's wells (glockmag
+        // / stanag30 restrictions). Loose ammo cannot reload a well.
+        item loose( itype_38_special, calendar::turn, 7 );
+        item_location loose_loc = you.i_add( loose );
+        REQUIRE( loose_loc );
+
+        const reload_target *match = find_matching_reload_target( targets, loose_loc );
+        CHECK( match == nullptr );
+    }
 }
 
 TEST_CASE( "Character::unload ejects every loaded magazine", "[multimag][unload]" )

--- a/tests/multimag_test.cpp
+++ b/tests/multimag_test.cpp
@@ -1,10 +1,10 @@
 #include <algorithm>
 #include <cstddef>
 #include <functional>
-#include <list>
 #include <set>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "activity_actor_definitions.h"
@@ -14,6 +14,7 @@
 #include "coordinates.h"
 #include "debug.h"
 #include "item.h"
+#include "item_group.h"
 #include "item_location.h"
 #include "item_pocket.h"
 #include "inventory_ui.h"
@@ -30,6 +31,8 @@
 #include "ret_val.h"
 #include "type_id.h"
 #include "visitable.h"
+
+static const item_group_id Item_spawn_data_test_multimag_full_load( "test_multimag_full_load" );
 
 static const itype_id itype_38_special( "38_special" );
 static const itype_id itype_556( "556" );
@@ -184,7 +187,7 @@ TEST_CASE( "dual_well_magazine_operations", "[multimag]" )
     }
 }
 
-TEST_CASE( "rate_action_unload across wells", "[multimag][hint]" )
+TEST_CASE( "rate_action_unload_across_wells", "[multimag][hint]" )
 {
     clear_avatar();
     Character &you = get_player_character();
@@ -208,7 +211,7 @@ TEST_CASE( "rate_action_unload across wells", "[multimag][hint]" )
     }
 }
 
-TEST_CASE( "display_name multi-well per-well counts", "[multimag][display]" )
+TEST_CASE( "display_name_multi_well_per_well_counts", "[multimag][display]" )
 {
     SECTION( "single loaded well prints (amount/max ammo) once" ) {
         item gun = make_loaded_glock();
@@ -230,7 +233,7 @@ TEST_CASE( "display_name multi-well per-well counts", "[multimag][display]" )
         CAPTURE( inner );
         CHECK( inner.find( "15/15" ) != std::string::npos );
         CHECK( inner.find( "30/30" ) != std::string::npos );
-        CHECK( inner.find( "," ) != std::string::npos );
+        CHECK( inner.find( ',' ) != std::string::npos );
     }
 
     SECTION( "one well loaded out of two still emits per-well segments" ) {
@@ -277,7 +280,7 @@ TEST_CASE( "display_name multi-well per-well counts", "[multimag][display]" )
     }
 }
 
-TEST_CASE( "iteminfo Magazine label pluralization", "[multimag][display]" )
+TEST_CASE( "iteminfo_magazine_label_pluralization", "[multimag][display]" )
 {
     auto iteminfo_for = []( const item & it ) {
         std::vector<iteminfo> info_v;
@@ -315,7 +318,7 @@ TEST_CASE( "iteminfo Magazine label pluralization", "[multimag][display]" )
         if( glock_pos != std::string::npos && stanag_pos != std::string::npos ) {
             const size_t lo = std::min( glock_pos, stanag_pos );
             const size_t hi = std::max( glock_pos, stanag_pos );
-            CHECK( info.substr( lo, hi - lo ).find( "," ) != std::string::npos );
+            CHECK( info.substr( lo, hi - lo ).find( ',' ) != std::string::npos );
         }
     }
 
@@ -330,7 +333,7 @@ TEST_CASE( "iteminfo Magazine label pluralization", "[multimag][display]" )
     }
 }
 
-TEST_CASE( "per-well ammo_remaining / ammo_capacity / remaining_ammo_capacity overloads",
+TEST_CASE( "per_well_ammo_remaining_capacity_overloads",
            "[multimag][capacity]" )
 {
     item gun = make_dual_well_gun();
@@ -392,7 +395,7 @@ TEST_CASE( "per-well ammo_remaining / ammo_capacity / remaining_ammo_capacity ov
     }
 }
 
-TEST_CASE( "Character::list_ammo per_well_targets flag", "[multimag][reload]" )
+TEST_CASE( "character_list_ammo_per_well_targets_flag", "[multimag][reload]" )
 {
     clear_avatar();
     Character &you = get_player_character();
@@ -550,7 +553,7 @@ TEST_CASE( "Character::list_ammo per_well_targets flag", "[multimag][reload]" )
     }
 }
 
-TEST_CASE( "item::reload with pocket_index targets a specific well", "[multimag][reload]" )
+TEST_CASE( "item_reload_with_pocket_index_targets_specific_well", "[multimag][reload]" )
 {
     clear_avatar();
     Character &you = get_player_character();
@@ -621,7 +624,7 @@ TEST_CASE( "item::reload with pocket_index targets a specific well", "[multimag]
     }
 }
 
-TEST_CASE( "reload_option::qty forces 1 for pocket-targeted (class a) reloads",
+TEST_CASE( "reload_option_qty_forces_1_for_pocket_targeted_reloads",
            "[multimag][reload]" )
 {
     clear_avatar();
@@ -665,7 +668,7 @@ TEST_CASE( "reload_option::qty forces 1 for pocket-targeted (class a) reloads",
     CHECK( opt.qty() == 1 );
 }
 
-TEST_CASE( "get_possible_reload_targets emits per-well reload_target entries",
+TEST_CASE( "get_possible_reload_targets_emits_per_well_entries",
            "[multimag][reload]" )
 {
     clear_avatar();
@@ -710,7 +713,7 @@ TEST_CASE( "get_possible_reload_targets emits per-well reload_target entries",
     }
 }
 
-TEST_CASE( "find_matching_reload_target routes ammo to the correct well",
+TEST_CASE( "find_matching_reload_target_routes_ammo_to_correct_well",
            "[multimag][reload]" )
 {
     clear_avatar();
@@ -873,7 +876,7 @@ TEST_CASE( "find_matching_reload_target routes ammo to the correct well",
     }
 }
 
-TEST_CASE( "Character::unload ejects every loaded magazine", "[multimag][unload]" )
+TEST_CASE( "character_unload_ejects_every_loaded_magazine", "[multimag][unload]" )
 {
     clear_avatar();
     clear_map();
@@ -907,7 +910,7 @@ TEST_CASE( "Character::unload ejects every loaded magazine", "[multimag][unload]
     CHECK( found_stanag );
 }
 
-TEST_CASE( "same-type dual-well: targeted reload replaces a specific well",
+TEST_CASE( "same_type_dual_well_targeted_reload_replaces_specific_well",
            "[multimag][reload]" )
 {
     clear_avatar();
@@ -964,7 +967,7 @@ TEST_CASE( "same-type dual-well: targeted reload replaces a specific well",
     CHECK( wells_after[1]->magazine_current()->ammo_remaining() == 15 );
 }
 
-TEST_CASE( "reload_activity_actor serializes pocket_index",
+TEST_CASE( "reload_activity_actor_serializes_pocket_index",
            "[multimag][reload][serialize]" )
 {
     clear_avatar();
@@ -990,7 +993,7 @@ TEST_CASE( "reload_activity_actor serializes pocket_index",
     CHECK( serialized.find( "\"pocket_index\":0" ) != std::string::npos );
 }
 
-TEST_CASE( "wield-collision sees mags from every well, not just the first",
+TEST_CASE( "wield_collision_sees_mags_from_every_well",
            "[multimag][wield]" )
 {
     item gun = make_dual_well_gun();
@@ -1002,4 +1005,98 @@ TEST_CASE( "wield-collision sees mags from every well, not just the first",
     }
     CHECK( mag_types.count( itype_glockmag ) == 1 );
     CHECK( mag_types.count( itype_stanag30 ) == 1 );
+}
+
+TEST_CASE( "item_group_spawn_fills_every_well",
+           "[multimag][spawn]" )
+{
+    const item_group::ItemList items = item_group::items_from(
+                                           Item_spawn_data_test_multimag_full_load );
+    REQUIRE( items.size() == 1 );
+    const item &gun = items[0];
+    REQUIRE( gun.typeId() == itype_test_multimag_gun );
+
+    const std::vector<const item *> mags = gun.magazines_current();
+    CHECK( mags.size() == 2 );
+
+    std::set<itype_id> mag_types;
+    for( const item *m : mags ) {
+        mag_types.insert( m->typeId() );
+    }
+    CHECK( mag_types.count( itype_glockmag ) == 1 );
+    CHECK( mag_types.count( itype_stanag30 ) == 1 );
+
+    for( const item *m : mags ) {
+        CHECK( m->ammo_remaining() > 0 );
+    }
+}
+
+TEST_CASE( "item_wide_charges_on_multi_well_rejected",
+           "[multimag][spawn]" )
+{
+    Item_modifier modifier;
+    modifier.charges = { 20, 20 };
+    item gun( itype_test_multimag_gun );
+
+    const std::string dmsg = capture_debugmsg_during( [&modifier, &gun]() {
+        modifier.modify( gun, "test_multimag_charges_ambiguous" );
+    } );
+
+    CHECK( dmsg.find( "ambiguous" ) != std::string::npos );
+    CHECK( gun.typeId() == itype_test_multimag_gun );
+    CHECK( gun.magazines_current().empty() );
+    CHECK( gun.ammo_remaining() == 0 );
+}
+
+TEST_CASE( "item_magazines_default_one_entry_per_well",
+           "[multimag][spawn]" )
+{
+    item gun( itype_test_multimag_gun );
+    const std::vector<itype_id> defaults = gun.magazines_default();
+    REQUIRE( defaults.size() == 2 );
+
+    std::set<itype_id> uniq( defaults.begin(), defaults.end() );
+    CHECK( uniq.count( itype_glockmag ) == 1 );
+    CHECK( uniq.count( itype_stanag30 ) == 1 );
+}
+
+TEST_CASE( "dress_magazine_wells_fills_empty_siblings",
+           "[multimag][spawn]" )
+{
+    item gun( itype_test_multimag_gun );
+    // Pre-load only the glock well.
+    item glock_mag( itype_glockmag );
+    glock_mag.ammo_set( itype_9mm, 15 );
+    REQUIRE( gun.put_in( glock_mag, pocket_type::MAGAZINE_WELL ).success() );
+    REQUIRE( gun.magazines_current().size() == 1 );
+
+    gun.dress_magazine_wells( /*insert_default_mag=*/true, /*fill_with_default_ammo=*/true );
+
+    const std::vector<item *> mags = gun.magazines_current();
+    REQUIRE( mags.size() == 2 );
+    std::set<itype_id> mag_types;
+    for( const item *m : mags ) {
+        mag_types.insert( m->typeId() );
+    }
+    CHECK( mag_types.count( itype_glockmag ) == 1 );
+    CHECK( mag_types.count( itype_stanag30 ) == 1 );
+    for( const item *m : mags ) {
+        CHECK( m->ammo_remaining() > 0 );
+    }
+}
+
+TEST_CASE( "dress_magazine_wells_tops_up_empty_mag",
+           "[multimag][spawn]" )
+{
+    item gun( itype_test_multimag_gun );
+    item empty_mag( itype_glockmag );
+    REQUIRE( empty_mag.ammo_remaining() == 0 );
+    REQUIRE( gun.put_in( empty_mag, pocket_type::MAGAZINE_WELL ).success() );
+
+    gun.dress_magazine_wells( /*insert_default_mag=*/false, /*fill_with_default_ammo=*/true );
+
+    const std::vector<item *> mags = gun.magazines_current();
+    REQUIRE( mags.size() == 1 );
+    CHECK( mags[0]->typeId() == itype_glockmag );
+    CHECK( mags[0]->ammo_remaining() > 0 );
 }

--- a/tests/multimag_test.cpp
+++ b/tests/multimag_test.cpp
@@ -1,16 +1,24 @@
 #include <algorithm>
 #include <cstddef>
+#include <functional>
+#include <list>
+#include <set>
+#include <sstream>
 #include <string>
 #include <vector>
 
+#include "activity_actor_definitions.h"
 #include "calendar.h"
 #include "cata_catch.h"
 #include "character.h"
 #include "coordinates.h"
+#include "debug.h"
 #include "item.h"
 #include "item_location.h"
+#include "item_pocket.h"
 #include "iteminfo_query.h"
 #include "itype.h"
+#include "json.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "options_helpers.h"
@@ -20,10 +28,12 @@
 #include "point.h"
 #include "ret_val.h"
 #include "type_id.h"
+#include "visitable.h"
 
 static const itype_id itype_38_special( "38_special" );
 static const itype_id itype_556( "556" );
 static const itype_id itype_9mm( "9mm" );
+static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_flashlight( "flashlight" );
 static const itype_id itype_glock_19( "glock_19" );
 static const itype_id itype_glockmag( "glockmag" );
@@ -222,19 +232,17 @@ TEST_CASE( "display_name multi-well per-well counts", "[multimag][display]" )
     }
 
     SECTION( "one well loaded out of two still emits per-well segments" ) {
+        override_option opt( "AMMO_IN_NAMES", "false" );
         item gun( itype_test_multimag_gun );
         gun.put_in( make_loaded_stanag(), pocket_type::MAGAZINE_WELL );
         const std::string name = remove_color_tags( gun.display_name() );
         CAPTURE( name );
-        // Loaded stanag well still shows full count; empty glock well shows 0/cap.
-        CHECK( name.find( "30/30" ) != std::string::npos );
-        CHECK( name.find( "0/15" ) != std::string::npos );
         const size_t open = name.find( '(' );
         const size_t close = name.find( ')', open );
         REQUIRE( open != std::string::npos );
         REQUIRE( close != std::string::npos );
         const std::string inner = name.substr( open + 1, close - open - 1 );
-        CHECK( inner.find( "," ) != std::string::npos );
+        CHECK( inner == "0/15, 30/30" );
     }
 
     SECTION( "dual loaded wells use variant ammo names, not generic class names" ) {
@@ -320,11 +328,347 @@ TEST_CASE( "iteminfo Magazine label pluralization", "[multimag][display]" )
     }
 }
 
+TEST_CASE( "per-well ammo_remaining / ammo_capacity / remaining_ammo_capacity overloads",
+           "[multimag][capacity]" )
+{
+    item gun = make_dual_well_gun();
+    REQUIRE( gun.magazines_current().size() == 2 );
+    // Drain a few rounds out of the first well so the per-well numbers diverge
+    // from the second well's full count.
+    {
+        clear_map();
+        map &here = get_map();
+        const tripoint_bub_ms pos( tripoint_bub_ms::zero );
+        REQUIRE( gun.ammo_consume( 5, here, pos, nullptr ) == 5 );
+    }
+
+    // Compute well indices from the fixture; do not hardcode.
+    int glock_idx = -1;
+    int stanag_idx = -1;
+    {
+        int idx = 0;
+        for( const item_pocket *p : gun.get_pockets( []( const item_pocket & ) {
+        return true;
+    } ) ) {
+            if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                if( const item *mag = p->magazine_current() ) {
+                    if( mag->typeId() == itype_glockmag ) {
+                        glock_idx = idx;
+                    } else if( mag->typeId() == itype_stanag30 ) {
+                        stanag_idx = idx;
+                    }
+                }
+            }
+            ++idx;
+        }
+    }
+    REQUIRE( glock_idx >= 0 );
+    REQUIRE( stanag_idx >= 0 );
+
+    SECTION( "per-well ammo_remaining returns each well's loaded count" ) {
+        CHECK( gun.ammo_remaining( glock_idx ) == 10 );
+        CHECK( gun.ammo_remaining( stanag_idx ) == 30 );
+        // Aggregate is the sum.
+        CHECK( gun.ammo_remaining() == 40 );
+    }
+
+    SECTION( "per-well ammo_capacity returns each loaded magazine's capacity" ) {
+        CHECK( gun.ammo_capacity( glock_idx ) == 15 );
+        CHECK( gun.ammo_capacity( stanag_idx ) == 30 );
+    }
+
+    SECTION( "per-well remaining_ammo_capacity is per-mag, not item-aggregate" ) {
+        CHECK( gun.remaining_ammo_capacity( glock_idx ) == 5 );
+        CHECK( gun.remaining_ammo_capacity( stanag_idx ) == 0 );
+    }
+
+    SECTION( "out-of-range or non-well indices return 0" ) {
+        CHECK( gun.ammo_remaining( -1 ) == 0 );
+        CHECK( gun.ammo_remaining( 999 ) == 0 );
+        CHECK( gun.ammo_capacity( -1 ) == 0 );
+        CHECK( gun.remaining_ammo_capacity( -1 ) == 0 );
+    }
+}
+
+TEST_CASE( "Character::list_ammo per_well_targets flag", "[multimag][reload]" )
+{
+    clear_avatar();
+    Character &you = get_player_character();
+    // Without storage, i_add silently drops items on the ground and find_ammo
+    // would not see them.
+    you.wear_item( item( itype_backpack ) );
+
+    SECTION( "default flag emits one option per item plus one per loaded magazine" ) {
+        item gun = make_dual_well_gun();
+        item_location gun_loc = you.i_add( gun );
+        REQUIRE( gun_loc );
+        // Loose ammo so list_ammo has something beyond the loaded mags.
+        you.i_add( item( itype_9mm, calendar::turn, 15 ) );
+        you.i_add( item( itype_556, calendar::turn, 30 ) );
+
+        std::vector<item::reload_option> ammo_list;
+        you.list_ammo( gun_loc, ammo_list, /*empty=*/true );
+        // Every emitted option must carry the first-compatible-well sentinel
+        // when the per_well_targets flag is unset.
+        for( const item::reload_option &opt : ammo_list ) {
+            CHECK( opt.pocket_index < 0 );
+        }
+    }
+
+    SECTION( "per_well_targets=true emits per-well options with stable pocket_index" ) {
+        // Use an empty multi-well gun so find_ammo will accept the spare
+        // magazines as valid reload candidates (find_ammo rejects spares
+        // when the well is already full and now=true).
+        item gun( itype_test_multimag_gun );
+        item_location gun_loc = you.i_add( gun );
+        REQUIRE( gun_loc );
+        item glock_extra( itype_glockmag );
+        glock_extra.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+        item stanag_extra( itype_stanag30 );
+        stanag_extra.put_in( item( itype_556, calendar::turn, 30 ), pocket_type::MAGAZINE );
+        you.i_add( glock_extra );
+        you.i_add( stanag_extra );
+
+        // Collect the two well indices in gun_loc->contents.
+        std::vector<int> well_indices;
+        {
+            int idx = 0;
+            for( const item_pocket *p : gun_loc->get_pockets(
+            []( const item_pocket & ) {
+            return true;
+        } ) ) {
+                if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                    well_indices.push_back( idx );
+                }
+                ++idx;
+            }
+        }
+        REQUIRE( well_indices.size() == 2 );
+
+        std::vector<item::reload_option> ammo_list;
+        you.list_ammo( gun_loc, ammo_list, /*empty=*/true, /*per_well_targets=*/true );
+
+        std::set<int> emitted_pocket_indices;
+        for( const item::reload_option &opt : ammo_list ) {
+            emitted_pocket_indices.insert( opt.pocket_index );
+        }
+        // Both wells emit at their contents index.
+        for( int idx : well_indices ) {
+            CHECK( emitted_pocket_indices.count( idx ) == 1 );
+        }
+
+        // No cross-well leak: a glockmag option must not target the stanag well.
+        const item_pocket *first_well = nullptr;
+        const item_pocket *second_well = nullptr;
+        {
+            int idx = 0;
+            for( const item_pocket *p : gun_loc->get_pockets(
+            []( const item_pocket & ) {
+            return true;
+        } ) ) {
+                if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                    if( idx == well_indices[0] ) {
+                        first_well = p;
+                    } else if( idx == well_indices[1] ) {
+                        second_well = p;
+                    }
+                }
+                ++idx;
+            }
+        }
+        REQUIRE( first_well != nullptr );
+        REQUIRE( second_well != nullptr );
+        for( const item::reload_option &opt : ammo_list ) {
+            if( opt.pocket_index < 0 ) {
+                continue;
+            }
+            const item_pocket *picked = opt.pocket_index == well_indices[0] ? first_well : second_well;
+            CAPTURE( opt.pocket_index );
+            CAPTURE( opt.ammo->tname() );
+            CHECK( picked->can_reload_with( *opt.ammo, true ) );
+        }
+
+        // Class-(a) entries swap one magazine: qty() == 1.
+        for( const item::reload_option &opt : ammo_list ) {
+            if( opt.pocket_index >= 0 ) {
+                CHECK( opt.qty() == 1 );
+            }
+        }
+    }
+
+    SECTION( "empty-well pocket_index is the position in contents, not a "
+             "magazines_current() position" ) {
+        // Indices must match contents, not magazines_current().
+        item gun( itype_test_multimag_gun );
+        gun.put_in( make_loaded_stanag(), pocket_type::MAGAZINE_WELL );
+        item_location gun_loc = you.i_add( gun );
+        REQUIRE( gun_loc );
+
+        item glock_extra( itype_glockmag );
+        glock_extra.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+        item stanag_extra( itype_stanag30 );
+        stanag_extra.put_in( item( itype_556, calendar::turn, 30 ), pocket_type::MAGAZINE );
+        you.i_add( glock_extra );
+        you.i_add( stanag_extra );
+
+        // Locate each well in gun_loc->contents.
+        int empty_well_idx = -1;
+        int loaded_well_idx = -1;
+        {
+            int idx = 0;
+            for( const item_pocket *p : gun_loc->get_pockets(
+            []( const item_pocket & ) {
+            return true;
+        } ) ) {
+                if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                    if( p->magazine_current() == nullptr ) {
+                        empty_well_idx = idx;
+                    } else {
+                        loaded_well_idx = idx;
+                    }
+                }
+                ++idx;
+            }
+        }
+        REQUIRE( empty_well_idx >= 0 );
+        REQUIRE( loaded_well_idx >= 0 );
+        REQUIRE( empty_well_idx != loaded_well_idx );
+
+        std::vector<item::reload_option> ammo_list;
+        you.list_ammo( gun_loc, ammo_list, /*empty=*/true, /*per_well_targets=*/true );
+
+        // Empty well still addressable by its stable contents index.
+        bool saw_empty = false;
+        for( const item::reload_option &opt : ammo_list ) {
+            if( opt.pocket_index == empty_well_idx ) {
+                saw_empty = true;
+            }
+        }
+        CHECK( saw_empty );
+    }
+}
+
+TEST_CASE( "item::reload with pocket_index targets a specific well", "[multimag][reload]" )
+{
+    clear_avatar();
+    Character &you = get_player_character();
+    you.wear_item( item( itype_backpack ) );
+
+    // Multi-well gun with only the first (glock) well loaded; the stanag
+    // well stays empty so item::reload(stanag_idx) has somewhere to insert.
+    item gun( itype_test_multimag_gun );
+    item glock_mag( itype_glockmag );
+    glock_mag.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+    gun.put_in( glock_mag, pocket_type::MAGAZINE_WELL );
+
+    item_location gun_loc = you.i_add( gun );
+    REQUIRE( gun_loc );
+
+    // Identify the two well indices (glock-loaded and empty-stanag) in
+    // gun_loc->contents.
+    int loaded_well_idx = -1;
+    int empty_well_idx = -1;
+    {
+        int idx = 0;
+        for( const item_pocket *p : gun_loc->get_pockets(
+        []( const item_pocket & ) {
+        return true;
+    } ) ) {
+            if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                if( p->magazine_current() != nullptr ) {
+                    loaded_well_idx = idx;
+                } else {
+                    empty_well_idx = idx;
+                }
+            }
+            ++idx;
+        }
+    }
+    REQUIRE( loaded_well_idx >= 0 );
+    REQUIRE( empty_well_idx >= 0 );
+
+    SECTION( "pocket_index = empty stanag well inserts there, leaves glock untouched" ) {
+        item replacement_stanag( itype_stanag30 );
+        replacement_stanag.put_in( item( itype_556, calendar::turn, 10 ), pocket_type::MAGAZINE );
+        item_location replacement_loc = you.i_add( replacement_stanag );
+        REQUIRE( replacement_loc );
+
+        const int glock_count_before = gun_loc->ammo_remaining( loaded_well_idx );
+        REQUIRE( gun_loc->reload( you, replacement_loc, 1, empty_well_idx ) );
+        CHECK( gun_loc->ammo_remaining( empty_well_idx ) == 10 );
+        CHECK( gun_loc->ammo_remaining( loaded_well_idx ) == glock_count_before );
+    }
+
+    SECTION( "invalid pocket_index aborts reload" ) {
+        item replacement_stanag( itype_stanag30 );
+        replacement_stanag.put_in( item( itype_556, calendar::turn, 10 ), pocket_type::MAGAZINE );
+        item_location replacement_loc = you.i_add( replacement_stanag );
+        REQUIRE( replacement_loc );
+
+        const int glock_count_before = gun_loc->ammo_remaining( loaded_well_idx );
+        bool reload_result = true;
+        const std::string dmsg = capture_debugmsg_during( [&]() {
+            // Out-of-range index. Aborts with a debugmsg, which we capture
+            // so it does not flag the test as failed.
+            reload_result = gun_loc->reload( you, replacement_loc, 1, 99 );
+        } );
+        CHECK( !reload_result );
+        CHECK( dmsg.find( "pocket_index" ) != std::string::npos );
+        CHECK( gun_loc->ammo_remaining( loaded_well_idx ) == glock_count_before );
+        CHECK( gun_loc->ammo_remaining( empty_well_idx ) == 0 );
+    }
+}
+
+TEST_CASE( "reload_option::qty forces 1 for pocket-targeted (class a) reloads",
+           "[multimag][reload]" )
+{
+    clear_avatar();
+    Character &you = get_player_character();
+    you.wear_item( item( itype_backpack ) );
+
+    item gun = make_dual_well_gun();
+    item_location gun_loc = you.i_add( gun );
+    REQUIRE( gun_loc );
+
+    // A whole stack of replacement glock magazines so available_ammo > 1.
+    item glock_extra( itype_glockmag );
+    glock_extra.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+    item_location mag_loc = you.i_add( glock_extra );
+    REQUIRE( mag_loc );
+    you.i_add( glock_extra );
+    you.i_add( glock_extra );
+
+    int glock_idx = -1;
+    {
+        int idx = 0;
+        for( const item_pocket *p : gun_loc->get_pockets( []( const item_pocket & ) {
+        return true;
+    } ) ) {
+            if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                if( const item *mag = p->magazine_current() ) {
+                    if( mag->typeId() == itype_glockmag ) {
+                        glock_idx = idx;
+                        break;
+                    }
+                }
+            }
+            ++idx;
+        }
+    }
+    REQUIRE( glock_idx >= 0 );
+
+    item::reload_option opt( &you, gun_loc, mag_loc );
+    opt.pocket_index = glock_idx;
+    opt.qty( 1000 );
+    CHECK( opt.qty() == 1 );
+}
+
 TEST_CASE( "Character::unload ejects every loaded magazine", "[multimag][unload]" )
 {
     clear_avatar();
     clear_map();
     Character &you = get_player_character();
+    you.wear_item( item( itype_backpack ) );
 
     item gun = make_dual_well_gun();
     REQUIRE( gun.magazines_current().size() == 2 );
@@ -337,4 +681,115 @@ TEST_CASE( "Character::unload ejects every loaded magazine", "[multimag][unload]
 
     const std::vector<item *> remaining = gun_loc->magazines_current();
     CHECK( remaining.empty() );
+
+    bool found_glockmag = false;
+    bool found_stanag = false;
+    you.visit_items( [&]( const item * it, item * ) {
+        if( it->typeId() == itype_glockmag ) {
+            found_glockmag = true;
+        }
+        if( it->typeId() == itype_stanag30 ) {
+            found_stanag = true;
+        }
+        return VisitResponse::NEXT;
+    } );
+    CHECK( found_glockmag );
+    CHECK( found_stanag );
+}
+
+TEST_CASE( "same-type dual-well: targeted reload replaces a specific well",
+           "[multimag][reload]" )
+{
+    clear_avatar();
+    Character &you = get_player_character();
+    you.wear_item( item( itype_backpack ) );
+
+    item gun( itype_test_multimag_gun_same_type );
+    item glock_a( itype_glockmag );
+    glock_a.ammo_set( itype_9mm, 15 );
+    item glock_b( itype_glockmag );
+    glock_b.ammo_set( itype_9mm, 5 );
+
+    std::vector<int> well_indices;
+    {
+        int idx = 0;
+        for( const item_pocket *p : gun.get_pockets( []( const item_pocket & ) {
+        return true;
+    } ) ) {
+            if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                well_indices.push_back( idx );
+            }
+            ++idx;
+        }
+    }
+    REQUIRE( well_indices.size() == 2 );
+
+    std::vector<item_pocket *> wells = gun.get_pockets( []( const item_pocket & p ) {
+        return p.is_type( pocket_type::MAGAZINE_WELL );
+    } );
+    REQUIRE( wells.size() == 2 );
+    REQUIRE( wells[0]->insert_item( glock_a ).success() );
+    REQUIRE( wells[1]->insert_item( glock_b ).success() );
+
+    item_location gun_loc = you.i_add( gun );
+    REQUIRE( gun_loc );
+
+    item replacement( itype_glockmag );
+    replacement.ammo_set( itype_9mm, 15 );
+    item_location replacement_loc = you.i_add( replacement );
+    REQUIRE( replacement_loc );
+
+    const int target_well = well_indices[1];
+    const bool ok = gun_loc->reload( you, replacement_loc, 1, target_well );
+    REQUIRE( ok );
+
+    std::vector<const item_pocket *> wells_after = std::as_const( *gun_loc ).get_pockets(
+    []( const item_pocket & p ) {
+        return p.is_type( pocket_type::MAGAZINE_WELL );
+    } );
+    REQUIRE( wells_after.size() == 2 );
+    REQUIRE( wells_after[0]->magazine_current() != nullptr );
+    REQUIRE( wells_after[1]->magazine_current() != nullptr );
+    CHECK( wells_after[0]->magazine_current()->ammo_remaining() == 15 );
+    CHECK( wells_after[1]->magazine_current()->ammo_remaining() == 15 );
+}
+
+TEST_CASE( "reload_activity_actor serializes pocket_index",
+           "[multimag][reload][serialize]" )
+{
+    clear_avatar();
+    Character &you = get_player_character();
+    you.wear_item( item( itype_backpack ) );
+
+    item gun = make_dual_well_gun();
+    item_location gun_loc = you.i_add( gun );
+    REQUIRE( gun_loc );
+    item ammo( itype_glockmag );
+    ammo.ammo_set( itype_9mm, 15 );
+    item_location ammo_loc = you.i_add( ammo );
+    REQUIRE( ammo_loc );
+
+    item::reload_option opt( &you, gun_loc, ammo_loc, /*pocket_index=*/0 );
+    reload_activity_actor actor( std::move( opt ) );
+
+    std::ostringstream oss;
+    JsonOut jsout( oss );
+    actor.serialize( jsout );
+    const std::string serialized = oss.str();
+    CAPTURE( serialized );
+    CHECK( serialized.find( "\"pocket_index\":0" ) != std::string::npos );
+}
+
+TEST_CASE( "wield-collision sees mags from every well, not just the first",
+           "[multimag][wield]" )
+{
+    item gun = make_dual_well_gun();
+    const std::vector<item *> mags = gun.magazines_current();
+    REQUIRE( mags.size() == 2 );
+    std::set<itype_id> mag_types;
+    for( const item *m : mags ) {
+        mag_types.insert( m->typeId() );
+    }
+    CHECK( mag_types.count( itype_glockmag ) == 1 );
+    CHECK( mag_types.count( itype_stanag30 ) == 1 );
 }


### PR DESCRIPTION
#### Summary

Infrastructure "Generalize magazine handling so items can carry more than one magazine pocket"

#### Purpose of change

Follow-up to #86190. Continues implementation of #85928.

After this lands, any item with two MAGAZINE_WELL pockets works.. better: display, reload, unload, save/load, and initial spawn all stop assuming a single magazine.

#### Describe the solution

- Display: per-well counts in the gun name, plural Magazine line in iteminfo, every loaded mag considered for unload/wield hints.
- Reload: `item::reload()` takes an optional pocket index. The reload UI groups by well with a separator and prompts on ambiguity. Per-pocket capacity overloads.
- Save/load: pocket index round-trips through `reload_activity_actor`.
- Unload: ejects every loaded mag; with more than one, you can pick which one (or All).
- Spawn: itemgroups, mapgen dressing, vehicle gun-mounts, and NPC starting gear iterate every well via a shared `item::dress_magazine_wells`.

Design choices worth mentioning:

- Pocket-targeted reload only on the interactive player path. NPC reload, target practice, and the favorite-ammo single-keypress flow keep the legacy first-compatible-well fallback (see TODOs).
- Spawn dressing uses one `with_ammo` / `with_magazine` roll per item, with the outcome applied to every empty well. Item-wide `charges: N` on a multi-well item is rejected with a debugmsg (couldn't come up with a rule for splitting the count). Ammo without a magazine is a no-op.

#### Describe alternatives you've considered

- One selector entry per (ammo source, destination) pair in the reload UI, instead of one entry per source plus a follow-up disambig prompt. More pre-selection clarity, but a bigger diff and a wider return-path API. Will followup if the prompt becomes noisy in practice.
- Per-well JSON keys for `ammo` / `magazine` chance instead of one roll for the whole item. Saner once items with 3+ wells exist; for now the single-roll behavior matches single-well authorial intent and keeps the JSON surface unchanged.

#### Testing

New regression tests coverage; existing item, pocket, and reload tests pass.
Verified in-game with a multi-well airsoft gun (compressed air + BB, only available in DLC).

#### Additional context

N/A