### PR TITLE
Demote GCC 16 -Wsfinae-incomplete to warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,12 @@ if (NOT MSVC)
     if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
         set(CATA_WARNINGS "${CATA_WARNINGS} -Wno-unknown-warning-option")
     endif()
+    # GCC 16 -Wsfinae-incomplete: SFINAE on incomplete forward-declared types
+    # (e.g. std::reference_wrapper<vehicle>) is link-compatible across TUs.
+    check_cxx_compiler_flag(-Wsfinae-incomplete HAVE_SFINAE_INCOMPLETE)
+    if (HAVE_SFINAE_INCOMPLETE)
+        set(CATA_WARNINGS "${CATA_WARNINGS} -Wno-error=sfinae-incomplete")
+    endif ()
     if (NOT "${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
         set(CATA_WARNINGS "${CATA_WARNINGS} -Wredundant-decls")
     endif ()

--- a/Makefile
+++ b/Makefile
@@ -414,6 +414,12 @@ else
   endif
   CXX_WARNINGS += -Wno-unknown-warning
   WARNINGS += -Wno-unknown-warning
+  # GCC 16 -Wsfinae-incomplete: SFINAE on incomplete forward-declared types
+  # (e.g. std::reference_wrapper<vehicle>) is link-compatible across TUs.
+  GCC_MAJOR := $(shell $(CROSS)$(OS_COMPILER) -dumpversion 2>/dev/null | cut -d. -f1)
+  ifeq ($(shell expr $(GCC_MAJOR) \>= 16 2>/dev/null), 1)
+    CXX_WARNINGS += -Wno-error=sfinae-incomplete
+  endif
 endif
 
 STRIP = $(CROSS)strip


### PR DESCRIPTION
#### Summary
Build "Demote GCC 16 -Wsfinae-incomplete to warning"

#### Purpose of change
Updated to GCC 16.1 today, CDDA won't build without this one. New `-Wsfinae-incomplete` diagnostic fires on forward-declared types used in SFINAE traits (e.g. `std::reference_wrapper<vehicle>`), which is all over the codebase.

#### Describe the solution
Add `-Wno-error=sfinae-incomplete` on GCC >= 16. Still surfaces as a warning, just not fatal. Both Makefile and CMakeLists.txt.

#### Describe alternatives you've considered
Actually fixing the includes. There are a lot. And then to deal with IWYU...

#### Testing
N/A, build-only.

#### Additional context
N/A