### PR TITLE
Blocking Fields

### DIFF
--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -4452,6 +4452,7 @@ Fields can exist on top of terrain/furniture, and support different intensity le
     "decay_amount_factor": 2, // The field's rain decay amount is divided by this when processing the field, the rain decay is a function of the weather type's precipitation class: very_light = 5s, light = 15s, heavy = 45 s
     "half_life": "3 minutes", // If above 0 the field will disappear after two half-lifes on average
     "underwater_age_speedup": "25 minutes", // Increase the field's age by this time every tick if it's on a terrain with the SWIMMABLE flag
+    "block_mtypes": [ "zombie", "animal" ], // these monster types cannot move on tile with this field
     "linear_half_life": "true", // If true the half life decay is converted to a non-random, linear wait based on the defined half_life time. 
     "outdoor_age_speedup": "20 minutes", // Increase the field's age by this duration if it's on an outdoor tile
     "accelerated_decay": true, // If the field should use a more simple decay calculation, used for cosmetic fields like gibs

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -197,8 +197,6 @@ void field_effect::deserialize( const JsonObject &jo )
     optional( jo, false, "message_type", env_message_type, game_message_type_reader );
     JsonObject jid = jo.get_object( "immunity_data" );
     field_types::load_immunity( jid, immunity_data );
-    JsonObject jid = jo.get_object( "weakness_data" );
-    field_types::load_weakness( jid, weakness_data );
 }
 
 void field_type::load( const JsonObject &jo, std::string_view )
@@ -292,9 +290,6 @@ void field_type::load( const JsonObject &jo, std::string_view )
 
     JsonObject jid = jo.get_object( "immunity_data" );
     field_types::load_immunity( jid, immunity_data );
-
-    JsonObject jid = jo.get_object( "weakness_data" );
-    field_types::load_weakness( jid, weakness_data );
 
     optional( jo, was_loaded, "immune_mtypes", immune_mtypes );
     optional( jo, was_loaded, "weak_mtypes", weak_mtypes );
@@ -432,13 +427,6 @@ void field_types::load_immunity( const JsonObject &jid, field_immunity_data &fd 
         fd.immunity_data_part_item_flags_any.emplace_back(
             io::string_to_enum<bp_type>
             ( jao.get_string( 0 ) ), jao.get_string( 1 ) );
-    }
-}
-
-void field_types::load_weakness( const JsonObject &jid, field_weakness_data &fd )
-{
-    for( const std::string id : jid.get_array( "flags" ) ) {
-        fd.weakness_data_flags.emplace_back( id );
     }
 }
 

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -292,7 +292,7 @@ void field_type::load( const JsonObject &jo, std::string_view )
     field_types::load_immunity( jid, immunity_data );
 
     optional( jo, was_loaded, "immune_mtypes", immune_mtypes );
-    optional( jo, was_loaded, "weak_mtypes", weak_mtypes );
+    optional( jo, was_loaded, "block_mtypes", block_mtypes );
     optional( jo, was_loaded, "underwater_age_speedup", underwater_age_speedup, 0_turns );
     optional( jo, was_loaded, "outdoor_age_speedup", outdoor_age_speedup, 0_turns );
     optional( jo, was_loaded, "decay_amount_factor", decay_amount_factor, 0 );
@@ -359,9 +359,9 @@ void field_type::finalize()
         }
     }
 
-    for( const mtype_id &m_id : weak_mtypes ) {
+    for( const mtype_id &m_id : block_mtypes ) {
         if( !m_id.is_valid() ) {
-            debugmsg( "Invalid mtype_id %s in weak_mtypes for field %s.", m_id.c_str(), id.c_str() );
+            debugmsg( "Invalid mtype_id %s in block_mtypes for field %s.", m_id.c_str(), id.c_str() );
         }
     }
 

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -197,6 +197,8 @@ void field_effect::deserialize( const JsonObject &jo )
     optional( jo, false, "message_type", env_message_type, game_message_type_reader );
     JsonObject jid = jo.get_object( "immunity_data" );
     field_types::load_immunity( jid, immunity_data );
+    JsonObject jid = jo.get_object( "weakness_data" );
+    field_types::load_weakness( jid, weakness_data );
 }
 
 void field_type::load( const JsonObject &jo, std::string_view )
@@ -291,7 +293,11 @@ void field_type::load( const JsonObject &jo, std::string_view )
     JsonObject jid = jo.get_object( "immunity_data" );
     field_types::load_immunity( jid, immunity_data );
 
+    JsonObject jid = jo.get_object( "weakness_data" );
+    field_types::load_weakness( jid, weakness_data );
+
     optional( jo, was_loaded, "immune_mtypes", immune_mtypes );
