### PR TITLE
Rework of Medical professions

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -2163,8 +2163,8 @@
     "name": "Medical Resident",
     "description": "Fresh out of med school, you've got little in the way of practical experience and just a handful of first-aid supplies.  You just hope it will be enough if 'physician, heal thyself' turns out to be more literal than you expected.",
     "npc_background": "BG_survival_story_MEDICAL",
-    "points": 2,
-    "skills": [ { "level": 5, "name": "firstaid" } ],
+    "points": 5,
+    "skills": [ { "level": 7, "name": "firstaid" }, { "level": 2, "name": "speech" }, { "level": 4, "name": "chemistry" } ],
     "proficiencies": [
       "prof_wound_care",
       "prof_wound_care_expert",
@@ -2172,7 +2172,9 @@
       "prof_intro_chemistry",
       "prof_physiology",
       "prof_burn_care",
-      "prof_dissect_humans"
+      "prof_dissect_humans",
+      "prof_organic_chemistry",
+      "prof_gross_anatomy"
     ],
     "traits": [ "PROF_MED" ],
     "items": {
@@ -2199,7 +2201,9 @@
       },
       "male": { "entries": [ { "item": "boxer_shorts" } ] },
       "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
-    }
+    },
+    "age_lower": 26,
+    "age_upper": 33
   },
   {
     "type": "profession",
@@ -2208,8 +2212,8 @@
     "requirement": "achievement_reach_hospital",
     "description": "You were a patient-facing doctor practicing general or specialized medicine.  While your bedside manner might not get you far in this new world, your medical skills will certainly help.",
     "npc_background": "BG_survival_story_MEDICAL",
-    "points": 5,
-    "skills": [ { "level": 7, "name": "firstaid" }, { "level": 3, "name": "speech" } ],
+    "points": 6,
+    "skills": [ { "level": 8, "name": "firstaid" }, { "level": 3, "name": "speech" }, { "level": 4, "name": "chemistry" } ],
     "proficiencies": [
       "prof_wound_care",
       "prof_wound_care_expert",
@@ -2217,7 +2221,9 @@
       "prof_intro_chemistry",
       "prof_physiology",
       "prof_burn_care",
-      "prof_dissect_humans"
+      "prof_dissect_humans",
+      "prof_organic_chemistry",
+      "prof_gross_anatomy"
     ],
     "traits": [ "PROF_MED" ],
     "items": {
@@ -2250,7 +2256,7 @@
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
     },
-    "age_lower": 25
+    "age_lower": 30
   },
   {
     "type": "profession",
@@ -2260,9 +2266,18 @@
     "description": "You were a pharmacist working in a community pharmacy.  No simple pill-pusher, you have a plethora of knowledge of drug preparation, biochemistry, and biology.  With your trusty mortar and pestle, you hope to grind the undead to a pulp.",
     "npc_background": "BG_survival_story_MEDICAL",
     "points": 5,
-    "skills": [ { "level": 6, "name": "firstaid" }, { "level": 1, "name": "speech" } ],
-    "proficiencies": [ "prof_intro_biology", "prof_intro_chemistry", "prof_organic_chemistry", "prof_biochemistry", "prof_physiology" ],
-    "traits": [ "PROF_MED" ],
+    "skills": [ { "level": 5, "name": "firstaid" }, { "level": 1, "name": "speech" }, { "level": 5, "name": "chemistry" } ],
+    "proficiencies": [
+      "prof_wound_care",
+      "prof_intro_biology",
+      "prof_intro_chemistry",
+      "prof_organic_chemistry",
+      "prof_gross_anatomy",
+      "prof_biochemistry",
+      "prof_intro_chem_synth",
+      "prof_chem_synth",
+      "prof_pharmaceutical"
+    ],
     "items": {
       "both": {
         "items": [
@@ -2271,7 +2286,6 @@
           "socks",
           "dress_shoes",
           "coat_lab",
-          "badge_doctor",
           "goggles_chem",
           "wristwatch",
           "mortar_pestle",
@@ -2328,7 +2342,7 @@
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
     },
-    "age_lower": 25
+    "age_lower": 26
   },
   {
     "type": "profession",
@@ -3546,19 +3560,18 @@
     "npc_background": "BG_survival_story_WORKER_FIREFIGHTER",
     "points": 5,
     "skills": [
-      { "level": 6, "name": "firstaid" },
+      { "level": 5, "name": "firstaid" },
       { "level": 4, "name": "melee" },
       { "level": 4, "name": "bashing" },
-      { "level": 4, "name": "swimming" },
+      { "level": 3, "name": "swimming" },
       { "level": 4, "name": "driving" }
     ],
     "proficiencies": [
       "prof_wound_care",
       "prof_wound_care_expert",
-      "prof_intro_biology",
-      "prof_physiology",
       "prof_burn_care",
-      "prof_dissect_humans",
+      "prof_gross_anatomy",
+      "prof_intro_biology",
       "prof_driver"
     ],
     "vehicle": "fire_engine",
@@ -4476,9 +4489,10 @@
       { "level": 4, "name": "melee" },
       { "level": 4, "name": "bashing" },
       { "level": 4, "name": "firstaid" },
-      { "level": 3, "name": "swimming" }
+      { "level": 3, "name": "swimming" },
+      { "level": 4, "name": "driving" }
     ],
-    "proficiencies": [ "prof_burn_care" ],
+    "proficiencies": [ "prof_burn_care", "prof_wound_care" ],
     "items": {
       "both": {
         "entries": [
@@ -6892,10 +6906,9 @@
     "name": "EMT",
     "description": "You were responding to a call with your partner before you got separated.  Now all you have is your trusty ambulance, ready to transport patients through the apocalypse.",
     "npc_background": "BG_survival_story_MEDICAL",
-    "points": 3,
-    "skills": [ { "level": 5, "name": "firstaid" }, { "level": 4, "name": "driving" }, { "level": 2, "name": "mechanics" } ],
-    "proficiencies": [ "prof_wound_care", "prof_intro_biology", "prof_physiology", "prof_burn_care", "prof_driver", "prof_gross_anatomy" ],
-    "traits": [ "PROF_MED" ],
+    "points": 2,
+    "skills": [ { "level": 4, "name": "firstaid" }, { "level": 4, "name": "driving" } ],
+    "proficiencies": [ "prof_wound_care", "prof_wound_care_expert", "prof_burn_care", "prof_driver" ],
     "vehicle": "ambulance",
     "items": {
       "both": {
@@ -6925,17 +6938,15 @@
     "description": "You were separated from your partner while out on a call.  You managed to hang onto some medical supplies, but it's looking like the only life that needs saving now is yours.",
     "npc_background": "BG_survival_story_MEDICAL",
     "points": 3,
-    "skills": [ { "level": 6, "name": "firstaid" }, { "level": 3, "name": "driving" }, { "level": 1, "name": "mechanics" } ],
+    "skills": [ { "level": 5, "name": "firstaid" }, { "level": 4, "name": "driving" } ],
     "proficiencies": [
       "prof_wound_care",
       "prof_wound_care_expert",
-      "prof_intro_biology",
-      "prof_physiology",
       "prof_burn_care",
-      "prof_dissect_humans",
-      "prof_gross_anatomy"
+      "prof_gross_anatomy",
+      "prof_intro_biology",
+      "prof_driver"
     ],
-    "traits": [ "PROF_MED" ],
     "items": {
       "both": {
         "entries": [
@@ -6971,7 +6982,7 @@
     "npc_background": "BG_survival_story_SOLDIER",
     "points": 5,
     "skills": [
-      { "level": 6, "name": "firstaid" },
+      { "level": 4, "name": "firstaid" },
       { "level": 4, "name": "gun" },
       { "level": 4, "name": "rifle" },
       { "level": 3, "name": "pistol" },
@@ -6986,10 +6997,7 @@
       "prof_spotting",
       "prof_wound_care",
       "prof_wound_care_expert",
-      "prof_intro_biology",
-      "prof_physiology",
       "prof_burn_care",
-      "prof_dissect_humans",
       "prof_gun_cleaning",
       "prof_knives_familiar",
       "prof_auto_rifles_familiar",
@@ -7105,15 +7113,17 @@
     "name": "Hazmat Unit",
     "description": "You were deployed to autopsy one of the rioters showing feral behavior before being put down.  When they got back up, you knew this was out of your pay grade.",
     "npc_background": "BG_survival_story_WORKER_FIREFIGHTER",
-    "points": 4,
-    "skills": [ { "level": 6, "name": "firstaid" } ],
+    "points": 5,
+    "skills": [ { "level": 7, "name": "firstaid" }, { "level": 4, "name": "chemistry" } ],
     "proficiencies": [
       "prof_wound_care",
       "prof_wound_care_expert",
       "prof_intro_biology",
+      "prof_intro_chemistry",
       "prof_physiology",
       "prof_burn_care",
       "prof_dissect_humans",
+      "prof_organic_chemistry",
       "prof_gross_anatomy"
     ],
     "traits": [ "PROF_MED" ],
@@ -7134,7 +7144,8 @@
       },
       "male": { "entries": [ { "item": "boxer_shorts" } ] },
       "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
-    }
+    },
+    "age_lower": 26
   },
   {
     "type": "profession",


### PR DESCRIPTION

#### Summary

Balance "Rebalancing medical professions"

#### Purpose of change

I thought this was needed due to the odd proficiencies given to EMTs and Paramedics.  They get PROF_MED as if they were doctors.  They get the physiology as if they have advanced knowledge and paramedics even get dissection.  In reality, EMTs have only a couple of months of training, and paramedics around two years.

#### Describe the solution

Paramedics/EMTs went down mainly in proficiencies, Doctors and Residents go up. Particularly, doctors need to study chemistry as premeds, so get some science skill and proficiencies.

Pharmacists were oddly mainly health people.  I lowered the first aid skills, but gave them substantial science, as they really are chemists.

Hazmat is a bit odd.  I would have nerfed them, but their description said they were hired to do autopsies.  Really only doctors have that type of experience, so I made them more or less medical residents, MD flag and all.

Firefighters are included due to the firefighter paramedic.  I merely gave them wound care, as it seems odd to have first aid 4 without it.

Combat medics are trained like EMTs, so I changed the skills to reflect that.  Unlike firefighters, there are a ton of military professions, so I left the others alone.

So now health care skills go
8: doctor
7: resident, hazmat
6: paramedic, paramedic firefighter
5: EMT, combat medic, pharmacist
4: firefighters (and many soldiers and such)

And EMTs on up get wound care expert.  Pharmacists don't, because they don't really deal with that end of medical care.

All in all, this seems closer to reflecting their real training.

Other differences include removing mechanics from EMTs/Paramedics, as they don't learn that.  I left the 4 driving because trucks are harder to drive than cars.

And I moved some ages around.  Mainly to bump them due to necessary schooling, though I also gave a top end to medical residents.  As those are only used when being randomly generated, people are still free to make Doogie Houser if they'd like.

And I did change the point values, although I don't think they are in use anymore.  Due to that, I only gave a small amount of thought to the points.

#### Describe alternatives you've considered

Nothing.  But EMTs doing autopsies seemed too weird.

I thought about more speech skill all around, as many of these professions learn bed side manner and deescalation techniques.  But I kept that relatively minimal.

I thought about ignoring the firefighters and combat medic but decided to include them mainly due to their really odd proficiencies.

Thought about not bothering with points at all but gave them at least a cursory glance.

And as much of this was about prof_dissect_humans, I took a look at that.  The 1K hours it takes to learn that is insane, and doctors don't spend anything close to that.  I thought about lowering it to 100, which would still make it very difficult to obtain.  But I thought perhaps that was there simply to stop people from getting it at all and was a game balance / tone type decision rather than an attempt to reflect reality, so I left it alone.

#### Testing

Started games, ensured I had the expected skills.

#### Additional context

