### PR TITLE
defining speed for more power tools. Adding TEMPER quality

### DIFF
--- a/data/json/construction/appliances.json
+++ b/data/json/construction/appliances.json
@@ -314,6 +314,18 @@
   },
   {
     "type": "construction",
+    "id": "app_steel_kiln",
+    "group": "place_steel_kiln",
+    "category": "APPLIANCE",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "5 m",
+    "components": [ [ [ "steel_kiln", 1 ] ] ],
+    "pre_special": "check_empty",
+    "post_special": "done_appliance",
+    "activity_level": "LIGHT_EXERCISE"
+  },
+  {
+    "type": "construction",
     "id": "app_arc_furnace",
     "group": "place_arc_furnace",
     "category": "APPLIANCE",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1377,6 +1377,11 @@
   },
   {
     "type": "construction_group",
+    "id": "place_steel_kiln",
+    "name": "Place Tempering Kiln"
+  },
+  {
+    "type": "construction_group",
     "id": "place_tablesaw",
     "name": "Place Table Saw"
   },

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -194,6 +194,23 @@
   },
   {
     "type": "vehicle_part",
+    "id": "f_steel_kiln",
+    "name": "tempering kiln",
+    "looks_like": "f_kiln_empty",
+    "color": "light_blue",
+    "categories": [ "utility" ],
+    "description": "A very long electric kiln made for heat treating metal.  Unlike a forge, it can't get extremely hot, but its temperature is completely programmable.",
+    "broken_color": "light_blue",
+    "damage_modifier": 10,
+    "damage_reduction": { "all": 30 },
+    "durability": 80,
+    "flags": [ "APPLIANCE" ],
+    "pseudo_tools": [ { "id": "steel_kiln_tool" } ],
+    "item": "steel_kiln",
+    "variants": [ { "symbols": "8", "symbols_broken": "x" } ]
+  },
+  {
+    "type": "vehicle_part",
     "id": "ap_tablesaw",
     "name": { "str": "table saw" },
     "looks_like": "f_machinery_light",

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -893,6 +893,22 @@
   },
   {
     "type": "furniture",
+    "id": "f_steel_kiln",
+    "name": "tempering kiln",
+    "looks_like": "f_kiln_empty",
+    "description": "A very long electric kiln made for heat treating metal.  Unlike a forge, it can't get extremely hot, but its temperature is completely programmable.  Needs to be placed and plugged into a power source.",
+    "symbol": "8",
+    "color": "light_blue",
+    "move_cost_mod": -1,
+    "coverage": 10,
+    "required_str": 8,
+    "mass": "110 kg",
+    "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "steel_kiln" },
+    "flags": [ "EASY_DECONSTRUCT" ],
+    "bash": { "str_min": 40, "str_max": 150, "sound_fail": "clang!" }
+  },
+  {
+    "type": "furniture",
     "id": "f_firefly_terrarium",
     "name": "firefly terrarium",
     "description": "While many survivors would have focused on trying to bring back electric lights, whoever lives here has apparently decided to make use of the changes wrought by the Cataclysm to provide light.  This vivarium contains soil, strange plants you don't recognize immediately, and most strikingly, a giant mutant firefly.",

--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -13,7 +13,7 @@
     "insulation": 3,
     "volume": "290 L",
     "weight": "77 kg",
-    "charged_qualities": [ [ "OVEN", 2 ] ],
+    "charged_qualities": [ { "id": "OVEN", "level": 2 }, { "id": "TEMPERING", "level": 1 } ],
     "pocket_data": [ { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "120 L", "max_contains_weight": "200 kg" } ]
   },
   {

--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -13,7 +13,7 @@
     "insulation": 3,
     "volume": "290 L",
     "weight": "77 kg",
-    "charged_qualities": [ { "id": "OVEN", "level": 2 }, { "id": "TEMPERING", "level": 1 } ],
+    "charged_qualities": [ { "id": "OVEN", "level": 2 }, { "id": "TEMPER", "level": 1 } ],
     "pocket_data": [ { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "120 L", "max_contains_weight": "200 kg" } ]
   },
   {
@@ -82,6 +82,20 @@
     "longest_side": "170 cm",
     "volume": "1000 L",
     "weight": "1100 kg"
+  },
+  {
+    "id": "steel_kiln",
+    "type": "ITEM",
+    "looks_like": "f_kiln",
+    "name": { "str": "disconnected tempering kiln" },
+    "description": "A very long electric kiln made for heat treating metal.  Unlike a forge, it can't get extremely hot, but its temperature is completely programmable.  Needs to be placed and plugged into a power source.",
+    "symbol": "8",
+    "color": "light_blue",
+    "weight": "110 kg",
+    "volume": "300 L",
+    "longest_side": "150 cm",
+    "material": [ "steel" ],
+    "//": "Based off of Evenheat Knife Oven - KF 49.5 Extreme Depth"
   },
   {
     "type": "ITEM",

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -310,6 +310,15 @@
     "extend": { "flags": [ "ALLOWS_REMOTE_USE" ] }
   },
   {
+    "id": "steel_kiln_tool",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "tempering kiln" },
+    "copy-from": "fake_appliance_tool",
+    "charges_per_use": 25,
+    "charged_qualities": [ { "id": "TEMPER", "level": 2, "speed": 0.8 } ]
+  },
+  {
     "id": "glassblowers_crucible_tool",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/data/json/items/resources/metal.json
+++ b/data/json/items/resources/metal.json
@@ -318,7 +318,7 @@
     "symbol": ",",
     "color": "light_gray",
     "ammo_type": "components",
-    "qualities": [ [ "HAMMER", 1 ] ],
+    "qualities": [ [ "HAMMER", 1 ], ["TEMPERING", 1 ] ],
     "melee_damage": { "bash": 8 }
   },
   {
@@ -341,7 +341,7 @@
     "symbol": ",",
     "color": "light_gray",
     "ammo_type": "components",
-    "qualities": [ [ "HAMMER", 1 ] ],
+    "qualities": [ [ "HAMMER", 1 ], [ "TEMPERING", 1 ] ],
     "melee_damage": { "bash": 12 }
   },
   {

--- a/data/json/items/resources/metal.json
+++ b/data/json/items/resources/metal.json
@@ -318,7 +318,7 @@
     "symbol": ",",
     "color": "light_gray",
     "ammo_type": "components",
-    "qualities": [ [ "HAMMER", 1 ], ["TEMPERING", 1 ] ],
+    "qualities": [ [ "HAMMER", 1 ] ],
     "melee_damage": { "bash": 8 }
   },
   {
@@ -341,7 +341,7 @@
     "symbol": ",",
     "color": "light_gray",
     "ammo_type": "components",
-    "qualities": [ [ "HAMMER", 1 ], [ "TEMPERING", 1 ] ],
+    "qualities": [ [ "HAMMER", 1 ] ],
     "melee_damage": { "bash": 12 }
   },
   {

--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -649,5 +649,26 @@
     "color": "dark_gray",
     "symbol": "B",
     "qualities": [ { "id": "TEMPER", "level": 1, "speed": 1.2 } ]
+  },
+  {
+    "id": "makeshift_steel_kiln",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "makeshift tempering kiln" },
+    "looks_like": "f_kiln_empty",
+    "description": "A very large brick kiln with a sheet metal shell.  Used for tempering metal of all sizes.",
+    "weight": "80 kg",
+    "volume": "300 L",
+    "longest_side": "160 cm",
+    "price_postapoc": "30 USD",
+    "material": [ "steel" ],
+    "symbol": "B",
+    "color": "light_gray",
+    "flags": [ "ALLOWS_REMOTE_USE", "WATER_BREAK" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
+    "charged_qualities": [ { "id": "TEMPER", "level": 2, "speed": 1.05 } ],
+    "charges_per_use": 30,
+    "use_action": [ { "type": "link_up", "cable_length": 10, "charge_rate": "1600 W" } ],
+    "tool_ammo": [ "battery" ]
   }
 ]

