### PR TITLE
Update use_action messages, part 4

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -17,7 +17,7 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "NO_TEMP" ],
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You take a melatonin tablet.",
+      "activation_message": "You take a %s.",
       "effects": [ { "id": "melatonin", "duration": "14 h" } ]
     }
   },
@@ -302,7 +302,7 @@
     "stim": 12,
     "addiction_potential": 3,
     "addiction_type": "caffeine",
-    "use_action": { "type": "consume_drug", "activation_message": "You take a caffeine pill." },
+    "use_action": { "type": "consume_drug", "activation_message": "You take a %s." },
     "sleepiness_mod": 9
   },
   {
@@ -1297,11 +1297,7 @@
     "color": "white",
     "container": "bottle_plastic_pill_supplement",
     "flags": [ "NO_TEMP" ],
-    "use_action": {
-      "type": "consume_drug",
-      "activation_message": "You take some potassium iodide.",
-      "effects": [ { "id": "iodine", "duration": 7200 } ]
-    }
+    "use_action": { "type": "consume_drug", "activation_message": "You take a %s.", "effects": [ { "id": "iodine", "duration": 7200 } ] }
   },
   {
     "id": "joint",
@@ -1541,7 +1537,7 @@
     "addiction_type": "sleeping pill",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You take an antihistamine pill.",
+      "activation_message": "You take an %s.",
       "effects": [ { "id": "took_antihistamine", "duration": "10 h" } ]
     }
   },
@@ -1740,11 +1736,7 @@
     "symbol": "!",
     "color": "blue",
     "container": "bottle_plastic_pill_supplement",
-    "use_action": {
-      "type": "consume_drug",
-      "activation_message": "You take some Prussian blue.",
-      "effects": [ { "id": "pblue", "duration": 3600 } ]
-    }
+    "use_action": { "type": "consume_drug", "activation_message": "You take a %s.", "effects": [ { "id": "pblue", "duration": 3600 } ] }
   },
   {
     "id": "quikclot",
@@ -1908,7 +1900,7 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "NO_TEMP" ],
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You take the %s.",
+      "activation_message": "You take a %s.",
       "vitamins": [ [ "calcium", 24, 48 ], [ "iron", 24, 48 ], [ "vitC", 24, 48 ] ]
     },
     "//": "Yes, the vitamins are intentionally duplicated here. The consume/use/iteminfo UI needs them in use_action, but to actually pass on the vitamins they need to be in the comestible data, as below.",
@@ -1931,7 +1923,7 @@
     "symbol": "!",
     "color": "magenta",
     "container": "bottle_plastic_pill_supplement",
-    "use_action": { "type": "consume_drug", "activation_message": "You take the %s.", "vitamins": [ [ "calcium", 75 ] ] }
+    "use_action": { "type": "consume_drug", "activation_message": "You take a %s.", "vitamins": [ [ "calcium", 75 ] ] }
   },
   {
     "id": "bonemeal_tablet",
@@ -1951,7 +1943,7 @@
     "color": "white",
     "looks_like": "calcium_tablet",
     "flags": [ "NO_TEMP" ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take the %s.", "vitamins": [ [ "calcium", 24 ] ] },
+    "use_action": { "type": "consume_drug", "activation_message": "You take a %s.", "vitamins": [ [ "calcium", 24 ] ] },
     "vitamins": [ [ "meat_allergen", 1 ] ]
   },
   {
@@ -1972,7 +1964,7 @@
     "color": "yellow",
     "looks_like": "calcium_tablet",
     "flags": [ "NO_TEMP" ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take the %s.", "vitamins": [ [ "calcium", 23 ] ] },
+    "use_action": { "type": "consume_drug", "activation_message": "You take a %s.", "vitamins": [ [ "calcium", 23 ] ] },
     "vitamins": [ [ "meat_allergen", 1 ] ]
   },
   {
@@ -1990,7 +1982,7 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "NO_TEMP" ],
     "symbol": "!",
     "color": "magenta",
-    "use_action": { "type": "consume_drug", "activation_message": "You take the %s.", "vitamins": [ [ "vitC", 556 ] ] }
+    "use_action": { "type": "consume_drug", "activation_message": "You take a %s.", "vitamins": [ [ "vitC", 556 ] ] }
   },
   {
     "id": "vitc_fragment",
@@ -2007,7 +1999,7 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "NO_TEMP" ],
     "symbol": "!",
     "color": "magenta",
-    "use_action": { "type": "consume_drug", "activation_message": "You take the %s.", "vitamins": [ [ "vitC", 92 ] ] }
+    "use_action": { "type": "consume_drug", "activation_message": "You take a %s.", "vitamins": [ [ "vitC", 92 ] ] }
   },
   {
     "id": "gummy_vitamins",
@@ -2202,7 +2194,7 @@
     "color": "white",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You take some heartburn medicine.",
+      "activation_message": "You take some %s.",
       "effects": [ { "id": "tummy_tablet", "duration": 6400 } ]
     },
     "flags": [ "NPC_SAFE", "IRREPLACEABLE_CONSUMABLE" ]
@@ -2227,7 +2219,7 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "NPC_SAFE", "NO_TEMP" ],
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You take an antacid tablet.",
+      "activation_message": "You take an %s.",
       "effects": [ { "id": "tummy_tablet", "duration": 6400 } ],
       "vitamins": [ [ "calcium", 25 ] ]
     }
