### PR TITLE
Trash cans can't be installed on vehicles

### DIFF
--- a/data/json/vehicleparts/cargo.json
+++ b/data/json/vehicleparts/cargo.json
@@ -220,6 +220,7 @@
     "broken_color": "light_gray",
     "size": "359614 ml",
     "item": "trashcan_large",
+    "extend": { "flags": [ "NO_INSTALL_HIDDEN" ] },
     "delete": { "flags": [ "CARGO_PASSABLE" ] },
     "variants_bases": [ { "id": "trash can", "label": "Trash Can" } ],
     "variants": [ { "symbols": ")", "symbols_broken": "#" } ]


### PR DESCRIPTION
#### Summary
Balance "Trash cans can't be installed on vehicles"

#### Purpose of change
After another round of soul-searching on the development discord and talking about these trash cans... nobody has managed to come up with a way that makes the current ability to install them onto vehicles make sense.

Primary concerns:
-It is a giant tub of plastic. How does one secure it to a vehicle frame with only a screwdriver?
-How does it safely hold fuel? (Remember: Gasoline eats through plastic)
-How does it *pump* fuel? (it doesn't make any sense that they work as a fuel tank)

Now since we have no answers to these questions...

#### Describe the solution
They can't be installed onto vehicles.

Trash cans will continue to spawn in the world, and you can put them onto bike racks, or drag them around. You just can't take the trash can part and install it onto the side of a family sedan.

#### Describe alternatives you've considered
Just removing their ability to hold liquid would go a long way towards making more sense.

#### Testing
Opened vehicle install menu on a track, searched for it, it wasn't there. Working as intended.

#### Additional context
This one-line JSON-only PR took one and a half hours of today's time alone. I am not counting any of the many, many discussions regarding trash cans that we've previously had on discord. Everytime I think about how long these PRs take I think "Damn I should really just push out PRs quicker".