+    optional( jo, was_loaded, "weak_mtypes", weak_mtypes );
     optional( jo, was_loaded, "underwater_age_speedup", underwater_age_speedup, 0_turns );
     optional( jo, was_loaded, "outdoor_age_speedup", outdoor_age_speedup, 0_turns );
     optional( jo, was_loaded, "decay_amount_factor", decay_amount_factor, 0 );
@@ -358,6 +364,12 @@ void field_type::finalize()
         }
     }
 
+    for( const mtype_id &m_id : weak_mtypes ) {
+        if( !m_id.is_valid() ) {
+            debugmsg( "Invalid mtype_id %s in weak_mtypes for field %s.", m_id.c_str(), id.c_str() );
+        }
+    }
+
     // should be the last operation for the type
     processors = map_field_processing::processors_for_type( *this );
 }
@@ -420,6 +432,13 @@ void field_types::load_immunity( const JsonObject &jid, field_immunity_data &fd 
         fd.immunity_data_part_item_flags_any.emplace_back(
             io::string_to_enum<bp_type>
             ( jao.get_string( 0 ) ), jao.get_string( 1 ) );
+    }
+}
+
+void field_types::load_weakness( const JsonObject &jid, field_weakness_data &fd )
+{
+    for( const std::string id : jid.get_array( "flags" ) ) {
+        fd.weakness_data_flags.emplace_back( id );
     }
 }
 

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -216,6 +216,7 @@ struct field_type {
         field_immunity_data immunity_data;
 
         std::set<mtype_id> immune_mtypes;
+        std::set<mtype_id> weak_mtypes;
 
         int priority = 0;
         time_duration half_life = 0_turns;

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -216,7 +216,7 @@ struct field_type {
         field_immunity_data immunity_data;
 
         std::set<mtype_id> immune_mtypes;
-        std::set<mtype_id> weak_mtypes;
+        std::set<mtype_id> block_mtypes;
 
         int priority = 0;
         time_duration half_life = 0_turns;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -139,6 +139,12 @@ bool monster::is_immune_field( const field_type_id &fid ) const
     if( check_immunity_data( ft.immunity_data ) ) {
         return true;
     }
+    if( ft.weak_mtypes.count( type->id ) > 0 ) {
+        return true;
+    }
+    if( check_weakness_data( ft.weakness_data ) ) {
+        return true;
+    }
     // No specific immunity was found, so fall upwards
     return Creature::is_immune_field( fid );
 }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -156,7 +156,7 @@ bool monster::will_move_to( map *here, const tripoint_bub_ms &p ) const
     for( const std::pair<const int_id<field_type>, field_entry> &pair : here->field_at( p ) ) {
         const field_type_id &fid = pair.first;
         const field_type &ft = fid.obj();
-        if( ft.weak_mtypes.count( type->id ) > 0 ) {
+        if( ft.block_mtypes.count( type->id ) > 0 ) {
             return false;
         }
     }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -139,12 +139,6 @@ bool monster::is_immune_field( const field_type_id &fid ) const
     if( check_immunity_data( ft.immunity_data ) ) {
         return true;
     }
-    if( ft.weak_mtypes.count( type->id ) > 0 ) {
-        return true;
-    }
-    if( check_weakness_data( ft.weakness_data ) ) {
-        return true;
-    }
     // No specific immunity was found, so fall upwards
     return Creature::is_immune_field( fid );
 }
@@ -158,6 +152,14 @@ static bool z_is_valid( int z )
 bool monster::will_move_to( map *here, const tripoint_bub_ms &p ) const
 {
     const std::vector<field_type_id> impassable_field_ids = here->get_impassable_field_type_ids_at( p );
+
+    for( const std::pair<const int_id<field_type>, field_entry> &pair : here->field_at( p ) ) {
+        const field_type_id &fid = pair.first;
+        const field_type &ft = fid.obj();
+        if( ft.weak_mtypes.count( type->id ) > 0 ) {
+            return false;
+        }
+    }
 
     if( here->has_flag( ter_furn_flag::TFLAG_MON_AVOID_STRICT, p ) ) {
         return false;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Fields that block movement"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Probably changing the name to blocks_mtype but the goal is to have fields that can block specific monster types from crossing the field.  
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Mirrored and reversed immune_type in fields
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I'd also like a flag based system to block PC's and NPCs but that's followup.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested with mon_zombies.  Seemed like it was working until one zombie stepped into a field and broke the line.  Remembered that zombies have stumble movement that often causes problems in tests like this.  Closed out game and restarted with Feral pipe people.   Ferals couldn't cross.   Remove the field I added to fd_webs and then retested ferals walked into webs got stuck and then exited.   
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