--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -634,5 +634,20 @@
     "flags": [ "ALLOWS_REMOTE_USE" ],
     "melee_damage": { "bash": 20 },
     "tool_ammo": [ "propane" ]
+  },
+  {
+    "id": "temper_block",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "tempering block set" },
+    "description": "Two square blocks of steel used for tempering metal via heating the blocks and sandwiching the metal between them.",
+    "weight": "2000 g",
+    "volume": "500 ml",
+    "price": "10 USD",
+    "price_postapoc": "2 USD",
+    "material": [ "mc_steel" ],
+    "color": "dark_gray",
+    "symbol": "B",
+    "qualities": [ { "id": "TEMPER", "level": 1, "speed": 1.2 } ]
   }
 ]

--- a/data/json/items/tool/pseudo.json
+++ b/data/json/items/tool/pseudo.json
@@ -64,7 +64,7 @@
     "copy-from": "fake_item",
     "symbol": "[",
     "color": "dark_gray",
-    "qualities": [ [ "OVEN", 2 ] ]
+    "qualities": [ { "id": "OVEN", "level": 2 }, { "id": "TEMPERING", "level": 2, "speed": 1.1 } ]
   },
   {
     "id": "butter_churn",

--- a/data/json/items/tool/pseudo.json
+++ b/data/json/items/tool/pseudo.json
@@ -64,7 +64,7 @@
     "copy-from": "fake_item",
     "symbol": "[",
     "color": "dark_gray",
-    "qualities": [ { "id": "OVEN", "level": 2 }, { "id": "TEMPERING", "level": 2, "speed": 1.1 } ]
+    "qualities": [ { "id": "OVEN", "level": 2 }, { "id": "TEMPER", "level": 2, "speed": 1.1 } ]
   },
   {
     "id": "butter_churn",

--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -234,7 +234,11 @@
     "to_hit": { "grip": "solid", "length": "long", "surface": "line", "balance": "clumsy" },
     "power_draw": "1200 W",
     "revert_to": "circsaw_off",
-    "qualities": [ { "id": "CUT", "level": 1, "speed": 0.5 }, { "id": "SAW_W", "level": 2, "speed": 0.3 }, { "id": "BUTCHER", "level": -40 } ],
+    "qualities": [
+      { "id": "CUT", "level": 1, "speed": 0.5 },
+      { "id": "SAW_W", "level": 2, "speed": 0.3 },
+      { "id": "BUTCHER", "level": -40 }
+    ],
     "use_action": { "target": "circsaw_off", "msg": "Your %s goes quiet.", "menu_text": "Turn off", "type": "transform" },
     "tick_action": {
       "type": "effect_on_conditions",

--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -234,7 +234,7 @@
     "to_hit": { "grip": "solid", "length": "long", "surface": "line", "balance": "clumsy" },
     "power_draw": "1200 W",
     "revert_to": "circsaw_off",
-    "qualities": [ [ "CUT", 1 ], [ "SAW_W", 2 ], [ "BUTCHER", -40 ] ],
+    "qualities": [ { "id": "CUT", "level": 1, "speed": 0.5 }, { "id": "SAW_W", "level": 2, "speed": 0.3 }, { "id": "BUTCHER", "level": -40 } ],
     "use_action": { "target": "circsaw_off", "msg": "Your %s goes quiet.", "menu_text": "Turn off", "type": "transform" },
     "tick_action": {
       "type": "effect_on_conditions",

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -66,7 +66,7 @@
     "material": [ "steel", "plastic" ],
     "symbol": "/",
     "color": "yellow",
-    "charged_qualities": [ [ "GRIND", 2 ], [ "SAW_M", 10 ] ],
+    "charged_qualities": [ { "id": "GRIND", "level": 2, "speed": 0.6 }, { "id": "SAW_M", "level": 10, "speed": 0.3 } ],
     "charges_per_use": 1,
     "power_draw": "800 W",
     "flags": [ "NONCONDUCTIVE", "WATER_BREAK" ],

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -918,7 +918,7 @@
     "charges_per_use": 8,
     "//0": "above is for 1/2 kg of steel - currently a door is 7 kg of material to cut",
     "use_action": [ "OXYTORCH" ],
-    "charged_qualities": [ [ "WELD", 2 ] ],
+    "charged_qualities": [ { "id": "WELD", "level": 2 }, { "id": "TEMPER", "level": 1, "speed": 1.2 } ],
     "flags": [ "ALLOWS_REMOTE_USE" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "weldtank", "smallweldtank", "tinyweldtank" ] } ],
     "to_hit": { "grip": "solid", "length": "short", "surface": "any", "balance": "neutral" },

--- a/data/json/mapgen/Metalworker.json
+++ b/data/json/mapgen/Metalworker.json
@@ -49,8 +49,8 @@
         "4": "t_gutter_downspout"
       },
       "furniture": {
-        "3": "f_machinery_heavy",
-        "1": "f_machinery_old",
+        "3": [ [ "f_machinery_heavy", 70 ], [ "f_steel_kiln", 30 ] ],
+        "1": [ [ "f_machinery_old", 80 ], [ "f_steel_kiln", 20 ] ],
         "H": "f_bench",
         "S": "f_sink",
         "#": "f_stool",

--- a/data/json/mapgen/s_lightindustry.json
+++ b/data/json/mapgen/s_lightindustry.json
@@ -174,7 +174,7 @@
         "y": "f_trashcan",
         "B": "f_trashcan",
         "v": "f_safe_l",
-        "1": "f_arcfurnace_empty",
+        "1": [ [ "f_arcfurnace_empty", 85 ], [ "f_steel_kiln", 15 ] ],
         "2": [ [ "f_hydraulic_press", 80 ], [ "f_power_hammer", 20 ] ],
         "3": "f_air_compressor",
         "4": "f_drill_press",

--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -310,6 +310,20 @@
   },
   {
     "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "temper_block",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "time": "1 h",
+    "autolearn": true,
+    "proficiencies": [ { "proficiency": "prof_metalworking" } ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "mc_steel_standard", 2 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "GRIND", "level": 2 } ]
+  },
+  {
+    "type": "recipe",
     "activity_level": "BRISK_EXERCISE",
     "result": "hammer",
     "category": "CC_OTHER",

--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -2077,5 +2077,76 @@
       { "id": "DRILL", "level": 2 }
     ],
     "tools": [ [ [ "casting_mold", -1 ] ], [ [ "hotcut_any", 1, "LIST" ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "makeshift_steel_kiln",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "skills_required": [ "electronics", 3 ],
+    "difficulty": 5,
+    "autolearn": false,
+    "using": [ [ "welding_standard", 60 ], [ "soldering_standard", 10 ], [ "steel_standard", 2 ] ],
+    "book_learn": [ [ "textbook_fabrication", 4 ], [ "manual_electronics", 2 ] ],
+    "components": [
+      [ [ "sheet_metal", 6 ] ],
+      [ [ "fire_brick", 30 ] ],
+      [ [ "thermometer", 2 ] ],
+      [ [ "cable", 10 ] ],
+      [ [ "mortar_build", 150 ] ],
+      [ [ "water", 20 ], [ "water_clean", 20 ] ],
+      [ [ "small_lcd_screen", 1 ] ],
+      [ [ "element", 4 ], [ "crude_heating_element", 6 ] ],
+      [ [ "hinge", 2 ] ],
+      [ [ "amplifier", 1 ] ],
+      [ [ "motor_micro", 1 ] ],
+      [ [ "fanblade_metal", 1 ] ]
+    ],
+    "steps": [
+      {
+        "name": "Mixing the mortar and carefully lining the fire bricks.",
+        "time": "1 h 20 m",
+        "activity_level": "LIGHT_EXERCISE"
+      },
+      {
+        "name": "Cutting and welding the hinges and sheet metal to form outer shell",
+        "time": "50 m",
+        "qualities": [ { "id": "SAW_M", "level": 2 } ],
+        "activity_level": "MODERATE_EXERCISE",
+        "proficiencies": [ { "proficiency": "prof_welding_basic" } ]
+      },
+      {
+        "name": "Grinding  grooves for the heating elements",
+        "time": "1 h",
+        "qualities": [ { "id": "GRIND", "level": 2 } ],
+        "activity_level": "BRISK_EXERCISE"
+      },
+      {
+        "name": "Inserting thermometers in the heating chamber.  Installing the fan.",
+        "time": "20 m",
+        "qualities": [ { "id": "DRILL", "level": 2 } ],
+        "activity_level": "LIGHT_EXERCISE"
+      },
+      {
+        "name": "Soldering connections for PID temperature controller and fan",
+        "time": "50 m",
+        "activity_level": "MODERATE_EXERCISE",
+        "proficiencies": [ { "proficiency": "prof_elec_soldering" }, { "proficiency": "prof_welding_basic" } ]
+      },
+      {
+        "name": "Making small control box to protect electronics.",
+        "time": "40 m",
+        "activity_level": "BRISK_EXERCISE",
+        "qualities": [ { "id": "SAW_M", "level": 2 } ],
+        "proficiencies": [ { "proficiency": "prof_welding_basic" } ]
+      },
+      {
+        "name": "Fit shell over forge.  Assembling door, and performing a low-temp burn to cure the mortar.",
+        "time": "1 h",
+        "activity_level": "LIGHT_EXERCISE",
+        "proficiencies": [ { "proficiency": "prof_welding_basic" } ]
+      }
+    ]
   }
 ]

--- a/data/json/tool_qualities.json
+++ b/data/json/tool_qualities.json
@@ -480,8 +480,8 @@
   },
   {
     "type": "tool_quality",
-    "id": "TEMPERING",
+    "id": "TEMPER",
     "//": "An item that can be used to temper metal with. Levels corresponds to size of metal that can be reasonably tempered",
-    "name": { "str": "tempering" }
+    "name": { "str": "TEMPER" }
   }
 ]

