### PR TITLE
Mayapple should not have mutant toxins

### DIFF
--- a/data/json/items/comestibles/raw_fruit.json
+++ b/data/json/items/comestibles/raw_fruit.json
@@ -269,6 +269,7 @@
     "spoils_in": "3 days",
     "comestible_type": "FOOD",
     "symbol": "%",
+    "use_action": [ "POISON" ],
     "calories": 30,
     "healthy": -1,
     "description": "A small, edible fruit of an otherwise toxic plant.  You should not eat too many of them.",
@@ -278,8 +279,8 @@
     "volume": "20 ml",
     "flags": [ "FORAGE_POISON" ],
     "smoking_result": "dry_fruit",
-    "//": "entire plant contains poison interacting with the central nervous system, but the fruit is edible in small quantities. the effect of the poison is very similar to our mutant_toxin excess, a dedicated toxin just for this would be a waste of time and resources.",
-    "vitamins": [ [ "vitC", 3 ], [ "mutant_toxin", 15 ], [ "fruit_allergen", 1 ] ]
+    "//": "entire plant contains poison interacting with the central nervous system, but the fruit is edible in small quantities. When nervous toxin will be created it can be added to this fruit",
+    "vitamins": [ [ "vitC", 3 ], [ "fruit_allergen", 1 ] ]
   },
   {
     "type": "ITEM",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Mayapple do not have mutant toxin"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Mayapple do not have mutant toxin. And after recent changes because of mutant toxin the fruit and its cooking result became disgusting
fix #86697
When the nervous system intoxication will be implement it can be added to this fruit
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Deleted mutant toxin vitamin and added poison flag
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Add nervous system or any other vitamin/use action flag with appropriate effects and add this to this fruit
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Edited
Spawned fruit
See no mutant toxins
<img width="388" height="233" alt="image" src="https://github.com/user-attachments/assets/feacd4ef-c9ee-4ed5-8003-906af78e0dcd" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
