### PR TITLE
Add per faction steal preferences to thief mode

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -54,6 +54,7 @@
 #include "enums.h"
 #include "event.h"
 #include "event_bus.h"
+#include "faction.h"
 #include "fault.h"
 #include "field_type.h"
 #include "flag.h"
@@ -3088,10 +3089,6 @@ void pickup_activity_actor::do_turn( player_activity &, Character &who )
 
         cancel_pickup( who );
 
-        if( who.get_value( "THIEF_MODE_KEEP" ).str() != "YES" ) {
-            who.set_value( "THIEF_MODE", "THIEF_ASK" );
-        }
-
         if( !keep_going ) {
             // The user canceled the activity, so we're done
             // AIM might have more pickup activities pending, also cancel them.
@@ -5796,9 +5793,6 @@ void consume_activity_actor::finish( player_activity &act, Character & )
             player_character.consume( consume_item, /*force=*/true );
         } else {
             debugmsg( "Item location/name to be consumed should not be null." );
-        }
-        if( player_character.get_value( "THIEF_MODE_KEEP" ).str() != "YES" ) {
-            player_character.set_value( "THIEF_MODE", "THIEF_ASK" );
         }
     }
 
@@ -9458,18 +9452,22 @@ std::unique_ptr<activity_actor> haircut_activity_actor::deserialize( JsonValue &
 static bool check_stealing( Character &who, item &it )
 {
     if( !it.is_owned_by( who, true ) ) {
-        // Has the player given input on if stealing is ok?
-        if( who.get_value( "THIEF_MODE" ).str() == "THIEF_ASK" ) {
-            Pickup::query_thief( it );
-        }
-        if( who.get_value( "THIEF_MODE" ).str() == "THIEF_HONEST" ) {
-            if( who.get_value( "THIEF_MODE_KEEP" ).str() != "YES" ) {
-                who.set_value( "THIEF_MODE", "THIEF_ASK" );
-            }
+        const std::string thief_mode = who.get_value( "THIEF_MODE" ).str();
+        if( thief_mode == "THIEF_HONEST" ) {
             return false;
+        } else if( thief_mode != "THIEF_STEAL" ) {
+            // Default (THIEF_ASK) - check faction steal_persist
+            faction *owner_fac = g->faction_manager_ptr->get( it.get_owner(), false );
+            if( owner_fac && owner_fac->steal_persist.has_value() ) {
+                if( !*owner_fac->steal_persist ) {
+                    return false; // NEVER
+                }
+                // ALWAYS
+            } else if( !Pickup::query_thief( it ) ) {
+                return false;
+            }
         }
     }
-
     return true;
 }
 

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -32,6 +32,7 @@
 #include "enums.h"
 #include "event.h"
 #include "event_bus.h"
+#include "faction.h"
 #include "flag.h"
 #include "flat_set.h"
 #include "game.h"
@@ -1907,12 +1908,20 @@ time_duration Character::get_consume_time( const item &it ) const
 static bool query_consume_ownership( item &target, Character &p )
 {
     if( !target.is_owned_by( p, true ) ) {
-        bool choice = true;
-        if( p.get_value( "THIEF_MODE" ).str() == "THIEF_ASK" ) {
-            choice = Pickup::query_thief( target );
-        }
-        if( p.get_value( "THIEF_MODE" ).str() == "THIEF_HONEST" || !choice ) {
+        const std::string thief_mode = p.get_value( "THIEF_MODE" ).str();
+        if( thief_mode == "THIEF_HONEST" ) {
             return false;
+        } else if( thief_mode != "THIEF_STEAL" ) {
+            // Default (THIEF_ASK) - check faction steal_persist
+            faction *owner_fac = g->faction_manager_ptr->get( target.get_owner(), false );
+            if( owner_fac && owner_fac->steal_persist.has_value() ) {
+                if( !*owner_fac->steal_persist ) {
+                    return false; // NEVER
+                }
+                // ALWAYS
+            } else if( !Pickup::query_thief( target ) ) {
+                return false;
+            }
         }
         g->on_witness_theft( target );
     }

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -39,6 +39,7 @@ faction_template::faction_template()
     lone_wolf_faction = false;
     limited_area_claim = false;
     currency = itype_id::NULL_ID();
+    steal_persist = std::nullopt; // Default ask
 }
 
 faction::faction( const faction_template &templ )

--- a/src/faction.h
+++ b/src/faction.h
@@ -153,6 +153,9 @@ class faction_template
         translation desc;
         int size; // How big is our sphere of influence?
         int power; // General measure of our power
+        // Three steal states: Always, Never, Ask
+        // Always = true, Never = false, Ask = std::nullopt
+        std::optional<bool> steal_persist;
     protected:
         // Sorted list of nutrients and when they expire
         // The time_point == 0 mod 1_days, and calendar::turn_zero is non-perishable food

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -3162,19 +3162,16 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
         case ACTION_TOGGLE_THIEF_MODE:
             if( player_character.get_value( "THIEF_MODE" ).str() == "THIEF_ASK" ) {
                 player_character.set_value( "THIEF_MODE", "THIEF_HONEST" );
-                player_character.set_value( "THIEF_MODE_KEEP", "YES" );
                 //~ Thief mode cycled between THIEF_ASK/THIEF_HONEST/THIEF_STEAL
-                add_msg( _( "You will not pick up other peoples belongings." ) );
+                add_msg( _( "Thief mode: Always Honest - you will not pick up others' belongings." ) );
             } else if( player_character.get_value( "THIEF_MODE" ).str() == "THIEF_HONEST" ) {
                 player_character.set_value( "THIEF_MODE", "THIEF_STEAL" );
-                player_character.set_value( "THIEF_MODE_KEEP", "YES" );
                 //~ Thief mode cycled between THIEF_ASK/THIEF_HONEST/THIEF_STEAL
-                add_msg( _( "You will pick up also those things that belong to others!" ) );
+                add_msg( _( "Thief mode: Always Steal - you will pick up others' belongings without prompting." ) );
             } else if( player_character.get_value( "THIEF_MODE" ).str() == "THIEF_STEAL" ) {
                 player_character.set_value( "THIEF_MODE", "THIEF_ASK" );
-                player_character.set_value( "THIEF_MODE_KEEP", "NO" );
                 //~ Thief mode cycled between THIEF_ASK/THIEF_HONEST/THIEF_STEAL
-                add_msg( _( "You will be reminded not to steal." ) );
+                add_msg( _( "Thief mode: Default - you will be prompted when picking up owned items." ) );
             } else {
                 // ERROR
                 add_msg( _( "THIEF_MODE CONTAINED BAD VALUE [ %s ]!" ),

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -36,6 +36,7 @@
 #include "messages.h"
 #include "overmapbuffer.h"
 #include "options.h"
+#include "pimpl.h"
 #include "player_activity.h"
 #include "point.h"
 #include "popup.h"

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -17,6 +17,7 @@
 #include "contents_change_handler.h"
 #include "debug.h"
 #include "enums.h"
+#include "faction.h"
 #include "flexbuffer_json.h"
 #include "game.h"
 #include "game_constants.h"
@@ -111,7 +112,6 @@ static pickup_answer handle_problematic_pickup( const item &it, const std::strin
 
 bool Pickup::query_thief( const item &it )
 {
-    Character &u = get_player_character();
     const bool force_uc = get_option<bool>( "FORCE_CAPITAL_YN" );
     const auto &allow_key = force_uc ? input_context::disallow_lower_case_or_non_modified_letters
                             : input_context::allow_all_keys;
@@ -132,21 +132,28 @@ bool Pickup::query_thief( const item &it )
                          .cursor( 1 ) // default to the second option `NO`
                          .query()
                          .action; // retrieve the input action
+    // Get faction info for item so we can set steal persist
+    const faction_id owner = it.get_owner();
+    faction *owner_fac = g->faction_manager_ptr->get( owner, false );
     if( answer == "YES" ) {
-        u.set_value( "THIEF_MODE", "THIEF_STEAL" );
-        u.set_value( "THIEF_MODE_KEEP", "NO" );
+        if( owner_fac ) {
+            owner_fac->steal_persist = std::nullopt;
+        }
         return true;
     } else if( answer == "NO" ) {
-        u.set_value( "THIEF_MODE", "THIEF_HONEST" );
-        u.set_value( "THIEF_MODE_KEEP", "NO" );
+        if( owner_fac ) {
+            owner_fac->steal_persist = std::nullopt;
+        }
         return false;
     } else if( answer == "ALWAYS" ) {
-        u.set_value( "THIEF_MODE", "THIEF_STEAL" );
-        u.set_value( "THIEF_MODE_KEEP", "YES" );
+        if( owner_fac ) {
+            owner_fac->steal_persist = true;
+        }
         return true;
     } else if( answer == "NEVER" ) {
-        u.set_value( "THIEF_MODE", "THIEF_HONEST" );
-        u.set_value( "THIEF_MODE_KEEP", "YES" );
+        if( owner_fac ) {
+            owner_fac->steal_persist = false;
+        }
         return false;
     } else {
         // error
@@ -206,14 +213,21 @@ static bool pick_one_up( item_location &loc, int quantity, bool &got_water, bool
         it.erase_var( "activity_var" );
         newit.erase_var( "activity_var" );
     }
-
     if( !newit.is_owned_by( player_character, true ) ) {
-        // Has the player given input on if stealing is ok?
-        if( player_character.get_value( "THIEF_MODE" ).str() == "THIEF_ASK" ) {
-            Pickup::query_thief( newit );
-        }
-        if( player_character.get_value( "THIEF_MODE" ).str() == "THIEF_HONEST" ) {
-            return true; // Since we are honest, return no problem before picking up
+        const std::string thief_mode = player_character.get_value( "THIEF_MODE" ).str();
+        if( thief_mode == "THIEF_HONEST" ) {
+            return true;
+        } else if( thief_mode != "THIEF_STEAL" ) {
+            // Default (THIEF_ASK) - check faction steal_persist
+            faction *owner_fac = g->faction_manager_ptr->get( newit.get_owner(), false );
+            if( owner_fac && owner_fac->steal_persist.has_value() ) {
+                if( !*owner_fac->steal_persist ) {
+                    return true; // NEVER
+                }
+                // ALWAYS
+            } else if( !Pickup::query_thief( newit ) ) {
+                return true;
+            }
         }
     }
     if( newit.invlet != '\0' &&

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3854,6 +3854,7 @@ void faction::deserialize( const JsonObject &jo )
     jo.read( "known_by_u", known_by_u );
     jo.read( "size", size );
     jo.read( "power", power );
+    jo.read( "steal_persist", steal_persist );
     if( jo.has_int( "food_supply" ) ) {
         int calories;
         // Legacy kcal value found, migrate to calories
@@ -3888,6 +3889,7 @@ void faction::serialize( JsonOut &json ) const
     json.member( "known_by_u", known_by_u );
     json.member( "size", size );
     json.member( "power", power );
+    json.member( "steal_persist", steal_persist );
     // pruned version of the food supply
     cata::list<std::pair<time_point, nutrients>> pruned_food_supply = _food_supply;
     for( auto it = pruned_food_supply.begin(); it != pruned_food_supply.end(); ) {


### PR DESCRIPTION
#### Summary
Features "Add per faction steal preferences to thief mode"

#### Purpose of change
When you answer "Always" or "Never" to a steal item prompt, that answer is remembered globally and applies to every faction.  This can present a problem when you want to always steal from Raiders but never from others such as the Artisans/Free Merchants.  This can present a serious problem in conjunction with auto-pickup: you choose to always steal from Raiders, but auto-pickup will silently steal from the Free Merchants, Artisans or any other faction the next time you are near their items without any prompt.

#### Describe the solution
Store "Always" and "Never" steal preferences as per faction instead of globally for all. Choosing to always steal from Raiders will not affect how the game handles items owned by other factions. 

The global thief mode toggle (Always Honest / Always Steal) still works as before and overrides per faction preferences when set.

#### Describe alternatives you've considered


#### Testing
Compiled in Windows.
Loaded a game and verified the global toggle for Always Honest/Always Steal worked as expected.
Verified steal preferences were stored for each faction.
Verified serialization stored the steal preference data on exiting and reload.

#### Additional context