--- a/data/json/tool_qualities.json
+++ b/data/json/tool_qualities.json
@@ -477,5 +477,11 @@
     "id": "STRIKING_SURFACE",
     "//": "If item can be used to ignite matches.",
     "name": { "str": "striking surface" }
+  },
+  {
+    "type": "tool_quality",
+    "id": "TEMPERING",
+    "//": "An item that can be used to temper metal with. Levels corresponds to size of metal that can be reasonably tempered",
+    "name": { "str": "tempering" }
   }
 ]


### PR DESCRIPTION

#### Summary
Balance "Define speed for more power tools. Add tempering quality"

#### Purpose of change

A couple of power tools used in crafting recipes didn't have speeds, so defined them. Currently a lot of tempering is very much handwaved, but tempering long blades or large pieces of armor uniformly is not a trivial process.

#### Describe the solution

- [x] Add speed to power tools such as circular saw and angle grinder.
- [x] Add tempering quality.
- [x] Add tempering quality to some items, like the oven and oxy torch, and brick oven. (reasoning explained below)
- [x] Add items used for tempering large pieces of metal.
- [x] Add makeshift tempering kiln.

Tempering is a 2 level quality where the level corresponds to the size of metal that the tool can reliably temper. Level 1 is up to about a short sword, and level two is capable of accomodating very large blades or armor.  

Currently added items with tempering are steel blocks (temper 1) and tempering kiln (temper 2). 

Makeshift tempering oven is also added based on an IRL schematic by Dan Comeau. 
You can watch an example build [here,](https://youtu.be/DaNvgqdRKFs?si=-VyHQFNuNtO9Dxjg)

#### Describe alternatives you've considered

Continue to hand-wave tempering.
Don't add speed to power tools.

#### Testing

Loaded, works.

#### Additional context

The oven is pretty self-explanatory, it will help get steel up to temperature exactly, the problem is the oven is too small for some weapons and armor. The 'tempering blocks' are meant to portray a method where you heat steel blocks up to temperature and press them against the spine/middle of the blade or armor, and let the heat dissipate into it and temper the blade that way. The oxy torch is much the same, where you point the torch at the thickest part of the steel and very carefully run the colours. Takes A LOT of skill for an even temper, unreliable for very long, very thin blades.
