### PR TITLE
Reduce maximum intensity of hand-staunchable bleeding

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8213,7 +8213,7 @@ void Character::pause()
                                    _( "Your bleeding is beyond staunching barehanded!  A tourniquet might help." ),
                                    _( "<npcname>'s bleeding is beyond staunching barehanded!" ) );
         } else {
-            // 5 - 30 sec per turn (with standard hands)
+            // 5 - 20 sec per turn (with standard hands)
             time_duration benefit = 5_turns + 1_turns * max;
             effect &e = get_effect( effect_bleed, bp_id );
             e.mod_duration( - benefit );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8210,7 +8210,7 @@ void Character::pause()
         if( bp_id == bodypart_str_id::NULL_ID() ) {
             // We're bleeding, but couldn't find any bp we can staunch
             add_msg_player_or_npc( m_warning,
-                                   _( "Your bleeding is beyond staunching barehanded!  A tourniquet might help." ),
+                                   _( "Your bleeding is beyond staunching barehanded!  Bandaging it or using a tourniquet might help." ),
                                    _( "<npcname>'s bleeding is beyond staunching barehanded!" ) );
         } else {
             // 5 - 20 sec per turn (with standard hands)

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8089,8 +8089,8 @@ bodypart_id Character::most_staunchable_bp()
 bodypart_id Character::most_staunchable_bp( int &max_staunch )
 {
     // Calculate max staunchable bleed level
-    // Top out at 20 intensity for base, unencumbered survivors
-    max_staunch = 20;
+    // Top out at 10 intensity for base, unencumbered survivors
+    max_staunch = 10;
     max_staunch *= get_modifier( character_modifier_bleed_staunch_mod );
     add_msg_debug( debugmode::DF_CHARACTER, "Staunch limit after limb score modifier %d", max_staunch );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Reduce maximum intensity of hand-staunchable bleeding"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

If you've played long enough, you know that bandages are more useful for long-term healing than for staunching bleeding because the character's hands are surprisingly effective. This is because with your hands, you can currently staunch any bleeding of intensity 20 or below (out of 40), +5 if you have either of the wound care proficiencies. That means that unless you're shot, or occasionally if you get stabbed by a zombie predator or something similar, you can stop basically all bleeding with your hands. It's a bit much.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Reduce the maximum intensity of bleeding you can stop from 20 to 10 (leave the +5 alone). This has the knock-on effect that each `You put pressure on the bleeding wound…` reduces bleeding less than before, because the time is based on your maximum possible staunchable intensity, making it take longer and causing you to lose more blood. Carry bandages with you and use them.

This does not change the bonus you get from having extra arms, the penalty from lower manipulation, etc. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Reduce it even further to 5. That seems too much--ten means you can staunch all "Bleeding" but not "Bad Bleeding", whereas 5 would only let you staunch "Minor Bleeding" (all of this is ignoring the proficiency bonus)

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Works with new limit.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

The real solution is probably a Wounds system where some Wounds have hand-staunchable bleeding and some do not, but that's a long way away. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