@@ -2404,7 +2396,7 @@
     "symbol": "!",
     "color": "white",
     "flags": [ "NO_TEMP" ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take the pill." }
+    "use_action": { "type": "consume_drug", "activation_message": "You take a %s." }
   },
   {
     "id": "estrogen",

--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -613,7 +613,7 @@
     "is_visible_when_installed": true,
     "use_action": {
       "type": "transform",
-      "msg": "You turn the mounted flashlight on.",
+      "msg": "You turn on the %s.",
       "target": "mounted_flashlight_on",
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead."
@@ -640,7 +640,7 @@
     "use_action": {
       "menu_text": "Turn off",
       "type": "transform",
-      "msg": "You turn the mounted flashlight off.",
+      "msg": "You turn off the %s.",
       "target": "mounted_flashlight",
       "ammo_scale": 0
     },

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -31,7 +31,7 @@
     "material": [ "rdx" ],
     "symbol": ";",
     "color": "light_gray",
-    "use_action": { "type": "message", "message": "You've already set the %s's timer, you might want to get away from it." },
+    "use_action": { "type": "message", "message": "You've already activated the %s.  Get rid of it and clear out!" },
     "countdown_action": { "type": "explosion", "explosion": { "power": 2000 } },
     "countdown_interval": "6 seconds",
     "flags": [ "NPC_THROW_NOW", "SPAWN_ACTIVE" ]
@@ -74,7 +74,7 @@
     "copy-from": "dynamite",
     "symbol": "*",
     "color": "red",
-    "use_action": { "type": "message", "message": "You've already lit the %s, try throwing it instead.", "name": "Light fuse" },
+    "use_action": { "type": "message", "message": "You've already lit the fuse, try throwing it instead.", "name": "Light fuse" },
     "flags": [ "TRADER_AVOID", "BOMB", "SPAWN_ACTIVE" ],
     "countdown_action": { "type": "explosion", "explosion": { "power": 938 } }
   },
@@ -116,7 +116,7 @@
     "copy-from": "dynamite_bomb",
     "symbol": "*",
     "color": "red",
-    "use_action": { "type": "message", "message": "You've already lit the %s, try throwing it instead.", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already lit the fuse.  Get rid of it and clear out!", "name": "Light fuse" },
     "flags": [ "TRADER_AVOID", "BOMB", "SPAWN_ACTIVE" ],
     "countdown_action": { "type": "explosion", "explosion": { "power": 938, "shrapnel": { "casing_mass": 1597, "fragment_mass": 0.5 } } }
   },
@@ -142,7 +142,7 @@
       "target": "EMPbomb_act",
       "msg": "You activate the EMP bomb.",
       "target_timer": "50 seconds",
-      "menu_text": "Activate bomb",
+      "menu_text": "Activate",
       "type": "transform"
     },
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "GRENADE", "WATER_BREAK" ],
@@ -165,7 +165,7 @@
     "explode_in_fire": true,
     "explosion": { "power": 600, "shrapnel": { "casing_mass": 3214, "fragment_mass": 0.5 } },
     "color": "light_gray",
