### PR TITLE
Allow ferals to unlock car doors.

### DIFF
--- a/data/json/faults/faults_vehicles.json
+++ b/data/json/faults/faults_vehicles.json
@@ -99,6 +99,15 @@
     "flags": [ "FLAT_TIRE" ]
   },
   {
+    "id": "fault_broken_window",
+    "type": "fault",
+    "fault_type": "mechanical_damage",
+    "name": { "str": "broken window" },
+    "description": "Something broke through this door's window.",
+    "//COMMENT": "Hardcoded effects. Allows locked doors to be opened from the outside.",
+    "item_suffix": "broken window"
+  },
+  {
     "id": "fault_axle_broken",
     "type": "fault",
     "name": { "str": "Broken axle" },

--- a/data/json/items/vehicle/frames.json
+++ b/data/json/items/vehicle/frames.json
@@ -45,6 +45,7 @@
     "price": "55 USD",
     "price_postapoc": "1 USD",
     "copy-from": "foldframe",
+    "faults": [ { "fault": "fault_broken_window" } ],
     "melee_damage": { "bash": 20 }
   },
   {

--- a/data/json/vehicleparts/doors.json
+++ b/data/json/vehicleparts/doors.json
@@ -9,7 +9,18 @@
     "damage_reduction": { "all": 20 },
     "description": "A door.  Has a window so you can see out of it, even when closed.",
     "durability": 225,
-    "flags": [ "CARGO", "CARGO_PASSABLE", "OBSTACLE", "OPENABLE", "BOARDABLE", "WINDOW", "DOOR", "LOCKABLE_DOOR", "HUGE_OK" ],
+    "flags": [
+      "CARGO",
+      "CARGO_PASSABLE",
+      "OBSTACLE",
+      "OPENABLE",
+      "BOARDABLE",
+      "WINDOW",
+      "DOOR",
+      "LOCKABLE_DOOR",
+      "HUGE_OK",
+      "FRAGILE_COMPONENTS"
+    ],
     "item": "frame",
     "location": "center",
     "looks_like": "t_door_metal_c",
@@ -210,7 +221,7 @@
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "5 m", "using": [ [ "repair_welding_lc_steel", 3 ] ] }
     },
     "size": "125000 ml",
-    "extend": { "flags": [ "LOCKABLE_CARGO", "MULTISQUARE", "COVERED" ] },
+    "extend": { "flags": [ "LOCKABLE_CARGO", "MULTISQUARE", "COVERED", "FRAGILE_COMPONENTS" ] },
     "type": "vehicle_part"
   },
   {
@@ -232,7 +243,7 @@
     },
     "breaks_into": [ { "item": "splinter", "count": [ 7, 9 ] } ],
     "extend": { "flags": [ "SIMPLE_PART" ] },
