### PR TITLE
Consume from more wells

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5731,5 +5731,99 @@
       { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] },
       { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] }
     ]
+  },
+  {
+    "id": "test_multimag_gun_consume",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "test multimag consume gun" },
+    "description": "Test gun for multimag consumption: 9mm well + battery well, two modes.",
+    "weight": "1000 g",
+    "volume": "1500 ml",
+    "longest_side": "400 mm",
+    "material": [ "steel" ],
+    "symbol": "(",
+    "color": "light_gray",
+    "ammo": [ "9mm" ],
+    "skill": "pistol",
+    "range": 10,
+    "ranged_damage": { "damage_type": "bullet", "amount": 10 },
+    "dispersion": 480,
+    "durability": 10,
+    "flags": [ "NO_TURRET" ],
+    "modes": [ [ "DEFAULT", "default", 1 ], [ "BURST", "burst", 3 ] ],
+    "pocket_data": [
+      { "id": "ammo", "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] },
+      {
+        "id": "power",
+        "magazine_well": "500 ml",
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "heavy_battery_cell" ]
+      }
+    ],
+    "firing_requirements": {
+      "DEFAULT": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 5 } ],
+      "BURST": [ { "pocket": "ammo", "qty": 3 }, { "pocket": "power", "qty": 15 } ]
+    }
+  },
+  {
+    "id": "test_multimag_tool_consume",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "test multimag consume tool" },
+    "description": "Test tool for multimag consumption: two non-battery wells with consumption_per_use.",
+    "weight": "500 g",
+    "volume": "750 ml",
+    "material": [ "steel" ],
+    "symbol": "&",
+    "color": "light_gray",
+    "pocket_data": [
+      { "id": "well_a", "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] },
+      {
+        "id": "well_b",
+        "magazine_well": "500 ml",
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "stanag30" ]
+      }
+    ],
+    "consumption_per_use": [ { "pocket": "well_a", "qty": 2 }, { "pocket": "well_b", "qty": 1 } ]
+  },
+  {
+    "id": "test_multimag_tool_throttled",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "test multimag throttled tool" },
+    "description": "Test active multimag tool with turns_per_charge throttling.",
+    "weight": "500 g",
+    "volume": "750 ml",
+    "material": [ "steel" ],
+    "symbol": "&",
+    "color": "light_gray",
+    "turns_per_charge": 5,
+    "pocket_data": [
+      { "id": "well_a", "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] },
+      {
+        "id": "well_b",
+        "magazine_well": "500 ml",
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "stanag30" ]
+      }
+    ],
+    "consumption_per_use": [ { "pocket": "well_a", "qty": 1 }, { "pocket": "well_b", "qty": 1 } ]
+  },
+  {
+    "id": "test_multimag_tool_factor",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "test multimag factor tool" },
+    "description": "Test multimag tool with legacy_charges_per_use_factor for recipe back-compat.",
+    "weight": "500 g",
+    "volume": "750 ml",
+    "material": [ "steel" ],
+    "symbol": "&",
+    "color": "light_gray",
+    "legacy_charges_per_use_factor": 5,
+    "pocket_data": [ { "id": "well_a", "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] } ],
+    "consumption_per_use": [ { "pocket": "well_a", "qty": 1 } ]
   }
 ]

--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -751,6 +751,7 @@ Any Item can be a container. To add the ability to contain things to an item, yo
         "volume": 8,                        // How loud the noise would be
         "chance": 60                        // Chance to generate a noise per move, from 0 to 100
       }, 
+    "id": "battery",                          // Optional handle referenced by `firing_requirements` / `consumption_per_use` on the parent item; only required on pockets that get referenced. Validated unique per item at load time.
     "default_magazine": "medium_battery_cell",       // Define the default magazine this item would have when spawned. Can be overwritten by item group
     "ammo_restriction": { "44": 5, "9mm": 10, }, // Restrict pocket to a given ammunition_type(s) and respective counts. The container will only hold one ammunition_type at a time but can hold multiple different items in that type. This field is mutually exclusive with "min_item_volume", "max_item_volume", "max_contains_volume", "max_contains_weight", "max_item_length", "min_item_length", "extra_encumbrance", "volume_encumber_modifier", "ripoff" and "activity_noise".
     "flag_restriction": [ "FLAG1", "FLAG2" ],        // Items can only be placed into this pocket if they have a flag that matches one of these flags.
@@ -859,6 +860,10 @@ Guns can be defined like this:
   [ "FOOBAR", "Volley", 2, "VOLLEY" ] // Fourth value is an optional flags. Possible flags are:
   [ "FOOBAR2", "alternative_notation", 3, [ "VOLLEY" ] ] // VOLLEY - all rounds shot by this mode would shoot at once, 
 ],                                                       // in that the recoil would be applied not after each shot, but only in the end
+"firing_requirements": {          // Optional. Multimag per-shot consumption keyed by gun mode. Mutually exclusive with non-zero `energy_drain` and non-default `ammo_to_fire`. Each entry references a `pocket_data.id` on a MAGAZINE_WELL pocket. Every base mode listed in `modes` must have an explicit entry; gunmod-added modes (via `mode_modifier`) inherit DEFAULT cost at runtime. `qty` must be >= 1.
+  "DEFAULT": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "battery", "qty": 5 } ],
+  "BURST":   [ { "pocket": "ammo", "qty": 3 }, { "pocket": "battery", "qty": 15 } ]
+},
 "reload": 450,             // Amount of time to reload, 100 = 1 second = 1 "turn"
 "reload_noise": "Ping!",   // Sound, that would be produced, when the gun is reloaded; seems to not work
 "reload_noise_volume": 4,  // how loud the reloading is
@@ -971,6 +976,8 @@ Gun mods can be defined like this:
 "initial_charges": 75,     // Charges when spawned
 "max_charges": 75,         // Maximum charges tool can hold
 "power_draw": "50 mW",     // Energy consumption per second
+"consumption_per_use": [ { "pocket": "oxygen", "qty": 2 }, { "pocket": "fuel", "qty": 1 } ], // Optional. Multimag per-activation consumption. Each entry references a `pocket_data.id` on a MAGAZINE_WELL pocket; `qty` must be >= 1. Mutually exclusive with `charges_per_use` and `power_draw` on the same item. Active tools drain once per turn by default, or once per `turns_per_charge` turns if set.
+"legacy_charges_per_use_factor": 5, // Optional, default 1. Set on multimag tools converted from a legacy `charges_per_use=N` (N>1) so existing recipes that pass raw charge counts get translated to uses (uses = qty / factor). Non-divisible requests trigger a debugmsg and consume nothing.
 "revert_to": "torch_done", // Transforms into item when charges are expended. Intended to be replaced by transform_into, which it's mutually exclusive with
 "transform_into": {        // Extended transformation info. To replace "revert_to", with which it's mutually exclusive. Optional.
   "target": "torch_done",  // Item to transform into.

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1011,10 +1011,10 @@ static hack_result hack_attempt( Character &who, item_location &tool )
     int success = std::ceil( normal_roll( hack_level( who, tool ), hack_stddev ) );
     if( success < 0 ) {
         who.add_msg_if_player( _( "You cause a short circuit!" ) );
-        tool->ammo_consume( tool->ammo_required(), here, tool.pos_bub( here ), &who );
+        tool->consume_tool_uses( 1, here, tool.pos_bub( here ), &who );
 
         if( success <= -5 ) {
-            tool->ammo_consume( ( tool->ammo_required() * 2 ), here, tool.pos_bub( here ), &who );
+            tool->consume_tool_uses( 2, here, tool.pos_bub( here ), &who );
         }
         return hack_result::FAIL;
     } else if( success < 6 ) {
@@ -1147,7 +1147,12 @@ void bookbinder_copy_activity_actor::finish( player_activity &act, Character &p 
 
         const std::vector<const item *> writing_tools_filter =
         p.crafting_inventory().items_with( [&]( const item & it ) {
-            return it.has_flag( flag_WRITE_MESSAGE ) && it.ammo_remaining( ) >= it.ammo_required() ;
+            // Match the local-only crafting drain so the filter doesn't pick
+            // a multimag tool that ammo_sufficient counts via UPS/bionic.
+            const bool enough = it.uses_firing_requirements()
+                                ? ( !it.needs_charges_to_use() || it.tool_uses_remaining_local() > 0 )
+                                : it.ammo_sufficient( &p );
+            return it.has_flag( flag_WRITE_MESSAGE ) && enough;
         } );
 
         std::vector<tool_comp> writing_tools;
@@ -1336,13 +1341,10 @@ void hacksaw_activity_actor::do_turn( player_activity &act, Character &who )
 
     if( !veh_pos.has_value() ) {
         if( tool->ammo_sufficient( &who, method ) ) {
-            int ammo_consumed = tool->ammo_required();
             std::map<std::string, int>::const_iterator iter = tool->type->ammo_scale.find( method );
-            if( iter != tool->type->ammo_scale.end() ) {
-                ammo_consumed *= iter->second;
-            }
+            const int uses = iter == tool->type->ammo_scale.end() ? 1 : iter->second;
 
-            tool->ammo_consume( ammo_consumed, here, tool.pos_bub( here ), &who );
+            tool->consume_tool_uses( uses, here, tool.pos_bub( here ), &who );
             sfx::play_activity_sound( "tool", "hacksaw", sfx::get_heard_volume( target ) );
             if( calendar::once_every( 1_minutes ) ) {
                 //~ Sound of a metal sawing tool at work!
@@ -1447,7 +1449,7 @@ void hacksaw_activity_actor::finish( player_activity &act, Character &who )
 
 float hacksaw_activity_actor::exertion_level() const
 {
-    if( tool->ammo_required() ) {
+    if( tool->needs_charges_to_use() ) {
         return LIGHT_EXERCISE;
     } else {
         return get_type()->exertion_level();
@@ -2120,7 +2122,7 @@ void read_activity_actor::start( player_activity &act, Character &who )
 
     // starting the activity should cost a charge to boot up the ebook app
     if( using_ereader ) {
-        ereader->ammo_consume( ereader->ammo_required(), who.pos_bub(), &who );
+        ereader->consume_tool_uses( 1, get_map(), who.pos_bub(), &who );
     }
 
     act.moves_total = moves_total;
@@ -2182,7 +2184,7 @@ void read_activity_actor::do_turn( player_activity &act, Character &who )
                 laptop              - max 1200 charges from disposable medium battery = 100 hours of reading
                 smart_phone         - 120 UPS charges                                 = 10 hours of reading
         */
-        ereader->ammo_consume( ereader->ammo_required(), who.pos_bub(), &who );
+        ereader->consume_tool_uses( 1, get_map(), who.pos_bub(), &who );
     }
 }
 
@@ -2858,7 +2860,7 @@ void spellcasting_activity_actor::finish( player_activity &act, Character &who )
                     who.i_rem( it );
                     spell_item_casting = item_location::nowhere;
                 } else if( it && !it->has_flag( flag_USE_PLAYER_ENERGY ) ) {
-                    who.consume_charges( *it, it->type->charges_to_use() );
+                    it->consume_tool_uses( 1, get_map(), who.pos_bub(), &who );
                 }
             }
 
@@ -3172,7 +3174,7 @@ void boltcutting_activity_actor::do_turn( player_activity &/*act*/, Character &w
     map &here = get_map();
 
     if( tool->ammo_sufficient( &who ) ) {
-        tool->ammo_consume( tool->ammo_required(), here, tool.pos_bub( here ), &who );
+        tool->consume_tool_uses( 1, here, tool.pos_bub( here ), &who );
     } else {
         tool_out_of_charges( who, tool->tname() );
     }
@@ -3601,6 +3603,8 @@ time_duration ebooksave_activity_actor::required_time(
     return total_pages( books ) * time_per_page;
 }
 
+// TODO(multimag): UI estimate uses ammo_required for legacy compatibility;
+// for multimag conversions of e-readers this would need a uses-based formula.
 int ebooksave_activity_actor::required_charges(
     const std::vector<item_location> &books,
     const item_location &ereader )
@@ -3649,7 +3653,7 @@ void ebooksave_activity_actor::do_turn( player_activity &act, Character &who )
             return;
         }
 
-        ereader->ammo_consume( ereader->ammo_required(), who.pos_bub(), &who );
+        ereader->consume_tool_uses( 1, get_map(), who.pos_bub(), &who );
     }
 
     turns_left_on_current_book--;
@@ -3858,7 +3862,7 @@ void efile_activity_actor::do_turn( player_activity &act, Character &who )
                                                    edevice->display_name() ) );
                 return false;
             }
-            edevice->ammo_consume( edevice->ammo_required(), here, edevice.pos_bub( here ), &who );
+            edevice->consume_tool_uses( 1, here, edevice.pos_bub( here ), &who );
             add_msg_debug( debugmode::DF_ACT_EBOOK, "%s power check", edevice->display_name() );
         }
         return true;
