### PR TITLE
Change character creation keybindings so they relate more to the command descriptions

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1797,13 +1797,13 @@
     "type": "keybinding",
     "id": "CHANGE_GENDER",
     "name": "Change gender",
-    "bindings": [ { "input_method": "keyboard_char", "key": "@" }, { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "g" } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_OUTFIT",
     "name": "Change outfit",
-    "bindings": [ { "input_method": "keyboard_char", "key": "$" }, { "input_method": "keyboard_code", "key": "4", "mod": [ "shift" ] } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "o" } ]
   },
   {
     "type": "keybinding",
@@ -1827,7 +1827,7 @@
     "type": "keybinding",
     "id": "CHANGE_HEIGHT",
     "name": "Change height",
-    "bindings": [ { "input_method": "keyboard_char", "key": "e" } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "h" } ]
   },
   {
     "type": "keybinding",
@@ -1914,11 +1914,7 @@
     "type": "keybinding",
     "id": "RANDOMIZE_CHAR_DESCRIPTION",
     "name": "Pick random character description",
-    "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1870,7 +1870,7 @@
     "type": "keybinding",
     "id": "SAVE_TEMPLATE",
     "name": "Save template",
-    "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "s" } ]
   },
   {
     "type": "keybinding",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1950,7 +1950,7 @@
     "type": "keybinding",
     "id": "CHOOSE_LOCATION",
     "name": "Choose character starting location",
-    "bindings": [ { "input_method": "keyboard_any", "key": ":" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "l" } ]
   },
   {
     "type": "keybinding",


### PR DESCRIPTION
#### Summary

Interface "The character creation screen's keybindings become more based on the crucial letters that are part of the command descriptions"

#### Purpose of change

I reckon the current keybindings are hard to remember because they look arbitrary.

#### Describe the solution

Pick the first letter of the whole command or the most essential word so you have to press the corresponding key to use the interface.

Location: ':' ⇨ 'l'
Randomize description: '*' ⇨ 'D'
Save template: '!' ⇨ 's'
Change height: 'e' ⇨ 'h'
Change outfit: '$' ⇨ 'o'
Change gender: '@' ⇨ 'g'

#### Describe alternatives you've considered

#### Testing

I changed some JSON definitions. The new keys worked.

#### Additional context

