### PR TITLE
Include installed gunmod/toolmod prices in item::price

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1796,6 +1796,16 @@ int item::price( bool practical ) const
         return VisitResponse::NEXT;
     } );
 
+    if( is_gun() ) {
+        for( const item *mod : gunmods() ) {
+            res += mod->price_no_contents( practical );
+        }
+    } else if( is_tool() ) {
+        for( const item *mod : toolmods() ) {
+            res += mod->price_no_contents( practical );
+        }
+    }
+
     return res;
 }
 

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -66,6 +66,7 @@ static const itype_id itype_aspirin( "aspirin" );
 static const itype_id itype_attachable_ear_muffs( "attachable_ear_muffs" );
 static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_bag_plastic( "bag_plastic" );
+static const itype_id itype_barrel_glock_short( "barrel_glock_short" );
 static const itype_id itype_battery( "battery" );
 static const itype_id itype_bottle_plastic_small( "bottle_plastic_small" );
 static const itype_id itype_butter( "butter" );
@@ -76,6 +77,7 @@ static const itype_id itype_detergent( "detergent" );
 static const itype_id itype_duffelbag( "duffelbag" );
 static const itype_id itype_efile_photos( "efile_photos" );
 static const itype_id itype_efile_recipes( "efile_recipes" );
+static const itype_id itype_glock_19( "glock_19" );
 static const itype_id itype_hammer( "hammer" );
 static const itype_id itype_hat_hard( "hat_hard" );
 static const itype_id itype_jeans( "jeans" );
@@ -149,6 +151,20 @@ TEST_CASE( "gun_layer", "[item]" )
     gun.put_in( mod, pocket_type::MOD );
     CHECK( gun.get_layer().front() == layer_level::BELTED );
     CHECK( gun.get_category_of_contents().id == item_category_guns );
+}
+
+TEST_CASE( "gun_with_gunmod_price_sums_components", "[item][price][gunmod]" )
+{
+    item gun( itype_glock_19 );
+    item mod( itype_barrel_glock_short );
+    REQUIRE( gun.is_gunmod_compatible( mod ).success() );
+    const int gun_pre = gun.price_no_contents( false );
+    const int mod_pre = mod.price_no_contents( false );
+    const int gun_post = gun.price_no_contents( true );
+    const int mod_post = mod.price_no_contents( true );
+    gun.put_in( mod, pocket_type::MOD );
+    CHECK( gun.price( false ) == gun_pre + mod_pre );
+    CHECK( gun.price( true ) == gun_post + mod_post );
 }
 
 TEST_CASE( "stacking_cash_cards", "[item]" )


### PR DESCRIPTION
#### Summary
Bugfixes "Item price now includes installed gunmod/toolmod prices"

#### Purpose of change
A gun with an installed gunmod reports just the bare gun price. `item::price()` walks `visit_items`, but `item_contents::visit_contents` only descends into CONTAINER pockets, so MOD pocket contents never contribute. Same for tools with toolmods.

#### Describe the solution
After the existing visit, sum `gunmods()` for guns and `toolmods()` for tools and add their `price_no_contents` to the result.

#### Describe alternatives you've considered
Teaching `item_contents::visit_contents` to descend into MOD pockets. Broader blast radius across every visit_items caller, not worth it for a price fix.

#### Testing
Added a test that installs `barrel_glock_short` on a `glock_19` and asserts `gun.price()` matches the gun price plus mod price for both pre and post apoc. Existing item, price, and gunmod tests still pass.

#### Additional context
N/A