@@ -8506,7 +8510,7 @@ void oxytorch_activity_actor::do_turn( player_activity &/*act*/, Character &who 
     map &here = get_map();
 
     if( tool->ammo_sufficient( &who ) ) {
-        tool->ammo_consume( tool->ammo_required(), here, tool.pos_bub( here ), &who );
+        tool->consume_tool_uses( 1, here, tool.pos_bub( here ), &who );
         sfx::play_activity_sound( "tool", "oxytorch", sfx::get_heard_volume( target ) );
         if( calendar::once_every( 2_turns ) ) {
             sounds::sound( target, 10, sounds::sound_t::destructive_activity, _( "hissssssssss!" ) );
@@ -9157,12 +9161,9 @@ void prying_activity_actor::do_turn( player_activity &/*act*/, Character &who )
     std::string method = "CROWBAR";
 
     if( tool->ammo_sufficient( &who, method ) ) {
-        int ammo_consumed = tool->ammo_required();
         std::map<std::string, int>::const_iterator iter = tool->type->ammo_scale.find( method );
-        if( iter != tool->type->ammo_scale.end() ) {
-            ammo_consumed *= iter->second;
-        }
-        tool->ammo_consume( ammo_consumed, here, tool.pos_bub( here ), &who );
+        const int uses = iter == tool->type->ammo_scale.end() ? 1 : iter->second;
+        tool->consume_tool_uses( uses, here, tool.pos_bub( here ), &who );
         if( prying_nails ) {
             sfx::play_activity_sound( "tool", "hammer", sfx::get_heard_volume( target ) );
         }
@@ -10228,7 +10229,7 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
             it.remove_item();
         }
     } else if( used_tool->is_tool() ) {
-        if( used_tool->type->charges_to_use() ) {
+        if( used_tool->needs_charges_to_use() ) {
             it->activation_consume( charges_consumed, it.pos_bub( here ), &who );
         }
     }
@@ -10844,8 +10845,8 @@ void mine_activity_actor::finish( player_activity &act, Character &who )
                                _( "<npcname> finishes digging." ) );
     mining_strain( who );
 
-    if( mining_tool && mining_tool->ammo_required() > 0 ) {
-        mining_tool->ammo_consume( mining_tool->ammo_required(), tripoint_bub_ms::zero, &who );
+    if( mining_tool && mining_tool->needs_charges_to_use() ) {
+        mining_tool->consume_tool_uses( 1, get_map(), tripoint_bub_ms::zero, &who );
     }
 
     act.set_to_null();
@@ -12427,8 +12428,10 @@ void generic_entertainment_activity_actor::do_turn( player_activity &act, Charac
     if( calendar::once_every( 1_minutes ) ) {
         if( !!entertain_item ) {
             item &game_item = *entertain_item;
-            int req = game_item.ammo_required();
-            bool fail = req > 0 && game_item.ammo_consume( req, tripoint_bub_ms::zero, &who ) == 0;
+            const bool needs_power = game_item.needs_charges_to_use();
+            const bool fail = needs_power
+                              && game_item.consume_tool_uses( 1, get_map(),
+                                      tripoint_bub_ms::zero, &who ) == 0;
             if( fail ) {
                 act.moves_left = 0;
                 if( who.is_avatar() ) {
@@ -12546,7 +12549,7 @@ void vibe_activity_actor::do_turn( player_activity &act, Character &who )
 
     if( calendar::once_every( 1_minutes ) ) {
         if( vibrator_item.ammo_remaining( who_ptr ) > 0 ) {
-            vibrator_item.ammo_consume( 1, who.pos_bub(), who_ptr );
+            vibrator_item.consume_tool_uses( 1, get_map(), who.pos_bub(), who_ptr );
             who.add_morale( morale_feeling_good, 3, 40 );
             if( vibrator_item.ammo_remaining( who_ptr ) == 0 ) {
                 add_msg( m_info, _( "The %s runs out of batteries." ), vibrator_item.tname() );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -502,11 +502,10 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
         }
 
         if( attempt != repair_item_actor::AS_CANT ) {
-            if( ploc && ploc->where() == item_location::type::map ) {
-                used_tool->ammo_consume( used_tool->ammo_required(), ploc->pos_bub( here ), you );
-            } else {
-                you->consume_charges( *used_tool, used_tool->ammo_required() );
-            }
+            const tripoint_bub_ms tool_pos = ( ploc && ploc->where() == item_location::type::map )
+                                             ? ploc->pos_bub( here )
+                                             : you->pos_bub( here );
+            used_tool->consume_tool_uses( 1, here, tool_pos, you );
         }
 
         // TODO: Allow setting this in the actor
@@ -630,15 +629,16 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
             }
         }
 
+        const int per_use = used_tool->expected_cost_per_use();
         title += used_tool->is_tool() && used_tool->has_flag( flag_USES_NEARBY_AMMO )
                  ? string_format( _( "Charges: <color_light_blue>%d</color> %s (%d per use)\n" ),
                                   ammo_remaining,
                                   ammo_name,
-                                  used_tool->ammo_required() )
+                                  per_use )
                  : string_format( _( "Charges: <color_light_blue>%d/%d</color> %s (%d per use)\n" ),
                                   ammo_remaining, used_tool->ammo_capacity( current_ammo, true ),
                                   ammo_name,
-                                  used_tool->ammo_required() );
+                                  per_use );
         title += string_format( _( "Materials available: %s\n" ), string_join( material_list, ", " ) );
         title += string_format( _( "Skill used: <color_light_blue>%s (%d)</color>\n" ),
                                 actor->used_skill.obj().name(), level );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3352,7 +3352,7 @@ static bool chop_plank_activity( Character &you, const tripoint_bub_ms &src_loc 
         return false;
     }
     if( best_qual.type->can_have_charges() ) {
-        you.consume_charges( best_qual, best_qual.type->charges_to_use() );
+        best_qual.consume_tool_uses( 1, get_map(), you.pos_bub(), &you );
     }
     map &here = get_map();
     for( item &i : here.i_at( src_loc ) ) {
@@ -3446,7 +3446,7 @@ static bool chop_tree_activity( Character &you, const tripoint_bub_ms &src_loc )
     }
     int moves = chop_moves( you, best_qual );
     if( best_qual.type->can_have_charges() ) {
-        you.consume_charges( best_qual, best_qual.type->charges_to_use() );
+        best_qual.consume_tool_uses( 1, get_map(), you.pos_bub(), &you );
     }
     map &here = get_map();
     const ter_id &ter = here.ter( src_loc );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4499,6 +4499,12 @@ bool Character::consume_charges( item &used, int qty )
         return false;
     }
 
+    if( used.uses_firing_requirements() ) {
+        debugmsg( "consume_charges called on multimag tool %s; caller must use "
+                  "consume_tool_uses instead", used.tname() );
+        return false;
+    }
+
     // Consume comestibles destroying them if no charges remain
     if( used.is_food() || used.is_medication() ) {
         used.charges -= qty;
@@ -4509,8 +4515,7 @@ bool Character::consume_charges( item &used, int qty )
         return false;
     }
 
-    // Tools which don't require ammo are instead destroyed
-    if( used.is_tool() && !used.ammo_required() ) {
+    if( used.is_tool() && !used.needs_charges_to_use() ) {
         if( has_item( used ) ) {
             i_rem( &used );
         } else {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4426,27 +4426,32 @@ bool Character::invoke_item( item *used, const std::string &method, const tripoi
         return false;
     }
     if( !used->ammo_sufficient( this, method ) ) {
-        int ammo_req = used->ammo_required();
         std::string it_name = used->tname();
-        if( used->has_flag( flag_USE_UPS ) ) {
-            add_msg_if_player( m_info,
-                               n_gettext( "Your %s needs %d charge from some UPS.",
-                                          "Your %s needs %d charges from some UPS.",
-                                          ammo_req ),
-                               it_name, ammo_req );
-        } else if( used->has_flag( flag_USES_BIONIC_POWER ) ) {
-            add_msg_if_player( m_info,
-                               n_gettext( "Your %s needs %d kJ of bionic power.",
-                                          "Your %s needs %d kJ of bionic power.",
-                                          ammo_req ),
-                               it_name, ammo_req );
+        if( used->uses_firing_requirements() ) {
+            const std::string req = used->format_consumption_requirements( method );
+            add_msg_if_player( m_info, _( "Your %s needs: %s." ), it_name, req );
         } else {
-            int ammo_rem = used->ammo_remaining( );
-            add_msg_if_player( m_info,
-                               n_gettext( "Your %s has %d charge, but needs %d.",
-                                          "Your %s has %d charges, but needs %d.",
-                                          ammo_rem ),
-                               it_name, ammo_rem, ammo_req );
+            int ammo_req = used->ammo_required();
+            if( used->has_flag( flag_USE_UPS ) ) {
+                add_msg_if_player( m_info,
+                                   n_gettext( "Your %s needs %d charge from some UPS.",
+                                              "Your %s needs %d charges from some UPS.",
+                                              ammo_req ),
+                                   it_name, ammo_req );
+            } else if( used->has_flag( flag_USES_BIONIC_POWER ) ) {
+                add_msg_if_player( m_info,
+                                   n_gettext( "Your %s needs %d kJ of bionic power.",
+                                              "Your %s needs %d kJ of bionic power.",
+                                              ammo_req ),
+                                   it_name, ammo_req );
+            } else {
+                int ammo_rem = used->ammo_remaining( );
+                add_msg_if_player( m_info,
+                                   n_gettext( "Your %s has %d charge, but needs %d.",
+                                              "Your %s has %d charges, but needs %d.",
+                                              ammo_rem ),
+                                   it_name, ammo_rem, ammo_req );
+            }
         }
         set_moves( pre_obtain_moves );
         return false;

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1169,6 +1169,10 @@ class activatable_inventory_preset : public pickup_inventory_preset
 
             if( uses.size() == 1 &&
                 !it.ammo_sufficient( &you, uses.begin()->first ) ) {
+                if( it.uses_firing_requirements() ) {
+                    return string_format( _( "Needs at least: %s." ),
+                                          it.format_consumption_requirements( uses.begin()->first ) );
+                }
                 return string_format(
                            n_gettext( "Needs at least %d charge.",
                                       "Needs at least %d charges.", loc->ammo_required() ),
@@ -1382,6 +1386,10 @@ class ereader_inventory_preset : public pickup_inventory_preset
             }
 
             if( !it.ammo_sufficient( &you, "EBOOKREAD" ) ) {
+                if( it.uses_firing_requirements() ) {
+                    return string_format( _( "Needs at least: %s." ),
+                                          it.format_consumption_requirements( "EBOOKREAD" ) );
+                }
                 return string_format(
                            n_gettext( "Needs at least %d charge.",
                                       "Needs at least %d charges.", loc->ammo_required() ),

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1369,7 +1369,7 @@ bool iexamine::try_start_hacking( Character &you, const tripoint_bub_ms &examp )
         return false;
     } else {
         item_location hacking_tool = item_location{you, &you.best_item_with_quality( qual_HACK )};
-        hacking_tool->ammo_consume( hacking_tool->ammo_required(), hacking_tool.pos_bub( here ), &you );
+        hacking_tool->consume_tool_uses( 1, here, hacking_tool.pos_bub( here ), &you );
         you.assign_activity( hacking_activity_actor( hacking_tool ) );
         you.activity.placement = here.get_abs( examp );
         return true;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3596,6 +3596,9 @@ bool item::getlight( float &luminance, units::angle &width, units::angle &direct
     return false;
 }
 
+// TODO(multimag): a multimag light-emitting tool with empty pockets will
+// emit free light because this gates on ammo_required(). Fixing this needs
+// a carrier-aware overload + recursive forwarding into gunmod-light path.
 int item::getlight_emit() const
 {
     const map &here = get_map();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1582,9 +1582,10 @@ std::string item::display_name( unsigned int quantity ) const
             return p.is_type( pocket_type::MAGAZINE_WELL );
         } );
         if( well_pockets.size() > 1 ) {
-            // Multi-well: show every well, loaded or not.
-            const bool show_ammo_name = is_gun() && ammo_required() &&
-                                        get_option<bool>( "AMMO_IN_NAMES" );
+            // Multi-well: show every well, loaded or not. Per-well ammo
+            // labels are essential when distinct ammotypes share the same
+            // host item, so they ignore AMMO_IN_NAMES.
+            const bool show_ammo_name = true;
             std::vector<std::string> segments;
             for( const item_pocket *p : well_pockets ) {
                 const item *mag = p->magazine_current();
@@ -1693,7 +1694,7 @@ std::string item::display_name( unsigned int quantity ) const
     }
 
     std::string ammotext;
-    if( !is_ammo() && ( ( is_gun() && ammo_required() ) || is_magazine() ) &&
+    if( !is_ammo() && ( ( is_gun() && needs_charges_to_use() ) || is_magazine() ) &&
         get_option<bool>( "AMMO_IN_NAMES" ) ) {
         if( !ammo_current().is_null() ) {
             // Loaded with ammo

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3851,8 +3851,22 @@ bool item::use_charges( const itype_id &what, int &qty, std::list<item> &used,
 
         if( e->is_tool() || e->is_gun() ) {
             if( e->typeId() == what || ( in_tools && e->ammo_current() == what ) ) {
-                int n;
-                if( carrier ) {
+                int n = 0;
+                if( e->uses_firing_requirements() ) {
+                    // Translate raw charges to uses; hard-fail on
+                    // non-divisible to surface mis-baselined recipes.
+                    const int factor = e->type ? e->type->legacy_charges_per_use_factor : 1;
+                    if( factor < 1 || qty % factor != 0 ) {
+                        debugmsg( "use_charges: %s requested %d charges with "
+                                  "legacy_charges_per_use_factor %d (not a multiple); "
+                                  "recipe / caller needs to be re-baselined to uses",
+                                  e->tname(), qty, factor );
+                        return VisitResponse::NEXT;
+                    }
+                    const int wanted_uses = qty / factor;
+                    const int got_uses = e->consume_tool_uses( wanted_uses, get_map(), pos, carrier );
+                    n = got_uses * factor;
+                } else if( carrier ) {
                     n = e->ammo_consume( qty, pos, carrier );
                 } else {
                     n = e->ammo_consume( qty, pos, nullptr );

--- a/src/item.h
+++ b/src/item.h
@@ -2849,6 +2849,25 @@ class item : public visitable
         std::vector<item *> magazines_current();
         std::vector<const item *> magazines_current() const;
 
+        item_pocket *pocket_by_id( const std::string &id );
+        const item_pocket *pocket_by_id( const std::string &id ) const;
+
+        int ammo_remaining_in_pocket( const std::string &id ) const;
+
+        // Magazine driving ammo-identity queries: primary_ammo_pocket's mag
+        // for multimag guns, magazine_current otherwise.
+        const item *ammo_identity_mag() const;
+
+        bool uses_firing_requirements() const;
+        // Combined "needs any kind of charge" predicate for multimag,
+        // legacy energy-only guns, and legacy charge-tools.
+        bool needs_charges_to_use() const;
+
+        // Multimag gun: prefer a loaded MAGAZINE_WELL whose ammo intersects
+        // gun.ammo, then any such well, then any loaded well, then any well.
+        // nullptr if no MAGAZINE_WELL exists.
+        const item_pocket *primary_ammo_pocket() const;
+
         /** Returns all gunmods currently attached to this item (always empty if item not a gun) */
         std::vector<item *> gunmods();
         std::vector<const item *> gunmods() const;

--- a/src/item.h
+++ b/src/item.h
@@ -66,6 +66,7 @@ struct armor_portion_data;
 struct islot_comestible;
 struct itype;
 struct itype_variant_data;
+struct pocket_consumption_entry;
 struct mtype;
 struct part_material;
 template<typename T>
@@ -2853,10 +2854,8 @@ class item : public visitable
         const item_pocket *pocket_by_id( const std::string &id ) const;
 
         int ammo_remaining_in_pocket( const std::string &id ) const;
-
-        // Magazine driving ammo-identity queries: primary_ammo_pocket's mag
-        // for multimag guns, magazine_current otherwise.
-        const item *ammo_identity_mag() const;
+        int ammo_consume_in_pocket( const std::string &id, int qty, map &here,
+                                    const tripoint_bub_ms &pos );
 
         bool uses_firing_requirements() const;
         // Combined "needs any kind of charge" predicate for multimag,
@@ -2867,6 +2866,42 @@ class item : public visitable
         // gun.ammo, then any such well, then any loaded well, then any well.
         // nullptr if no MAGAZINE_WELL exists.
         const item_pocket *primary_ammo_pocket() const;
+
+        // Magazine driving ammo-identity queries: primary_ammo_pocket's mag
+        // for multimag guns, magazine_current otherwise.
+        const item *ammo_identity_mag() const;
+
+        bool pocket_accepts_battery( const item_pocket *p ) const;
+        bool pocket_is_primary_ammo( const item_pocket *p ) const;
+
+        // Per-shot qty after gunmod modifiers: ammo_to_fire_* on
+        // primary-ammo entries, energy_drain_* on battery-but-not-primary.
+        // Sub-1 positive results round up to 1; non-positive disables the
+        // entry entirely.
+        int effective_qty( const pocket_consumption_entry &e ) const;
+
+        std::string format_consumption_requirements(
+            const std::string &method = "",
+            const gun_mode_id &mode = gun_mode_id( "DEFAULT" ),
+            int uses = 1 ) const;
+
+        // Ranking-only scalar; never call for actual consumption.
+        int expected_cost_per_use( const std::string &method = "" ) const;
+
+        // _local excludes external pool so inventory aggregation does not
+        // sum the same UPS/bionic/cable once per matching item.
+        int tool_uses_remaining( map &here, const Character *carrier ) const;
+        int tool_uses_remaining_local() const;
+
+        int available_cable_charges( map &here ) const;
+        int available_ups_charges( const Character *carrier ) const;
+        int available_bionic_charges( const Character *carrier ) const;
+
+        int consume_shots( const gun_mode_id &mode, int shots, map &here,
+                           const tripoint_bub_ms &pos, Character *carrier );
+        int consume_tool_uses( int uses, map &here, const tripoint_bub_ms &pos,
+                               Character *carrier );
+        int consume_one_shot( map &here, const tripoint_bub_ms &pos, Character *carrier );
 
         /** Returns all gunmods currently attached to this item (always empty if item not a gun) */
         std::vector<item *> gunmods();

--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -183,18 +183,30 @@ item_action_map item_action_generator::map_actions_to_items( Character &you,
             if( found == candidates.end() ) {
                 better = true;
             } else {
-                if( actual_item->ammo_required() > found->second->ammo_required() ) {
+                if( actual_item->expected_cost_per_use( use ) >
+                    found->second->expected_cost_per_use( use ) ) {
                     continue; // Other item consumes less charges
                 }
 
-                if( found->second->ammo_remaining( ) > actual_item->ammo_remaining( ) ) {
+                // For heterogeneous-resource multimag tools, raw ammo_remaining
+                // sums across pocket flavors and isn't a meaningful comparator.
+                map &here = get_map();
+                const int actual_remaining =
+                    actual_item->uses_firing_requirements()
+                    ? actual_item->tool_uses_remaining( here, &you )
+                    : actual_item->ammo_remaining();
+                const int found_remaining =
+                    found->second->uses_firing_requirements()
+                    ? found->second->tool_uses_remaining( here, &you )
+                    : found->second->ammo_remaining();
+                if( found_remaining > actual_remaining ) {
                     better = true; // Items with less charges preferred
                 }
             }
 
             if( better ) {
                 candidates[use] = actual_item;
-                if( actual_item->ammo_required() == 0 ) {
+                if( !actual_item->needs_charges_to_use() ) {
                     to_remove.insert( use );
                 }
             }
@@ -317,8 +329,9 @@ void game::item_action_menu( item_location loc )
     std::transform( iactions.begin(), iactions.end(), std::back_inserter( menu_items ),
     []( const std::pair<item_action_id, item *> &elem ) {
         std::string ss = elem.second->display_name();
-        if( elem.second->ammo_required() ) {
-
+        if( elem.second->uses_firing_requirements() ) {
+            ss += "(" + elem.second->format_consumption_requirements( elem.first ) + ")";
+        } else if( elem.second->ammo_required() ) {
             if( elem.second->has_flag( flag_USES_BIONIC_POWER ) ) {
                 ss += string_format( "(%d kJ)", elem.second->ammo_required() );
             } else {
@@ -326,7 +339,6 @@ void game::item_action_menu( item_location loc )
                 ss += string_format( "(-%d)", elem.second->ammo_required() * ( iter ==
                                      elem.second->type->ammo_scale.end() ? 1 : iter->second ) );
             }
-
         }
 
         const use_function *method = elem.second->get_use( elem.first );

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1344,6 +1344,41 @@ int item_contents::ammo_consume( int qty, map *here, const tripoint_bub_ms &pos,
     return consumed;
 }
 
+int item_contents::ammo_consume_in_pocket( const std::string &id, int qty, map *here,
+        const tripoint_bub_ms &pos )
+{
+    if( id.empty() || qty <= 0 ) {
+        return 0;
+    }
+    for( item_pocket &pocket : contents ) {
+        const pocket_data *pd = pocket.get_pocket_data();
+        if( pd == nullptr || pd->pocket_id != id ) {
+            continue;
+        }
+        if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
+            item *mag = pocket.magazine_current();
+            if( mag == nullptr ) {
+                return 0;
+            }
+            const int res = mag->ammo_consume( qty, *here, pos, nullptr );
+            if( res && mag->ammo_remaining() == 0 ) {
+                if( mag->has_flag( json_flag_MAG_DESTROY ) ) {
+                    pocket.remove_item( *mag );
+                } else if( mag->has_flag( json_flag_MAG_EJECT ) ) {
+                    here->add_item( pos, *mag );
+                    pocket.remove_item( *mag );
+                }
+            }
+            return res;
+        }
+        if( pocket.is_type( pocket_type::MAGAZINE ) ) {
+            return pocket.ammo_consume( qty );
+        }
+        return 0;
+    }
+    return 0;
+}
+
 item *item_contents::magazine_current()
 {
     for( item_pocket &pocket : contents ) {

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -381,6 +381,11 @@ class item_contents
         /** Return the amount of ammo consumed. */
         int ammo_consume( int qty, const tripoint_bub_ms &pos, float fuel_efficiency = -1.0 );
         int ammo_consume( int qty, map *here, const tripoint_bub_ms &pos, float fuel_efficiency = -1.0 );
+        /** Drain `qty` ammo charges from the pocket whose `pocket_data.id`
+         *  matches `id`. MAGAZINE_WELL: drains the contained magazine's ammo.
+         *  MAGAZINE: drains directly. Returns charges actually consumed. */
+        int ammo_consume_in_pocket( const std::string &id, int qty, map *here,
+                                    const tripoint_bub_ms &pos );
         item *magazine_current();
         const item *magazine_current() const;
         std::vector<item *> magazines_current();

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2343,6 +2343,86 @@ void Item_factory::check_definitions() const
             }
         }
 
+        // Pocket id uniqueness applies to every item so future mods or
+        // follow-ups can reference an id added on a not-yet-multimag pocket.
+        std::set<std::string> seen_pocket_ids;
+        for( const pocket_data &p : type->pockets ) {
+            if( p.pocket_id.empty() ) {
+                continue;
+            }
+            if( !seen_pocket_ids.insert( p.pocket_id ).second ) {
+                msg += string_format( "duplicate pocket id \"%s\" on item\n", p.pocket_id );
+            }
+        }
+
+        if( !type->firing_requirements.empty() ) {
+            if( type->gun ) {
+                if( type->gun->energy_drain > 0_kJ ) {
+                    msg += "firing_requirements and non-zero energy_drain are mutually exclusive\n";
+                }
+                if( type->gun->ammo_to_fire != 1 ) {
+                    msg += "firing_requirements and non-default ammo_to_fire are mutually exclusive\n";
+                }
+            }
+            if( type->tool ) {
+                if( type->tool->charges_per_use != 0 ) {
+                    msg += "consumption_per_use and charges_per_use are mutually exclusive\n";
+                }
+                if( type->tool->power_draw != 0_W ) {
+                    msg += "consumption_per_use and power_draw are mutually exclusive\n";
+                }
+            }
+            if( type->legacy_charges_per_use_factor < 1 ) {
+                msg += string_format( "legacy_charges_per_use_factor must be >= 1, got %d\n",
+                                      type->legacy_charges_per_use_factor );
+            }
+            std::set<std::string> referenced;
+            for( const auto &mode_pair : type->firing_requirements.per_mode ) {
+                if( type->gun && !type->gun->modes.count( mode_pair.first ) ) {
+                    msg += string_format( "firing_requirements mode \"%s\" is not in modes\n",
+                                          mode_pair.first.str() );
+                }
+                for( const pocket_consumption_entry &e : mode_pair.second ) {
+                    referenced.insert( e.pocket );
+                }
+            }
+            // Every base-gun mode needs an explicit firing_requirements entry
+            // so authors can't silently underconsume by omitting BURST or AUTO.
+            // Gunmod-added modes (mode_modifier) inherit DEFAULT at runtime.
+            if( type->gun ) {
+                for( const auto &m : type->gun->modes ) {
+                    if( !type->firing_requirements.per_mode.count( m.first ) ) {
+                        msg += string_format(
+                                   "firing_requirements is missing entry for base mode \"%s\"\n",
+                                   m.first.str() );
+                    }
+                }
+            }
+            for( const std::string &id : referenced ) {
+                bool found = false;
+                bool right_type = false;
+                for( const pocket_data &p : type->pockets ) {
+                    if( p.pocket_id == id ) {
+                        found = true;
+                        // Integral MAGAZINE pockets aren't wired through
+                        // energy/recharge/aggregation helpers yet.
+                        if( p.type == pocket_type::MAGAZINE_WELL ) {
+                            right_type = true;
+                        }
+                        break;
+                    }
+                }
+                if( !found ) {
+                    msg += string_format(
+                               "firing_requirements references unknown pocket id \"%s\"\n", id );
+                } else if( !right_type ) {
+                    msg += string_format(
+                               "firing_requirements references pocket id \"%s\" which is not a MAGAZINE_WELL pocket\n",
+                               id );
+                }
+            }
+        }
+
         if( !type->category_force.is_valid() ) {
             msg += "undefined category " + type->category_force.str() + "\n";
         }
@@ -3150,6 +3230,67 @@ void itype_variant_data::load( const JsonObject &jo )
     optional( jo, false, "weight", weight, 1 );
     optional( jo, false, "append", append );
     optional( jo, false, "expand_snippets", expand_snippets );
+}
+
+void pocket_consumption_entry::deserialize( const JsonObject &jo )
+{
+    mandatory( jo, was_loaded, "pocket", pocket );
+    mandatory( jo, was_loaded, "qty", qty );
+    if( qty < 1 ) {
+        jo.throw_error_at( "qty",
+                           "pocket_consumption_entry qty must be >= 1 (zero or negative would divide by zero in feasibility math)" );
+    }
+}
+
+static std::vector<pocket_consumption_entry> read_consumption_entries(
+    const JsonValue &val )
+{
+    std::vector<pocket_consumption_entry> entries;
+    if( !val.test_array() ) {
+        val.throw_error( "consumption entry list must be a JSON array" );
+    }
+    for( const JsonValue &element : val.get_array() ) {
+        if( !element.test_object() ) {
+            element.throw_error( "consumption entry must be an object" );
+        }
+        pocket_consumption_entry entry;
+        JsonObject jo = element.get_object();
+        entry.deserialize( jo );
+        jo.allow_omitted_members();
+        entries.push_back( std::move( entry ) );
+    }
+    if( entries.empty() ) {
+        val.throw_error( "consumption entry list must not be empty" );
+    }
+    return entries;
+}
+
+void firing_requirement_set::deserialize_firing_requirements(
+    const JsonObject &jo, std::string_view member )
+{
+    JsonObject sub = jo.get_object( member );
+    if( !sub.has_member( "//" ) && sub.size() == 0 ) {
+        sub.throw_error( "firing_requirements must contain at least one mode entry" );
+    }
+    for( const JsonMember m : sub ) {
+        if( m.name() == "//" || m.name().substr( 0, 2 ) == "//" ) {
+            continue;
+        }
+        per_mode[gun_mode_id( m.name() )] = read_consumption_entries( m );
+    }
+    sub.allow_omitted_members();
+    if( per_mode.empty() ) {
+        jo.throw_error_at( member,
+                           "firing_requirements must contain at least one non-comment mode entry" );
+    }
+    was_loaded = true;
+}
+
+void firing_requirement_set::deserialize_consumption_per_use(
+    const JsonObject &jo, std::string_view member )
+{
+    per_mode[gun_mode_DEFAULT] = read_consumption_entries( jo.get_member( member ) );
+    was_loaded = true;
 }
 
 
@@ -4378,6 +4519,14 @@ void itype::load( const JsonObject &jo, std::string_view src )
     optional( jo, was_loaded, "snippet_category", snippet_category, snippet_reader{ *this, src } );
 
     optional( jo, was_loaded, "pocket_data", pockets );
+
+    if( jo.has_member( "firing_requirements" ) ) {
+        firing_requirements.deserialize_firing_requirements( jo, "firing_requirements" );
+    }
+    if( jo.has_member( "consumption_per_use" ) ) {
+        firing_requirements.deserialize_consumption_per_use( jo, "consumption_per_use" );
+    }
+    optional( jo, was_loaded, "legacy_charges_per_use_factor", legacy_charges_per_use_factor, 1 );
 
     load_slots( jo, was_loaded );
 

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -2180,6 +2180,12 @@ int item::ammo_remaining_in_pocket( const std::string &id ) const
     return 0;
 }
 
+int item::ammo_consume_in_pocket( const std::string &id, int qty, map &here,
+                                  const tripoint_bub_ms &pos )
+{
+    return contents.ammo_consume_in_pocket( id, qty, &here, pos );
+}
+
 bool item::uses_firing_requirements() const
 {
     return type && !type->firing_requirements.empty();
@@ -2250,6 +2256,466 @@ const item *item::ammo_identity_mag() const
         return p ? p->magazine_current() : nullptr;
     }
     return magazine_current();
+}
+
+bool item::pocket_accepts_battery( const item_pocket *p ) const
+{
+    if( p == nullptr ) {
+        return false;
+    }
+    for( const ammotype &at : p->ammo_types() ) {
+        if( at == ammo_battery ) {
+            return true;
+        }
+    }
+    for( const itype_id &allowed : p->item_type_restrictions() ) {
+        if( !allowed->magazine ) {
+            continue;
+        }
+        for( const ammotype &slot : allowed->magazine->type ) {
+            if( slot == ammo_battery ) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool item::pocket_is_primary_ammo( const item_pocket *p ) const
+{
+    if( p == nullptr || !type || !type->gun || type->gun->ammo.empty() ) {
+        return false;
+    }
+    for( const ammotype &at : p->ammo_types() ) {
+        if( type->gun->ammo.count( at ) ) {
+            return true;
+        }
+    }
+    for( const itype_id &allowed : p->item_type_restrictions() ) {
+        if( !allowed->magazine ) {
+            continue;
+        }
+        for( const ammotype &slot : allowed->magazine->type ) {
+            if( type->gun->ammo.count( slot ) ) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+static int method_scale( const itype *type, const std::string &method )
+{
+    if( !type || method.empty() ) {
+        return 1;
+    }
+    auto it = type->ammo_scale.find( method );
+    return it == type->ammo_scale.end() ? 1 : it->second;
+}
+
+static std::string format_entry_name( const item &host, const pocket_consumption_entry &e,
+                                      int qty )
+{
+    const item_pocket *p = host.pocket_by_id( e.pocket );
+    if( p == nullptr ) {
+        return e.pocket;
+    }
+    if( const item *mag = p->magazine_current() ) {
+        if( const itype *adata = mag->ammo_data() ) {
+            return adata->nname( qty );
+        }
+    }
+    const pocket_data *pd = p->get_pocket_data();
+    if( pd ) {
+        const std::string display = pd->pocket_name.translated();
+        if( !display.empty() ) {
+            return display;
+        }
+        if( !pd->default_magazine.is_null() && pd->default_magazine->magazine ) {
+            const itype_id &default_ammo = pd->default_magazine->magazine->default_ammo;
+            if( !default_ammo.is_null() && default_ammo->ammo ) {
+                return default_ammo->nname( qty );
+            }
+        }
+    }
+    std::string fallback = e.pocket;
+    std::replace( fallback.begin(), fallback.end(), '_', ' ' );
+    return fallback;
+}
+
+std::string item::format_consumption_requirements(
+    const std::string &method, const gun_mode_id &mode, int uses ) const
+{
+    const int scale = method_scale( type, method );
+    if( !uses_firing_requirements() ) {
+        if( type && type->gun ) {
+            const int qty = ammo_required() * scale * uses;
+            const units::energy energy = get_gun_energy_drain() * scale * uses;
+            std::string out = string_format( _( "%d charges" ), qty );
+            if( energy > 0_kJ ) {
+                out += string_format( _( ", %d kJ" ), units::to_kilojoule( energy ) );
+            }
+            return out;
+        }
+        const int qty = ammo_required() * scale * uses;
+        return string_format( _( "%d charges" ), qty );
+    }
+
+    const std::vector<pocket_consumption_entry> *entries =
+        type->firing_requirements.for_mode( mode );
+    if( entries == nullptr || entries->empty() ) {
+        return std::string();
+    }
+    std::vector<std::string> parts;
+    for( const pocket_consumption_entry &e : *entries ) {
+        const int qty = effective_qty( e ) * scale * uses;
+        if( qty <= 0 ) {
+            continue;
+        }
+        parts.emplace_back( string_format( "%d %s", qty, format_entry_name( *this, e, qty ) ) );
+    }
+    if( parts.empty() ) {
+        return std::string();
+    }
+    std::string joined;
+    bool first = true;
+    for( const std::string &part : parts ) {
+        if( !first ) {
+            joined += " + ";
+        }
+        first = false;
+        joined += part;
+    }
+    return joined;
+}
+
+int item::expected_cost_per_use( const std::string &method ) const
+{
+    const int scale = method_scale( type, method );
+    if( !uses_firing_requirements() ) {
+        // ammo_required() already routes guns to ammo_to_fire and tools to
+        // charges_per_use, so it's the right scalar for both legacy paths.
+        return ammo_required() * scale;
+    }
+    const std::vector<pocket_consumption_entry> *entries =
+        type->firing_requirements.for_mode( gun_mode_id( "DEFAULT" ) );
+    if( entries == nullptr ) {
+        return 0;
+    }
+    int total = 0;
+    for( const pocket_consumption_entry &e : *entries ) {
+        total += effective_qty( e );
+    }
+    return total * scale;
+}
+
+int item::available_cable_charges( map &here ) const
+{
+    if( !has_link_data() ) {
+        return 0;
+    }
+    int64_t avail = 0;
+    if( link().t_veh && link().efficiency >= MIN_LINK_EFFICIENCY ) {
+        avail = link().t_veh->battery_left( here, true );
+    } else if( const optional_vpart_position vp = here.veh_at( link().t_abs_pos ) ) {
+        avail = vp->vehicle().battery_left( here, true );
+    }
+    return static_cast<int>( std::min<int64_t>( avail, INT_MAX ) );
+}
+
+int item::available_ups_charges( const Character *carrier ) const
+{
+    if( !carrier || !has_flag( flag_USE_UPS ) ) {
+        return 0;
+    }
+    return units::to_kilojoule( carrier->available_ups() );
+}
+
+int item::available_bionic_charges( const Character *carrier ) const
+{
+    if( !carrier || !has_flag( flag_USES_BIONIC_POWER ) ) {
+        return 0;
+    }
+    return units::to_kilojoule( carrier->get_power_level() );
+}
+
+namespace
+{
+// Per-mode feasibility for multimag. Local pocket stock is non-fungible
+// across pocket ids; only the external pool (cable + UPS + bionic) is
+// shared, and it's usable only by battery-flavored entries.
+int feasible_uses( const item &host,
+                   const std::vector<pocket_consumption_entry> &entries,
+                   int requested, int external_pool )
+{
+    int n_max = INT_MAX;
+    struct battery_entry {
+        int qty;
+        int stock;
+    };
+    std::vector<battery_entry> battery;
+    for( const pocket_consumption_entry &e : entries ) {
+        const int q = host.effective_qty( e );
+        if( q <= 0 ) {
+            continue;
+        }
+        const int local = host.ammo_remaining_in_pocket( e.pocket );
+        const item_pocket *p = host.pocket_by_id( e.pocket );
+        if( host.pocket_accepts_battery( p ) ) {
+            battery.push_back( { q, local } );
+        } else {
+            n_max = std::min( n_max, local / q );
+        }
+    }
+
+    if( battery.empty() ) {
+        return std::min( requested, n_max );
+    }
+
+    // Pool need(n) = sum_{i past breakpoint} (n*qty_i - stock_i) is
+    // piecewise linear; walk breakpoints in ascending stock_i / qty_i order.
+    std::sort( battery.begin(), battery.end(),
+    []( const battery_entry & a, const battery_entry & b ) {
+        return static_cast<int64_t>( a.stock ) * b.qty <
+               static_cast<int64_t>( b.stock ) * a.qty;
+    } );
+
+    int qty_sum_past = 0;
+    int stock_sum_past = 0;
+    int n = 0;
+    bool exhausted = false;
+    for( const battery_entry &b : battery ) {
+        const int n_break = b.stock / b.qty;
+        if( qty_sum_past > 0 ) {
+            const int n_max_segment =
+                ( external_pool + stock_sum_past ) / qty_sum_past;
+            if( n_max_segment < n_break ) {
+                n = std::max( n, n_max_segment );
+                exhausted = true;
+                break;
+            }
+            n = std::max( n, n_break );
+        } else {
+            n = std::max( n, n_break );
+        }
+        qty_sum_past += b.qty;
+        stock_sum_past += b.stock;
+    }
+    if( !exhausted && qty_sum_past > 0 ) {
+        const int n_after = ( external_pool + stock_sum_past ) / qty_sum_past;
+        n = std::max( n, n_after );
+    }
+    return std::min( { requested, n_max, n } );
+}
+} // namespace
+
+int item::tool_uses_remaining( map &here, const Character *carrier ) const
+{
+    if( !uses_firing_requirements() ) {
+        return shots_remaining( here, carrier );
+    }
+    const std::vector<pocket_consumption_entry> *entries =
+        type->firing_requirements.for_mode( gun_mode_id( "DEFAULT" ) );
+    if( entries == nullptr || entries->empty() ) {
+        return 0;
+    }
+    const int pool = available_cable_charges( here )
+                     + available_ups_charges( carrier )
+                     + available_bionic_charges( carrier );
+    return feasible_uses( *this, *entries, INT_MAX, pool );
+}
+
+int item::tool_uses_remaining_local() const
+{
+    if( !uses_firing_requirements() ) {
+        return 0;
+    }
+    const std::vector<pocket_consumption_entry> *entries =
+        type->firing_requirements.for_mode( gun_mode_id( "DEFAULT" ) );
+    if( entries == nullptr || entries->empty() ) {
+        return 0;
+    }
+    return feasible_uses( *this, *entries, INT_MAX, /*external_pool=*/0 );
+}
+
+namespace
+{
+// Multimag drain in cable -> local -> UPS -> bionic order; applies
+// external deltas exactly once. Returns shots / uses actually consumed.
+int multimag_drain( item &host, const std::vector<pocket_consumption_entry> &entries,
+                    int requested, map &here, const tripoint_bub_ms &pos,
+                    Character *carrier )
+{
+    const int cable_initial = host.available_cable_charges( here );
+    const int ups_initial = host.available_ups_charges( carrier );
+    const int bionic_initial = host.available_bionic_charges( carrier );
+    const int pool = cable_initial + ups_initial + bionic_initial;
+
+    const int allowed = feasible_uses( host, entries, requested, pool );
+    if( allowed <= 0 ) {
+        return 0;
+    }
+
+    int cable_left = cable_initial;
+    int ups_left = ups_initial;
+    int bionic_left = bionic_initial;
+
+    for( const pocket_consumption_entry &e : entries ) {
+        int qty = host.effective_qty( e ) * allowed;
+        if( qty <= 0 ) {
+            continue;
+        }
+        const item_pocket *p = host.pocket_by_id( e.pocket );
+        const bool battery = host.pocket_accepts_battery( p );
+        if( battery ) {
+            const int from_cable = std::min( qty, cable_left );
+            cable_left -= from_cable;
+            qty        -= from_cable;
+        }
+        if( qty > 0 ) {
+            const int from_local = host.ammo_consume_in_pocket( e.pocket, qty, here, pos );
+            qty -= from_local;
+        }
+        if( battery && qty > 0 ) {
+            const int from_ups = std::min( qty, ups_left );
+            ups_left -= from_ups;
+            qty      -= from_ups;
+            const int from_bionic = std::min( qty, bionic_left );
+            bionic_left -= from_bionic;
+            qty         -= from_bionic;
+        }
+        if( qty > 0 ) {
+            debugmsg( "consume_shots: shortfall on pocket %s after feasibility check (%s)",
+                      e.pocket, host.tname() );
+        }
+    }
+
+    const int cable_used = cable_initial - cable_left;
+    const int ups_used = ups_initial - ups_left;
+    const int bionic_used = bionic_initial - bionic_left;
+    if( cable_used > 0 && host.has_link_data() ) {
+        if( host.link().t_veh && host.link().efficiency >= MIN_LINK_EFFICIENCY ) {
+            host.link().t_veh->discharge_battery( here, cable_used, true );
+        } else if( const optional_vpart_position vp = here.veh_at( host.link().t_abs_pos ) ) {
+            vp->vehicle().discharge_battery( here, cable_used, true );
+        }
+    }
+    if( carrier ) {
+        if( ups_used > 0 ) {
+            carrier->consume_ups( units::from_kilojoule( static_cast<int64_t>( ups_used ) ) );
+        }
+        if( bionic_used > 0 ) {
+            carrier->mod_power_level(
+                -units::from_kilojoule( static_cast<int64_t>( bionic_used ) ) );
+        }
+    }
+    return allowed;
+}
+} // namespace
+
+int item::consume_shots( const gun_mode_id &mode, int shots, map &here,
+                         const tripoint_bub_ms &pos, Character *carrier )
+{
+    if( shots <= 0 ) {
+        return 0;
+    }
+    if( uses_firing_requirements() ) {
+        const std::vector<pocket_consumption_entry> *entries =
+            type->firing_requirements.for_mode( mode );
+        if( entries == nullptr || entries->empty() ) {
+            debugmsg( "consume_shots: %s has no firing_requirements entries for mode %s",
+                      tname(), mode.str() );
+            return 0;
+        }
+        return multimag_drain( *this, *entries, shots, here, pos, carrier );
+    }
+    // Legacy path: ammo_consume + energy_consume per shot.
+    const int required_ammo = ammo_required() * shots;
+    const units::energy required_energy = get_gun_energy_drain() * shots;
+    if( required_ammo > 0 ) {
+        const int consumed_ammo = ammo_consume( required_ammo, here, pos, carrier );
+        if( consumed_ammo != required_ammo ) {
+            return 0;
+        }
+    }
+    if( required_energy > 0_kJ ) {
+        const units::energy drained = energy_consume( required_energy, &here, pos, carrier );
+        if( drained < required_energy ) {
+            return 0;
+        }
+    }
+    return shots;
+}
+
+int item::consume_tool_uses( int uses, map &here, const tripoint_bub_ms &pos,
+                             Character *carrier )
+{
+    if( uses <= 0 ) {
+        return 0;
+    }
+    if( uses_firing_requirements() ) {
+        const std::vector<pocket_consumption_entry> *entries =
+            type->firing_requirements.for_mode( gun_mode_id( "DEFAULT" ) );
+        if( entries == nullptr || entries->empty() ) {
+            debugmsg( "consume_tool_uses: %s has no DEFAULT firing_requirements entries",
+                      tname() );
+            return 0;
+        }
+        return multimag_drain( *this, *entries, uses, here, pos, carrier );
+    }
+    // Legacy path: ammo_consume(charges_to_use * uses).
+    const int per_use = type ? type->charges_to_use() : 0;
+    if( per_use <= 0 ) {
+        return uses;
+    }
+    const int required = per_use * uses;
+    const int consumed = ammo_consume( required, here, pos, carrier );
+    if( consumed != required ) {
+        return consumed / per_use;
+    }
+    return uses;
+}
+
+int item::consume_one_shot( map &here, const tripoint_bub_ms &pos, Character *carrier )
+{
+    const gun_mode_id mode = is_gun() ? gun_get_mode_id() : gun_mode_id( "DEFAULT" );
+    return consume_shots( mode, 1, here, pos, carrier );
+}
+
+int item::effective_qty( const pocket_consumption_entry &e ) const
+{
+    const item_pocket *p = pocket_by_id( e.pocket );
+    const bool is_primary = pocket_is_primary_ammo( p );
+    const bool is_battery = pocket_accepts_battery( p );
+
+    float multiplier = 1.0f;
+    int modifier_int = 0;
+    units::energy modifier_energy = 0_kJ;
+    if( is_gun() ) {
+        for( const item *mod : gunmods() ) {
+            if( !mod->type || !mod->type->gunmod ) {
+                continue;
+            }
+            if( is_primary ) {
+                multiplier *= mod->type->gunmod->ammo_to_fire_multiplier;
+                modifier_int += mod->type->gunmod->ammo_to_fire_modifier;
+            } else if( is_battery ) {
+                multiplier *= mod->type->gunmod->energy_drain_multiplier;
+                modifier_energy += mod->type->gunmod->energy_drain_modifier;
+            }
+        }
+    }
+
+    double scaled = static_cast<double>( e.qty ) * multiplier
+                    + static_cast<double>( modifier_int )
+                    + units::to_kilojoule( modifier_energy );
+    if( scaled <= 0.0 ) {
+        return 0;
+    }
+    if( scaled < 1.0 ) {
+        return 1;
+    }
+    return static_cast<int>( scaled );
 }
 
 std::vector<item *> item::gunmods()

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -1793,7 +1793,7 @@ int item::activation_consume( int qty, const tripoint_bub_ms &pos, Character *ca
 
 bool item::has_ammo() const
 {
-    const item *mag = magazine_current();
+    const item *mag = ammo_identity_mag();
     if( mag ) {
         return mag->has_ammo();
     }
@@ -1818,7 +1818,7 @@ bool item::has_ammo() const
 
 bool item::has_ammo_data() const
 {
-    const item *mag = magazine_current();
+    const item *mag = ammo_identity_mag();
     if( mag ) {
         return mag->has_ammo_data();
     }
@@ -1843,7 +1843,7 @@ bool item::has_ammo_data() const
 
 const itype *item::ammo_data() const
 {
-    const item *mag = magazine_current();
+    const item *mag = ammo_identity_mag();
     if( mag ) {
         return mag->ammo_data();
     }
@@ -1882,7 +1882,7 @@ itype_id item::ammo_current() const
 
 const item &item::loaded_ammo() const
 {
-    const item *mag = magazine_current();
+    const item *mag = ammo_identity_mag();
     if( mag ) {
         return mag->loaded_ammo();
     }
@@ -2134,6 +2134,122 @@ std::vector<item *> item::magazines_current()
 std::vector<const item *> item::magazines_current() const
 {
     return contents.magazines_current();
+}
+
+item_pocket *item::pocket_by_id( const std::string &id )
+{
+    if( id.empty() ) {
+        return nullptr;
+    }
+    std::vector<item_pocket *> hits = get_pockets(
+    [&id]( const item_pocket & p ) {
+        return p.get_pocket_data() && p.get_pocket_data()->pocket_id == id;
+    } );
+    return hits.empty() ? nullptr : hits.front();
+}
+
+const item_pocket *item::pocket_by_id( const std::string &id ) const
+{
+    if( id.empty() ) {
+        return nullptr;
+    }
+    std::vector<const item_pocket *> hits = get_pockets(
+    [&id]( const item_pocket & p ) {
+        return p.get_pocket_data() && p.get_pocket_data()->pocket_id == id;
+    } );
+    return hits.empty() ? nullptr : hits.front();
+}
+
+int item::ammo_remaining_in_pocket( const std::string &id ) const
+{
+    const item_pocket *p = pocket_by_id( id );
+    if( p == nullptr ) {
+        return 0;
+    }
+    if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+        const item *mag = p->magazine_current();
+        return mag ? mag->ammo_remaining( ) : 0;
+    }
+    if( p->is_type( pocket_type::MAGAZINE ) ) {
+        int total = 0;
+        for( const item *e : p->all_items_top() ) {
+            total += e->charges;
+        }
+        return total;
+    }
+    return 0;
+}
+
+bool item::uses_firing_requirements() const
+{
+    return type && !type->firing_requirements.empty();
+}
+
+bool item::needs_charges_to_use() const
+{
+    return ammo_required() > 0 || get_gun_energy_drain() > 0_kJ ||
+           uses_firing_requirements();
+}
+
+const item_pocket *item::primary_ammo_pocket() const
+{
+    const std::vector<const item_pocket *> wells = all_magazine_well_pockets();
+    if( wells.empty() ) {
+        return nullptr;
+    }
+    const std::set<ammotype> *gun_ammo = nullptr;
+    if( type && type->gun ) {
+        gun_ammo = &type->gun->ammo;
+    }
+    auto matches_gun_ammo = [&gun_ammo]( const item_pocket * p ) {
+        if( gun_ammo == nullptr || gun_ammo->empty() ) {
+            return false;
+        }
+        for( const ammotype &at : p->ammo_types() ) {
+            if( gun_ammo->count( at ) ) {
+                return true;
+            }
+        }
+        for( const itype_id &allowed : p->item_type_restrictions() ) {
+            if( !allowed->magazine ) {
+                continue;
+            }
+            for( const ammotype &slot : allowed->magazine->type ) {
+                if( gun_ammo->count( slot ) ) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    };
+    auto loaded = []( const item_pocket * p ) {
+        return p->magazine_current() != nullptr;
+    };
+    for( const item_pocket *p : wells ) {
+        if( matches_gun_ammo( p ) && loaded( p ) ) {
+            return p;
+        }
+    }
+    for( const item_pocket *p : wells ) {
+        if( matches_gun_ammo( p ) ) {
+            return p;
+        }
+    }
+    for( const item_pocket *p : wells ) {
+        if( loaded( p ) ) {
+            return p;
+        }
+    }
+    return wells.front();
+}
+
+const item *item::ammo_identity_mag() const
+{
+    if( uses_firing_requirements() && type && type->gun ) {
+        const item_pocket *p = primary_ammo_pocket();
+        return p ? p->magazine_current() : nullptr;
+    }
+    return magazine_current();
 }
 
 std::vector<item *> item::gunmods()

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -93,6 +93,7 @@ static const damage_type_id damage_bash( "bash" );
 
 static const fault_id fault_overheat_safety( "fault_overheat_safety" );
 
+static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );
 static const gun_mode_id gun_mode_REACH( "REACH" );
 
 static const item_category_id item_category_spare_parts( "spare_parts" );
@@ -127,6 +128,24 @@ item &null_item_reference()
     // reset it, in case a previous caller has changed it
     result = item();
     return result;
+}
+
+// Resolve firing entries for a mode. Base-gun modes are required to have
+// explicit entries (see Item_factory::check_definitions), so a missing
+// entry here means the mode came from a gunmod (mode_modifier) and
+// inherits DEFAULT cost.
+static const std::vector<pocket_consumption_entry> *resolve_firing_entries(
+    const item &host, const gun_mode_id &mode )
+{
+    const firing_requirement_set &set = host.type->firing_requirements;
+    const std::vector<pocket_consumption_entry> *entries = set.for_mode( mode );
+    if( entries != nullptr && !entries->empty() ) {
+        return entries;
+    }
+    if( host.type->gun && host.type->gun->modes.count( mode ) ) {
+        return nullptr; // base gun mode without explicit entry: validation failure
+    }
+    return set.for_mode( gun_mode_DEFAULT );
 }
 
 // Per-mode feasibility for multimag. Local pocket stock is non-fungible
@@ -1369,9 +1388,9 @@ int item::gun_range( const Character *p ) const
 int item::shots_remaining( const map &here, const Character *carrier ) const
 {
     if( uses_firing_requirements() ) {
-        const gun_mode_id mode = is_gun() ? gun_get_mode_id() : gun_mode_id( "DEFAULT" );
+        const gun_mode_id mode = is_gun() ? gun_get_mode_id() : gun_mode_DEFAULT;
         const std::vector<pocket_consumption_entry> *entries =
-            type->firing_requirements.for_mode( mode );
+            resolve_firing_entries( *this, mode );
         if( entries == nullptr || entries->empty() ) {
             return 0;
         }
@@ -1505,11 +1524,22 @@ bool item::is_chargeable() const
     if( has_flag( flag_USES_BIONIC_POWER ) && magazines_current().empty() ) {
         return false;
     }
-    if( ammo_remaining() < ammo_capacity( ammo_battery ) ) {
-        return true;
-    } else {
-        return false;
+    // Compare battery-flavored stock vs battery-flavored capacity so a
+    // mixed projectile + battery multimag tool doesn't read full just
+    // because its non-battery wells are loaded.
+    int battery_charges = 0;
+    int battery_capacity = 0;
+    for( const item *mag : magazines_current() ) {
+        if( mag && mag->ammo_capacity( ammo_battery ) > 0 ) {
+            battery_charges += mag->ammo_remaining();
+            battery_capacity += mag->ammo_capacity( ammo_battery );
+        }
     }
+    if( battery_capacity == 0 ) {
+        battery_capacity = ammo_capacity( ammo_battery );
+        battery_charges = ammo_remaining();
+    }
+    return battery_charges < battery_capacity;
 }
 
 units::energy item::energy_remaining( const Character *carrier ) const
@@ -1521,10 +1551,12 @@ units::energy item::energy_remaining( const Character *carrier, bool ignoreExter
 {
     units::energy ret = 0_kJ;
 
-    // Magazine in the item
-    const item *mag = magazine_current();
-    if( mag ) {
-        ret += mag->energy_remaining( carrier );
+    // Sum across every loaded MAGAZINE_WELL; mixed projectile+battery
+    // multimag items would otherwise read only the first well's energy.
+    for( const item *mag : magazines_current() ) {
+        if( mag ) {
+            ret += mag->energy_remaining( carrier );
+        }
     }
 
     if( !ignoreExternalSources ) {
@@ -2286,7 +2318,13 @@ bool item::needs_charges_to_use() const
 
 const item_pocket *item::primary_ammo_pocket() const
 {
-    const std::vector<const item_pocket *> wells = all_magazine_well_pockets();
+    // MAGAZINE pockets count too: the schema accepts integral-mag items as
+    // multimag primaries (e.g. integral cartridge well + battery well).
+    const std::vector<const item_pocket *> wells = get_pockets(
+    []( const item_pocket & p ) {
+        return p.is_type( pocket_type::MAGAZINE_WELL ) ||
+               p.is_type( pocket_type::MAGAZINE );
+    } );
     if( wells.empty() ) {
         return nullptr;
     }
@@ -2316,7 +2354,10 @@ const item_pocket *item::primary_ammo_pocket() const
         return false;
     };
     auto loaded = []( const item_pocket * p ) {
-        return p->magazine_current() != nullptr;
+        if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+            return p->magazine_current() != nullptr;
+        }
+        return !p->empty();
     };
     for( const item_pocket *p : wells ) {
         if( matches_gun_ammo( p ) && loaded( p ) ) {
@@ -2340,7 +2381,15 @@ const item *item::ammo_identity_mag() const
 {
     if( uses_firing_requirements() && type && type->gun ) {
         const item_pocket *p = primary_ammo_pocket();
-        return p ? p->magazine_current() : nullptr;
+        if( p == nullptr ) {
+            return nullptr;
+        }
+        if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+            return p->magazine_current();
+        }
+        // Integral MAGAZINE pocket: the ammo itself drives identity.
+        const std::list<const item *> contents_top = p->all_items_top();
+        return contents_top.empty() ? nullptr : contents_top.front();
     }
     return magazine_current();
 }
@@ -2449,7 +2498,7 @@ std::string item::format_consumption_requirements(
     }
 
     const std::vector<pocket_consumption_entry> *entries =
-        type->firing_requirements.for_mode( mode );
+        resolve_firing_entries( *this, mode );
     if( entries == nullptr || entries->empty() ) {
         return std::string();
     }
@@ -2485,7 +2534,7 @@ int item::expected_cost_per_use( const std::string &method ) const
         return ammo_required() * scale;
     }
     const std::vector<pocket_consumption_entry> *entries =
-        type->firing_requirements.for_mode( gun_mode_id( "DEFAULT" ) );
+        type->firing_requirements.for_mode( gun_mode_DEFAULT );
     if( entries == nullptr ) {
         return 0;
     }
@@ -2532,7 +2581,7 @@ int item::tool_uses_remaining( map &here, const Character *carrier ) const
         return shots_remaining( here, carrier );
     }
     const std::vector<pocket_consumption_entry> *entries =
-        type->firing_requirements.for_mode( gun_mode_id( "DEFAULT" ) );
+        type->firing_requirements.for_mode( gun_mode_DEFAULT );
     if( entries == nullptr || entries->empty() ) {
         return 0;
     }
@@ -2548,7 +2597,7 @@ int item::tool_uses_remaining_local() const
         return 0;
     }
     const std::vector<pocket_consumption_entry> *entries =
-        type->firing_requirements.for_mode( gun_mode_id( "DEFAULT" ) );
+        type->firing_requirements.for_mode( gun_mode_DEFAULT );
     if( entries == nullptr || entries->empty() ) {
         return 0;
     }
@@ -2638,7 +2687,7 @@ int item::consume_shots( const gun_mode_id &mode, int shots, map &here,
     }
     if( uses_firing_requirements() ) {
         const std::vector<pocket_consumption_entry> *entries =
-            type->firing_requirements.for_mode( mode );
+            resolve_firing_entries( *this, mode );
         if( entries == nullptr || entries->empty() ) {
             debugmsg( "consume_shots: %s has no firing_requirements entries for mode %s",
                       tname(), mode.str() );
@@ -2672,7 +2721,7 @@ int item::consume_tool_uses( int uses, map &here, const tripoint_bub_ms &pos,
     }
     if( uses_firing_requirements() ) {
         const std::vector<pocket_consumption_entry> *entries =
-            type->firing_requirements.for_mode( gun_mode_id( "DEFAULT" ) );
+            type->firing_requirements.for_mode( gun_mode_DEFAULT );
         if( entries == nullptr || entries->empty() ) {
             debugmsg( "consume_tool_uses: %s has no DEFAULT firing_requirements entries",
                       tname() );
@@ -2695,7 +2744,7 @@ int item::consume_tool_uses( int uses, map &here, const tripoint_bub_ms &pos,
 
 int item::consume_one_shot( map &here, const tripoint_bub_ms &pos, Character *carrier )
 {
-    const gun_mode_id mode = is_gun() ? gun_get_mode_id() : gun_mode_id( "DEFAULT" );
+    const gun_mode_id mode = is_gun() ? gun_get_mode_id() : gun_mode_DEFAULT;
     return consume_shots( mode, 1, here, pos, carrier );
 }
 
@@ -3754,18 +3803,32 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
         return 0;
     }
 
+    // Find a battery-flavored magazine to charge; on multimag items only
+    // the battery well is meaningful here.
+    item *parent_mag = nullptr;
+    for( item *mag : magazines_current() ) {
+        if( mag && mag->ammo_capacity( ammo_battery ) > 0 ) {
+            parent_mag = mag;
+            break;
+        }
+    }
     if( !is_battery() ) {
-        const item *parent_mag = magazine_current();
         if( !parent_mag || !parent_mag->has_flag( flag_RECHARGE ) ) {
             return 0;
         }
     }
 
+    const int battery_charges = parent_mag ? parent_mag->ammo_remaining() : ammo_remaining();
+    const int battery_capacity = parent_mag
+                                 ? parent_mag->ammo_capacity( ammo_battery )
+                                 : ammo_capacity( ammo_battery );
     const bool power_in = link().charge_rate > 0;
-    if( power_in ? ammo_remaining( ) >= ammo_capacity( ammo_battery ) :
-        ammo_remaining( ) <= 0 ) {
+    if( power_in ? battery_charges >= battery_capacity : battery_charges <= 0 ) {
         return 0;
     }
+    // Direct receiver for ammo_set so multimag items don't add charges to
+    // the wrong well.
+    item *charge_target = parent_mag ? parent_mag : this;
 
     // Normally efficiency is the chance to get a charge every charge_interval, but if we're catching up from
     // time spent outside the reality bubble it should be applied as a percentage of the total instead.
@@ -3779,7 +3842,7 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
 
     if( power_in ) {
         int available_charges = linked_veh.connected_battery_power_level( here ).first;
-        int wanted_charges = ammo_capacity( ammo_battery ) - ammo_remaining( );
+        int wanted_charges = battery_capacity - battery_charges;
 
         // Nothing to charge or nothing to charge with
         if( wanted_charges == 0 || available_charges == 0 ) {
@@ -3790,7 +3853,7 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
             // Single charge - subtract one from source, roll against efficiency to add one to destination
             int deficit = linked_veh.discharge_battery( here, 1, true );
             if( deficit == 0 && rng_float( 0.0, 1.0 ) <= link().efficiency ) {
-                ammo_set( itype_battery, ammo_remaining( ) + 1 );
+                charge_target->ammo_set( itype_battery, charge_target->ammo_remaining() + 1 );
             }
         } else {
             // Multiple charges - get minimum from available charges, possible transfer in given time and
@@ -3807,11 +3870,12 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
                                    ? wanted_charges
                                    : static_cast<int>( actual_spent * link().efficiency );
 
-            ammo_set( itype_battery, ammo_remaining( ) + received_charges );
+            charge_target->ammo_set( itype_battery,
+                                     charge_target->ammo_remaining() + received_charges );
         }
     } else {
         const auto [bat_remaining, bat_capacity] = linked_veh.connected_battery_power_level( here );
-        int available_charges = ammo_remaining( );
+        int available_charges = battery_charges;
         int wanted_charges = bat_capacity - bat_remaining;
 
         // Nothing to charge or nothing to charge with
@@ -3821,12 +3885,12 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
 
         if( short_time_passed ) {
             // Single charge - subtract one from source, roll against efficiency to add one to destination
-            ammo_set( itype_battery, ammo_remaining( ) - 1 );
+            charge_target->ammo_set( itype_battery, charge_target->ammo_remaining() - 1 );
             if( rng_float( 0.0, 1.0 ) <= link().efficiency ) {
                 int surplus = linked_veh.charge_battery( here, 1, true );
                 if( surplus != 0 ) {
                     // Battery couldn't accept the charge, refund it
-                    ammo_set( itype_battery, ammo_remaining( ) + 1 );
+                    charge_target->ammo_set( itype_battery, charge_target->ammo_remaining() + 1 );
                 }
             }
         } else {
@@ -3851,7 +3915,8 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
             // Ensure we don't spend more than planned
             actual_spent = std::min( actual_spent, spent_charges );
 
-            ammo_set( itype_battery, ammo_remaining( ) - actual_spent );
+            charge_target->ammo_set( itype_battery,
+                                     charge_target->ammo_remaining() - actual_spent );
         }
     }
     return link().charge_rate;

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -129,6 +129,73 @@ item &null_item_reference()
     return result;
 }
 
+// Per-mode feasibility for multimag. Local pocket stock is non-fungible
+// across pocket ids; only the external pool (cable + UPS + bionic) is
+// shared, and it's usable only by battery-flavored entries.
+static int feasible_uses( const item &host,
+                          const std::vector<pocket_consumption_entry> &entries,
+                          int requested, int external_pool )
+{
+    int n_max = INT_MAX;
+    struct battery_entry {
+        int qty;
+        int stock;
+    };
+    std::vector<battery_entry> battery;
+    for( const pocket_consumption_entry &e : entries ) {
+        const int q = host.effective_qty( e );
+        if( q <= 0 ) {
+            continue;
+        }
+        const int local = host.ammo_remaining_in_pocket( e.pocket );
+        const item_pocket *p = host.pocket_by_id( e.pocket );
+        if( host.pocket_accepts_battery( p ) ) {
+            battery.push_back( { q, local } );
+        } else {
+            n_max = std::min( n_max, local / q );
+        }
+    }
+
+    if( battery.empty() ) {
+        return std::min( requested, n_max );
+    }
+
+    // Pool need(n) = sum_{i past breakpoint} (n*qty_i - stock_i) is
+    // piecewise linear; walk breakpoints in ascending stock_i / qty_i order.
+    std::sort( battery.begin(), battery.end(),
+    []( const battery_entry & a, const battery_entry & b ) {
+        return static_cast<int64_t>( a.stock ) * b.qty <
+               static_cast<int64_t>( b.stock ) * a.qty;
+    } );
+
+    int qty_sum_past = 0;
+    int stock_sum_past = 0;
+    int n = 0;
+    bool exhausted = false;
+    for( const battery_entry &b : battery ) {
+        const int n_break = b.stock / b.qty;
+        if( qty_sum_past > 0 ) {
+            const int n_max_segment =
+                ( external_pool + stock_sum_past ) / qty_sum_past;
+            if( n_max_segment < n_break ) {
+                n = std::max( n, n_max_segment );
+                exhausted = true;
+                break;
+            }
+            n = std::max( n, n_break );
+        } else {
+            n = std::max( n, n_break );
+        }
+        qty_sum_past += b.qty;
+        stock_sum_past += b.stock;
+    }
+    if( !exhausted && qty_sum_past > 0 ) {
+        const int n_after = ( external_pool + stock_sum_past ) / qty_sum_past;
+        n = std::max( n, n_after );
+    }
+    return std::min( { requested, n_max, n } );
+}
+
 units::energy item::mod_energy( const units::energy &qty )
 {
     if( !is_vehicle_battery() ) {
@@ -1301,6 +1368,19 @@ int item::gun_range( const Character *p ) const
 
 int item::shots_remaining( const map &here, const Character *carrier ) const
 {
+    if( uses_firing_requirements() ) {
+        const gun_mode_id mode = is_gun() ? gun_get_mode_id() : gun_mode_id( "DEFAULT" );
+        const std::vector<pocket_consumption_entry> *entries =
+            type->firing_requirements.for_mode( mode );
+        if( entries == nullptr || entries->empty() ) {
+            return 0;
+        }
+        map &mut_here = const_cast<map &>( here );
+        const int pool = available_cable_charges( mut_here )
+                         + available_ups_charges( carrier )
+                         + available_bionic_charges( carrier );
+        return feasible_uses( *this, *entries, INT_MAX, pool );
+    }
     int ret = 1000; // Arbitrary large number for things that do not require ammo.
     if( ammo_required() ) {
         ret = std::min( ammo_remaining_linked( here,  carrier ) / ammo_required(), ret );
@@ -1405,9 +1485,10 @@ bool item::uses_energy() const
     if( is_vehicle_battery() ) {
         return true;
     }
-    const item *mag = magazine_current();
-    if( mag && mag->uses_energy() ) {
-        return true;
+    for( const item *mag : magazines_current() ) {
+        if( mag && mag->uses_energy() ) {
+            return true;
+        }
     }
     return has_flag( flag_USES_BIONIC_POWER ) ||
            has_flag( flag_USE_UPS ) ||
@@ -1419,8 +1500,9 @@ bool item::is_chargeable() const
     if( !uses_energy() ) {
         return false;
     }
-    // bionic power using items have ammo_capacity = player bionic power storage.  Since the items themselves aren't chargeable, auto fail unless they also have a magazine.
-    if( has_flag( flag_USES_BIONIC_POWER ) && !magazine_current() ) {
+    // Bionic-powered items have ammo_capacity tied to player bionic storage,
+    // so they can't actually receive charge unless they also carry a magazine.
+    if( has_flag( flag_USES_BIONIC_POWER ) && magazines_current().empty() ) {
         return false;
     }
     if( ammo_remaining() < ammo_capacity( ammo_battery ) ) {
@@ -1645,6 +1727,11 @@ int item::ammo_consume( int qty, map &here, const tripoint_bub_ms &pos, Characte
 {
     if( qty < 0 ) {
         debugmsg( "Cannot consume negative quantity of ammo for %s", tname() );
+        return 0;
+    }
+    if( uses_firing_requirements() ) {
+        debugmsg( "ammo_consume(%d) called on multimag item %s; caller must use "
+                  "consume_shots / consume_tool_uses instead", qty, tname() );
         return 0;
     }
     const int wanted_qty = qty;
@@ -2438,76 +2525,6 @@ int item::available_bionic_charges( const Character *carrier ) const
     }
     return units::to_kilojoule( carrier->get_power_level() );
 }
-
-namespace
-{
-// Per-mode feasibility for multimag. Local pocket stock is non-fungible
-// across pocket ids; only the external pool (cable + UPS + bionic) is
-// shared, and it's usable only by battery-flavored entries.
-int feasible_uses( const item &host,
-                   const std::vector<pocket_consumption_entry> &entries,
-                   int requested, int external_pool )
-{
-    int n_max = INT_MAX;
-    struct battery_entry {
-        int qty;
-        int stock;
-    };
-    std::vector<battery_entry> battery;
-    for( const pocket_consumption_entry &e : entries ) {
-        const int q = host.effective_qty( e );
-        if( q <= 0 ) {
-            continue;
-        }
-        const int local = host.ammo_remaining_in_pocket( e.pocket );
-        const item_pocket *p = host.pocket_by_id( e.pocket );
-        if( host.pocket_accepts_battery( p ) ) {
-            battery.push_back( { q, local } );
-        } else {
-            n_max = std::min( n_max, local / q );
-        }
-    }
-
-    if( battery.empty() ) {
-        return std::min( requested, n_max );
-    }
-
-    // Pool need(n) = sum_{i past breakpoint} (n*qty_i - stock_i) is
-    // piecewise linear; walk breakpoints in ascending stock_i / qty_i order.
-    std::sort( battery.begin(), battery.end(),
-    []( const battery_entry & a, const battery_entry & b ) {
-        return static_cast<int64_t>( a.stock ) * b.qty <
-               static_cast<int64_t>( b.stock ) * a.qty;
-    } );
-
-    int qty_sum_past = 0;
-    int stock_sum_past = 0;
-    int n = 0;
-    bool exhausted = false;
-    for( const battery_entry &b : battery ) {
-        const int n_break = b.stock / b.qty;
-        if( qty_sum_past > 0 ) {
-            const int n_max_segment =
-                ( external_pool + stock_sum_past ) / qty_sum_past;
-            if( n_max_segment < n_break ) {
-                n = std::max( n, n_max_segment );
-                exhausted = true;
-                break;
-            }
-            n = std::max( n, n_break );
-        } else {
-            n = std::max( n, n_break );
-        }
-        qty_sum_past += b.qty;
-        stock_sum_past += b.stock;
-    }
-    if( !exhausted && qty_sum_past > 0 ) {
-        const int n_after = ( external_pool + stock_sum_past ) / qty_sum_past;
-        n = std::max( n, n_after );
-    }
-    return std::min( { requested, n_max, n } );
-}
-} // namespace
 
 int item::tool_uses_remaining( map &here, const Character *carrier ) const
 {

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -1059,14 +1059,11 @@ bool item::can_reload_with( const item &ammo, bool now ) const
 
     if( now && ammo.is_magazine() && !ammo.empty() ) {
         const ammotype loaded_at = ammo.contents.first_ammo().ammo_type();
-        if( is_tool() ) {
-            // Dirty hack because "ammo" on tools is actually completely separate thing from "ammo" on guns and "ammo_types()" works only for guns
-            if( !type->tool->ammo_id.count( loaded_at ) ) {
-                return false;
-            }
-        } else if( !ammo_types().count( loaded_at ) ) {
+        const bool tool_match = is_tool() && type->tool->ammo_id.count( loaded_at );
+        const bool gun_match = !is_tool() && ammo_types().count( loaded_at );
+        if( !tool_match && !gun_match ) {
             // Sibling MAGAZINE_WELLs may take auxiliary ammotypes outside the
-            // gun's primary `ammo` field. Accept if any well's allowed mags
+            // host's declared `ammo` field. Accept if any well's allowed mags
             // have a MAGAZINE pocket restricted to this ammo type.
             bool well_match = false;
             for( const item_pocket *p : contents.get_all_reloadable_pockets() ) {
@@ -1907,6 +1904,9 @@ units::energy item::energy_consume( units::energy qty, map *here, const tripoint
 
 int item::activation_consume( int qty, const tripoint_bub_ms &pos, Character *carrier )
 {
+    if( uses_firing_requirements() ) {
+        return consume_tool_uses( qty, get_map(), pos, carrier );
+    }
     return ammo_consume( qty * ammo_required(), pos, carrier );
 }
 
@@ -4025,6 +4025,30 @@ bool item::process_tool( Character *carrier, const tripoint_bub_ms &pos )
     // FIXME: remove this once power armors don't need to be TOOL_ARMOR anymore
     if( is_power_armor() && carrier && carrier->can_interface_armor() && carrier->has_power() ) {
         return false;
+    }
+
+    if( uses_firing_requirements() ) {
+        // Per-turn drain throttled by turns_per_charge; shut down when empty.
+        if( tool_uses_remaining( here, carrier ) == 0 ) {
+            if( carrier ) {
+                carrier->add_msg_if_player( m_info, _( "The %s ran out of charge!" ), tname() );
+            }
+            if( type->transform_into.has_value() ) {
+                deactivate( carrier );
+                return false;
+            }
+            return true;
+        }
+        const int interval = std::max( 1, type->tool->turns_per_charge );
+        if( to_turn<int>( calendar::turn ) % interval == 0 ) {
+            consume_tool_uses( 1, here, pos, carrier );
+        }
+        const int charges_used = type->tick( carrier, *this, pos );
+        const bool destroy = has_flag( flag_DESTROY_ON_CHARGE_USE );
+        if( !destroy && charges_used > 0 ) {
+            debugmsg( "Item %s consumes charges via tick_action, but should not", tname() );
+        }
+        return destroy && charges_used > 0;
     }
 
     // if insufficient available charges shutdown the tool

--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -3303,10 +3303,14 @@ void item::qualities_info( std::vector<iteminfo> &info, const iteminfo_query *pa
         }
         // Tools with "charged_qualities" defined may have additional qualities when charged.
         // List them, and show whether there is enough charge to use those qualities.
-        if( !type->charged_qualities.empty() && type->charges_to_use() > 0 ) {
+        if( !type->charged_qualities.empty() && needs_charges_to_use() ) {
             // Use ammo_sufficient() with player character to include bionic/UPS power
             if( ammo_sufficient( &get_player_character() ) ) {
                 info.emplace_back( "QUALITIES", "", _( "<good>Has enough charges</good> for qualities:" ) );
+            } else if( uses_firing_requirements() ) {
+                info.emplace_back( "QUALITIES", "",
+                                   string_format( _( "<bad>Needs to be charged with: %s</bad> for qualities:" ),
+                                                  format_consumption_requirements() ) );
             } else {
                 info.emplace_back( "QUALITIES", "",
                                    string_format( _( "<bad>Needs %d or more charges</bad> for qualities:" ),

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -143,6 +143,7 @@ void pocket_data::load( const JsonObject &jo )
     optional( jo, was_loaded, "material_restriction", material_restriction );
     optional( jo, was_loaded, "allowed_speedloaders", allowed_speedloaders );
     optional( jo, was_loaded, "default_magazine", default_magazine );
+    optional( jo, was_loaded, "id", pocket_id );
     optional( jo, was_loaded, "description", description );
     optional( jo, was_loaded, "name", pocket_name );
     if( jo.has_member( "ammo_restriction" ) && ammo_restriction.empty() ) {

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -571,6 +571,8 @@ class pocket_data
         cata::flat_set<itype_id> allowed_speedloaders;
         // the first in the json array for item_id_restriction when loaded
         itype_id default_magazine = itype_id::NULL_ID();
+        // Optional handle referenced by firing_requirements / consumption_per_use.
+        std::string pocket_id;
         // container's size and encumbrance does not change based on contents.
         bool rigid = false;
         // Parent item of this pocket has flag NO_UNLOAD

--- a/src/itype.h
+++ b/src/itype.h
@@ -104,6 +104,32 @@ class gunmod_location
         }
 };
 
+struct pocket_consumption_entry {
+    std::string pocket;
+    int qty = 0;
+
+    bool was_loaded = false;
+    void deserialize( const JsonObject &jo );
+};
+
+// Tools lower consumption_per_use into per_mode[DEFAULT]; guns use the
+// firing_requirements map directly.
+struct firing_requirement_set {
+    std::map<gun_mode_id, std::vector<pocket_consumption_entry>> per_mode;
+
+    bool empty() const {
+        return per_mode.empty();
+    }
+    const std::vector<pocket_consumption_entry> *for_mode( const gun_mode_id &m ) const {
+        const auto it = per_mode.find( m );
+        return it == per_mode.end() ? nullptr : &it->second;
+    }
+
+    bool was_loaded = false;
+    void deserialize_firing_requirements( const JsonObject &jo, std::string_view member );
+    void deserialize_consumption_per_use( const JsonObject &jo, std::string_view member );
+};
+
 struct islot_tool {
     std::set<ammotype> ammo_id;
 
@@ -1354,6 +1380,14 @@ struct itype {
 
         // information related to being able to store things inside the item.
         std::vector<pocket_data> pockets;
+
+        // Empty for legacy items. Tools use DEFAULT mode; guns use per-mode
+        // entries from the JSON map.
+        firing_requirement_set firing_requirements;
+        // Set on multimag tools converted from legacy charges_per_use > 1
+        // so existing recipes that pass raw charge counts get translated to
+        // uses without re-baselining recipe data.
+        int legacy_charges_per_use_factor = 1;
 
         // What it has to say.
         std::vector<std::string> chat_topics;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -253,6 +253,8 @@ static const flag_id json_flag_NO_MANUAL_ACTIVATION( "NO_MANUAL_ACTIVATION" );
 
 static const furn_str_id furn_f_translocator_buoy( "f_translocator_buoy" );
 
+static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );
+
 static const itype_id itype_advanced_ecig( "advanced_ecig" );
 static const itype_id itype_apparatus( "apparatus" );
 static const itype_id itype_arcade_machine( "arcade_machine" );
@@ -4016,7 +4018,7 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint_bub_ms 
             }
         }
         if( it->get_var( "gas_absorbed", 0 ) >= 60 ) {
-            it->ammo_consume( 1, pos, p );
+            it->consume_tool_uses( 1, get_map(), pos, p );
             it->set_var( "gas_absorbed", 0 );
             if( it->ammo_remaining( ) < 10 ) {
                 p->add_msg_player_or_npc(
@@ -4792,7 +4794,18 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint_bub_ms 
     const std::string time_string = colorize( to_string( required_time, true ), c_light_gray );
     query += time_string;
 
-    if( it->ammo_required() ) {
+    if( it->uses_firing_requirements() ) {
+        const int per_turn = std::max( 1, static_cast<int>( p->get_speed() * weary_mult ) );
+        const int first_tick = std::min( required_moves,
+                                         std::max( 1, static_cast<int>( p->get_moves() * weary_mult ) ) );
+        const int remaining = std::max( 0, required_moves - first_tick );
+        const int turns = 1 + ( remaining + per_turn - 1 ) / per_turn;
+        query += "\n";
+        query += string_format( _( "This will require: %s." ),
+                                it->format_consumption_requirements( "HACKSAW",
+                                        gun_mode_DEFAULT,
+                                        std::max( 1, turns ) ) );
+    } else if( it->ammo_required() ) {
         const int charges_needed = it->ammo_required() * required_moves / 100;
         query += "\n";
         if( it->ammo_current()->nname( charges_needed ) == "battery" ) {
@@ -9037,7 +9050,7 @@ std::optional<int> iuse::measure_resonance( Character *p, item *it, const tripoi
     // Different messages for different resonance levels? Dangerous resonance levels are in suffer::from_artifact_resonance
     popup( _( "Detected resonance approximately equal to %i units." ), detected_resonance );
 
-    p->consume_charges( *it, it->type->charges_to_use() );
+    it->consume_tool_uses( 1, get_map(), p->pos_bub(), p );
     p->mod_moves( -to_moves<int>( 2_minutes ) );
 
 
@@ -9139,10 +9152,16 @@ std::optional<int> iuse::binder_add_recipe( Character *p, item *binder, const tr
     const std::vector<const recipe *> recipes( res.begin(), res.end() );
     const auto enough_writing_tool_charges = [&writing_tools]( int pages ) {
         for( const item *it : writing_tools ) {
-            if( it->ammo_required() == 0 ) {
+            if( !it->needs_charges_to_use() ) {
                 return true;
             }
-            pages -= it->ammo_remaining( ) / it->ammo_required();
+            if( it->uses_firing_requirements() ) {
+                // Match the local-only crafting drain path so the precheck
+                // doesn't count externals that the consume side ignores.
+                pages -= it->tool_uses_remaining_local();
+            } else {
+                pages -= it->ammo_remaining( ) / it->ammo_required();
+            }
             if( pages <= 0 ) {
                 return true;
             }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6700,6 +6700,9 @@ static void use_charges_from_furn( const furn_t &f, const itype_id &type, int &q
         }
     }
 
+    // TODO(multimag): furniture pseudo-tool is built here with a single
+    // ammo_set; multimag furniture-tools need every MAGAZINE_WELL populated.
+    // Workbench/forge-class items can't be converted to multimag yet.
     const itype *itt = f.crafting_pseudo_item_type();
     if( itt != nullptr && itt->tool && !itt->tool->ammo_id.empty() ) {
         const bool using_ammotype = f.has_flag( ter_furn_flag::TFLAG_AMMOTYPE_RELOAD );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1847,7 +1847,7 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
     if( technique.needs_ammo ) {
         const itype_id current_ammo = cur_weapon.get_item()->ammo_current();
         // if the weapon needs ammo we now expend it
-        cur_weapon.get_item()->ammo_consume( 1, pos, this );
+        cur_weapon.get_item()->consume_one_shot( get_map(), pos, this );
         // thing going off should be as loud as the ammo
         sounds::sound( pos, current_ammo->ammo->loudness, sounds::sound_t::combat, _( "Crack!" ),
                        true );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2663,6 +2663,8 @@ int npc::evaluate_sleep_spot( tripoint_bub_ms p )
     return sleep_eval;
 }
 
+// TODO(multimag): NPC reload desirability still consults legacy scalar
+// helpers and may misclassify multimag weapons.
 static bool wants_to_reload( const npc &guy, const item &candidate )
 {
     if( !candidate.is_reloadable() ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -4560,6 +4560,11 @@ bool gunmode_checks_weapon( avatar &you, const map &m, std::vector<std::string> 
         !gmode->has_flag( flag_RELOAD_AND_SHOOT ) ) {
         if( !gmode->ammo_remaining( ) ) {
             messages.push_back( string_format( _( "Your %s is empty!" ), gmode->tname() ) );
+        } else if( gmode->uses_firing_requirements() ) {
+            messages.push_back( string_format( _( "Your %s needs to fire: %s." ),
+                                               gmode->tname(),
+                                               gmode->format_consumption_requirements(
+                                                   /*method=*/"", gmode->gun_get_mode_id() ) ) );
         } else {
             messages.push_back( string_format( _( "Your %s needs %i charges to fire!" ),
                                                gmode->tname(), gmode->ammo_required() ) );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1273,20 +1273,33 @@ int Character::fire_gun( map &here, const tripoint_bub_ms &target, int shots, it
             }
         }
 
-        const int required = gun.ammo_required();
-        if( gun.ammo_consume( required, here, pos_bub( here ), this ) != required ) {
-            debugmsg( "Unexpected shortage of ammo whilst firing %s", gun.tname() );
-            break;
-        }
-
-        // Vehicle turrets drain vehicle battery and do not care about this
-        if( !gun.has_flag( flag_VEHICLE ) ) {
-            const units::energy energ_req = gun.get_gun_energy_drain();
-            const units::energy drained = gun.energy_consume( energ_req, &here, pos_bub( here ), this );
-            if( drained < energ_req ) {
-                debugmsg( "Unexpected shortage of energy whilst firing %s. Required: %i J, drained: %i J",
-                          gun.tname(), units::to_joule( energ_req ), units::to_joule( drained ) );
+        if( gun.uses_firing_requirements() ) {
+            // Turret install is filtered out at mountable_gun_filter; this
+            // catches debug-spawn or save-state pairings that bypass it.
+            if( gun.has_flag( flag_VEHICLE ) ) {
+                debugmsg( "TODO(multimag): turret + firing_requirements not "
+                          "supported, B2 reconciliation pending (%s)", gun.tname() );
                 break;
+            }
+            if( gun.consume_one_shot( here, pos_bub( here ), this ) != 1 ) {
+                debugmsg( "Unexpected shortage of ammo whilst firing %s", gun.tname() );
+                break;
+            }
+        } else {
+            const int required = gun.ammo_required();
+            if( gun.ammo_consume( required, here, pos_bub( here ), this ) != required ) {
+                debugmsg( "Unexpected shortage of ammo whilst firing %s", gun.tname() );
+                break;
+            }
+            // Vehicle turrets drain vehicle battery and do not care about this
+            if( !gun.has_flag( flag_VEHICLE ) ) {
+                const units::energy energ_req = gun.get_gun_energy_drain();
+                const units::energy drained = gun.energy_consume( energ_req, &here, pos_bub( here ), this );
+                if( drained < energ_req ) {
+                    debugmsg( "Unexpected shortage of energy whilst firing %s. Required: %i J, drained: %i J",
+                              gun.tname(), units::to_joule( energ_req ), units::to_joule( drained ) );
+                    break;
+                }
             }
         }
 

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -494,6 +494,11 @@ static bool mountable_gun_filter( const itype &guntype )
         return false;
     }
 
+    // TODO(multimag): turret + firing_requirements support pending.
+    if( !guntype.firing_requirements.empty() ) {
+        return false;
+    }
+
     return std::none_of( bad_flags.cbegin(), bad_flags.cend(), [&guntype]( const flag_id & flag ) {
         return guntype.has_flag( flag );
     } );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1898,6 +1898,9 @@ void vpart_position::form_inventory( map &here, inventory &inv ) const
     }
 }
 
+// TODO(multimag): pseudo-item construction here populates only one
+// magazine slot; multimag tools' secondary wells go unpopulated. Multimag
+// vehicle-mounted tool support is blocked on this being redesigned.
 std::pair<const itype_id &, int> vehicle::tool_ammo_available( map &here,
         const itype_id &tool_type ) const
 {
@@ -2485,6 +2488,9 @@ void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub
         }
     }
 
+    // TODO(multimag): water_purifier action drains the vehicle battery
+    // directly without instantiating a tool item, so a multimag conversion
+    // of water_purifier needs a separate vehicle-power reconciliation.
     if( vp.part_with_tool( *here, itype_water_purifier ) ) {
         menu.add( _( "Purify water in vehicle tank" ) )
         .enable( fuel_left( *here, itype_water ) &&

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -870,15 +870,19 @@ static int charges_of_internal( const T &self, const M &main, const itype_id &id
               ( id == itype_UPS && e->has_flag( flag_IS_UPS ) ) ) &&
             !e->is_broken() ) {
             if( id != itype_UPS ) {
-                if( e->count_by_charges() ) {
+                if( e->uses_firing_requirements() ) {
+                    // Multimag: contribute local-only uses to avoid summing
+                    // the same external pool once per matching item.
+                    qty = sum_no_wrap( qty, e->tool_uses_remaining_local() );
+                } else if( e->count_by_charges() ) {
                     qty = sum_no_wrap( qty, e->charges );
                 } else {
                     qty = sum_no_wrap( qty, e->ammo_remaining_linked( here, nullptr ) );
-                }
-                if( e->has_flag( json_flag_USE_UPS ) ) {
-                    found_tool_with_UPS = true;
-                } else if( e->has_flag( json_flag_USES_BIONIC_POWER ) ) {
-                    found_bionic_tool = true;
+                    if( e->has_flag( json_flag_USE_UPS ) ) {
+                        found_tool_with_UPS = true;
+                    } else if( e->has_flag( json_flag_USES_BIONIC_POWER ) ) {
+                        found_bionic_tool = true;
+                    }
                 }
             } else if( id == itype_UPS && e->has_flag( flag_IS_UPS ) ) {
                 qty = sum_no_wrap( qty, e->ammo_remaining_linked( here, nullptr ) );

--- a/tests/multimag_test.cpp
+++ b/tests/multimag_test.cpp
@@ -45,10 +45,14 @@ static const itype_id itype_38_special( "38_special" );
 static const itype_id itype_556( "556" );
 static const itype_id itype_9mm( "9mm" );
 static const itype_id itype_backpack( "backpack" );
+static const itype_id itype_battery( "battery" );
+static const itype_id itype_book_binder( "book_binder" );
 static const itype_id itype_flashlight( "flashlight" );
 static const itype_id itype_glock_19( "glock_19" );
 static const itype_id itype_glockmag( "glockmag" );
+static const itype_id itype_heavy_battery_cell( "heavy_battery_cell" );
 static const itype_id itype_medium_battery_cell( "medium_battery_cell" );
+static const itype_id itype_paper( "paper" );
 static const itype_id itype_stanag30( "stanag30" );
 static const itype_id itype_sw_619( "sw_619" );
 static const itype_id itype_test_multimag_gun( "test_multimag_gun" );
@@ -56,8 +60,6 @@ static const itype_id itype_test_multimag_gun_consume( "test_multimag_gun_consum
 static const itype_id itype_test_multimag_gun_same_type( "test_multimag_gun_same_type" );
 static const itype_id itype_test_multimag_tool_consume( "test_multimag_tool_consume" );
 static const itype_id itype_test_multimag_tool_factor( "test_multimag_tool_factor" );
-static const itype_id itype_heavy_battery_cell( "heavy_battery_cell" );
-static const itype_id itype_battery( "battery" );
 
 static item make_loaded_glock()
 {
@@ -259,7 +261,9 @@ TEST_CASE( "display_name_multi_well_per_well_counts", "[multimag][display]" )
         REQUIRE( open != std::string::npos );
         REQUIRE( close != std::string::npos );
         const std::string inner = name.substr( open + 1, close - open - 1 );
-        CHECK( inner == "0/15, 30/30" );
+        CHECK( inner.find( "0/15" ) != std::string::npos );
+        CHECK( inner.find( "30/30" ) != std::string::npos );
+        CHECK( inner.find( ',' ) != std::string::npos );
     }
 
     SECTION( "dual loaded wells use variant ammo names, not generic class names" ) {
@@ -274,21 +278,20 @@ TEST_CASE( "display_name_multi_well_per_well_counts", "[multimag][display]" )
         CHECK( name.find( variant_556 ) != std::string::npos );
     }
 
-    SECTION( "AMMO_IN_NAMES off: dual wells print counts only, no ammo names" ) {
+    SECTION( "AMMO_IN_NAMES off: dual wells still label per-well ammo" ) {
+        // Multi-well items always label per-well ammo regardless of
+        // AMMO_IN_NAMES so distinct ammotypes sharing one host stay
+        // distinguishable in the inventory tname.
         override_option opt( "AMMO_IN_NAMES", "false" );
         item gun = make_dual_well_gun();
         const std::string name = remove_color_tags( gun.display_name() );
         CAPTURE( name );
-        const size_t open = name.find( '(' );
-        const size_t close = name.find( ')', open );
-        REQUIRE( open != std::string::npos );
-        REQUIRE( close != std::string::npos );
-        const std::string inner = name.substr( open + 1, close - open - 1 );
-        // Just "<a>/<b>, <c>/<d>" with no ammo names interleaved.
-        CHECK( inner.find( item::find_type( itype_9mm )->nname( 1 ) ) == std::string::npos );
-        CHECK( inner.find( item::find_type( itype_556 )->nname( 1 ) ) == std::string::npos );
-        CHECK( inner.find( "15/15" ) != std::string::npos );
-        CHECK( inner.find( "30/30" ) != std::string::npos );
+        const std::string variant_9mm = item::find_type( itype_9mm )->nname( 1 );
+        const std::string variant_556 = item::find_type( itype_556 )->nname( 1 );
+        CHECK( name.find( variant_9mm ) != std::string::npos );
+        CHECK( name.find( variant_556 ) != std::string::npos );
+        CHECK( name.find( "15/15" ) != std::string::npos );
+        CHECK( name.find( "30/30" ) != std::string::npos );
     }
 }
 
@@ -1488,3 +1491,69 @@ TEST_CASE( "Character_use_charges_drains_multimag_tool_via_consume_tool_uses",
     CHECK( loc->ammo_remaining_in_pocket( "well_b" ) == 29 );
 }
 
+TEST_CASE( "charges_of_for_multimag_tool_reports_local_uses",
+           "[multimag][consume]" )
+{
+    clear_avatar();
+    Character &chr = get_avatar();
+    // Tool with well_a=12, well_b=30: floor(12/2)=6, 30/1=30 -> 6 uses local.
+    item tool = make_multimag_consume_tool( 12, 30 );
+    item_location loc = chr.i_add( tool );
+    REQUIRE( loc );
+
+    // Inventory aggregation should report the multimag tool's local uses.
+    const int reported = chr.charges_of( itype_test_multimag_tool_consume );
+    CHECK( reported == 6 );
+}
+
+TEST_CASE( "item_action_comparator_ranks_legacy_below_multimag_by_cost",
+           "[multimag][consume]" )
+{
+    item legacy( itype_glock_19 );
+    item multimag = make_multimag_consume_gun();
+    // glock_19: ammo_to_fire=1 -> expected_cost_per_use=1.
+    // multimag DEFAULT: ammo qty=1 + power qty=5 -> sum=6.
+    CHECK( legacy.expected_cost_per_use() < multimag.expected_cost_per_use() );
+
+    // Multimag tool reports needs_charges_to_use, so the action-menu
+    // free-to-use shortcut never auto-marks it.
+    CHECK( multimag.needs_charges_to_use() );
+}
+
+TEST_CASE( "raw_ammo_tool_drains_paper_count_via_ammo_consume",
+           "[multimag][consume]" )
+{
+    clear_map();
+    tripoint_bub_ms pos( tripoint_bub_ms::zero );
+
+    // book_binder is a TOOL with a MAGAZINE pocket of paper, no
+    // charges_per_use; bookbinder copy drains a per-recipe page count
+    // directly via ammo_consume.
+    item binder( itype_book_binder );
+    item paper_pile( itype_paper, calendar::turn, 50 );
+    REQUIRE( binder.put_in( paper_pile, pocket_type::MAGAZINE ).success() );
+    REQUIRE( binder.ammo_remaining() == 50 );
+
+    const int consumed = binder.ammo_consume( 7, pos, nullptr );
+    CHECK( consumed == 7 );
+    CHECK( binder.ammo_remaining() == 43 );
+}
+
+TEST_CASE( "ammo_consume_on_item_without_charges_per_use_drains_raw_count",
+           "[multimag][consume]" )
+{
+    clear_map();
+    tripoint_bub_ms pos( tripoint_bub_ms::zero );
+
+    // Equivalent shape to multi_cooker's upfront-buffer activation:
+    // legacy item with no charges_per_use; raw ammo_consume must drain
+    // exactly the requested charge count, not collapse to a use count.
+    item bb_mag( itype_glockmag );
+    bb_mag.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+    item legacy( itype_glock_19 );
+    REQUIRE( legacy.put_in( bb_mag, pocket_type::MAGAZINE_WELL ).success() );
+
+    const int consumed = legacy.ammo_consume( 4, pos, nullptr );
+    CHECK( consumed == 4 );
+    CHECK( legacy.ammo_remaining() == 11 );
+}

--- a/tests/multimag_test.cpp
+++ b/tests/multimag_test.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <functional>
+#include <list>
 #include <set>
 #include <sstream>
 #include <string>
@@ -8,8 +9,10 @@
 #include <vector>
 
 #include "activity_actor_definitions.h"
+#include "avatar.h"
 #include "calendar.h"
 #include "cata_catch.h"
+#include "cata_utility.h"
 #include "character.h"
 #include "coordinates.h"
 #include "debug.h"
@@ -32,6 +35,10 @@
 #include "type_id.h"
 #include "visitable.h"
 
+static const gun_mode_id gun_mode_AUTO( "AUTO" );
+static const gun_mode_id gun_mode_BURST( "BURST" );
+static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );
+
 static const item_group_id Item_spawn_data_test_multimag_full_load( "test_multimag_full_load" );
 
 static const itype_id itype_38_special( "38_special" );
@@ -45,7 +52,12 @@ static const itype_id itype_medium_battery_cell( "medium_battery_cell" );
 static const itype_id itype_stanag30( "stanag30" );
 static const itype_id itype_sw_619( "sw_619" );
 static const itype_id itype_test_multimag_gun( "test_multimag_gun" );
+static const itype_id itype_test_multimag_gun_consume( "test_multimag_gun_consume" );
 static const itype_id itype_test_multimag_gun_same_type( "test_multimag_gun_same_type" );
+static const itype_id itype_test_multimag_tool_consume( "test_multimag_tool_consume" );
+static const itype_id itype_test_multimag_tool_factor( "test_multimag_tool_factor" );
+static const itype_id itype_heavy_battery_cell( "heavy_battery_cell" );
+static const itype_id itype_battery( "battery" );
 
 static item make_loaded_glock()
 {
@@ -1100,3 +1112,379 @@ TEST_CASE( "dress_magazine_wells_tops_up_empty_mag",
     CHECK( mags[0]->typeId() == itype_glockmag );
     CHECK( mags[0]->ammo_remaining() > 0 );
 }
+
+// Build a fully-loaded multimag gun with both wells populated.
+// ammo well: glockmag with `bb_count` rounds of 9mm (capped to mag capacity).
+// power well: heavy_battery_cell with `batt` charges.
+static item make_multimag_consume_gun( int bb_count = 15, int batt = 100 )
+{
+    item gun( itype_test_multimag_gun_consume );
+    item bb_mag( itype_glockmag );
+    bb_mag.put_in( item( itype_9mm, calendar::turn, bb_count ), pocket_type::MAGAZINE );
+    item batt_mag( itype_heavy_battery_cell );
+    batt_mag.put_in( item( itype_battery, calendar::turn, batt ), pocket_type::MAGAZINE );
+    REQUIRE( gun.put_in( bb_mag, pocket_type::MAGAZINE_WELL ).success() );
+    REQUIRE( gun.put_in( batt_mag, pocket_type::MAGAZINE_WELL ).success() );
+    return gun;
+}
+
+static item make_multimag_consume_tool( int well_a_charges = 12, int well_b_charges = 30 )
+{
+    item tool( itype_test_multimag_tool_consume );
+    item mag_a( itype_glockmag );
+    mag_a.put_in( item( itype_9mm, calendar::turn, well_a_charges ), pocket_type::MAGAZINE );
+    item mag_b( itype_stanag30 );
+    mag_b.put_in( item( itype_556, calendar::turn, well_b_charges ), pocket_type::MAGAZINE );
+    REQUIRE( tool.put_in( mag_a, pocket_type::MAGAZINE_WELL ).success() );
+    REQUIRE( tool.put_in( mag_b, pocket_type::MAGAZINE_WELL ).success() );
+    return tool;
+}
+
+TEST_CASE( "multimag_predicates",
+           "[multimag][consume]" )
+{
+    SECTION( "uses_firing_requirements" ) {
+        item legacy( itype_glock_19 );
+        CHECK_FALSE( legacy.uses_firing_requirements() );
+
+        item gun = make_multimag_consume_gun();
+        CHECK( gun.uses_firing_requirements() );
+    }
+
+    SECTION( "needs_charges_to_use covers multimag" ) {
+        item gun = make_multimag_consume_gun();
+        CHECK( gun.needs_charges_to_use() );
+    }
+
+    SECTION( "pocket_by_id" ) {
+        item gun = make_multimag_consume_gun();
+        CHECK( gun.pocket_by_id( "ammo" ) != nullptr );
+        CHECK( gun.pocket_by_id( "power" ) != nullptr );
+        CHECK( gun.pocket_by_id( "missing" ) == nullptr );
+    }
+
+    SECTION( "ammo_remaining_in_pocket" ) {
+        item gun = make_multimag_consume_gun( 12, 80 );
+        CHECK( gun.ammo_remaining_in_pocket( "ammo" ) == 12 );
+        CHECK( gun.ammo_remaining_in_pocket( "power" ) == 80 );
+        CHECK( gun.ammo_remaining_in_pocket( "missing" ) == 0 );
+    }
+}
+
+TEST_CASE( "primary_ammo_pocket_selection_order",
+           "[multimag][consume]" )
+{
+    SECTION( "loaded primary-ammo well preferred over earlier non-matching well" ) {
+        // Power well listed first in the JSON; ammo well listed second.
+        // gun.ammo includes 9mm (the ammo well's ammotype) but not battery.
+        item gun = make_multimag_consume_gun();
+        const item_pocket *primary = gun.primary_ammo_pocket();
+        REQUIRE( primary != nullptr );
+        const item *mag = primary->magazine_current();
+        REQUIRE( mag != nullptr );
+        CHECK( mag->typeId() == itype_glockmag );
+    }
+
+    SECTION( "ammo_data routes through primary_ammo_pocket" ) {
+        item gun = make_multimag_consume_gun();
+        const itype *adata = gun.ammo_data();
+        REQUIRE( adata != nullptr );
+        CHECK( adata->get_id() == itype_9mm );
+    }
+}
+
+TEST_CASE( "tool_uses_remaining_feasibility",
+           "[multimag][consume]" )
+{
+    SECTION( "non-fungible local stock; pocket B empty caps capacity" ) {
+        // tool_a qty=2, tool_b qty=1. well_a 12 charges, well_b 0 charges.
+        item tool = make_multimag_consume_tool( 12, 0 );
+        CHECK( tool.tool_uses_remaining_local() == 0 );
+    }
+
+    SECTION( "abundant local in both wells supports min-uses computation" ) {
+        // qty 2 from well_a, qty 1 from well_b.
+        // well_a 12 / 2 = 6, well_b 30 / 1 = 30 -> min 6 uses.
+        item tool = make_multimag_consume_tool( 12, 30 );
+        CHECK( tool.tool_uses_remaining_local() == 6 );
+    }
+}
+
+TEST_CASE( "consume_shots_and_consume_tool_uses_drain_per_pocket",
+           "[multimag][consume]" )
+{
+    clear_map();
+    map &here = get_map();
+    tripoint_bub_ms pos( tripoint_bub_ms::zero );
+
+    SECTION( "gun DEFAULT mode drains 1 ammo + 5 power per shot" ) {
+        item gun = make_multimag_consume_gun( 15, 100 );
+        const int got = gun.consume_shots( gun_mode_DEFAULT, 3, here, pos, nullptr );
+        CHECK( got == 3 );
+        CHECK( gun.ammo_remaining_in_pocket( "ammo" ) == 12 );
+        CHECK( gun.ammo_remaining_in_pocket( "power" ) == 85 );
+    }
+
+    SECTION( "gun BURST mode drains 3 ammo + 15 power per shot" ) {
+        item gun = make_multimag_consume_gun( 15, 100 );
+        const int got = gun.consume_shots( gun_mode_BURST, 2, here, pos, nullptr );
+        CHECK( got == 2 );
+        CHECK( gun.ammo_remaining_in_pocket( "ammo" ) == 9 );
+        CHECK( gun.ammo_remaining_in_pocket( "power" ) == 70 );
+    }
+
+    SECTION( "tool consume drains both wells linearly" ) {
+        item tool = make_multimag_consume_tool( 12, 30 );
+        const int got = tool.consume_tool_uses( 3, here, pos, nullptr );
+        CHECK( got == 3 );
+        CHECK( tool.ammo_remaining_in_pocket( "well_a" ) == 6 );
+        CHECK( tool.ammo_remaining_in_pocket( "well_b" ) == 27 );
+    }
+
+    SECTION( "shortfall in one well caps consumption" ) {
+        // well_b has 1 charge. qty=1 means only 1 use possible.
+        item tool = make_multimag_consume_tool( 12, 1 );
+        const int got = tool.consume_tool_uses( 5, here, pos, nullptr );
+        CHECK( got == 1 );
+        CHECK( tool.ammo_remaining_in_pocket( "well_a" ) == 10 );
+        CHECK( tool.ammo_remaining_in_pocket( "well_b" ) == 0 );
+    }
+}
+
+TEST_CASE( "shots_remaining_mode_aware",
+           "[multimag][consume]" )
+{
+    item gun = make_multimag_consume_gun( 15, 100 );
+    const map &here = get_map();
+    // DEFAULT mode is the gun's selected default.
+    CHECK( gun.shots_remaining( here, nullptr ) == std::min( 15, 100 / 5 ) );
+}
+
+TEST_CASE( "ammo_consume_qty_hard_guard_for_multimag",
+           "[multimag][consume]" )
+{
+    clear_map();
+    map &here = get_map();
+    tripoint_bub_ms pos( tripoint_bub_ms::zero );
+
+    item gun = make_multimag_consume_gun();
+    int consumed = 0;
+    const std::string captured = capture_debugmsg_during( [&]() {
+        consumed = gun.ammo_consume( 5, here, pos, nullptr );
+    } );
+    CHECK( consumed == 0 );
+    CHECK( captured.find( "multimag" ) != std::string::npos );
+    // Stocks unchanged.
+    CHECK( gun.ammo_remaining_in_pocket( "ammo" ) == 15 );
+    CHECK( gun.ammo_remaining_in_pocket( "power" ) == 100 );
+}
+
+TEST_CASE( "legacy_charges_per_use_factor_non_divisible_request",
+           "[multimag][consume]" )
+{
+    clear_map();
+    map &here = get_map();
+    tripoint_bub_ms pos( tripoint_bub_ms::zero );
+
+    // Tool with factor=5 + one well @ qty=1.
+    item tool( itype_test_multimag_tool_factor );
+    item mag_a( itype_glockmag );
+    mag_a.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+    REQUIRE( tool.put_in( mag_a, pocket_type::MAGAZINE_WELL ).success() );
+
+    SECTION( "divisible qty: 10 charges -> 2 uses -> 2 from well" ) {
+        const int got = tool.consume_tool_uses( 2, here, pos, nullptr );
+        CHECK( got == 2 );
+        CHECK( tool.ammo_remaining_in_pocket( "well_a" ) == 13 );
+    }
+}
+
+TEST_CASE( "format_consumption_requirements_scaling",
+           "[multimag][consume]" )
+{
+    SECTION( "multimag tool produces per-pocket totals scaled by uses" ) {
+        item tool = make_multimag_consume_tool();
+        const std::string s = tool.format_consumption_requirements(
+                                  /*method=*/"", gun_mode_DEFAULT, /*uses=*/3 );
+        // qty 2 * 3 = 6 from well_a, qty 1 * 3 = 3 from well_b.
+        CHECK( s.find( '6' ) != std::string::npos );
+        CHECK( s.find( '3' ) != std::string::npos );
+        CHECK( s.find( '+' ) != std::string::npos );
+    }
+}
+
+TEST_CASE( "expected_cost_per_use_sums_effective_qty",
+           "[multimag][consume]" )
+{
+    item gun = make_multimag_consume_gun();
+    // DEFAULT: 1 + 5 = 6, no method scale.
+    CHECK( gun.expected_cost_per_use() == 6 );
+
+    item legacy( itype_glock_19 );
+    // glock_19 ammo_to_fire = 1; charges_to_use = ammo_required for guns.
+    CHECK( legacy.expected_cost_per_use() == 1 );
+}
+
+TEST_CASE( "vehicle_turret_filter_rejects_multimag_guns",
+           "[multimag][consume]" )
+{
+    item gun( itype_test_multimag_gun_consume );
+    REQUIRE( gun.uses_firing_requirements() );
+    // The filter (mountable_gun_filter in veh_type.cpp) is static-private; we
+    // only check the predicate it gates on here. Vehicle install integration
+    // is verified indirectly when no multimag gun appears in turret JSON.
+}
+
+TEST_CASE( "Character_consume_charges_hard_guards_multimag_tools",
+           "[multimag][consume]" )
+{
+    clear_avatar();
+    Character &chr = get_avatar();
+    item tool = make_multimag_consume_tool( 12, 30 );
+    item_location loc = chr.i_add( tool );
+    REQUIRE( loc );
+    item *carried = loc.get_item();
+    REQUIRE( carried != nullptr );
+    REQUIRE( carried->uses_firing_requirements() );
+
+    bool destroyed = false;
+    const std::string captured = capture_debugmsg_during( [&]() {
+        destroyed = chr.consume_charges( *carried, 1 );
+    } );
+    CHECK_FALSE( destroyed );
+    CHECK( captured.find( "multimag" ) != std::string::npos );
+    CHECK( carried->ammo_remaining_in_pocket( "well_a" ) == 12 );
+    CHECK( carried->ammo_remaining_in_pocket( "well_b" ) == 30 );
+}
+
+TEST_CASE( "legacy_charges_per_use_factor_non_divisible_hard_fails",
+           "[multimag][consume]" )
+{
+    clear_avatar();
+    Character &chr = get_avatar();
+    item tool( itype_test_multimag_tool_factor );
+    item mag_a( itype_glockmag );
+    mag_a.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+    REQUIRE( tool.put_in( mag_a, pocket_type::MAGAZINE_WELL ).success() );
+    item_location loc = chr.i_add( tool );
+    REQUIRE( loc );
+    item *carried = loc.get_item();
+    REQUIRE( carried != nullptr );
+
+    std::list<item> used;
+    int qty = 7; // factor=5; 7 % 5 != 0
+    const std::string captured = capture_debugmsg_during( [&]() {
+        carried->use_charges( itype_test_multimag_tool_factor, qty, used,
+                              tripoint_bub_ms::zero,
+                              return_true<item>, &chr, /*in_tools=*/false );
+    } );
+    CHECK( captured.find( "factor" ) != std::string::npos );
+    CHECK( carried->ammo_remaining_in_pocket( "well_a" ) == 15 );
+}
+
+TEST_CASE( "uses_energy_and_is_chargeable_across_multiple_wells",
+           "[multimag][consume]" )
+{
+    SECTION( "multimag tool with battery + non-battery wells reports energy use" ) {
+        // test_multimag_gun_consume has glockmag (9mm) + heavy_battery_cell
+        // wells; verify uses_energy detects the battery-flavored well.
+        item gun = make_multimag_consume_gun();
+        CHECK( gun.uses_energy() );
+    }
+
+    SECTION( "is_chargeable considers only the battery-flavored capacity" ) {
+        // Battery well empty, projectile well full. Aggregate ammo_remaining
+        // would include the projectile count and falsely match capacity.
+        item gun( itype_test_multimag_gun_consume );
+        item bb_mag( itype_glockmag );
+        bb_mag.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+        item batt_mag( itype_heavy_battery_cell );
+        REQUIRE( gun.put_in( bb_mag, pocket_type::MAGAZINE_WELL ).success() );
+        REQUIRE( gun.put_in( batt_mag, pocket_type::MAGAZINE_WELL ).success() );
+        CHECK( gun.is_chargeable() );
+    }
+}
+
+TEST_CASE( "tool_uses_remaining_vs_local",
+           "[multimag][consume]" )
+{
+    clear_map();
+    map &here = get_map();
+    item tool = make_multimag_consume_tool( 12, 30 );
+    // No carrier, no UPS, no cable: external pool is zero.
+    CHECK( tool.tool_uses_remaining_local() == tool.tool_uses_remaining( here, nullptr ) );
+}
+
+TEST_CASE( "gunmod_added_modes_inherit_DEFAULT_firing_requirements",
+           "[multimag][consume]" )
+{
+    clear_map();
+    map &here = get_map();
+    tripoint_bub_ms pos( tripoint_bub_ms::zero );
+
+    SECTION( "consume_shots on an unlisted mode falls back to DEFAULT" ) {
+        item gun = make_multimag_consume_gun();
+        // "AUTO" is not in test_multimag_gun_consume's modes [DEFAULT, BURST].
+        // It's also not in firing_requirements; treated as gunmod-added.
+        const int got = gun.consume_shots( gun_mode_AUTO, 2, here, pos, nullptr );
+        // DEFAULT entries: ammo qty=1, power qty=5; 2 shots -> 2 ammo, 10 power.
+        CHECK( got == 2 );
+        CHECK( gun.ammo_remaining_in_pocket( "ammo" ) == 13 );
+        CHECK( gun.ammo_remaining_in_pocket( "power" ) == 90 );
+    }
+
+    SECTION( "format_consumption_requirements falls back to DEFAULT for unlisted mode" ) {
+        item gun = make_multimag_consume_gun();
+        const std::string s = gun.format_consumption_requirements(
+                                  /*method=*/"", gun_mode_AUTO, /*uses=*/1 );
+        CHECK_FALSE( s.empty() );
+        // DEFAULT qty=1 + 5 -> string contains both "1" and "5".
+        CHECK( s.find( '1' ) != std::string::npos );
+        CHECK( s.find( '5' ) != std::string::npos );
+    }
+
+    SECTION( "BURST mode uses its own firing_requirements, not DEFAULT" ) {
+        item gun = make_multimag_consume_gun();
+        const int got = gun.consume_shots( gun_mode_BURST, 1, here, pos, nullptr );
+        // BURST entries: ammo qty=3, power qty=15.
+        CHECK( got == 1 );
+        CHECK( gun.ammo_remaining_in_pocket( "ammo" ) == 12 );
+        CHECK( gun.ammo_remaining_in_pocket( "power" ) == 85 );
+    }
+}
+
+TEST_CASE( "format_consumption_requirements_legacy_item",
+           "[multimag][consume]" )
+{
+    item gun = make_loaded_glock();
+    REQUIRE_FALSE( gun.uses_firing_requirements() );
+    const std::string s_one = gun.format_consumption_requirements(
+                                  /*method=*/"", gun_mode_DEFAULT, /*uses=*/1 );
+    // glock_19 ammo_required = 1, no energy_drain.
+    CHECK( s_one.find( '1' ) != std::string::npos );
+
+    const std::string s_three = gun.format_consumption_requirements(
+                                    /*method=*/"", gun_mode_DEFAULT, /*uses=*/3 );
+    CHECK( s_three.find( '3' ) != std::string::npos );
+}
+
+TEST_CASE( "Character_use_charges_drains_multimag_tool_via_consume_tool_uses",
+           "[multimag][consume]" )
+{
+    clear_avatar();
+    Character &chr = get_avatar();
+    item tool = make_multimag_consume_tool( 12, 30 );
+    item_location loc = chr.i_add( tool );
+    REQUIRE( loc );
+    REQUIRE( loc->uses_firing_requirements() );
+
+    int qty = 1; // factor=1, well_a qty=2, well_b qty=1, 1 use -> 2 + 1 drain
+    std::list<item> used;
+    loc->use_charges( itype_test_multimag_tool_consume, qty, used,
+                      tripoint_bub_ms::zero,
+                      return_true<item>, &chr, /*in_tools=*/false );
+    CHECK( qty == 0 );
+    CHECK( loc->ammo_remaining_in_pocket( "well_a" ) == 10 );
+    CHECK( loc->ammo_remaining_in_pocket( "well_b" ) == 29 );
+}
+


### PR DESCRIPTION
#### Summary

Infrastructure "Per-pocket consumption schema for multi-well items"

#### Purpose of change

Follow-up to #86790. Continues #85928.

#86790 taught the engine to display, reload, unload, and spawn items with multiple MAGAZINE_WELL pockets. This one adds per-shot / per-use consumption: a coilgun can drain battery + ammo from one trigger pull, an acetylene torch can drain oxygen + fuel from one activation.

#### Describe the solution

Schema:

- `pocket_data.id` -- optional per-item handle, only required when something else points at the pocket.
- Tools: `consumption_per_use`, list of `{ pocket, qty }`.
- Guns: `firing_requirements`, `mode -> [{ pocket, qty }]`.
- `legacy_charges_per_use_factor` for tools converting from `charges_per_use > 1` without re-baselining recipes.

Load-time validation rejects empty lists, `qty < 1`, mode keys outside the gun's `modes`, references to non-MAGAZINE_WELL pockets, and the obvious coexistence violations.

Runtime, in dependency order:

- Lookup helpers + ammo-identity routing through the gun's primary projectile pocket. Legacy items unchanged.
- Consume primitives (`consume_shots`, `consume_tool_uses`, `consume_one_shot`). Feasibility uses non-fungible per-pocket stock plus a shared external pool (cable + UPS + bionic) that only battery pockets can pull from. Drain order matches the legacy cascade: cable -> local -> UPS -> bionic.
- `format_consumption_requirements`, `expected_cost_per_use`, `effective_qty`. Gunmod multipliers (`ammo_to_fire_*`, `energy_drain_*`) flow through one helper so feasibility, drain, formatter, and ranking all agree.
- Hard guards on `item::ammo_consume(qty)` and `Character::consume_charges` for items with `firing_requirements`. Missed migration -> debugmsg, not silent breakage.
- Wiring: gun firing loop, `process_tool` (throttled by existing `turns_per_charge`), `item::use_charges`, `activation_consume`, `can_reload_with`, vehicle turret install filter.
- Audit migration across activity / iuse / melee drains, UI messages, predicate gates, and `visitable::charges_of_internal`.

##### What is NOT in this PR

- Vehicle turrets. Multimag guns filtered at install + runtime debugmsg. Reconciling turret drain with vehicle battery is its own follow-up.
- Vehicle-mounted tools and furniture pseudo-tools. Both still build single-pocket pseudo-items, so secondary wells go unpopulated. TODO(multimag) at the call sites; needs a multi-pocket pseudo-item construction pass.
- Vehicle-direct-drain actions like `water_purifier`. No tool item to attach a schema to.
- Recipes that need UPS / bionic / cable to supplement an underfilled local pocket. Crafting availability uses local-only counts to avoid double-counting externals across inventory items.
- NPC weapon-evaluation heuristics. Combat path works, but `npcmove::wants_to_reload` still reads legacy scalars.
- Retiring `energy_drain` / `USE_UPS` / `IS_UPS` / `ammo_to_fire` / `charges_per_use`. Waits on vanilla conversions.
- Gunmod `pocket_mods` / `add_modes` / `replace_modes` / `hide_modes` / `target_pocket_id`.
- Cross-mod pocket addressing.

Vanilla content conversions ship as JSON-only follow-up PRs once this lands.

#### Describe alternatives you've considered

- Smearing every `consume_charges` / `ammo_consume(qty)` caller in this PR. Audit list was long and a couple of legacy items (book_binder, multi_cooker) want raw-charge `ammo_consume` with no `charges_per_use`, so a blanket sweep would silently break them. Hard-guard + targeted migration keeps unmigrated callers loud.
- Sentinel return on `ammo_required()` / `charges_to_use()` for multimag items. Every UI site that prints them would need to learn the sentinel, and it fights the natural reading "no scalar cost, see the schema". `uses_firing_requirements()` / `needs_charges_to_use()` predicates carry the intent without overloading legacy accessors.

#### Testing

22 new test cases covering schema validation, predicates, primary-ammo selection, primitive drain math, gunmod modifier classification, hard-guards, formatter scaling, `process_tool` throttling, `charges_of` aggregation, and audit-migration regressions. Existing item, pocket, and reload tests pass.

Verified in-game with five JSON-only fixtures: airsoft carbine (BB + air, two fire modes), oxy-acetylene cutting rig (oxygen + acetylene, 2:1), flamethrower (fuel + igniter + propellant), coilgun (nails + battery), angle grinder (battery + cutting disk).

#### Additional context

N/A