-    "delete": { "flags": [ "CARGO", "CARGO_PASSABLE" ] },
+    "delete": { "flags": [ "CARGO", "CARGO_PASSABLE", "LOCKABLE_DOOR" ] },
     "damage_reduction": { "all": 8 }
   },
   {

--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -116,6 +116,11 @@
     "info": "Each boat hull will reduce the draft of your vehicle and increase the height sealed against water.  If the draft is less than the sealed height, your vehicle will float if placed in water."
   },
   {
+    "id": "FRAGILE_COMPONENTS",
+    "type": "json_flag",
+    "info": "Some components of this part are <color_red>fragile</color> and might be damaged even if the part itself isn't."
+  },
+  {
     "id": "FURNITURE_TIEDOWN",
     "type": "json_flag",
     "info": "You can tie down a furniture here."

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -1722,6 +1722,7 @@ Note: Vehicle parts requiring other parts is defined by setting a `requires_flag
 - ```E_STARTS_INSTANTLY``` Is an engine that starts instantly, like food pedals.
 - ```FLAT_SURF``` Part with a flat hard surface (e.g. table).
 - ```FLUIDTANK``` Allow to store liquid in this part.  Amount of liquid should be defined in item for this vehicle part.
+- ```FRAGILE_COMPONENTS``` This vehicle part can get a fault when receiving damage, even if that damage is nullified or reduced to 0.
 - ```FREEZER``` Can freeze items in below zero degrees Celsius temperature.
 - ```FRIDGE``` Can refrigerate items.
 - ```FUNNEL``` If installed over a vehicle tank, can collect rainwater during rains.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8932,7 +8932,7 @@ void game::on_move_effects()
 {
     // TODO: Move this to a character method
     if( !u.is_mounted() ) {
-        const item muscle( fuel_type_muscle );
+        static const item muscle( fuel_type_muscle );
         for( const bionic_id &bid : u.get_bionic_fueled_with_muscle() ) {
             if( u.has_active_bionic( bid ) ) {// active power gen
                 u.mod_power_level( muscle.fuel_energy() * bid->fuel_efficiency );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7671,6 +7671,13 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
             }
             u.mounted_creature->shove_vehicle( dest_loc + diff.xy(),
                                                dest_loc );
+        } else if( vp_there && vp_there->vehicle().part_has_lock( vp_there->part_index() ) ) {
+            // Automatically try to open locked door. Prints appropriate messages to log, etc.
+            if( doors::can_unlock_door( here, u, dest_loc ) ) {
+                doors::unlock_door( here, u, dest_loc );
+            } else {
+                iexamine::locked_object( u, dest_loc );
+            }
         }
         return false;
     }
@@ -8932,7 +8939,9 @@ void game::on_move_effects()
 {
     // TODO: Move this to a character method
     if( !u.is_mounted() ) {
-        static const item muscle( fuel_type_muscle );
+        // FIXME: stop initializing new items every time this runs.
+        // Can't make it static, itype can change if we quit to menu and load a different set of mods...
+        const item muscle( fuel_type_muscle );
         for( const bionic_id &bid : u.get_bionic_fueled_with_muscle() ) {
             if( u.has_active_bionic( bid ) ) {// active power gen
                 u.mod_power_level( muscle.fuel_energy() * bid->fuel_efficiency );

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -55,6 +55,9 @@ constexpr int VEHICLE_HANDLING_PENALTY = 80;
 // Amount by which to charge an item for each unit of plutonium cell.
 constexpr int PLUTONIUM_CHARGES = 500;
 
+// "Natural" damage nullification for durable veh parts, even if no damage reduction is defined
+constexpr int VEH_PART_DMG_REDUCTION_FROM_DURABILITY_CAP = 20;
+
 // Temperature constants.
 namespace temperatures
 {

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -40,6 +40,8 @@
 #include "viewer.h"
 #include "vpart_position.h"
 
+static const fault_id fault_broken_window( "fault_broken_window" );
+
 static const furn_str_id furn_f_crate_o( "f_crate_o" );
 static const furn_str_id furn_f_safe_o( "f_safe_o" );
 
@@ -586,15 +588,36 @@ bool doors::unlock_door( map &m, Creature &who, const tripoint_bub_ms &lockp )
         const int unlockable = veh->next_part_to_unlock( vpart, !inside_vehicle );
 
         if( unlockable >= 0 ) {
-            if( const Character *const ch = who.as_character() ) {
-                if( !veh->handle_potential_theft( *ch ) ) {
-                    return false;
-                }
-                veh->unlock( unlockable );
-                who.add_msg_if_player( _( "You unlock the %1$s's %2$s." ), veh->name,
-                                       veh->part( unlockable ).name() );
-                didit = true;
+            if( who.as_character() && !veh->handle_potential_theft( *who.as_character() ) ) {
+                return false;
             }
+            // For various... reasons, we are forced to manually check if a broken window was responsible for letting us unlock the door.
+            // TODO: Separate this out into a function or something not awful.
+            // It's a lambda right now so we don't have to check it unless we need it.
+            auto has_broken_window = [&]() {
+                std::vector<vehicle_part *> parts_at_target = veh->get_parts_at( &m, lockp, "LOCKABLE_DOOR",
+                        part_status_flag::available );
+                return !parts_at_target.empty() && parts_at_target.front()->has_fault( fault_broken_window );
+            };
+            const bool reaches_in = !inside_vehicle && has_broken_window();
+            veh->unlock( unlockable );
+            if( reaches_in ) {
+                if( who.as_avatar() ) {
+                    add_msg( _( "You reach in through the broken glass and unlock the %1$s's %2$s." ), veh->name,
+                             veh->part( unlockable ).name() );
+                } else {
+                    add_msg( _( "%1$s reaches in through the broken glass and unlocks the %2$s's %3$s." ),
+                             who.disp_name(), veh->name, veh->part( unlockable ).name() );
+                }
+            } else {
+                if( who.as_avatar() ) {
+                    add_msg( _( "You unlock the %1$s's %2$s." ), veh->name, veh->part( unlockable ).name() );
+                } else {
+                    add_msg( _( "%1$s unlocks the %2$s's %3$s." ), who.disp_name(), veh->name,
+                             veh->part( unlockable ).name() );
+                }
+            }
+            didit = true;
         } else if( inside_unlockable >= 0 ) {
             who.add_msg_if_player( m_info, _( "That %s can only be unlocked from the inside." ),
                                    veh->part( inside_unlockable ).name() );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3343,23 +3343,12 @@ const material_type &item::get_random_material() const
 
 const material_type &item::get_base_material() const
 {
-    const std::map<material_id, int> &mats = made_of();
-    const material_type *m = &material_id::NULL_ID().obj();
-    int portion = 0;
-    for( const std::pair<const material_id, int> &mat : mats ) {
-        if( mat.second > portion ) {
-            portion = mat.second;
-            m = &mat.first.obj();
-        }
+    // Monsters corpses are made out of what the monster is made of.
+    // Corpses don't usally have specific itypes.
+    if( is_corpse() && get_corpse_mon() ) {
+        return get_corpse_mon()->mat.begin()->first.obj();
     }
-    // Material portions all equal / not specified. Select first material.
-    if( portion == 1 ) {
-        if( is_corpse() ) {
-            return corpse->mat.begin()->first.obj();
-        }
-        return *type->default_mat;
-    }
-    return *m;
+    return type->get_base_material();
 }
 
 bool item::operator<( const item &other ) const

--- a/src/item.h
+++ b/src/item.h
@@ -1805,8 +1805,6 @@ class item : public visitable
         units::energy fuel_energy() const;
         /** Returns the string of the id of the terrain that pumps this fuel, if any. */
         std::string fuel_pump_terrain() const;
-        bool has_explosion_data() const;
-        fuel_explosion_data get_explosion_data() const;
 
         /**
          * returns whether any of the pockets is compatible with the specified item.

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -945,15 +945,6 @@ std::string item::fuel_pump_terrain() const
     return get_base_material().get_fuel_data().pump_terrain;
 }
 
-bool item::has_explosion_data() const
-{
-    return !get_base_material().get_fuel_data().explosion_data.is_empty();
-}
-
-struct fuel_explosion_data item::get_explosion_data() const {
-    return get_base_material().get_fuel_data().explosion_data;
-}
-
 bool item::is_magazine_full() const
 {
     return contents.is_magazine_full();

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -84,6 +84,27 @@ std::string enum_to_string<itype_variant_kind>( itype_variant_kind data )
 }
 } // namespace io
 
+const material_type &itype::get_base_material() const
+{
+    const material_type *m = &material_id::NULL_ID().obj();
+    int portion = 0;
+    for( const std::pair<const material_id, int> &mat : materials ) {
+        if( mat.second > portion ) {
+            portion = mat.second;
+            m = &mat.first.obj();
+        }
+    }
+    // Material portions all equal / not specified. Select first material.
+    if( portion == 1 ) {
+        return *default_mat;
+    }
+    return *m;
+}
+
+struct fuel_explosion_data itype::get_explosion_data() const {
+    return get_base_material().get_fuel_data().explosion_data;
+}
+
 std::string itype::get_item_type_string() const
 {
     if( tool ) {

--- a/src/itype.h
+++ b/src/itype.h
@@ -32,6 +32,7 @@
 #include "item_transformation.h"
 #include "iuse.h" // use_function
 #include "mapdata.h"
+#include "material.h"
 #include "proficiency.h"
 #include "relic.h"
 #include "stomach.h"
@@ -1611,6 +1612,15 @@ struct itype {
         * item damage [ 4000 - 4000 ] returns 5
         */
         int damage_level( int damage ) const;
+
+        /**
+         * Get the basic (main) material of this item. May return the null-material.
+         * This is the material with the highest "portion" value.
+         */
+        const material_type &get_base_material() const;
+
+        // Ways in which this itype does or does not explode.
+        fuel_explosion_data get_explosion_data() const;
 
         std::string get_item_type_string() const;
 

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -25,6 +25,7 @@
 #include "field.h"
 #include "field_type.h"
 #include "game.h"
+#include "gates.h"
 #include "item.h"
 #include "line.h"
 #include "map.h"
@@ -1269,6 +1270,11 @@ void monster::move()
             // is there an openable door?
             if( can_open_doors &&
                 here.open_door( *this, candidate, !here.is_outside( pos_bub() ), true ) ) {
+                moved = true;
+                next_step = candidate_abs;
+                continue;
+            } else if( can_open_doors && doors::can_unlock_door( here, *this, candidate ) ) {
+                doors::unlock_door( here, *this, candidate );
                 moved = true;
                 next_step = candidate_abs;
                 continue;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5365,7 +5365,7 @@ void vehicle::consume_fuel( map &here, int load, bool idling )
         int base_burn = actual_staminaRegen - 3;
         base_burn = std::max( eff_load / 3, base_burn );
         //charge bionics when using muscle engine
-        const item muscle( fuel_type_muscle );
+        static const item muscle( fuel_type_muscle );
         for( const bionic_id &bid : driver->get_bionic_fueled_with_muscle() ) {
             if( driver->has_active_bionic( bid ) ) { // active power gen
                 // more pedaling = more power
@@ -8029,15 +8029,17 @@ int vehicle::break_off( map &here, vehicle_part &vp, int dmg )
 
 bool vehicle::explode_fuel( map &here, vehicle_part &vp, const damage_type_id &type )
 {
-    const itype_id &ft = vp.info().fuel_type;
-    item fuel = item( ft );
-    if( !fuel.has_explosion_data() ) {
+    const itype_id &ft = vp.fuel_current();
+    if( ft.is_null() ) {
         return false;
     }
-    const fuel_explosion_data &data = fuel.get_explosion_data();
-
     if( vp.is_broken() ) {
         leak_fuel( here, vp );
+    }
+
+    const fuel_explosion_data &data = ft->get_explosion_data();
+    if( data.is_empty() ) {
+        return false;
     }
 
     int explosion_chance = type == damage_heat ? data.explosion_chance_hot :

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -103,6 +103,7 @@ static const damage_type_id damage_pure( "pure" );
 static const efftype_id effect_harnessed( "harnessed" );
 static const efftype_id effect_winded( "winded" );
 
+static const fault_id fault_broken_window( "fault_broken_window" );
 static const fault_id fault_engine_immobiliser( "fault_engine_immobiliser" );
 static const fault_id fault_flat_tire_riding_on_rims( "fault_flat_tire_riding_on_rims" );
 static const fault_id fault_punctured_tires( "fault_punctured_tires" );
@@ -3265,7 +3266,8 @@ int vehicle::next_part_to_unlock( int p, bool outside ) const
     }
     for( const int elem : parts_at_relative( parts[p].mount, true, true ) ) {
         const vehicle_part &vp = part( elem );
-        if( vp.info().has_flag( "LOCKABLE_DOOR" ) && vp.is_available() && vp.locked && !outside ) {
+        const bool accessible_lock = !outside || vp.has_fault( fault_broken_window );
+        if( vp.info().has_flag( "LOCKABLE_DOOR" ) && vp.is_available() && vp.locked && accessible_lock ) {
             return elem;
         }
     }
@@ -5365,7 +5367,9 @@ void vehicle::consume_fuel( map &here, int load, bool idling )
         int base_burn = actual_staminaRegen - 3;
         base_burn = std::max( eff_load / 3, base_burn );
         //charge bionics when using muscle engine
-        static const item muscle( fuel_type_muscle );
+        // FIXME: stop initializing new items every time this runs.
+        // Can't make it static, itype can change if we quit to menu and load a different set of mods...
+        const item muscle( fuel_type_muscle );
         for( const bionic_id &bid : driver->get_bionic_fueled_with_muscle() ) {
             if( driver->has_active_bionic( bid ) ) { // active power gen
                 // more pedaling = more power
@@ -8079,6 +8083,9 @@ int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_t
         // Volatile fuel still has a chance to explode.
         if( type == damage_heat && vp.is_fuel_store() ) {
             explode_fuel( here, vp, type );
+        } else if( vpi.has_flag( "FRAGILE_COMPONENTS" ) && one_in( 5 ) ) {
+            // Then any damage has a chance to cause faults, even if it would be nulled out.
+            vp.base.set_random_fault_of_type( "mechanical_damage" );
         }
 
         return dmg;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8049,9 +8049,10 @@ bool vehicle::explode_fuel( map &here, vehicle_part &vp, const damage_type_id &t
         explosion_handler::explosion( nullptr, bub_part_pos( here, vp ), pow, 0.7, data.fiery_explosion );
         mod_hp( vp, -vp.hp() );
         vp.ammo_unset();
+        return true;
     }
 
-    return true;
+    return false;
 }
 
 int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_type_id &type )
@@ -8070,8 +8071,10 @@ int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_t
         return break_off( here, vp, dmg );
     }
 
-    int tsh = std::min( 20, vpi.durability / 10 );
-    if( dmg < tsh && type != damage_pure ) {
+    // Parts have a minimum threshold to be damaged, durability/10.
+    int dmg_threshold = std::min( VEH_PART_DMG_REDUCTION_FROM_DURABILITY_CAP, vpi.durability / 10 );
+    if( dmg < dmg_threshold && type != damage_pure ) {
+        // Volatile fuel still has a chance to explode.
         if( type == damage_heat && vp.is_fuel_store() ) {
             explode_fuel( here, vp, type );
         }
@@ -8082,7 +8085,7 @@ int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_t
     if( !type->no_resist ) {
         dmg -= std::min<int>( dmg, vpi.damage_reduction.at( type ) );
     }
-    int dres = dmg - vp.hp();
+    int overkill_dmg = dmg - vp.hp();
     if( mod_hp( vp, -dmg ) ) {
         if( is_flyable() && !rotors.empty() && !vpi.has_flag( VPFLAG_SIMPLE_PART ) ) {
             // If we break a part, we can no longer fly the vehicle.
@@ -8145,7 +8148,7 @@ int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_t
         }
     }
 
-    return std::max( dres, 0 );
+    return std::max( overkill_dmg, 0 );
 }
 
 void vehicle::leak_fuel( map &here, vehicle_part &pt ) const

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2647,13 +2647,13 @@ void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub
         vp.avail_part_with_feature( "LOCKABLE_DOOR" );
     const std::optional<vpart_reference> vp_door_lock = vp.avail_part_with_feature( "DOOR_LOCKING" );
     if( vp_lockable_door && vp_door_lock && !vp_lockable_door->part().open ) {
-        if( player_inside && !vp_lockable_door->part().locked ) {
+        if( doors::can_lock_door( *here, get_player_character(), p ) ) {
             menu.add( string_format( _( "Lock %s" ), vp_lockable_door->part().name() ) )
             .hotkey( "LOCK_DOOR" )
             .on_submit( [p, here] {
                 doors::lock_door( *here, get_player_character(), p );
             } );
-        } else if( player_inside && vp_lockable_door->part().locked ) {
+        } else if( doors::can_unlock_door( *here, get_player_character(), p ) ) {
             menu.add( string_format( _( "Unlock %s" ), vp_lockable_door->part().name() ) )
             .hotkey( "UNLOCK_DOOR" )
             .on_submit( [p, here] {


### PR DESCRIPTION
#### Summary
Features "Allow ferals to unlock car doors."

#### Purpose of change
Did you know that a feral human stuck in a locked car can't get out?

#### Describe the solution
Fix that and also fix a whole tree of problems found along the way.

Add broken window fault (allows door to be unlocked from the outside). Applied when the part receives damage.
Allow can_open_doors monsters to open unlockable doors
Various UX improvements for handling locked vehicle doors (automatically tries to unlock). (How did anyone use these before??)

#### Describe alternatives you've considered
Door locks should not be a separate vehicle part 😫

#### Testing
(For the purposes of the video the window was pre-broken)

https://github.com/user-attachments/assets/523c093c-b3cc-4b18-a3c1-7d33c7dd9308


#### Additional context

Known issues:
-Regular door's base part is just a `steel frame` so if you uninstall one you'll get a `steel frame(broken window)`, which is nonsense. But I didn't make the vehicle part 🤷 

-No sprite support for faults/broken windows