### PR TITLE
[Magiclysm] Add sells_belongings: false to Forge of Wonders NPCs

### DIFF
--- a/data/mods/Magiclysm/npc/TALK_FORGE_ARDELIA.json
+++ b/data/mods/Magiclysm/npc/TALK_FORGE_ARDELIA.json
@@ -29,6 +29,8 @@
     "bonus_per": { "one_in": 4 },
     "shopkeeper_item_group": [ { "group": "NC_FORGE_LORD_STORE_LIBRARY_SHOP", "rigid": true } ],
     "worn_override": "NC_FORGE_LIBRARIAN_clothes",
+    "carry_override": "EMPTY_GROUP",
+    "sells_belongings": false,
     "skills": [
       {
         "skill": "ALL",

--- a/data/mods/Magiclysm/npc/TALK_FORGE_HELEN_TAVREL.json
+++ b/data/mods/Magiclysm/npc/TALK_FORGE_HELEN_TAVREL.json
@@ -26,6 +26,8 @@
     "shopkeeper_price_rules": [ { "category": "guns", "premium": 1 }, { "category": "ammo", "premium": 1 } ],
     "worn_override": "NC_FORGE_REAGENT_clothes",
     "weapon_override": "NC_FORGE_REAGENT_wield",
+    "carry_override": "EMPTY_GROUP",
+    "sells_belongings": false,
     "skills": [
       {
         "skill": "ALL",

--- a/data/mods/Magiclysm/npc/TALK_FORGE_MERCHANT.json
+++ b/data/mods/Magiclysm/npc/TALK_FORGE_MERCHANT.json
@@ -25,6 +25,8 @@
     "shopkeeper_item_group": [ { "group": "NC_FORGE_LORD_SHOP", "rigid": true } ],
     "shopkeeper_price_rules": [ { "group": "NC_FORGE_LORD_ACCEPTED_BOOKS", "price": 2500, "fixed_adj": 0 } ],
     "worn_override": "NC_FORGE_LORD_clothes",
+    "carry_override": "EMPTY_GROUP",
+    "sells_belongings": false,
     "skills": [
       {
         "skill": "ALL",


### PR DESCRIPTION
#### Summary
Mods "Forge Lords should not sell their belongings"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Previously, you could buy their weapon from Ardelia. Now, you can only buy books from her.

#### Describe the solution

Added the flag "sells_belongings": false to FoW NPCs.

#### Describe alternatives you've considered

Considered making her unarmed but decided against it.

#### Testing

Did not test. Should work.