-    "use_action": { "type": "message", "message": "You've already activated the %s, try throwing it instead.", "name": "Activate bomb" },
+    "use_action": { "type": "message", "message": "You've already activated the %s.  Get rid of it and clear out!", "name": "Activate" },
     "countdown_action": {
       "type": "explosion",
       "draw_explosion_radius": 10,
@@ -191,7 +191,6 @@
     "color": "red",
     "use_action": {
       "type": "transform",
-      "need_fire_msg": "You need a source of fire!",
       "target": "firecracker_act",
       "target_timer": "2 seconds",
       "msg": "You light the firecracker.",
@@ -231,7 +230,6 @@
     "color": "red",
     "use_action": {
       "type": "transform",
-      "need_fire_msg": "You need a source of fire!",
       "target": "firecracker_pack_act",
       "target_timer": "27 seconds",
       "msg": "You light the pack of firecrackers.",
@@ -275,7 +273,7 @@
     "use_action": {
       "need_wielding": true,
       "target": "flashbang_act",
-      "msg": "You pull the pin on the flashbang.",
+      "msg": "You pull the pin on the %s.",
       "target_timer": "2 seconds",
       "menu_text": "Pull pin",
       "type": "transform"
@@ -292,7 +290,7 @@
     "description": "This flashbang is active, and will soon detonate with intense light and sound, blinding, deafening, and disorienting anyone nearby.  It may be a good idea to throw it!",
     "price": "0 cent",
     "price_postapoc": "0 cent",
-    "use_action": { "type": "message", "message": "You've already pulled the %s's pin, try throwing it instead.", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already pulled the pin, try throwing it instead.", "name": "Pull pin" },
     "countdown_action": { "type": "explosion", "do_flashbang": true },
     "flags": [ "TRADER_AVOID", "SPAWN_ACTIVE" ]
   },
@@ -307,7 +305,7 @@
     "use_action": {
       "need_wielding": true,
       "menu_text": "Pull pin",
-      "msg": "You pull the pin.",
+      "msg": "You pull the pin on the %s.",
       "type": "transform",
       "target_timer": "50 seconds",
       "target": "fungicidalbomb_act"
@@ -332,7 +330,7 @@
     "use_action": {
       "need_wielding": true,
       "menu_text": "Pull pin",
-      "msg": "You pull the pin.",
+      "msg": "You pull the pin on the %s.",
       "type": "transform",
       "target_timer": "50 seconds",
       "target": "fungicidalbomb_makeshift_act"
@@ -361,7 +359,7 @@
       "target": "gasbomb_makeshift_act",
       "msg": "You arm the makeshift gas canister.",
       "target_timer": "10 seconds",
-      "menu_text": "Arm",
+      "menu_text": "Arm bomb",
       "type": "transform"
     },
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "CYLINDER_GRENADE" ]
@@ -381,7 +379,7 @@
     "material": [ "steel" ],
     "symbol": "*",
     "color": "dark_gray",
-    "use_action": { "type": "message", "message": "You've already armed the %s, try throwing it instead.", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already activated the %s, try throwing it instead.", "name": "Arm bomb" },
     "revert_to": "canister_empty",
     "countdown_action": {
       "type": "explosion",
@@ -413,7 +411,7 @@
     "use_action": {
       "need_wielding": true,
       "target": "grenade_act",
-      "msg": "You pull the pin on the grenade.",
+      "msg": "You pull the pin on the %s.",
       "target_timer": "5 seconds",
       "menu_text": "Pull pin",
       "type": "transform"
@@ -436,7 +434,7 @@
     "material": [ "steel", "plastic" ],
     "symbol": "*",
     "color": "green",
-    "use_action": { "type": "message", "message": "You've already pulled the %s's pin, try throwing it instead.", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already pulled the pin, try throwing it instead.", "name": "Pull pin" },
     "countdown_action": { "type": "explosion", "explosion": { "power": 240, "shrapnel": { "casing_mass": 217, "fragment_mass": 0.02 } } },
     "countdown_interval": "5 seconds",
     "flags": [ "BOMB", "TRADER_AVOID", "DANGEROUS", "SPAWN_ACTIVE" ],
@@ -485,7 +483,7 @@
     "material": [ "steel", "plastic" ],
     "symbol": "*",
     "color": "cyan",
-    "use_action": { "type": "message", "message": "You've already pulled the %s's pin, try throwing it instead.", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already pulled the pin, try throwing it instead.", "name": "Pull pin" },
     "countdown_action": {
       "type": "explosion",
       "fields_type": "fd_electricity",
@@ -515,7 +513,7 @@
     "use_action": {
       "need_wielding": true,
       "target": "grenade_inc_act",
-      "msg": "You pull the pin on the grenade.",
+      "msg": "You pull the pin on the %s.",
       "target_timer": "5 seconds",
       "menu_text": "Pull pin",
       "type": "transform"
@@ -562,7 +560,7 @@
     "use_action": {
       "need_wielding": true,
       "menu_text": "Pull pin",
-      "msg": "You pull the pin.",
+      "msg": "You pull the pin on the %s.",
       "type": "transform",
       "target_timer": "50 seconds",
       "target": "gasbomb_act"
@@ -593,7 +591,7 @@
     "use_action": {
       "need_wielding": true,
       "menu_text": "Pull pin",
-      "msg": "You pull the pin.",
+      "msg": "You pull the pin on the %s.",
       "type": "transform",
       "target_timer": "50 seconds",
       "target": "insecticidalbomb_act"
@@ -618,7 +616,7 @@
     "use_action": {
       "need_wielding": true,
       "menu_text": "Pull pin",
-      "msg": "You pull the pin.",
+      "msg": "You pull the pin on the %s.",
       "type": "transform",
       "target_timer": "100 seconds",
       "target": "insecticidalbomb_makeshift_act"
@@ -659,7 +657,7 @@
       "msg": "You pull the activating lever, readying the LAW to fire.",
       "target_charges": 1,
       "target_ammo": "66mm_HEAT",
-      "menu_text": "Activate",
+      "menu_text": "Unpack",
       "need_wielding": true,
       "type": "transform"
     },
@@ -704,7 +702,7 @@
     "description": "The nuclear bomb looks no different from the outside, yet you know that the device is armed and counting down.  You should probably get far, far away from it.",
     "price": "0 cent",
     "price_postapoc": "0 cent",
-    "use_action": { "type": "message", "message": "You've already set the %s's timer, you might want to get away from it." },
+    "use_action": { "type": "message", "message": "You've already activated the %s.  Get rid of it and clear out!" },
     "countdown_action": {
       "type": "explosion",
       "fields_type": "fd_nuke_gas",
@@ -855,7 +853,7 @@
     "material": [ "steel", "plastic" ],
     "symbol": "*",
     "color": "yellow",
-    "use_action": { "type": "message", "message": "You've already pulled the %s's pin, try throwing it instead.", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already pulled the pin, try throwing it instead.", "name": "Pull pin" },
     "countdown_action": { "type": "explosion", "draw_explosion_radius": 4, "draw_explosion_color": "cyan", "scrambler_blast_radius": 4 },
     "flags": [ "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "melee_damage": { "bash": 2 }
@@ -909,7 +907,7 @@
       "target": "tool_rocket_candy_act",
       "msg": "You light the rocket candy on fire.  Throw it!",
       "target_timer": "2 seconds",
-      "menu_text": "Light candy",
+      "menu_text": { "str": "Light", "ctxt": "verb" },
       "type": "transform"
     },
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB" ],
@@ -929,7 +927,11 @@
     "material": [ "steel", "plastic" ],
     "symbol": "*",
     "color": "green",
-    "use_action": { "type": "message", "message": "You've already lit the fuse - get rid of it immediately!", "name": "Pull pin" },
+    "use_action": {
+      "type": "message",
+      "message": "You've already lit the rocket candy, try throwing it instead.",
+      "name": { "str": "Light", "ctxt": "verb" }
+    },
     "countdown_action": {
       "type": "explosion",
       "fields_type": "fd_smoke",
@@ -976,7 +978,7 @@
     "name": { "str": "active military explosive small homemade grenade" },
     "description": "The fuse on this improvised grenade is lit, and it will explode any second now.  Better throw it!",
     "price": "0 cent",
-    "use_action": { "type": "message", "message": "You've already lit the %s's fuse, try throwing it instead.", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already lit the fuse, try throwing it instead.", "name": "Light fuse" },
     "countdown_action": { "type": "explosion", "explosion": { "power": 460, "shrapnel": { "casing_mass": 200, "fragment_mass": 0.4 } } },
     "flags": [ "BOMB", "TRADER_AVOID", "DANGEROUS", "SPAWN_ACTIVE" ]
   },
@@ -1015,7 +1017,7 @@
     "name": { "str": "active military explosive homemade grenade" },
     "description": "The fuse on this improvised grenade is lit, and it will explode any second now.  Better throw it!",
     "price": "0 cent",
-    "use_action": { "type": "message", "message": "You've already lit the %s's fuse, try throwing it instead.", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already lit the fuse, try throwing it instead.", "name": "Light fuse" },
     "countdown_action": { "type": "explosion", "explosion": { "power": 920, "shrapnel": { "casing_mass": 400, "fragment_mass": 0.4 } } },
     "flags": [ "BOMB", "TRADER_AVOID", "DANGEROUS", "SPAWN_ACTIVE" ]
   },
@@ -1040,7 +1042,7 @@
     "use_action": {
       "need_wielding": true,
       "target": "military_explosive_pipebomb_act",
-      "msg": "You pull the pin on the pipebomb.",
+      "msg": "You pull the pin on the %s.",
       "target_timer": "5 seconds",
       "menu_text": "Pull pin",
       "type": "transform"
@@ -1058,7 +1060,7 @@
     "description": "This pipebomb's pin is pulled, and it will explode any second now.  Throw it immediately!",
     "price": "0 cent",
     "color": "light_gray",
-    "use_action": { "type": "message", "message": "You've already pulled the %s's pin, try throwing it instead.", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already pulled the pin, try throwing it instead.", "name": "Pull pin" },
     "countdown_action": { "type": "explosion", "explosion": { "power": 920, "shrapnel": { "casing_mass": 410, "fragment_mass": 0.5 } } },
     "flags": [ "BOMB", "TRADER_AVOID", "DANGEROUS", "SPAWN_ACTIVE" ]
   },
@@ -1079,7 +1081,7 @@
     "use_action": {
       "need_wielding": true,
       "target": "military_explosive_bomb_act",
-      "msg": "You pull the pin on the small bootleg fragmentation device.  Get rid of it quickly!",
+      "msg": "You pull the pin on the %s.",
       "target_timer": "20 seconds",
       "menu_text": "Pull pin",
       "type": "transform"
@@ -1096,7 +1098,7 @@
     "description": "A homemade explosive device, consisting of a large plastic jug filled with military explosives and scrap metal.  Its fuse has been lit, its final countdown starting.",
     "price": "0 cent",
     "color": "light_red",
-    "use_action": { "type": "message", "message": "You've already pulled the pin - run!", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already activated the %s.  Get rid of it and clear out!", "name": "Pull pin" },
     "countdown_action": {
       "type": "explosion",
       "explosion": { "power": 6970, "shrapnel": { "casing_mass": 3000, "fragment_mass": 0.5, "drop": "scrap", "recovery": 20 } }
@@ -1124,7 +1126,7 @@
       "target": "military_explosive_half_barrel_bomb_act",
       "msg": "You activate the fuse on the barrel bomb.  Clear the area!",
       "target_timer": "100 seconds",
-      "menu_text": "Activate fuze",
+      "menu_text": "Activate fuse",
       "type": "transform"
     },
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "ALLOWS_REMOTE_USE" ],
@@ -1145,7 +1147,11 @@
     "material": [ "steel" ],
     "symbol": "(",
     "color": "light_red",
-    "use_action": { "type": "message", "message": "You've already activated the bomb - clear the area immediately!", "name": "Pull pin" },
+    "use_action": {
+      "type": "message",
+      "message": "You've already activated the %s.  Get rid of it and clear out!",
+      "name": "Activate fuse"
+    },
     "explode_in_fire": true,
     "explosion": { "power": 100000, "shrapnel": { "casing_mass": 12600, "fragment_mass": 600 } },
     "countdown_action": { "type": "explosion", "explosion": { "power": 100000, "shrapnel": { "casing_mass": 12600, "fragment_mass": 600 } } },
@@ -1172,7 +1178,7 @@
       "target": "military_explosive_full_barrel_bomb_act",
       "msg": "You activate the fuse on the barrel bomb.  Clear the area!",
       "target_timer": "100 seconds",
-      "menu_text": "Activate fuze",
+      "menu_text": "Activate fuse",
       "type": "transform"
     },
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "ALLOWS_REMOTE_USE" ],
@@ -1192,7 +1198,11 @@
     "material": [ "steel" ],
     "symbol": "(",
     "color": "light_red",
-    "use_action": { "type": "message", "message": "You've already activated the bomb - clear the area immediately!", "name": "Pull pin" },
+    "use_action": {
+      "type": "message",
+      "message": "You've already activated the %s.  Get rid of it and clear out!",
+      "name": "Activate fuse"
+    },
     "explode_in_fire": true,
     "explosion": { "power": 200000, "shrapnel": { "casing_mass": 12600, "fragment_mass": 600 } },
     "countdown_action": { "type": "explosion", "explosion": { "power": 200000, "shrapnel": { "casing_mass": 12600, "fragment_mass": 600 } } },
@@ -1234,7 +1244,7 @@
     "name": { "str": "active small homemade grenade" },
     "description": "The fuse on this improvised grenade is lit, and it will explode any second now.  Better throw it!",
     "price": "0 cent",
-    "use_action": { "type": "message", "message": "You've already lit the %s's fuse, try throwing it instead.", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already lit the fuse, try throwing it instead.", "name": "Light fuse" },
     "countdown_action": { "type": "explosion", "explosion": { "power": 150, "shrapnel": { "casing_mass": 200, "fragment_mass": 0.4 } } },
     "flags": [ "BOMB", "TRADER_AVOID", "DANGEROUS", "SPAWN_ACTIVE" ]
   },
@@ -1271,7 +1281,7 @@
     "name": { "str": "active homemade grenade" },
     "description": "The fuse on this improvised grenade is lit, and it will explode any second now.  Better throw it!",
     "price": "0 cent",
-    "use_action": { "type": "message", "message": "You've already lit the %s's fuse, try throwing it instead.", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already lit the fuse, try throwing it instead.", "name": "Light fuse" },
     "countdown_action": { "type": "explosion", "explosion": { "power": 300, "shrapnel": { "casing_mass": 400, "fragment_mass": 0.4 } } },
     "flags": [ "BOMB", "TRADER_AVOID", "DANGEROUS", "SPAWN_ACTIVE" ]
   },
@@ -1322,7 +1332,7 @@
     "material": [ "steel" ],
     "symbol": "*",
     "color": "light_gray",
-    "use_action": { "type": "message", "message": "You've already lit the %s, try throwing it instead.", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already lit the fuse, try throwing it instead.", "name": "Light fuse" },
     "explode_in_fire": true,
     "explosion": { "power": 300, "shrapnel": { "casing_mass": 410, "fragment_mass": 0.5 } },
     "countdown_action": { "type": "explosion", "explosion": { "power": 300, "shrapnel": { "casing_mass": 410, "fragment_mass": 0.5 } } },
@@ -1347,7 +1357,7 @@
     "use_action": {
       "need_wielding": true,
       "target": "homemade_bomb_act",
-      "msg": "You light the fuse on the small improvised fragmentation device.  Get rid of it quickly!",
+      "msg": "You light the fuse on the bomb.  Get rid of it quickly!",
       "target_timer": "20 seconds",
       "menu_text": "Light fuse",
       "type": "transform"
@@ -1367,7 +1377,7 @@
     "material": [ "steel", "plastic" ],
     "symbol": "*",
     "color": "light_red",
-    "use_action": { "type": "message", "message": "You've already lit the fuse - run!", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already lit the fuse.  Get rid of it and clear out!", "name": "Light fuse" },
     "explode_in_fire": true,
     "explosion": { "power": 2320, "shrapnel": { "casing_mass": 3000, "fragment_mass": 0.5, "drop": "scrap", "recovery": 20 } },
     "countdown_action": {
@@ -1394,7 +1404,7 @@
     "explosion": { "power": 2590 },
     "use_action": {
       "target": "homemade_demolition_charge_act",
-      "msg": "You light the %s.",
+      "msg": "You light the fuse on the bomb.  Get rid of it quickly!",
       "target_timer": "20 seconds",
       "need_fire": 1,
       "menu_text": "Light fuse",
@@ -1418,7 +1428,7 @@
     "material": [ "plastic", "powder" ],
     "symbol": "*",
     "color": "red",
-    "use_action": { "type": "message", "message": "You've already lit the %s, try throwing it instead.", "name": "Light fuse" },
+    "use_action": { "type": "message", "message": "You've already lit the fuse.  Get rid of it and clear out!", "name": "Light fuse" },
     "explode_in_fire": true,
     "explosion": { "power": 2590 },
     "countdown_action": { "type": "explosion", "explosion": { "power": 2590 } },
@@ -1467,7 +1477,7 @@
     "color": "light_red",
     "use_action": {
       "type": "message",
-      "message": "You've already activated the bomb - clear the area immediately!",
+      "message": "You've already activated the %s.  Get rid of it and clear out!",
       "name": "Activate fuse"
     },
     "explode_in_fire": true,
@@ -1518,7 +1528,7 @@
     "color": "light_red",
     "use_action": {
       "type": "message",
-      "message": "You've already activated the bomb - clear the area immediately!",
+      "message": "You've already activated the %s.  Get rid of it and clear out!",
       "name": "Activate fuse"
     },
     "explode_in_fire": true,

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -67,7 +67,7 @@
       {
         "type": "transform",
         "target": "electric_lantern_on",
-        "msg": "You turn the lamp on.",
+        "msg": "You turn on the %s.",
         "need_charges": 1,
         "need_charges_msg": "The batteries are dead."
       },
@@ -92,7 +92,7 @@
         "ammo_scale": 0,
         "type": "transform",
         "target": "electric_lantern",
-        "msg": "You turn the lamp off."
+        "msg": "You turn off the %s."
       },
       { "type": "link_up", "cable_length": 2, "charge_rate": "20 W" }
     ],
@@ -658,7 +658,7 @@
     "light": 200,
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK" ],
     "use_action": [
-      { "target": "lightstrip_inactive", "msg": "You turn off the LED strip.", "need_charges": 1, "type": "transform" },
+      { "target": "lightstrip_inactive", "menu_text": "Turn off", "msg": "You turn off the %s.", "type": "transform" },
       { "type": "link_up", "cable_length": 10, "charge_rate": "5 W" }
     ]
   },
@@ -677,7 +677,7 @@
     "color": "white",
     "//": "25 feet (7.5 m) + 1.5 meters for plug",
     "use_action": [
-      { "target": "lightstrip", "msg": "You turn on the LED strip.", "need_charges": 1, "type": "transform" },
+      { "target": "lightstrip", "msg": "You turn on the %s.", "need_charges": 1, "type": "transform" },
       { "type": "link_up", "cable_length": 9, "charge_rate": "5 W" }
     ],
     "tool_ammo": [ "battery" ]
@@ -851,7 +851,7 @@
     "charges_per_use": 1,
     "use_action": {
       "target": "reading_light_on",
-      "msg": "You switch on the reading light.",
+      "msg": "You turn on the %s.",
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead.",
       "type": "transform"
@@ -871,7 +871,7 @@
     "use_action": {
       "ammo_scale": 0,
       "target": "reading_light",
-      "msg": "You switch off the reading light.",
+      "msg": "You turn off the %s.",
       "menu_text": "Turn off",
       "type": "transform"
     },
@@ -897,7 +897,7 @@
     "use_action": [
       {
         "target": "smart_lamp_on",
-        "msg": "You turn the smart lamp on.",
+        "msg": "You turn on the %s.",
         "need_charges": 1,
         "need_charges_msg": "The batteries are dead.",
         "type": "transform"
@@ -930,13 +930,7 @@
     "revert_to": "smart_lamp",
     "light": 240,
     "use_action": [
-      {
-        "ammo_scale": 0,
-        "target": "smart_lamp",
-        "msg": "Your smart lamp turned off.",
-        "menu_text": "Turn off",
-        "type": "transform"
-      },
+      { "ammo_scale": 0, "target": "smart_lamp", "msg": "You turn off the %s.", "menu_text": "Turn off", "type": "transform" },
       { "type": "link_up", "cable_length": 3, "charge_rate": "6 W" }
     ],
     "flags": [

--- a/data/json/items/tool/radio_tools.json
+++ b/data/json/items/tool/radio_tools.json
@@ -70,7 +70,7 @@
     "description": "A remote-controlled toy car.  It is turned on and draining its batteries just like a real electric car!  Use a remote control to drive it around.",
     "turns_per_charge": 12,
     "revert_to": "radio_car",
-    "use_action": { "type": "transform", "target": "radio_car", "msg": "You turned off your RC car.", "menu_text": "Turn off" },
+    "use_action": { "type": "transform", "target": "radio_car", "msg": "You turn off the %s.", "menu_text": "Turn off" },
     "tick_action": [
       {
         "type": "sound",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -569,7 +569,12 @@
       "CALORIES_INTAKE_TRACKER",
       "FITNESS_CHECK",
       "PORTABLE_GAME",
-      { "type": "mp3", "transform": "smart_watch", "message": "The smart watch turns off.", "activate": false }
+      {
+        "type": "mp3",
+        "transform": "smart_watch",
+        "message": "You stop listening to music and take your earbuds out.",
+        "activate": false
+      }
     ],
     "tick_action": [ "MP3_ON" ],
     "extend": { "flags": [ "TRADER_AVOID" ] }
@@ -632,7 +637,12 @@
       "CALORIES_INTAKE_TRACKER",
       "FITNESS_CHECK",
       "PORTABLE_GAME",
-      { "type": "mp3", "transform": "smart_watch_adv", "message": "The smart watch turns off.", "activate": false },
+      {
+        "type": "mp3",
+        "transform": "smart_watch_adv",
+        "message": "You stop listening to music and take your earbuds out.",
+        "activate": false
+      },
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
     "tick_action": [ "MP3_ON" ],
@@ -1021,7 +1031,7 @@
     "charges_per_use": 1,
     "use_action": {
       "type": "transform",
-      "msg": "You turn the headlamp on.",
+      "msg": "You turn on the %s.",
       "target": "wearable_light_on",
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead."
@@ -1095,7 +1105,7 @@
       "ammo_scale": 0,
       "type": "transform",
       "menu_text": "Turn off",
-      "msg": "The %s flicks off.",
+      "msg": "You turn off the %s.",
       "target": "wearable_light"
     }
   },
@@ -1114,7 +1124,7 @@
       "ammo_scale": 0,
       "type": "transform",
       "menu_text": "Turn off",
-      "msg": "The %s flicks off.",
+      "msg": "You turn off the %s.",
       "target": "wearable_big_light"
     }
   },
@@ -1137,7 +1147,7 @@
     "charges_per_use": 1,
     "use_action": {
       "type": "transform",
-      "msg": "You turn the headlamp on.",
+      "msg": "You turn on the %s.",
       "target": "wearable_big_light_on",
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead."
@@ -3333,7 +3343,7 @@
     "use_action": {
       "menu_text": "Turn off",
       "type": "transform",
-      "msg": "You turn the %s off.",
+      "msg": "You turn off the %s.",
       "target": "basic_papr_belt_off",
       "ammo_scale": 0
     },
@@ -3429,7 +3439,7 @@
     "use_action": {
       "menu_text": "Turn off",
       "type": "transform",
-      "msg": "You turn the %s off.",
+      "msg": "You turn off the %s.",
       "target": "military_papr_blower_off",
       "ammo_scale": 0
     },
@@ -3525,7 +3535,7 @@
     "use_action": {
       "menu_text": "Turn off",
       "type": "transform",
-      "msg": "You turn the %s off.",
+      "msg": "You turn off the %s.",
       "target": "molle_papr_blower_off",
       "ammo_scale": 0
     },
@@ -4244,7 +4254,7 @@
     "charges_per_use": 1,
     "use_action": {
       "type": "transform",
-      "msg": "You turn the earmuffs on.",
+      "msg": "You turn on the %s.",
       "target": "powered_earmuffs_on",
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead."
@@ -4286,7 +4296,7 @@
       "ammo_scale": 0,
       "type": "transform",
       "menu_text": "Turn off",
-      "msg": "The %s flicks off.",
+      "msg": "You turn off the %s.",
       "target": "powered_earmuffs"
     },
     "warmth": 5,
@@ -4320,7 +4330,7 @@
     "volume": "200 ml",
     "use_action": {
       "type": "transform",
-      "msg": "You turn the earplugs on.",
+      "msg": "You turn on the %s.",
       "target": "powered_earplugs_on",
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead."
@@ -4346,7 +4356,7 @@
       "ammo_scale": 0,
       "type": "transform",
       "menu_text": "Turn off",
-      "msg": "The %s flicks off.",
+      "msg": "You turn off the %s.",
       "target": "powered_earplugs"
     }
   },
@@ -4811,7 +4821,7 @@
     "charges_per_use": 1,
     "use_action": {
       "type": "transform",
-      "msg": "You turn the flight helmet on.",
+      "msg": "You turn on the %s.",
       "target": "flight_helmet_on",
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead."
@@ -4854,7 +4864,7 @@
       "type": "transform",
       "ammo_scale": 0,
       "menu_text": "Turn off",
-      "msg": "The %s flicks off.",
+      "msg": "You turn off the %s.",
       "target": "flight_helmet"
     },
     "tool_ammo": "battery"

--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -15,7 +15,7 @@
     "use_action": {
       "need_wielding": true,
       "target": "granade_act",
-      "msg": "You pull the pin on the Granade.",
+      "msg": "You pull the pin on the %s.",
       "target_timer": "5 seconds",
       "type": "transform"
     },
@@ -34,7 +34,7 @@
     "material": [ "steel", "plastic" ],
     "symbol": "*",
     "color": "green",
-    "use_action": { "type": "message", "message": "You've already pulled the %s's pin, try throwing it instead." },
+    "use_action": { "type": "message", "message": "You've already pulled the pin, try throwing it instead.", "name": "Pull pin" },
     "tick_action": [
       { "type": "sound", "sound_message": "Merged!", "sound_volume": 0, "sound_id": "speech", "sound_variant": "granade_act" }
     ],

--- a/data/mods/MindOverMatter/items/weapons.json
+++ b/data/mods/MindOverMatter/items/weapons.json
@@ -18,7 +18,7 @@
     "use_action": {
       "need_wielding": true,
       "target": "grenade_inferno_act",
-      "msg": "You pull the pin on the grenade.",
+      "msg": "You pull the pin on the %s.",
       "target_timer": "5 seconds",
       "menu_text": "Pull pin",
       "type": "transform"
@@ -72,7 +72,7 @@
     "use_action": {
       "need_wielding": true,
       "target": "grenade_inferno_makeshift_act",
-      "msg": "You pull the pin on the grenade.",
+      "msg": "You pull the pin on the %s.",
       "target_timer": "5 seconds",
       "menu_text": "Pull pin",
       "type": "transform"
@@ -148,7 +148,7 @@
     "material": [ "steel", "plastic", "nether_crystal" ],
     "symbol": "*",
     "color": "dark_gray",
-    "use_action": { "type": "message", "message": "The %s is already active, try throwing it instead.", "name": "Push buttons" },
+    "use_action": { "type": "message", "message": "You've already activated the %s, try throwing it instead.", "name": "Push buttons" },
     "countdown_action": { "type": "cast_spell", "spell_id": "grenade_anti_psi_explosion", "no_fail": true, "level": 0 },
     "countdown_interval": "5 seconds",
     "flags": [ "BOMB", "TRADER_AVOID", "DANGEROUS" ],

--- a/data/mods/Xedra_Evolved/items/inventor/consumables.json
+++ b/data/mods/Xedra_Evolved/items/inventor/consumables.json
@@ -152,7 +152,7 @@
     "use_action": {
       "need_wielding": true,
       "target": "inventor_warp_grenade_act",
-      "msg": "You pull the pin on the grenade.",
+      "msg": "You pull the pin on the %s.",
       "target_timer": "5 seconds",
       "menu_text": "Pull pin",
       "type": "transform"
@@ -174,7 +174,7 @@
     "material": [ "mc_steel", "plastic" ],
     "symbol": "*",
     "color": "green",
-    "use_action": { "type": "message", "message": "You've already pulled the %s's pin, try throwing it instead.", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already pulled the pin, try throwing it instead.", "name": "Pull pin" },
     "countdown_action": { "type": "cast_spell", "spell_id": "netherium_warp_grenade_detonation", "no_fail": true, "level": 0 },
     "countdown_interval": "5 seconds",
     "flags": [ "BOMB", "TRADER_AVOID", "DANGEROUS" ],

--- a/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_modules.json
+++ b/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_modules.json
@@ -305,7 +305,7 @@
       "ammo_scale": 0,
       "menu_text": "Turn off",
       "type": "transform",
-      "msg": "You turn the heavy-duty flashlight off.",
+      "msg": "You turn the lamp off.",
       "target": "exo_flashlight"
     },
     "light": 500,

--- a/data/mods/aftershock_exoplanet/items/grenades.json
+++ b/data/mods/aftershock_exoplanet/items/grenades.json
@@ -22,7 +22,7 @@
     "use_action": {
       "need_wielding": true,
       "target": "afs_kaburaya_bomb_act",
-      "msg": "You activate the device.",
+      "msg": "You pull the pin on the %s.",
       "target_timer": "3 seconds",
       "menu_text": "Pull pin",
       "type": "transform"
@@ -37,7 +37,7 @@
     "looks_like": "c4",
     "name": "armed Kabura-ya antipersonnel device",
     "description": "A tiny plastic explosive meant to be installed within a Kabura-ya drone.  It is on the verge of exploding.",
-    "use_action": { "type": "message", "message": "You've already activated the %s, try throwing it instead.", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already pulled the pin, try throwing it instead.", "name": "Pull pin" },
     "countdown_action": {
       "type": "explosion",
       "explosion": { "power": 100, "max_noise": 25, "shrapnel": { "casing_mass": 217, "fragment_mass": 0.125 }, "distance_factor": 0.2 }
@@ -71,7 +71,7 @@
     "name": "active demolition charge",
     "looks_like": "c4armed",
     "description": "A powerful explosive with a highly focused blast radius, often used for mining or demolition work.  It's currently active.",
-    "use_action": { "type": "message", "message": "You've already activated the %s, try throwing it instead." },
+    "use_action": { "type": "message", "message": "You've already activated the %s.  Get rid of it and clear out!" },
     "countdown_action": { "type": "explosion", "explosion": { "power": 3000, "max_noise": 250, "distance_factor": 0.3 } },
     "extend": { "flags": [ "TRADER_AVOID" ] }
   },
@@ -89,7 +89,7 @@
     "use_action": {
       "need_wielding": true,
       "target": "afs_HE_grenade_act",
-      "msg": "You pull the pin on the grenade.",
+      "msg": "You pull the pin on the %s.",
       "target_timer": "5 seconds",
       "menu_text": "Pull pin",
       "type": "transform"
@@ -104,7 +104,7 @@
     "name": "active HE grenade",
     "looks_like": "grenade_act",
     "description": "A high explosive grenade that deals most of its damage through a powerful shockwave.  It's currently active.",
-    "use_action": { "type": "message", "message": "You've already activated the %s, try throwing it instead." },
+    "use_action": { "type": "message", "message": "You've already pulled the pin, try throwing it instead.", "name": "Pull pin" },
     "countdown_action": { "type": "explosion", "explosion": { "power": 3000, "max_noise": 250, "distance_factor": 0.7 } },
     "extend": { "flags": [ "TRADER_AVOID" ] }
   },
@@ -156,7 +156,7 @@
     "use_action": {
       "need_wielding": true,
       "target": "grenade_cryo_act",
-      "msg": "You pull the pin on the grenade.",
+      "msg": "You pull the pin on the %s.",
       "target_timer": "5 seconds",
       "menu_text": "Pull pin",
       "type": "transform"
@@ -179,7 +179,7 @@
     "material": [ "superalloy" ],
     "symbol": "*",
     "color": "green",
-    "use_action": { "type": "message", "message": "You've already pulled the %s's pin, try throwing it instead.", "name": "Pull pin" },
+    "use_action": { "type": "message", "message": "You've already pulled the pin, try throwing it instead.", "name": "Pull pin" },
     "countdown_action": {
       "type": "explosion",
       "fields_type": "fd_rad_glimmer",
@@ -205,7 +205,7 @@
     "use_action": {
       "need_wielding": true,
       "target": "afs_toxic_grenade_act",
-      "msg": "You pull the pin on the grenade.",
+      "msg": "You pull the pin on the %s.",
       "target_timer": "5 seconds",
       "menu_text": "Pull pin",
       "type": "transform"
@@ -220,7 +220,7 @@
     "name": "active neurotoxin grenade",
     "looks_like": "grenade_act",
     "description": "A neurotoxic device that deploys thick swathes of toxic foam upon detonation.  It's currently active.",
-    "use_action": { "type": "message", "message": "You've already activated the %s, try throwing it instead." },
+    "use_action": { "type": "message", "message": "You've already pulled the pin, try throwing it instead." },
     "countdown_action": {
       "type": "explosion",
       "explosion": { "power": 150, "max_noise": 250, "distance_factor": 0.7 },
@@ -243,9 +243,9 @@
     "use_action": {
       "need_wielding": true,
       "target": "afs_oxygen_bomb_act",
-      "msg": "You pull the pin on the bomb.",
+      "msg": "You pull the pin on the %s.",
       "target_timer": "3 seconds",
-      "menu_text": "Pull the pin",
+      "menu_text": "Pull pin",
       "type": "transform"
     },
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "NPC_ACTIVATE" ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Continutaion of #84179. The last PR for `use_action`.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Some medications already used the message `You take a %s`. It's now also used for pills wherever possible.
2. Explosives have a small "hack" where `use_action` is overwritten with `"type": "message"`. The player is unlikely to see these messages; but now they use a few standardized messages instead.
3. The grenade pin-pulling message has also been standardized.
4. Fixed some incorrect/missing `menu_text` fields: `Light fuse` for explosives with a fuse that require a fire source, `Pull pin` for explosives with a pin.
5. Some lamps now also use the standardized activation message.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<img width="341" height="84" alt="a-tool3" src="https://github.com/user-attachments/assets/be9caf10-a79e-47be-b7b7-8d6bd1799e61" />

---

<img width="587" height="69" alt="a-tool6" src="https://github.com/user-attachments/assets/c521835f-ff35-44f5-a032-d7d95d30eab1" />

---

<img width="489" height="63" alt="a-tool8" src="https://github.com/user-attachments/assets/5a2d1f1b-d58d-4f45-82e4-f9227014229f" />

---

<img width="671" height="231" alt="b-tool1" src="https://github.com/user-attachments/assets/f804de2e-7fce-4405-a6bc-725cb3f13181" />

---

<img width="606" height="99" alt="b-tool2" src="https://github.com/user-attachments/assets/4440fbd7-f75f-4340-806b-8e7b30610af7" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Explosives have a few minor issues (e.g., being able to sell active C-4...), but that's for another PR.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
