### PR TITLE
Refugee Center Mercenary Updates

### DIFF
--- a/data/json/npcs/refugee_center/surface_visitors/NPC_scavenger_mercenary.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_scavenger_mercenary.json
@@ -4,6 +4,7 @@
     "id": "scavenger_merc",
     "//": "Appears in the refugee center as a partner for hire.",
     "name_suffix": "Merc",
+    "age": 37,
     "class": "NC_SCAVENGER_MERC",
     "attitude": 0,
     "mission": 7,
@@ -34,9 +35,16 @@
     "weapon_override": "NC_SCAVENGER_MERC_wield",
     "skills": [
       { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "rng": [ 0, -4 ] } ] } ] } },
-      { "skill": "gun", "bonus": { "rng": [ 2, 5 ] } },
-      { "skill": "pistol", "bonus": { "rng": [ 1, 3 ] } },
-      { "skill": "rifle", "bonus": { "rng": [ 3, 6 ] } }
+      { "skill": "gun", "bonus": { "rng": [ 3, 6 ] } },
+      { "skill": "pistol", "bonus": { "rng": [ 2, 5 ] } },
+      { "skill": "rifle", "bonus": { "rng": [ 3, 6 ] } },
+      { "skill": "melee", "bonus": { "rng": [ 1, 4 ] } },
+      { "skill": "stabbing", "bonus": { "rng": [ 1, 4 ] } },
+      { "skill": "dodge", "bonus": { "rng": [ 1, 4 ] } },
+      { "skill": "firstaid", "bonus": { "rng": [ 1, 4 ] } },
+      { "skill": "swimming", "bonus": { "rng": [ 1, 4 ] } },
+      { "skill": "survival", "bonus": { "rng": [ 0, 3 ] } },
+      { "skill": "speech", "bonus": -4 }
     ]
   },
   {


### PR DESCRIPTION
#### Summary

Bugfixes "No more teenage or unskilled RC mercenary"

#### Purpose of change

The Refugee Center mercenary is an interesting NPC. They have a unusual setup where they can be hired to become a follower. Due to this, their age is visible. If you follow the conversations sufficiently, you find a Marine Vet, who then spent a number of years in the private sector. They are supposedly skilled enough that it is surprising to know they guarded a warehouse, and they have a taste for good scotch.

The RNG sometimes makes characters that don't match that at all. I've had teenagers as my mercenary. And the low roll of skills was bad enough that the "Why was a guy with your skillset guarding a warehouse? Must've been some warehouse." dialog doesn't make sense.

#### Describe the solution

First off, I went with a fixed age. They are now 37. Any age from low thirties to low forties seems good. Higher isn't even a big deal, but lower gets weird.

I figured the Merc is an ex Marine. Thus I used the marine profession as a base point. Their highest skill (rifles) ranged from 1 above to 2 below what a Marine had. So I took all the skills of a Marine and used that metric.

Notably, they now have a minimum of 1 melee, which means they are always able to enter Brawling stance. I expect that to be more visible than your aim with a rifle, and now I think the dialog "Why was a guy with your skillset guarding a warehouse? Must've been some warehouse." shouldn't seem strange due to a particularly low roll on skills.

Lastly, I added an adjustment to their Social skill. They get random skills on top of the base ones, which I like in general, as they flesh out the character. But considering their general gruffness, a high roll on social feels off. I once had a Merc with a 3 social skill, who didn't want talk. So now they always have a zero.

#### Describe alternatives you've considered

Doing nothing. But I felt that teenager risk at the very least needed fixing.

Just changing the age. This would be acceptable, but I thought left too many situations where the characters stats didn't match their story. And unlike basically every other defined NPC, you get to see their full stats.

Changing their age to a random, but within a fixed range. I never tested this, but I'm pretty sure it could be done based on the "rng" entries I found in the json in other places (such as the merc's skills). I decided to go with 37 just as a random Monty Python reference.

Lowering the skills to use the marksmanship metric instead of rifles. That would mean all skills are 0 to 3 worse than the Marine profession. But this meant a low roll on melee would be zero, not allowing Brawling stance, which feels more visible than marksmanship.

Ignoring the social bit. But I thought that kept the flavor intact even with odd RNG.

Upping the cost. I could have increased the pay.

Not calling this a 'Bugfix'. Most of it is more of a mood thing, trying to make everything seem as believable as possible. I decided to leave Bugfix because hiring your hardened experienced Mercenary with a taste for scotch, only to find out their 18, seems to qualify. That, and 'mood' isn't a category, and I imagine 'Content' is for new stuff, not minor tweaks of old stuff.

#### Testing

Spawned a slew of Mercs. Bought them, and viewed their stats.

#### Additional context
