### PR TITLE
Multimag: more engine plumbing for vehicle and crafting paths

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5982,6 +5982,41 @@
     "consumption_per_use": [ { "pocket": "power", "qty": 5 }, { "pocket": "fluid", "qty": 2 } ]
   },
   {
+    "id": "test_multimag_well_fluid_mag",
+    "type": "ITEM",
+    "subtypes": [ "MAGAZINE" ],
+    "name": { "str": "test multimag well fluid mag" },
+    "description": "Test fluid magazine for vehicle tank synth.",
+    "weight": "100 g",
+    "volume": "500 ml",
+    "material": [ "steel" ],
+    "symbol": "(",
+    "color": "white",
+    "ammo_type": [ "gasoline" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "watertight": true, "ammo_restriction": { "gasoline": 40 } } ]
+  },
+  {
+    "id": "test_multimag_well_fluid",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "test multimag well fluid" },
+    "description": "Test multimag pseudo-tool: MAGAZINE_WELL accepting fluid magazine, sourced from vehicle tank.",
+    "weight": "500 g",
+    "volume": "750 ml",
+    "material": [ "steel" ],
+    "symbol": "&",
+    "color": "light_gray",
+    "pocket_data": [
+      {
+        "id": "fuel",
+        "magazine_well": "500 ml",
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "test_multimag_well_fluid_mag" ]
+      }
+    ],
+    "consumption_per_use": [ { "pocket": "fuel", "qty": 3 } ]
+  },
+  {
     "id": "test_multimag_two_battery",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5767,6 +5767,39 @@
     }
   },
   {
+    "id": "test_multimag_turret_gun",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "test multimag turret gun" },
+    "description": "Test multimag turret: 9mm well (player) + battery well (vehicle).",
+    "weight": "1000 g",
+    "volume": "1500 ml",
+    "longest_side": "400 mm",
+    "material": [ "steel" ],
+    "symbol": "(",
+    "color": "light_gray",
+    "ammo": [ "9mm" ],
+    "skill": "pistol",
+    "range": 10,
+    "ranged_damage": { "damage_type": "bullet", "amount": 10 },
+    "dispersion": 480,
+    "durability": 10,
+    "modes": [ [ "DEFAULT", "default", 1 ], [ "BURST", "burst", 3 ] ],
+    "pocket_data": [
+      { "id": "ammo", "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] },
+      {
+        "id": "power",
+        "magazine_well": "500 ml",
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "heavy_battery_cell" ]
+      }
+    ],
+    "firing_requirements": {
+      "DEFAULT": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 5 } ],
+      "BURST": [ { "pocket": "ammo", "qty": 3 }, { "pocket": "power", "qty": 15 } ]
+    }
+  },
+  {
     "id": "test_multimag_tool_consume",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5825,5 +5825,29 @@
     "legacy_charges_per_use_factor": 5,
     "pocket_data": [ { "id": "well_a", "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] } ],
     "consumption_per_use": [ { "pocket": "well_a", "qty": 1 } ]
+  },
+  {
+    "id": "test_multimag_vehicle_welder",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "test multimag vehicle welder" },
+    "description": "Test multimag pseudo-tool: battery well + oxygen pocket + filler pocket.",
+    "weight": "500 g",
+    "volume": "750 ml",
+    "material": [ "steel" ],
+    "symbol": "&",
+    "color": "light_gray",
+    "flags": [ "USE_UPS" ],
+    "pocket_data": [
+      {
+        "id": "power",
+        "magazine_well": "500 ml",
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "heavy_battery_cell" ]
+      },
+      { "id": "oxygen", "pocket_type": "MAGAZINE", "rigid": true, "airtight": true, "ammo_restriction": { "oxygen": 40 } },
+      { "id": "rod", "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "components": 40 } }
+    ],
+    "consumption_per_use": [ { "pocket": "power", "qty": 5 }, { "pocket": "oxygen", "qty": 2 }, { "pocket": "rod", "qty": 1 } ]
   }
 ]

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5845,9 +5845,129 @@
         "pocket_type": "MAGAZINE_WELL",
         "item_restriction": [ "heavy_battery_cell" ]
       },
-      { "id": "oxygen", "pocket_type": "MAGAZINE", "rigid": true, "airtight": true, "ammo_restriction": { "oxygen": 40 } },
+      {
+        "id": "oxygen",
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "airtight": true,
+        "ammo_restriction": { "oxygen": 40 }
+      },
       { "id": "rod", "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "components": 40 } }
     ],
     "consumption_per_use": [ { "pocket": "power", "qty": 5 }, { "pocket": "oxygen", "qty": 2 }, { "pocket": "rod", "qty": 1 } ]
+  },
+  {
+    "id": "test_multimag_vehicle_combo",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "test multimag vehicle combo" },
+    "description": "Test multimag pseudo-tool: battery well + tank pocket (gasoline).",
+    "weight": "500 g",
+    "volume": "750 ml",
+    "material": [ "steel" ],
+    "symbol": "&",
+    "color": "light_gray",
+    "pocket_data": [
+      {
+        "id": "power",
+        "magazine_well": "500 ml",
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "heavy_battery_cell" ]
+      },
+      {
+        "id": "fluid",
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "watertight": true,
+        "ammo_restriction": { "gasoline": 40 }
+      }
+    ],
+    "consumption_per_use": [ { "pocket": "power", "qty": 5 }, { "pocket": "fluid", "qty": 2 } ]
+  },
+  {
+    "id": "test_multimag_two_battery",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "test multimag two battery" },
+    "description": "Test multimag pseudo-tool with two battery wells sharing one network.",
+    "weight": "500 g",
+    "volume": "750 ml",
+    "material": [ "steel" ],
+    "symbol": "&",
+    "color": "light_gray",
+    "pocket_data": [
+      {
+        "id": "left",
+        "magazine_well": "500 ml",
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "heavy_battery_cell" ]
+      },
+      {
+        "id": "right",
+        "magazine_well": "500 ml",
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "heavy_battery_cell" ]
+      }
+    ],
+    "consumption_per_use": [ { "pocket": "left", "qty": 5 }, { "pocket": "right", "qty": 5 } ]
+  },
+  {
+    "id": "test_multimag_two_fluid",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "test multimag two fluid" },
+    "description": "Test multimag pseudo-tool with two same-fuel tank pockets.",
+    "weight": "500 g",
+    "volume": "750 ml",
+    "material": [ "steel" ],
+    "symbol": "&",
+    "color": "light_gray",
+    "pocket_data": [
+      { "id": "left", "pocket_type": "MAGAZINE", "rigid": true, "watertight": true, "ammo_restriction": { "gasoline": 40 } },
+      {
+        "id": "right",
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "watertight": true,
+        "ammo_restriction": { "gasoline": 40 }
+      }
+    ],
+    "consumption_per_use": [ { "pocket": "left", "qty": 2 }, { "pocket": "right", "qty": 2 } ]
+  },
+  {
+    "id": "test_multimag_direct_battery",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "test multimag direct battery" },
+    "description": "Test multimag pseudo-tool with one direct MAGAZINE battery pocket.",
+    "weight": "500 g",
+    "volume": "750 ml",
+    "material": [ "steel" ],
+    "symbol": "&",
+    "color": "light_gray",
+    "pocket_data": [ { "id": "core", "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 40 } } ],
+    "consumption_per_use": [ { "pocket": "core", "qty": 5 } ]
+  },
+  {
+    "id": "test_multimag_mixed_battery",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "test multimag mixed battery" },
+    "description": "Test multimag pseudo-tool with one MAGAZINE_WELL and one direct MAGAZINE battery pocket.",
+    "weight": "500 g",
+    "volume": "750 ml",
+    "material": [ "steel" ],
+    "symbol": "&",
+    "color": "light_gray",
+    "pocket_data": [
+      {
+        "id": "well",
+        "magazine_well": "500 ml",
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "heavy_battery_cell" ]
+      },
+      { "id": "direct", "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 40 } }
+    ],
+    "consumption_per_use": [ { "pocket": "well", "qty": 5 }, { "pocket": "direct", "qty": 3 } ]
   }
 ]

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5733,27 +5733,26 @@
     ]
   },
   {
-    "id": "test_multimag_gun_consume",
+    "id": "test_multimag_turret_flamethrower",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "test multimag consume gun" },
-    "description": "Test gun for multimag consumption: 9mm well + battery well, two modes.",
-    "weight": "1000 g",
-    "volume": "1500 ml",
-    "longest_side": "400 mm",
+    "name": { "str": "test multimag flamethrower turret" },
+    "description": "Direct MAGAZINE liquid pocket + battery; exercises USE_TANKS heuristic.",
+    "weight": "2500 g",
+    "volume": "2000 ml",
+    "longest_side": "600 mm",
     "material": [ "steel" ],
     "symbol": "(",
-    "color": "light_gray",
-    "ammo": [ "9mm" ],
-    "skill": "pistol",
-    "range": 10,
-    "ranged_damage": { "damage_type": "bullet", "amount": 10 },
+    "color": "red",
+    "ammo": [ "gasoline" ],
+    "skill": "rifle",
+    "range": 6,
+    "ranged_damage": { "damage_type": "heat", "amount": 5 },
     "dispersion": 480,
     "durability": 10,
-    "flags": [ "NO_TURRET" ],
-    "modes": [ [ "DEFAULT", "default", 1 ], [ "BURST", "burst", 3 ] ],
+    "modes": [ [ "DEFAULT", "default", 1 ] ],
     "pocket_data": [
-      { "id": "ammo", "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] },
+      { "id": "fuel", "pocket_type": "MAGAZINE", "rigid": true, "watertight": true, "ammo_restriction": { "gasoline": 50 } },
       {
         "id": "power",
         "magazine_well": "500 ml",
@@ -5761,10 +5760,7 @@
         "item_restriction": [ "heavy_battery_cell" ]
       }
     ],
-    "firing_requirements": {
-      "DEFAULT": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 5 } ],
-      "BURST": [ { "pocket": "ammo", "qty": 3 }, { "pocket": "power", "qty": 15 } ]
-    }
+    "firing_requirements": { "DEFAULT": [ { "pocket": "fuel", "qty": 5 }, { "pocket": "power", "qty": 2 } ] }
   },
   {
     "id": "test_multimag_turret_gun",
@@ -5784,6 +5780,74 @@
     "ranged_damage": { "damage_type": "bullet", "amount": 10 },
     "dispersion": 480,
     "durability": 10,
+    "modes": [ [ "DEFAULT", "default", 1 ], [ "BURST", "burst", 3 ] ],
+    "pocket_data": [
+      { "id": "ammo", "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] },
+      {
+        "id": "power",
+        "magazine_well": "500 ml",
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "heavy_battery_cell" ]
+      }
+    ],
+    "firing_requirements": {
+      "DEFAULT": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 5 } ],
+      "BURST": [ { "pocket": "ammo", "qty": 3 }, { "pocket": "power", "qty": 15 } ]
+    }
+  },
+  {
+    "id": "test_multimag_turret_gun_ups",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "test multimag turret gun (USE_UPS)" },
+    "description": "Carrier-null isolation variant: same shape but flagged USE_UPS.",
+    "weight": "1000 g",
+    "volume": "1500 ml",
+    "longest_side": "400 mm",
+    "material": [ "steel" ],
+    "symbol": "(",
+    "color": "light_gray",
+    "ammo": [ "9mm" ],
+    "skill": "pistol",
+    "range": 10,
+    "ranged_damage": { "damage_type": "bullet", "amount": 10 },
+    "dispersion": 480,
+    "durability": 10,
+    "flags": [ "USE_UPS" ],
+    "modes": [ [ "DEFAULT", "default", 1 ], [ "BURST", "burst", 3 ] ],
+    "pocket_data": [
+      { "id": "ammo", "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] },
+      {
+        "id": "power",
+        "magazine_well": "500 ml",
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "heavy_battery_cell" ]
+      }
+    ],
+    "firing_requirements": {
+      "DEFAULT": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 5 } ],
+      "BURST": [ { "pocket": "ammo", "qty": 3 }, { "pocket": "power", "qty": 15 } ]
+    }
+  },
+  {
+    "id": "test_multimag_gun_consume",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "test multimag consume gun" },
+    "description": "Test gun for multimag consumption: 9mm well + battery well, two modes.",
+    "weight": "1000 g",
+    "volume": "1500 ml",
+    "longest_side": "400 mm",
+    "material": [ "steel" ],
+    "symbol": "(",
+    "color": "light_gray",
+    "ammo": [ "9mm" ],
+    "skill": "pistol",
+    "range": 10,
+    "ranged_damage": { "damage_type": "bullet", "amount": 10 },
+    "dispersion": 480,
+    "durability": 10,
+    "flags": [ "NO_TURRET" ],
     "modes": [ [ "DEFAULT", "default", 1 ], [ "BURST", "burst", 3 ] ],
     "pocket_data": [
       { "id": "ammo", "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] },

--- a/src/item.h
+++ b/src/item.h
@@ -2893,6 +2893,11 @@ class item : public visitable
         int tool_uses_remaining( map &here, const Character *carrier ) const;
         int tool_uses_remaining_local() const;
 
+        // Multimag uses given an arbitrary external (cable / UPS / bionic)
+        // budget. Used by inventory aggregation to greedily allocate a shared
+        // pool across multiple matching tools.
+        int feasible_tool_uses( int external_pool ) const;
+
         int available_cable_charges( map &here ) const;
         int available_ups_charges( const Character *carrier ) const;
         int available_bionic_charges( const Character *carrier ) const;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2404,9 +2404,8 @@ void Item_factory::check_definitions() const
                 for( const pocket_data &p : type->pockets ) {
                     if( p.pocket_id == id ) {
                         found = true;
-                        // Integral MAGAZINE pockets aren't wired through
-                        // energy/recharge/aggregation helpers yet.
-                        if( p.type == pocket_type::MAGAZINE_WELL ) {
+                        if( p.type == pocket_type::MAGAZINE_WELL ||
+                            ( p.type == pocket_type::MAGAZINE && !p.ammo_restriction.empty() ) ) {
                             right_type = true;
                         }
                         break;
@@ -2417,7 +2416,7 @@ void Item_factory::check_definitions() const
                                "firing_requirements references unknown pocket id \"%s\"\n", id );
                 } else if( !right_type ) {
                     msg += string_format(
-                               "firing_requirements references pocket id \"%s\" which is not a MAGAZINE_WELL pocket\n",
+                               "firing_requirements references pocket id \"%s\" which is neither a MAGAZINE_WELL nor a MAGAZINE with ammo_restriction\n",
                                id );
                 }
             }

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -2604,10 +2604,26 @@ int item::tool_uses_remaining_local() const
     return feasible_uses( *this, *entries, INT_MAX, /*external_pool=*/0 );
 }
 
+int item::feasible_tool_uses( int external_pool ) const
+{
+    if( !uses_firing_requirements() ) {
+        return 0;
+    }
+    const std::vector<pocket_consumption_entry> *entries =
+        type->firing_requirements.for_mode( gun_mode_DEFAULT );
+    if( entries == nullptr || entries->empty() ) {
+        return 0;
+    }
+    return feasible_uses( *this, *entries, INT_MAX, std::max( 0, external_pool ) );
+}
+
 namespace
 {
 // Multimag drain in cable -> local -> UPS -> bionic order; applies
 // external deltas exactly once. Returns shots / uses actually consumed.
+// TODO(multimag): cable-before-local order can misallocate when 2+ battery
+// pockets share cable and have mixed local stocks. Drain local first per
+// pocket, then bill external for the residual.
 int multimag_drain( item &host, const std::vector<pocket_consumption_entry> &entries,
                     int requested, map &here, const tripoint_bub_ms &pos,
                     Character *carrier )

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -103,6 +103,12 @@ std::string pocket_data::check_definition() const
             return string_format( "invalid ammotype %s", at.str() );
         }
         const itype_id &it = at->default_ammotype();
+        // Abstract ammotypes (e.g. "components", "thrown") intentionally point
+        // their default at an undefined itype; ammunition_type::check_consistency
+        // skips them and so does the per-pocket phase check.
+        if( it.is_empty() || !item::type_is_defined( it ) ) {
+            continue;
+        }
         if( it->phase == phase_id::LIQUID && !watertight ) {
             return string_format( "restricted to liquid item %s but not watertight\n",
                                   it->get_id().str() );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1119,6 +1119,11 @@ int Character::fire_gun( map &here, const tripoint_bub_ms &target, int shots, it
         const int ammo_left = ammo ? ammo.get_item()->count() : gun.ammo_remaining( );
         shots = std::min( shots, ammo_left / gun.ammo_required() );
     }
+    // Multimag vehicle turrets: also cap by per-pocket feasibility so the
+    // firing loop never overruns a vehicle-loaded battery pocket mid-burst.
+    if( gun.has_flag( flag_VEHICLE ) && gun.uses_firing_requirements() ) {
+        shots = std::min( shots, gun.shots_remaining( here, nullptr ) );
+    }
 
     if( shots <= 0 ) {
         debugmsg( "Attempted to fire zero or negative shots using %s", gun.tname() );
@@ -1274,14 +1279,11 @@ int Character::fire_gun( map &here, const tripoint_bub_ms &target, int shots, it
         }
 
         if( gun.uses_firing_requirements() ) {
-            // Turret install is filtered out at mountable_gun_filter; this
-            // catches debug-spawn or save-state pairings that bypass it.
-            if( gun.has_flag( flag_VEHICLE ) ) {
-                debugmsg( "TODO(multimag): turret + firing_requirements not "
-                          "supported, B2 reconciliation pending (%s)", gun.tname() );
-                break;
-            }
-            if( gun.consume_one_shot( here, pos_bub( here ), this ) != 1 ) {
+            // Vehicle turret passes nullptr carrier so multimag_drain skips
+            // player UPS/bionic. Vehicle is billed via drain_back_multimag
+            // in turret_data::post_fire.
+            Character *drain_carrier = gun.has_flag( flag_VEHICLE ) ? nullptr : this;
+            if( gun.consume_one_shot( here, pos_bub( here ), drain_carrier ) != 1 ) {
                 debugmsg( "Unexpected shortage of ammo whilst firing %s", gun.tname() );
                 break;
             }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -4328,16 +4328,20 @@ void target_ui::panel_gun_info( int &text_y )
     nc_color clr = c_light_gray;
     print_colored_text( w_target, point( 1, text_y++ ), clr, clr, str );
 
-    if( status == Status::OutOfAmmo ) {
-        mvwprintz( w_target, point( 1, text_y++ ), c_red, _( "OUT OF AMMO" ) );
-    } else if( mode == TargetMode::TurretManual && turret &&
-               relevant->uses_firing_requirements() ) {
+    if( mode == TargetMode::TurretManual && turret &&
+        relevant->uses_firing_requirements() ) {
+        // Show panel even when not ready, so player sees which pocket is short.
+        if( status == Status::OutOfAmmo ) {
+            mvwprintz( w_target, point( 1, text_y++ ), c_red, _( "OUT OF AMMO" ) );
+        }
         const std::vector<multimag_display_pocket> dps = turret->multimag_display_state();
         for( const multimag_display_pocket &dp : dps ) {
             const itype *ad = dp.ammo_itype.is_null() ? nullptr : item::find_type( dp.ammo_itype );
             const std::string ammo_name = ad ? ad->nname( std::max( dp.effective_qty, 1 ) ) :
                                           dp.pocket_id;
             const nc_color ammo_clr = ad ? ad->color : c_light_gray;
+            const bool short_of_one_use = dp.effective_qty < dp.per_use_qty;
+            nc_color row_clr = short_of_one_use ? c_red : clr;
             std::string ammo_str;
             if( dp.vehicle_bound ) {
                 ammo_str = string_format( _( "%s: %s (vehicle %d, need %d)" ),
@@ -4348,8 +4352,10 @@ void target_ui::panel_gun_info( int &text_y )
                                           dp.pocket_id, colorize( ammo_name, ammo_clr ),
                                           dp.effective_qty, dp.per_use_qty );
             }
-            print_colored_text( w_target, point( 1, text_y++ ), clr, clr, ammo_str );
+            print_colored_text( w_target, point( 1, text_y++ ), row_clr, row_clr, ammo_str );
         }
+    } else if( status == Status::OutOfAmmo ) {
+        mvwprintz( w_target, point( 1, text_y++ ), c_red, _( "OUT OF AMMO" ) );
     } else if( ammo ) {
         bool is_favorite = relevant->is_ammo_container() && relevant->first_ammo().is_favorite;
         str = string_format( m->ammo_remaining( ) ? _( "Ammo: %s%s (%d/%d)" ) : _( "Ammo: %s%s" ),

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -4330,6 +4330,26 @@ void target_ui::panel_gun_info( int &text_y )
 
     if( status == Status::OutOfAmmo ) {
         mvwprintz( w_target, point( 1, text_y++ ), c_red, _( "OUT OF AMMO" ) );
+    } else if( mode == TargetMode::TurretManual && turret &&
+               relevant->uses_firing_requirements() ) {
+        const std::vector<multimag_display_pocket> dps = turret->multimag_display_state();
+        for( const multimag_display_pocket &dp : dps ) {
+            const itype *ad = dp.ammo_itype.is_null() ? nullptr : item::find_type( dp.ammo_itype );
+            const std::string ammo_name = ad ? ad->nname( std::max( dp.effective_qty, 1 ) ) :
+                                          dp.pocket_id;
+            const nc_color ammo_clr = ad ? ad->color : c_light_gray;
+            std::string ammo_str;
+            if( dp.vehicle_bound ) {
+                ammo_str = string_format( _( "%s: %s (vehicle %d, need %d)" ),
+                                          dp.pocket_id, colorize( ammo_name, ammo_clr ),
+                                          dp.effective_qty, dp.per_use_qty );
+            } else {
+                ammo_str = string_format( _( "%s: %s (%d, need %d)" ),
+                                          dp.pocket_id, colorize( ammo_name, ammo_clr ),
+                                          dp.effective_qty, dp.per_use_qty );
+            }
+            print_colored_text( w_target, point( 1, text_y++ ), clr, clr, ammo_str );
+        }
     } else if( ammo ) {
         bool is_favorite = relevant->is_ammo_container() && relevant->first_ammo().is_favorite;
         str = string_format( m->ammo_remaining( ) ? _( "Ammo: %s%s (%d/%d)" ) : _( "Ammo: %s%s" ),

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -119,6 +119,14 @@ const itype *turret_data::ammo_data() const
     if( !veh || !part ) {
         return nullptr;
     }
+    if( part->base.uses_firing_requirements() ) {
+        // Same prep-on-temp-copy pattern as range() so callers always see the
+        // post-prep ammo identity, not the empty pre-fire pocket state.
+        item gun_copy( part->base );
+        const gun_mode_id mode = gun_copy.gun_get_mode_id();
+        vehicle::prepare_multimag_pockets( *veh, get_map(), gun_copy, mode, ammo_current() );
+        return gun_copy.ammo_data();
+    }
     if( uses_vehicle_tanks_or_batteries() ) {
         return !ammo_current().is_null() ? item::find_type( ammo_current() ) : nullptr;
     }
@@ -182,6 +190,19 @@ std::set<ammo_effect_str_id> turret_data::ammo_effects() const
     if( !veh || !part ) {
         return std::set<ammo_effect_str_id>();
     }
+    if( part->base.uses_firing_requirements() ) {
+        // Auto-fire reads ammo_effects() to size AoE before firing. Vehicle-
+        // bound pockets are empty until prep loads them, so prep on a temp
+        // copy and read effects from the resulting ammo_data.
+        item gun_copy( part->base );
+        const gun_mode_id mode = gun_copy.gun_get_mode_id();
+        vehicle::prepare_multimag_pockets( *veh, get_map(), gun_copy, mode, ammo_current() );
+        auto res = gun_copy.ammo_effects();
+        if( const itype *ad = gun_copy.ammo_data() ) {
+            res.insert( ad->ammo->ammo_effects.begin(), ad->ammo->ammo_effects.end() );
+        }
+        return res;
+    }
     auto res = part->base.ammo_effects();
     if( uses_vehicle_tanks_or_batteries() && ammo_data() ) {
         res.insert( ammo_data()->ammo->ammo_effects.begin(), ammo_data()->ammo->ammo_effects.end() );
@@ -193,6 +214,19 @@ int turret_data::range() const
 {
     if( !veh || !part ) {
         return 0;
+    }
+    if( part->base.uses_firing_requirements() ) {
+        // Vehicle-bound pockets are empty pre-fire, so reading range off
+        // part->base.ammo_data() would miss the ammo bonus entirely. Prep a
+        // temp copy so range reflects what the firing path will actually load.
+        item gun_copy( part->base );
+        const gun_mode_id mode = gun_copy.gun_get_mode_id();
+        vehicle::prepare_multimag_pockets( *veh, get_map(), gun_copy, mode, ammo_current() );
+        int res = gun_copy.gun_range();
+        if( const itype *ad = gun_copy.ammo_data() ) {
+            res += ad->ammo->range;
+        }
+        return res;
     }
     int res = part->base.gun_range();
     if( uses_vehicle_tanks_or_batteries() && ammo_data() ) {
@@ -213,7 +247,13 @@ bool turret_data::in_range( const tripoint_abs_ms &target ) const
 
 bool turret_data::can_reload() const
 {
-    if( !veh || !part || uses_vehicle_tanks_or_batteries() ) {
+    if( !veh || !part ) {
+        return false;
+    }
+    if( part->base.uses_firing_requirements() ) {
+        return part->base.is_reloadable();
+    }
+    if( uses_vehicle_tanks_or_batteries() ) {
         return false;
     }
     if( !part->base.magazine_integral() ) {
@@ -228,7 +268,16 @@ bool turret_data::can_reload() const
 
 bool turret_data::can_unload() const
 {
-    if( !veh || !part || uses_vehicle_tanks_or_batteries() ) {
+    if( !veh || !part ) {
+        return false;
+    }
+    if( part->base.uses_firing_requirements() ) {
+        // Multimag aggregate: any loaded mag in any well, or any loose ammo
+        // in any direct MAGAZINE pocket. magazine_current() returns only the
+        // first well's mag and would miss the second well.
+        return !part->base.magazines_current().empty() || part->base.ammo_remaining() > 0;
+    }
+    if( uses_vehicle_tanks_or_batteries() ) {
         return false;
     }
     return part->base.ammo_remaining( ) || part->base.magazine_current();

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -156,6 +156,49 @@ std::set<itype_id> turret_data::ammo_options() const
         return opts;
     }
 
+    if( part->base.uses_firing_requirements() ) {
+        // Battery pockets are not user-selectable and never enumerated.
+        const item &gun = part->base;
+        const std::vector<pocket_consumption_entry> *entries =
+            gun.type->firing_requirements.for_mode( gun.gun_get_mode_id() );
+        if( entries == nullptr ) {
+            return opts;
+        }
+        for( const pocket_consumption_entry &pce : *entries ) {
+            const item_pocket *pkt = gun.pocket_by_id( pce.pocket );
+            if( pkt == nullptr ) {
+                continue;
+            }
+            const pocket_data *pdat = pkt->get_pocket_data();
+            if( pdat == nullptr ) {
+                continue;
+            }
+            if( gun.pocket_accepts_battery( pkt ) ) {
+                continue;
+            }
+            if( pdat->type == pocket_type::MAGAZINE ) {
+                for( const std::pair<const ammotype, int> &ar : pdat->ammo_restriction ) {
+                    for( const vpart_reference &tvp :
+                         veh->get_avail_parts( vpart_bitflags::VPFLAG_FLUIDTANK ) ) {
+                        const itype_id &tank_ammo = tvp.part().ammo_current();
+                        if( tank_ammo.is_null() || !tank_ammo->ammo ) {
+                            continue;
+                        }
+                        if( tank_ammo->ammo->type == ar.first ) {
+                            opts.insert( tank_ammo );
+                        }
+                    }
+                }
+            } else if( pdat->type == pocket_type::MAGAZINE_WELL ) {
+                const itype_id loaded = gun.ammo_data() ? gun.ammo_data()->get_id() : itype_id::NULL_ID();
+                if( !loaded.is_null() ) {
+                    opts.insert( loaded );
+                }
+            }
+        }
+        return opts;
+    }
+
     if( !uses_vehicle_tanks_or_batteries() ) {
         if( !part->base.ammo_current().is_null() ) {
             opts.insert( part->base.ammo_current() );
@@ -281,6 +324,51 @@ bool turret_data::can_unload() const
         return false;
     }
     return part->base.ammo_remaining( ) || part->base.magazine_current();
+}
+
+std::vector<multimag_display_pocket> turret_data::multimag_display_state() const
+{
+    std::vector<multimag_display_pocket> out;
+    if( !veh || !part ) {
+        return out;
+    }
+    const item &gun = part->base;
+    if( !gun.uses_firing_requirements() ) {
+        return out;
+    }
+    const gun_mode_id mode = gun.gun_get_mode_id();
+    const std::vector<pocket_consumption_entry> *entries =
+        gun.type->firing_requirements.for_mode( mode );
+    if( entries == nullptr ) {
+        return out;
+    }
+    item gun_copy( gun );
+    const std::map<std::string, multimag_pocket_state> bindings =
+        vehicle::prepare_multimag_pockets( *veh, get_map(), gun_copy, mode, ammo_current() );
+    for( const pocket_consumption_entry &pce : *entries ) {
+        multimag_display_pocket dp;
+        dp.pocket_id = pce.pocket;
+        dp.per_use_qty = pce.qty;
+        dp.local_qty = gun.ammo_remaining_in_pocket( pce.pocket );
+        dp.effective_qty = gun_copy.ammo_remaining_in_pocket( pce.pocket );
+        dp.vehicle_bound = bindings.count( pce.pocket ) > 0;
+        if( const item_pocket *pkt = gun_copy.pocket_by_id( pce.pocket ) ) {
+            for( const item *it : pkt->all_items_top() ) {
+                if( !it ) {
+                    continue;
+                }
+                if( const itype *ad = it->ammo_data() ) {
+                    dp.ammo_itype = ad->get_id();
+                    break;
+                }
+                if( !it->typeId().is_null() ) {
+                    dp.ammo_itype = it->typeId();
+                }
+            }
+        }
+        out.push_back( std::move( dp ) );
+    }
+    return out;
 }
 
 turret_data::status turret_data::query() const

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -244,6 +244,17 @@ turret_data::status turret_data::query() const
 
     const item &gun = part->base;
 
+    if( gun.uses_firing_requirements() ) {
+        // Temp-copy the gun, prep vehicle-backed pockets, then ask the same
+        // mode-aware feasibility the firing path will use. Vehicle is never
+        // mutated by prepare_multimag_pockets (only the temp gun is loaded).
+        item gun_copy( gun );
+        const gun_mode_id mode = gun_copy.gun_get_mode_id();
+        vehicle::prepare_multimag_pockets( *veh, here, gun_copy, mode, ammo_current() );
+        return gun_copy.shots_remaining( here, nullptr ) >= 1
+               ? status::ready : status::no_ammo;
+    }
+
     if( uses_vehicle_tanks_or_batteries() ) {
         if( veh->fuel_left( here, ammo_current() ) < gun.ammo_required() ) {
             return status::no_ammo;
@@ -273,6 +284,14 @@ void turret_data::prepare_fire( Character &you )
     cached_recoil = you.recoil;
     you.recoil = 0;
 
+    item &gun = part->base;
+    if( gun.uses_firing_requirements() ) {
+        const gun_mode_id mode = gun.gun_get_mode_id();
+        mm_bindings_ = vehicle::prepare_multimag_pockets( *veh, here, gun, mode,
+                       ammo_current() );
+        return;
+    }
+
     // set fuel tank fluid as ammo, if appropriate
     if( uses_vehicle_tanks_or_batteries() ) {
         gun_mode mode = base()->gun_current_mode();
@@ -301,6 +320,19 @@ void turret_data::post_fire( map *here, Character &you, int shots )
             pocket->clear_items();
         }
     };
+
+    item &gun = part->base;
+    if( gun.uses_firing_requirements() ) {
+        // Bill bound pockets, clear only those so player-loaded pockets keep residue.
+        vehicle::drain_back_multimag( *veh, *here, gun, mm_bindings_ );
+        for( const auto &b : mm_bindings_ ) {
+            if( item_pocket *pkt = gun.pocket_by_id( b.first ) ) {
+                pkt->clear_items();
+            }
+        }
+        mm_bindings_.clear();
+        return;
+    }
 
     // handle draining of vehicle tanks or batteries, if applicable
     if( uses_vehicle_tanks_or_batteries() ) {

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1560,9 +1560,49 @@ void veh_interact::calc_overview( map &here )
                                             details_ammo );
             }
             if( vpr.part().is_turret() ) {
-                overview_opts.emplace_back( "5_TURRET", &vpr.part(), selectable,
-                                            selectable ? next_hotkey( hotkey ) : input_event(),
-                                            details_ammo );
+                if( vpr.part().get_base().uses_firing_requirements() ) {
+                    auto multimag_details = [veh = this->veh]( const vehicle_part & pt,
+                    const catacurses::window & w, int y ) {
+                        const turret_data td = veh->turret_query( const_cast<vehicle_part &>( pt ) );
+                        const std::vector<multimag_display_pocket> dps = td.multimag_display_state();
+                        int row = y + 1;
+                        for( const multimag_display_pocket &dp : dps ) {
+                            const std::string &label = dp.pocket_id;
+                            std::string ammo_text;
+                            nc_color ammo_clr = c_light_gray;
+                            if( !dp.ammo_itype.is_null() ) {
+                                const itype *ad = item::find_type( dp.ammo_itype );
+                                ammo_text = ad ? ad->nname( std::max( dp.effective_qty, 1 ) ) : dp.pocket_id;
+                                ammo_clr = ad ? ad->color : c_light_gray;
+                            } else {
+                                ammo_text = "-";
+                            }
+                            const nc_color row_clr = ( dp.effective_qty < dp.per_use_qty )
+                                                     ? c_red : c_light_gray;
+                            const std::string source_tag = dp.vehicle_bound ?
+                                                           colorize( "[v] ", c_cyan ) : "    ";
+                            trim_and_print( w, point( 8, row ), getmaxx( w ) - 14, row_clr, "%s",
+                                            label );
+                            right_print( w, row, 1, ammo_clr,
+                                         string_format( "%s%s   %5i", source_tag,
+                                                        colorize( ammo_text, ammo_clr ),
+                                                        dp.effective_qty ) );
+                            row++;
+                        }
+                    };
+                    auto multimag_extra_rows = [veh = this->veh]( const vehicle_part & pt ) {
+                        const turret_data td = veh->turret_query( const_cast<vehicle_part &>( pt ) );
+                        return static_cast<int>( td.multimag_display_state().size() );
+                    };
+                    overview_opts.emplace_back( "5_TURRET", &vpr.part(), selectable,
+                                                selectable ? next_hotkey( hotkey ) : input_event(),
+                                                multimag_details );
+                    overview_opts.back().extra_rows = multimag_extra_rows;
+                } else {
+                    overview_opts.emplace_back( "5_TURRET", &vpr.part(), selectable,
+                                                selectable ? next_hotkey( hotkey ) : input_event(),
+                                                details_ammo );
+                }
             }
         }
 
@@ -1632,7 +1672,9 @@ void veh_interact::display_overview( const map &here )
 
         // print extra columns (if any)
         overview_opts[idx].details( pt, w_list, y );
-        y++;
+        const int rows_used = 1 + ( overview_opts[idx].extra_rows
+                                    ? overview_opts[idx].extra_rows( pt ) : 0 );
+        y += rows_used;
         if( y < ( getmaxy( w_list ) - 1 ) ) {
             overview_limit = overview_offset;
         } else {

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -257,6 +257,9 @@ class veh_interact
             /** Writes any extra details for this entry */
             std::function<void( const vehicle_part &pt, const catacurses::window &w, int y )> details;
 
+            /** Number of additional rows past the title row that details writes. */
+            std::function<int( const vehicle_part &pt )> extra_rows;
+
             /** Writes to message window when part is selected */
             std::function<void( const vehicle_part &pt )> message;
         };

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -507,8 +507,15 @@ static bool gun_uses_liquid_ammo( const itype &guntype )
             return true;
         }
     }
-    for( const pocket_data &maybe_magwell : guntype.pockets ) {
-        for( const itype_id &restricted_types : maybe_magwell.item_id_restriction ) {
+    for( const pocket_data &pkt : guntype.pockets ) {
+        if( pkt.type == pocket_type::MAGAZINE ) {
+            for( const std::pair<const ammotype, int> &res : pkt.ammo_restriction ) {
+                if( res.first->default_ammotype()->phase == phase_id::LIQUID ) {
+                    return true;
+                }
+            }
+        }
+        for( const itype_id &restricted_types : pkt.item_id_restriction ) {
             for( const pocket_data &maybe_mag : restricted_types.obj().pockets ) {
                 for( const std::pair<const ammotype, int> &res : maybe_mag.ammo_restriction ) {
                     if( res.first->default_ammotype()->phase == phase_id::LIQUID ) {

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -494,11 +494,6 @@ static bool mountable_gun_filter( const itype &guntype )
         return false;
     }
 
-    // TODO(multimag): turret + firing_requirements support pending.
-    if( !guntype.firing_requirements.empty() ) {
-        return false;
-    }
-
     return std::none_of( bad_flags.cbegin(), bad_flags.cend(), [&guntype]( const flag_id & flag ) {
         return guntype.has_flag( flag );
     } );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8574,15 +8574,18 @@ void vehicle::update_time( map &here, const time_point &update_to )
         const double area_in_mm2 = std::pow( pt.info().bonus, 2 ) * M_PI;
         const int qty = roll_remainder( funnel_charges_per_turn( area_in_mm2, accum_weather.rain_amount ) );
         int c_qty = qty + ( tank->can_reload( water_clean ) ?  tank->ammo_remaining( ) : 0 );
-        int cost_to_purify = c_qty * itype_water_purifier->charges_to_use();
 
         if( qty > 0 ) {
             const std::optional<vpart_reference> vp_purifier = vpart_position( *this, idx )
                     .part_with_tool( here, itype_water_purifier );
+            const int64_t per_use = itype_water_purifier->charges_to_use();
+            const bool can_purify_all = vp_purifier &&
+                                        fuel_left( here, itype_battery ) >=
+                                        static_cast<int64_t>( c_qty ) * per_use;
 
-            if( vp_purifier && ( fuel_left( here, itype_battery ) > cost_to_purify ) ) {
+            if( can_purify_all ) {
+                run_legacy_charge_tool_uses( here, itype_water_purifier, c_qty );
                 tank->ammo_set( itype_water_clean, c_qty );
-                discharge_battery( here, cost_to_purify );
             } else {
                 tank->ammo_set( itype_water, tank->ammo_remaining( ) + qty );
             }

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -621,6 +621,18 @@ struct multimag_pocket_state {
     int vpart_index = -1;
 };
 
+// Per-pocket readiness summary for aim UI display of a multimag turret.
+// `effective_qty` is the count after prep would load vehicle-backed pockets;
+// `local_qty` is what the gun already holds without any vehicle help.
+struct multimag_display_pocket {
+    std::string pocket_id;
+    itype_id ammo_itype;
+    int local_qty = 0;
+    int effective_qty = 0;
+    int per_use_qty = 0;
+    bool vehicle_bound = false;
+};
+
 class turret_data
 {
         friend vehicle;
@@ -701,6 +713,8 @@ class turret_data
 
         bool can_reload() const;
         bool can_unload() const;
+
+        std::vector<multimag_display_pocket> multimag_display_state() const;
 
         enum class status : int {
             invalid,

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1949,6 +1949,23 @@ class vehicle
         * @return a pair of tool's first ammo type and the amount of it available from tanks / batteries
         */
         std::pair<const itype_id &, int> tool_ammo_available( map &here, const itype_id &tool_type ) const;
+
+        // Multimag pseudo-tool support.
+        struct multimag_pocket_state {
+            enum class source_kind { BATTERY, TANK };
+            int initial_qty = 0;
+            source_kind kind = source_kind::BATTERY;
+            int vpart_index = -1;
+        };
+        // Populates every consumption-schema pocket of a multimag tool from
+        // vehicle batteries or tanks and returns per-pocket source bindings
+        // keyed by pocket id. drain_back_multimag must consume the returned
+        // map verbatim to keep prep and drain billing the same store.
+        static std::map<std::string, multimag_pocket_state> prepare_multimag_pockets(
+            vehicle &veh, map &here, item &tool );
+        static void drain_back_multimag( vehicle &veh, map &here, const item &tool,
+                                         const std::map<std::string, multimag_pocket_state> &bindings );
+
         /**
         * @return pseudo- and attached tools available from this vehicle part,
         * marked with PSEUDO flags, pseudo_magazine_mod and pseudo_magazine attached, magazines filled

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -612,6 +612,15 @@ struct vehicle_part {
         }
 };
 
+// Per-pocket source binding from prepare_multimag_pockets, consumed by
+// drain_back_multimag to bill the same vehicle store for one fire cycle.
+struct multimag_pocket_state {
+    enum class source_kind { BATTERY, TANK };
+    int initial_qty = 0;
+    source_kind kind = source_kind::BATTERY;
+    int vpart_index = -1;
+};
+
 class turret_data
 {
         friend vehicle;
@@ -706,6 +715,10 @@ class turret_data
         turret_data( vehicle *veh, vehicle_part *part )
             : veh( veh ), part( part ) {}
         double cached_recoil = 0;
+        // Vehicle source bindings populated by prepare_fire for multimag
+        // turrets and consumed by post_fire to bill the same store. Lifetime
+        // is one fire() call; not serialized.
+        std::map<std::string, multimag_pocket_state> mm_bindings_;
 
     protected:
         vehicle *veh = nullptr;
@@ -1951,16 +1964,18 @@ class vehicle
         std::pair<const itype_id &, int> tool_ammo_available( map &here, const itype_id &tool_type ) const;
 
         // Multimag pseudo-tool support.
-        struct multimag_pocket_state {
-            enum class source_kind { BATTERY, TANK };
-            int initial_qty = 0;
-            source_kind kind = source_kind::BATTERY;
-            int vpart_index = -1;
-        };
         // Populates every consumption-schema pocket of a multimag tool from
         // vehicle batteries or tanks and returns per-pocket source bindings
         // keyed by pocket id. drain_back_multimag must consume the returned
         // map verbatim to keep prep and drain billing the same store.
+        // Pockets that already hold any content at call time are skipped:
+        // player-loaded pockets keep their ammo and stay unbound. Tank source
+        // picker prefers `preferred_primary` when set and the vehicle holds it.
+        static std::map<std::string, multimag_pocket_state> prepare_multimag_pockets(
+            vehicle &veh, map &here, item &tool, const gun_mode_id &mode,
+            const itype_id &preferred_primary = itype_id::NULL_ID() );
+        // Backwards-compatible wrapper for pseudo-tool callers that build a
+        // fresh tool every prep cycle and never need mode or ammo preference.
         static std::map<std::string, multimag_pocket_state> prepare_multimag_pockets(
             vehicle &veh, map &here, item &tool );
         static void drain_back_multimag( vehicle &veh, map &here, const item &tool,

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1966,6 +1966,14 @@ class vehicle
         static void drain_back_multimag( vehicle &veh, map &here, const item &tool,
                                          const std::map<std::string, multimag_pocket_state> &bindings );
 
+        // Run N uses of a legacy charge-driven tool (no implicit pocket) from
+        // the vehicle's battery network. Returns uses actually performed.
+        // Routes the drain through item::consume_tool_uses so the per-use
+        // scalar lives only in the tool's itype, not at vehicle call sites.
+        // TODO(multimag): retire once every legacy charges_per_use tool with
+        // a vehicle-direct-drain caller migrates to firing_requirements.
+        int run_legacy_charge_tool_uses( map &here, const itype_id &tool_type, int uses );
+
         /**
         * @return pseudo- and attached tools available from this vehicle part,
         * marked with PSEUDO flags, pseudo_magazine_mod and pseudo_magazine attached, magazines filled

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2048,6 +2048,31 @@ void vehicle::drain_back_multimag( vehicle &veh, map &here, const item &tool,
     }
 }
 
+int vehicle::run_legacy_charge_tool_uses( map &here, const itype_id &tool_type, int uses )
+{
+    if( uses <= 0 || !tool_type->tool ) {
+        return 0;
+    }
+    const int per_use = tool_type->charges_to_use();
+    if( per_use <= 0 ) {
+        return 0;
+    }
+    item tool( tool_type, calendar::turn );
+    const int ammo_in_tool = prepare_tool( here, tool );
+    const int max_uses = ammo_in_tool / per_use;
+    const int do_uses = std::min( uses, max_uses );
+    if( do_uses <= 0 ) {
+        return 0;
+    }
+    const int got_uses = tool.consume_tool_uses( do_uses, here,
+                         tripoint_bub_ms::zero, nullptr );
+    const int consumed = ammo_in_tool - tool.ammo_remaining_linked( here, nullptr );
+    if( consumed > 0 ) {
+        discharge_battery( here, consumed );
+    }
+    return got_uses;
+}
+
 std::pair<const itype_id &, int> vehicle::tool_ammo_available( map &here,
         const itype_id &tool_type ) const
 {
@@ -2674,9 +2699,6 @@ void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub
         }
     }
 
-    // TODO(multimag): water_purifier action drains the vehicle battery
-    // directly without instantiating a tool item, so a multimag conversion
-    // of water_purifier needs a separate vehicle-power reconciliation.
     if( vp.part_with_tool( *here, itype_water_purifier ) ) {
         menu.add( _( "Purify water in vehicle tank" ) )
         .enable( fuel_left( *here, itype_water ) &&
@@ -2695,18 +2717,21 @@ void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub
                 return;
             }
             vehicle_part &tank = vpr->part();
-            int64_t cost = static_cast<int64_t>( itype_water_purifier->charges_to_use() );
-            if( fuel_left( *here, itype_battery ) < tank.ammo_remaining( ) * cost )
+            const int charges = tank.ammo_remaining();
+            const int64_t per_use = itype_water_purifier->charges_to_use();
+            // All-or-nothing: refuse without burning power if the full batch
+            // does not fit. int64 prevents overflow on large tanks.
+            if( fuel_left( *here, itype_battery ) < static_cast<int64_t>( charges ) * per_use )
             {
                 //~ $1 - vehicle name, $2 - part name
                 add_msg( m_bad, _( "Insufficient power to purify the contents of the %1$s's %2$s" ),
                          name, tank.name() );
             } else
             {
+                run_legacy_charge_tool_uses( *here, itype_water_purifier, charges );
                 //~ $1 - vehicle name, $2 - part name
                 add_msg( m_good, _( "You purify the contents of the %1$s's %2$s" ), name, tank.name() );
-                discharge_battery( *here, tank.ammo_remaining( ) * cost );
-                tank.ammo_set( itype_water_clean, tank.ammo_remaining( ) );
+                tank.ammo_set( itype_water_clean, charges );
             }
         } );
     }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -23,6 +23,7 @@
 #include "dialogue.h"
 #include "effect_on_condition.h"
 #include "enums.h"
+#include "flat_set.h"
 #include "game.h"
 #include "game_inventory.h"
 #include "gates.h"
@@ -30,6 +31,7 @@
 #include "iexamine.h"
 #include "inventory.h"
 #include "item.h"
+#include "item_pocket.h"
 #include "itype.h"
 #include "iuse.h"
 #include "map.h"
@@ -1898,9 +1900,154 @@ void vpart_position::form_inventory( map &here, inventory &inv ) const
     }
 }
 
-// TODO(multimag): pseudo-item construction here populates only one
-// magazine slot; multimag tools' secondary wells go unpopulated. Multimag
-// vehicle-mounted tool support is blocked on this being redesigned.
+static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );
+
+std::map<std::string, vehicle::multimag_pocket_state>
+vehicle::prepare_multimag_pockets( vehicle &veh, map &here, item &tool )
+{
+    using state_t = vehicle::multimag_pocket_state;
+    std::map<std::string, state_t> out;
+    if( !tool.uses_firing_requirements() ) {
+        return out;
+    }
+    const std::vector<pocket_consumption_entry> *entries =
+        tool.type->firing_requirements.for_mode( gun_mode_DEFAULT );
+    if( entries == nullptr ) {
+        return out;
+    }
+    // Accumulate "claimed" budget per source so two pockets cannot double-load
+    // the same store. Battery network is a single global pool; tanks track
+    // per vpart index so live per-part reads stay accurate.
+    int battery_claimed = 0;
+    std::map<int, int> tank_claimed_by_vpart;
+
+    for( const pocket_consumption_entry &pce : *entries ) {
+        item_pocket *pkt = tool.pocket_by_id( pce.pocket );
+        if( pkt == nullptr ) {
+            continue;
+        }
+        const pocket_data *pdat = pkt->get_pocket_data();
+        if( pdat == nullptr ) {
+            continue;
+        }
+
+        if( tool.pocket_accepts_battery( pkt ) ) {
+            const int batt_total = static_cast<int>(
+                                       std::min<int64_t>( veh.battery_left( here ), INT_MAX ) );
+            const int batt_avail = std::max( 0, batt_total - battery_claimed );
+            if( pdat->type == pocket_type::MAGAZINE_WELL ) {
+                itype_id mag_type = pdat->default_magazine;
+                if( mag_type.is_null() && !pdat->item_id_restriction.empty() ) {
+                    mag_type = *pdat->item_id_restriction.begin();
+                }
+                if( mag_type.is_null() ) {
+                    continue;
+                }
+                item mag( mag_type );
+                mag.clear_items();
+                const int cap = mag.ammo_capacity( ammo_battery );
+                const int set_qty = std::min( batt_avail, cap );
+                mag.ammo_set( itype_battery, set_qty );
+                if( pkt->insert_item( mag ).success() ) {
+                    battery_claimed += set_qty;
+                    state_t st;
+                    st.kind = state_t::source_kind::BATTERY;
+                    st.initial_qty = tool.ammo_remaining_in_pocket( pce.pocket );
+                    out.emplace( pce.pocket, st );
+                }
+            } else if( pdat->type == pocket_type::MAGAZINE ) {
+                // Direct MAGAZINE battery pocket: insert raw battery items
+                // capped by the pocket's own capacity (no synthesized mag).
+                const int set_qty = std::min( batt_avail,
+                                              pkt->remaining_ammo_capacity( ammo_battery ) );
+                if( set_qty > 0 ) {
+                    item ammo_it( itype_battery, calendar::turn, set_qty );
+                    if( pkt->insert_item( ammo_it ).success() ) {
+                        battery_claimed += set_qty;
+                        state_t st;
+                        st.kind = state_t::source_kind::BATTERY;
+                        st.initial_qty = tool.ammo_remaining_in_pocket( pce.pocket );
+                        out.emplace( pce.pocket, st );
+                    }
+                }
+            }
+            continue;
+        }
+        if( pdat->type != pocket_type::MAGAZINE || pdat->ammo_restriction.empty() ) {
+            continue;
+        }
+
+        bool placed = false;
+        for( const std::pair<const ammotype, int> &ar : pdat->ammo_restriction ) {
+            // Scan tanks first; record the exact vpart and ammo itype so
+            // drain_back_multimag bills the same store with no re-search.
+            for( const vpart_reference &tvp :
+                 veh.get_avail_parts( vpart_bitflags::VPFLAG_FLUIDTANK ) ) {
+                const itype_id &tank_ammo = tvp.part().ammo_current();
+                if( tank_ammo.is_null() || !tank_ammo->ammo ) {
+                    continue;
+                }
+                if( tank_ammo->ammo->type != ar.first ) {
+                    continue;
+                }
+                const int vp_idx = static_cast<int>( tvp.part_index() );
+                // Per-part ammo so two same-fuel tanks each have their own
+                // budget; whole-vehicle fuel_left would let two pockets
+                // double-claim the same global total.
+                const int total = tvp.part().ammo_remaining();
+                const int avail = std::max( 0, total - tank_claimed_by_vpart[vp_idx] );
+                if( avail <= 0 ) {
+                    continue;
+                }
+                const int set_qty = std::min( avail, ar.second );
+                item ammo_it( tank_ammo, calendar::turn, set_qty );
+                if( pkt->insert_item( ammo_it ).success() ) {
+                    tank_claimed_by_vpart[vp_idx] += set_qty;
+                    state_t st;
+                    st.kind = state_t::source_kind::TANK;
+                    st.vpart_index = vp_idx;
+                    st.initial_qty = tool.ammo_remaining_in_pocket( pce.pocket );
+                    out.emplace( pce.pocket, st );
+                    placed = true;
+                    break;
+                }
+            }
+            if( placed ) {
+                break;
+            }
+        }
+    }
+    return out;
+}
+
+void vehicle::drain_back_multimag( vehicle &veh, map &here, const item &tool,
+                                   const std::map<std::string, multimag_pocket_state> &bindings )
+{
+    using state_t = multimag_pocket_state;
+    if( !tool.uses_firing_requirements() ) {
+        return;
+    }
+    for( const std::pair<const std::string, state_t> &b : bindings ) {
+        const std::string &pocket_id = b.first;
+        const state_t &st = b.second;
+        const int after = tool.ammo_remaining_in_pocket( pocket_id );
+        const int delta = st.initial_qty - after;
+        if( delta <= 0 ) {
+            continue;
+        }
+        switch( st.kind ) {
+            case state_t::source_kind::BATTERY:
+                veh.discharge_battery( here, delta );
+                break;
+            case state_t::source_kind::TANK:
+                if( st.vpart_index >= 0 ) {
+                    veh.drain( here, st.vpart_index, delta );
+                }
+                break;
+        }
+    }
+}
+
 std::pair<const itype_id &, int> vehicle::tool_ammo_available( map &here,
         const itype_id &tool_type ) const
 {
@@ -1923,6 +2070,18 @@ std::pair<const itype_id &, int> vehicle::tool_ammo_available( map &here,
 int vehicle::prepare_tool( map &here, item &tool ) const
 {
     tool.set_flag( json_flag_PSEUDO );
+
+    if( tool.uses_firing_requirements() ) {
+        // const_cast is safe: prepare_multimag_pockets only mutates the tool
+        // and re-reads vehicle state. It does not modify vehicle storage.
+        const std::map<std::string, vehicle::multimag_pocket_state> bindings =
+            vehicle::prepare_multimag_pockets( const_cast<vehicle &>( *this ), here, tool );
+        int total = 0;
+        for( const std::pair<const std::string, vehicle::multimag_pocket_state> &b : bindings ) {
+            total = std::min( INT_MAX - b.second.initial_qty, total ) + b.second.initial_qty;
+        }
+        return total;
+    }
 
     const auto &[ammo_itype_id, ammo_amount] = tool_ammo_available( here, tool.typeId() );
     if( ammo_itype_id.is_null() ) {
@@ -1964,12 +2123,27 @@ bool vehicle::use_vehicle_tool( vehicle &veh, map *here, const tripoint_bub_ms &
                                 bool no_invoke )
 {
     item tool( tool_type, calendar::turn );
-    const auto &[ammo_type_id, avail_ammo_amount] = veh.tool_ammo_available( *here, tool_type );
-    const int ammo_in_tool = veh.prepare_tool( *here, tool );
-    const bool is_battery_tool = !ammo_type_id.is_null() && ammo_type_id->ammo->type == ammo_battery;
-    if( tool.ammo_required() > avail_ammo_amount ) {
-        return false;
+    const bool is_multimag = !tool_type->firing_requirements.empty();
+    std::map<std::string, vehicle::multimag_pocket_state> mm_bindings;
+    int ammo_in_tool = 0;
+    int avail_ammo_amount = 0;
+    itype_id ammo_type_id = itype_id::NULL_ID();
+    if( is_multimag ) {
+        tool.set_flag( json_flag_PSEUDO );
+        mm_bindings = vehicle::prepare_multimag_pockets( veh, *here, tool );
+        if( tool.feasible_tool_uses( /*external_pool=*/0 ) < 1 ) {
+            return false;
+        }
+    } else {
+        const auto &[type_id, amount] = veh.tool_ammo_available( *here, tool_type );
+        ammo_type_id = type_id;
+        avail_ammo_amount = amount;
+        ammo_in_tool = veh.prepare_tool( *here, tool );
+        if( tool.ammo_required() > avail_ammo_amount ) {
+            return false;
+        }
     }
+    const bool is_battery_tool = !ammo_type_id.is_null() && ammo_type_id->ammo->type == ammo_battery;
     if( !no_invoke ) {
         // TODO: pass map or go abs
         get_player_character().invoke_item( &tool, vp_pos );
@@ -1995,13 +2169,17 @@ bool vehicle::use_vehicle_tool( vehicle &veh, map *here, const tripoint_bub_ms &
         act.coords.push_back( here->get_abs( vp_pos ) );
     }
 
-    const int used_charges = ammo_in_tool - tool.ammo_remaining_linked( *here, nullptr );
-    if( used_charges > 0 ) {
-        if( is_battery_tool ) {
-            // if tool has less battery charges than it started with - discharge from vehicle batteries
-            veh.discharge_battery( *here, used_charges );
-        } else {
-            veh.drain( here, tool.ammo_current(), used_charges );
+    if( is_multimag ) {
+        drain_back_multimag( veh, *here, tool, mm_bindings );
+    } else {
+        const int used_charges = ammo_in_tool - tool.ammo_remaining_linked( *here, nullptr );
+        if( used_charges > 0 ) {
+            if( is_battery_tool ) {
+                // if tool has less battery charges than it started with - discharge from vehicle batteries
+                veh.discharge_battery( *here, used_charges );
+            } else {
+                veh.drain( here, tool.ammo_current(), used_charges );
+            }
         }
     }
     return true;
@@ -2368,8 +2546,16 @@ void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub
             continue; // skip old passive tools
         }
         const auto &[tool_ammo, ammo_amount ] = tool_ammo_available( *here, tool_type );
+        bool enabled;
+        if( !tool_type->firing_requirements.empty() ) {
+            item tmp( tool_type, calendar::turn );
+            prepare_tool( *here, tmp );
+            enabled = tmp.feasible_tool_uses( /*external_pool=*/0 ) >= 1;
+        } else {
+            enabled = ammo_amount >= tool_item.typeId()->charges_to_use();
+        }
         menu.add( string_format( _( "Use %s" ), tool_type->nname( 1 ) ) )
-        .enable( ammo_amount >= tool_item.typeId()->charges_to_use() )
+        .enable( enabled )
         .hotkey( hk )
         .skip_locked_check( tool_ammo.is_null() || tool_ammo->ammo->type != ammo_battery )
         .on_submit( [this, vppos, tool_type, here] { use_vehicle_tool( *this, here, vppos, tool_type ); } );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1902,16 +1902,23 @@ void vpart_position::form_inventory( map &here, inventory &inv ) const
 
 static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );
 
-std::map<std::string, vehicle::multimag_pocket_state>
+std::map<std::string, multimag_pocket_state>
 vehicle::prepare_multimag_pockets( vehicle &veh, map &here, item &tool )
 {
-    using state_t = vehicle::multimag_pocket_state;
+    return prepare_multimag_pockets( veh, here, tool, gun_mode_DEFAULT, itype_id::NULL_ID() );
+}
+
+std::map<std::string, multimag_pocket_state>
+vehicle::prepare_multimag_pockets( vehicle &veh, map &here, item &tool,
+                                   const gun_mode_id &mode, const itype_id &preferred_primary )
+{
+    using state_t = multimag_pocket_state;
     std::map<std::string, state_t> out;
     if( !tool.uses_firing_requirements() ) {
         return out;
     }
     const std::vector<pocket_consumption_entry> *entries =
-        tool.type->firing_requirements.for_mode( gun_mode_DEFAULT );
+        tool.type->firing_requirements.for_mode( mode );
     if( entries == nullptr ) {
         return out;
     }
@@ -1928,6 +1935,11 @@ vehicle::prepare_multimag_pockets( vehicle &veh, map &here, item &tool )
         }
         const pocket_data *pdat = pkt->get_pocket_data();
         if( pdat == nullptr ) {
+            continue;
+        }
+        // Any existing content blocks prep, else drain_back would bill the
+        // vehicle for player-owned charges via the initial_qty delta.
+        if( !pkt->empty() ) {
             continue;
         }
 
@@ -1978,42 +1990,54 @@ vehicle::prepare_multimag_pockets( vehicle &veh, map &here, item &tool )
         }
 
         bool placed = false;
-        for( const std::pair<const ammotype, int> &ar : pdat->ammo_restriction ) {
-            // Scan tanks first; record the exact vpart and ammo itype so
-            // drain_back_multimag bills the same store with no re-search.
-            for( const vpart_reference &tvp :
-                 veh.get_avail_parts( vpart_bitflags::VPFLAG_FLUIDTANK ) ) {
-                const itype_id &tank_ammo = tvp.part().ammo_current();
-                if( tank_ammo.is_null() || !tank_ammo->ammo ) {
-                    continue;
+        // Two-pass tank picker: first pass honors `preferred_primary` if set
+        // (ammo_select preference for multi-tank turrets). Second pass falls
+        // back to first-match. Skips entirely if preference is not set.
+        for( int pass = 0; pass < 2 && !placed; pass++ ) {
+            const bool prefer_only = ( pass == 0 && !preferred_primary.is_null() );
+            if( pass == 0 && preferred_primary.is_null() ) {
+                continue;
+            }
+            for( const std::pair<const ammotype, int> &ar : pdat->ammo_restriction ) {
+                // Scan tanks; record the exact vpart and ammo itype so
+                // drain_back_multimag bills the same store with no re-search.
+                for( const vpart_reference &tvp :
+                     veh.get_avail_parts( vpart_bitflags::VPFLAG_FLUIDTANK ) ) {
+                    const itype_id &tank_ammo = tvp.part().ammo_current();
+                    if( tank_ammo.is_null() || !tank_ammo->ammo ) {
+                        continue;
+                    }
+                    if( tank_ammo->ammo->type != ar.first ) {
+                        continue;
+                    }
+                    if( prefer_only && tank_ammo != preferred_primary ) {
+                        continue;
+                    }
+                    const int vp_idx = static_cast<int>( tvp.part_index() );
+                    // Per-part ammo so two same-fuel tanks each have their own
+                    // budget; whole-vehicle fuel_left would let two pockets
+                    // double-claim the same global total.
+                    const int total = tvp.part().ammo_remaining();
+                    const int avail = std::max( 0, total - tank_claimed_by_vpart[vp_idx] );
+                    if( avail <= 0 ) {
+                        continue;
+                    }
+                    const int set_qty = std::min( avail, ar.second );
+                    item ammo_it( tank_ammo, calendar::turn, set_qty );
+                    if( pkt->insert_item( ammo_it ).success() ) {
+                        tank_claimed_by_vpart[vp_idx] += set_qty;
+                        state_t st;
+                        st.kind = state_t::source_kind::TANK;
+                        st.vpart_index = vp_idx;
+                        st.initial_qty = tool.ammo_remaining_in_pocket( pce.pocket );
+                        out.emplace( pce.pocket, st );
+                        placed = true;
+                        break;
+                    }
                 }
-                if( tank_ammo->ammo->type != ar.first ) {
-                    continue;
-                }
-                const int vp_idx = static_cast<int>( tvp.part_index() );
-                // Per-part ammo so two same-fuel tanks each have their own
-                // budget; whole-vehicle fuel_left would let two pockets
-                // double-claim the same global total.
-                const int total = tvp.part().ammo_remaining();
-                const int avail = std::max( 0, total - tank_claimed_by_vpart[vp_idx] );
-                if( avail <= 0 ) {
-                    continue;
-                }
-                const int set_qty = std::min( avail, ar.second );
-                item ammo_it( tank_ammo, calendar::turn, set_qty );
-                if( pkt->insert_item( ammo_it ).success() ) {
-                    tank_claimed_by_vpart[vp_idx] += set_qty;
-                    state_t st;
-                    st.kind = state_t::source_kind::TANK;
-                    st.vpart_index = vp_idx;
-                    st.initial_qty = tool.ammo_remaining_in_pocket( pce.pocket );
-                    out.emplace( pce.pocket, st );
-                    placed = true;
+                if( placed ) {
                     break;
                 }
-            }
-            if( placed ) {
-                break;
             }
         }
     }
@@ -2099,10 +2123,10 @@ int vehicle::prepare_tool( map &here, item &tool ) const
     if( tool.uses_firing_requirements() ) {
         // const_cast is safe: prepare_multimag_pockets only mutates the tool
         // and re-reads vehicle state. It does not modify vehicle storage.
-        const std::map<std::string, vehicle::multimag_pocket_state> bindings =
+        const std::map<std::string, multimag_pocket_state> bindings =
             vehicle::prepare_multimag_pockets( const_cast<vehicle &>( *this ), here, tool );
         int total = 0;
-        for( const std::pair<const std::string, vehicle::multimag_pocket_state> &b : bindings ) {
+        for( const std::pair<const std::string, multimag_pocket_state> &b : bindings ) {
             total = std::min( INT_MAX - b.second.initial_qty, total ) + b.second.initial_qty;
         }
         return total;
@@ -2149,7 +2173,7 @@ bool vehicle::use_vehicle_tool( vehicle &veh, map *here, const tripoint_bub_ms &
 {
     item tool( tool_type, calendar::turn );
     const bool is_multimag = !tool_type->firing_requirements.empty();
-    std::map<std::string, vehicle::multimag_pocket_state> mm_bindings;
+    std::map<std::string, multimag_pocket_state> mm_bindings;
     int ammo_in_tool = 0;
     int avail_ammo_amount = 0;
     itype_id ammo_type_id = itype_id::NULL_ID();

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -85,6 +85,8 @@ static const furn_str_id furn_f_plant_harvest( "f_plant_harvest" );
 static const furn_str_id furn_f_plant_seed( "f_plant_seed" );
 static const furn_str_id furn_f_plant_unharvested_overgrown( "f_plant_unharvested_overgrown" );
 
+static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );
+
 static const itype_id fuel_type_battery( "battery" );
 static const itype_id fuel_type_muscle( "muscle" );
 static const itype_id fuel_type_none( "null" );
@@ -1900,8 +1902,6 @@ void vpart_position::form_inventory( map &here, inventory &inv ) const
     }
 }
 
-static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );
-
 std::map<std::string, multimag_pocket_state>
 vehicle::prepare_multimag_pockets( vehicle &veh, map &here, item &tool )
 {
@@ -1985,7 +1985,30 @@ vehicle::prepare_multimag_pockets( vehicle &veh, map &here, item &tool,
             }
             continue;
         }
-        if( pdat->type != pocket_type::MAGAZINE || pdat->ammo_restriction.empty() ) {
+        // Resolve which ammo_restriction map to feed from a vehicle tank.
+        // - Direct MAGAZINE: pocket's own ammo_restriction.
+        // - MAGAZINE_WELL: synthesize a magazine of the well's accepted itype
+        //   and use that magazine's MAGAZINE pocket ammo_restriction.
+        const std::map<ammotype, int> *target_restriction = nullptr;
+        itype_id synth_mag_type = itype_id::NULL_ID();
+        if( pdat->type == pocket_type::MAGAZINE && !pdat->ammo_restriction.empty() ) {
+            target_restriction = &pdat->ammo_restriction;
+        } else if( pdat->type == pocket_type::MAGAZINE_WELL && !pdat->item_id_restriction.empty() ) {
+            synth_mag_type = pdat->default_magazine.is_null() ?
+                             *pdat->item_id_restriction.begin() : pdat->default_magazine;
+            if( !synth_mag_type->magazine ) {
+                continue;
+            }
+            for( const pocket_data &mp : synth_mag_type->pockets ) {
+                if( mp.type == pocket_type::MAGAZINE && !mp.ammo_restriction.empty() ) {
+                    target_restriction = &mp.ammo_restriction;
+                    break;
+                }
+            }
+            if( target_restriction == nullptr ) {
+                continue;
+            }
+        } else {
             continue;
         }
 
@@ -1994,11 +2017,11 @@ vehicle::prepare_multimag_pockets( vehicle &veh, map &here, item &tool,
         // (ammo_select preference for multi-tank turrets). Second pass falls
         // back to first-match. Skips entirely if preference is not set.
         for( int pass = 0; pass < 2 && !placed; pass++ ) {
-            const bool prefer_only = ( pass == 0 && !preferred_primary.is_null() );
+            const bool prefer_only = pass == 0 && !preferred_primary.is_null();
             if( pass == 0 && preferred_primary.is_null() ) {
                 continue;
             }
-            for( const std::pair<const ammotype, int> &ar : pdat->ammo_restriction ) {
+            for( const std::pair<const ammotype, int> &ar : *target_restriction ) {
                 // Scan tanks; record the exact vpart and ammo itype so
                 // drain_back_multimag bills the same store with no re-search.
                 for( const vpart_reference &tvp :
@@ -2019,12 +2042,25 @@ vehicle::prepare_multimag_pockets( vehicle &veh, map &here, item &tool,
                     // double-claim the same global total.
                     const int total = tvp.part().ammo_remaining();
                     const int avail = std::max( 0, total - tank_claimed_by_vpart[vp_idx] );
-                    if( avail <= 0 ) {
+                    // Skip tanks that cannot fully cover one shot's requirement.
+                    // Otherwise a low tank would bind the pocket and starve a
+                    // sibling tank that could feed the gun. Use effective_qty
+                    // so gunmod ammo_to_fire / energy_drain modifiers count.
+                    if( avail < tool.effective_qty( pce ) ) {
                         continue;
                     }
                     const int set_qty = std::min( avail, ar.second );
-                    item ammo_it( tank_ammo, calendar::turn, set_qty );
-                    if( pkt->insert_item( ammo_it ).success() ) {
+                    bool inserted = false;
+                    if( synth_mag_type.is_null() ) {
+                        item ammo_it( tank_ammo, calendar::turn, set_qty );
+                        inserted = pkt->insert_item( ammo_it ).success();
+                    } else {
+                        item mag( synth_mag_type );
+                        mag.clear_items();
+                        mag.ammo_set( tank_ammo, set_qty );
+                        inserted = pkt->insert_item( mag ).success();
+                    }
+                    if( inserted ) {
                         tank_claimed_by_vpart[vp_idx] += set_qty;
                         state_t st;
                         st.kind = state_t::source_kind::TANK;

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <climits>
+#include <cstdint>
 #include <limits>
 #include <map>
 #include <memory>
@@ -38,6 +39,8 @@
 #include "vehicle_selector.h"
 
 static const bionic_id bio_ups( "bio_ups" );
+
+static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );
 
 static const flag_id json_flag_ITEM_BROKEN( "ITEM_BROKEN" );
 static const flag_id json_flag_PSEUDO( "PSEUDO" );
@@ -853,67 +856,209 @@ std::list<item> vehicle_selector::remove_items_with( const
     return res;
 }
 
-template <typename T, typename M>
-static int charges_of_internal( const T &self, const M &main, const itype_id &id, int limit,
-                                const std::function<bool( const item & )> &filter,
-                                const std::function<void( int )> &visitor, bool in_tools )
+// Per-tool stock for charges_of dedup. Legacy contributes local charges;
+// multimag records per-battery-pocket so shared-pool greedy can bill K uses
+// without re-solving firing_requirements.
+struct tool_stock_entry {
+    enum class kind_t { LEGACY, MULTIMAG };
+    kind_t kind = kind_t::LEGACY;
+    bool uses_ups = false;
+    bool uses_bionic = false;
+    int local_charges = 0;
+    const item *src = nullptr;
+    std::vector<std::pair<int, int>> battery;
+};
+
+static tool_stock_entry build_multimag_entry( const item &e )
+{
+    tool_stock_entry out;
+    out.kind = tool_stock_entry::kind_t::MULTIMAG;
+    out.uses_ups = e.has_flag( json_flag_USE_UPS );
+    out.uses_bionic = e.has_flag( json_flag_USES_BIONIC_POWER );
+    out.src = &e;
+
+    // Tools lower consumption_per_use into firing_requirements per_mode[DEFAULT].
+    const std::vector<pocket_consumption_entry> *entries =
+        e.type->firing_requirements.for_mode( gun_mode_DEFAULT );
+    if( entries == nullptr ) {
+        return out;
+    }
+    for( const pocket_consumption_entry &pce : *entries ) {
+        const item_pocket *pkt = e.pocket_by_id( pce.pocket );
+        if( pkt == nullptr || pce.qty < 1 ) {
+            continue;
+        }
+        if( e.pocket_accepts_battery( pkt ) ) {
+            out.battery.emplace_back( e.ammo_remaining_in_pocket( pce.pocket ), pce.qty );
+        }
+    }
+    return out;
+}
+
+template <typename T>
+static void scan_tool_charges( const T &self, const itype_id &id,
+                               const std::function<bool( const item & )> &filter,
+                               bool in_tools, std::vector<tool_stock_entry> &entries,
+                               int &raw_ups_charges )
 {
     map &here = get_map();
-
-    int qty = 0;
-
-    bool found_tool_with_UPS = false;
-    bool found_bionic_tool = false;
     self.visit_items( [&]( const item * e, item * ) {
         if( filter( *e ) &&
             ( id == e->typeId() || ( in_tools && id == e->ammo_current() ) ||
               ( id == itype_UPS && e->has_flag( flag_IS_UPS ) ) ) &&
             !e->is_broken() ) {
-            if( id != itype_UPS ) {
+            if( id == itype_UPS && e->has_flag( flag_IS_UPS ) ) {
+                raw_ups_charges = sum_no_wrap( raw_ups_charges,
+                                               e->ammo_remaining_linked( here, nullptr ) );
+            } else if( id != itype_UPS ) {
                 if( e->uses_firing_requirements() ) {
-                    // Multimag: contribute local-only uses to avoid summing
-                    // the same external pool once per matching item.
-                    qty = sum_no_wrap( qty, e->tool_uses_remaining_local() );
-                } else if( e->count_by_charges() ) {
-                    qty = sum_no_wrap( qty, e->charges );
+                    entries.push_back( build_multimag_entry( *e ) );
                 } else {
-                    qty = sum_no_wrap( qty, e->ammo_remaining_linked( here, nullptr ) );
-                    if( e->has_flag( json_flag_USE_UPS ) ) {
-                        found_tool_with_UPS = true;
-                    } else if( e->has_flag( json_flag_USES_BIONIC_POWER ) ) {
-                        found_bionic_tool = true;
+                    tool_stock_entry entry;
+                    entry.kind = tool_stock_entry::kind_t::LEGACY;
+                    if( e->count_by_charges() ) {
+                        entry.local_charges = e->charges;
+                    } else {
+                        entry.local_charges = e->ammo_remaining_linked( here, nullptr );
+                        entry.uses_ups = e->has_flag( json_flag_USE_UPS );
+                        entry.uses_bionic = e->has_flag( json_flag_USES_BIONIC_POWER );
                     }
+                    entries.push_back( entry );
                 }
-            } else if( id == itype_UPS && e->has_flag( flag_IS_UPS ) ) {
-                qty = sum_no_wrap( qty, e->ammo_remaining_linked( here, nullptr ) );
             }
         }
-        if( qty >= limit ) {
-            return VisitResponse::ABORT;
-        }
-        // recurse through nested containers if any
         return e->is_container() ? VisitResponse::NEXT : VisitResponse::SKIP;
     } );
+}
 
-    if( found_tool_with_UPS && qty < limit && get_player_character().has_active_bionic( bio_ups ) ) {
+template <typename M>
+static int apply_external_pools_legacy( const M &main,
+                                        const std::vector<tool_stock_entry> &entries, int limit,
+                                        const std::function<void( int )> &visitor )
+{
+    int qty = 0;
+    bool any_ups = false;
+    bool any_bionic = false;
+    for( const tool_stock_entry &e : entries ) {
+        qty = sum_no_wrap( qty, e.local_charges );
+        any_ups = any_ups || e.uses_ups;
+        any_bionic = any_bionic || e.uses_bionic;
+    }
+    // bio_ups: USE_UPS tools also drain active bio_ups bionic energy.
+    if( any_ups && qty < limit && get_player_character().has_active_bionic( bio_ups ) ) {
         qty = sum_no_wrap( qty, static_cast<int>( units::to_kilojoule(
                                get_player_character().get_power_level() ) ) );
     }
-
-    if( found_bionic_tool ) {
+    if( any_bionic ) {
         qty = sum_no_wrap( qty, static_cast<int>( units::to_kilojoule(
                                get_player_character().get_power_level() ) ) );
     }
-
-    if( qty < limit && found_tool_with_UPS ) {
-        int used_ups = main.charges_of( itype_UPS, limit - qty );
+    if( qty < limit && any_ups ) {
+        const int used_ups = main.charges_of( itype_UPS, limit - qty );
         qty += used_ups;
         if( visitor ) {
             visitor( used_ups );
         }
     }
-
     return std::min( qty, limit );
+}
+
+template <typename M>
+static int apply_external_pools_multimag( const M &main,
+        const std::vector<tool_stock_entry> &entries, int limit )
+{
+    bool any_ups = false;
+    bool any_bionic = false;
+    for( const tool_stock_entry &e : entries ) {
+        any_ups = any_ups || e.uses_ups;
+        any_bionic = any_bionic || e.uses_bionic;
+    }
+    // UPS goes through main so ground UPS in crafting_inventory is seen.
+    // Character::charges_of(itype_UPS) strips bio_ups; add it back here.
+    int external = 0;
+    if( any_bionic ) {
+        external = sum_no_wrap( external, static_cast<int>( units::to_kilojoule(
+                                    get_player_character().get_power_level() ) ) );
+    }
+    if( any_ups ) {
+        if( get_player_character().has_active_bionic( bio_ups ) ) {
+            external = sum_no_wrap( external, static_cast<int>( units::to_kilojoule(
+                                        get_player_character().get_power_level() ) ) );
+        }
+        external = sum_no_wrap( external, main.charges_of( itype_UPS, INT_MAX ) );
+    }
+
+    int total = 0;
+    int external_remaining = external;
+    map &here = get_map();
+    for( const tool_stock_entry &e : entries ) {
+        if( e.src == nullptr ) {
+            continue;
+        }
+        // Cable to a linked vehicle battery is per-tool, not shared, so it
+        // adds to this tool's budget without affecting the shared external.
+        const int cable_pool = e.src->available_cable_charges( here );
+        const int budget = sum_no_wrap( external_remaining, cable_pool );
+        const int uses = e.src->feasible_tool_uses( budget );
+        // Battery consumed for K uses is sum max(0, K * per_use - local) over
+        // battery pockets. Drain cable first (matches firing-loop order), then
+        // bill the remainder to the shared external pool.
+        int64_t consumed = 0;
+        for( const std::pair<int, int> &b : e.battery ) {
+            const int64_t per = b.second;
+            const int64_t local = b.first;
+            consumed += std::max<int64_t>( 0, static_cast<int64_t>( uses ) * per - local );
+        }
+        const int64_t cable_used = std::min<int64_t>( consumed, cable_pool );
+        const int64_t shared_used = consumed - cable_used;
+        external_remaining -= static_cast<int>(
+                                  std::min<int64_t>( shared_used, external_remaining ) );
+        total = sum_no_wrap( total, uses );
+        if( total >= limit ) {
+            break;
+        }
+    }
+    return std::min( total, limit );
+}
+
+template <typename M>
+static int apply_external_pools( const M &main,
+                                 const std::vector<tool_stock_entry> &entries, int limit,
+                                 const std::function<void( int )> &visitor, int raw_ups_charges )
+{
+    if( raw_ups_charges > 0 ) {
+        return std::min( raw_ups_charges, limit );
+    }
+    std::vector<tool_stock_entry> legacy;
+    std::vector<tool_stock_entry> multi;
+    legacy.reserve( entries.size() );
+    multi.reserve( entries.size() );
+    for( const tool_stock_entry &e : entries ) {
+        if( e.kind == tool_stock_entry::kind_t::MULTIMAG ) {
+            multi.push_back( e );
+        } else {
+            legacy.push_back( e );
+        }
+    }
+    int total = 0;
+    if( !legacy.empty() ) {
+        total = sum_no_wrap( total, apply_external_pools_legacy( main, legacy, limit, visitor ) );
+    }
+    if( !multi.empty() && total < limit ) {
+        total = sum_no_wrap( total, apply_external_pools_multimag( main, multi, limit - total ) );
+    }
+    return std::min( total, limit );
+}
+
+template <typename T, typename M>
+static int charges_of_internal( const T &self, const M &main, const itype_id &id, int limit,
+                                const std::function<bool( const item & )> &filter,
+                                const std::function<void( int )> &visitor, bool in_tools )
+{
+    std::vector<tool_stock_entry> entries;
+    int raw_ups_charges = 0;
+    scan_tool_charges( self, id, filter, in_tools, entries, raw_ups_charges );
+    return apply_external_pools( main, entries, limit, visitor, raw_ups_charges );
 }
 
 template <typename T>
@@ -976,14 +1121,14 @@ int inventory::charges_of( const itype_id &what, int limit,
         return 0;
     }
 
-    int res = 0;
+    // Scan every matching item into one entry list so apply_external_pools can
+    // dedup the shared UPS / bionic pool across tools (legacy and multimag).
+    std::vector<tool_stock_entry> entries;
+    int raw_ups_charges = 0;
     for( const item *it : iter->second ) {
-        res = sum_no_wrap( res, charges_of_internal( *it, *this, what, limit, filter, visitor, in_tools ) );
-        if( res >= limit ) {
-            break;
-        }
+        scan_tool_charges( *it, what, filter, in_tools, entries, raw_ups_charges );
     }
-    return std::min( limit, res );
+    return apply_external_pools( *this, entries, limit, visitor, raw_ups_charges );
 }
 
 /** @relates visitable */

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -40,12 +40,12 @@
 
 static const bionic_id bio_ups( "bio_ups" );
 
-static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );
-
 static const flag_id json_flag_ITEM_BROKEN( "ITEM_BROKEN" );
 static const flag_id json_flag_PSEUDO( "PSEUDO" );
 static const flag_id json_flag_USES_BIONIC_POWER( "USES_BIONIC_POWER" );
 static const flag_id json_flag_USE_UPS( "USE_UPS" );
+
+static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );
 
 static const itype_id itype_UPS( "UPS" );
 static const itype_id itype_any( "any" );

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -137,6 +137,7 @@ static const itype_id itype_vac_mold( "vac_mold" );
 static const itype_id itype_water( "water" );
 static const itype_id itype_water_clean( "water_clean" );
 static const itype_id itype_water_faucet( "water_faucet" );
+static const itype_id itype_welder( "welder" );
 static const itype_id itype_wrench( "wrench" );
 
 static const morale_type morale_food_good( "morale_food_good" );
@@ -897,6 +898,55 @@ TEST_CASE( "UPS_modded_tools", "[crafting][ups]" )
         tinv.add_item_ref( *ups_loc );
     }
     REQUIRE( tinv.charges_of( soldering_iron->typeId() ) == ammo_count );
+}
+
+TEST_CASE( "UPS_modded_tools_dedup_one_pool_across_two_tools", "[crafting][ups]" )
+{
+    // Legacy USE_UPS dedup: two UPS-modded tools sharing one UPS must not
+    // double-count the UPS pool. inventory::charges_of is a feasibility query,
+    // not a reservation API, so the shared external pool counts once.
+    avatar dummy;
+    clear_character( dummy );
+    dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
+
+    // One UPS with N charges, carried.
+    constexpr int ups_charges = 259;
+    item_location ups_loc = dummy.i_add( item( itype_UPS_ON ) );
+    item ups_mag( ups_loc->magazine_default() );
+    ups_mag.ammo_set( ups_mag.ammo_default(), ups_charges );
+    REQUIRE( ups_loc->put_in( ups_mag, pocket_type::MAGAZINE_WELL ).success() );
+    REQUIRE( units::to_kilojoule( dummy.available_ups() ) == ups_charges );
+
+    GIVEN( "two UPS-modded soldering irons (charges_per_use 1) sharing one UPS" ) {
+        for( int i = 0; i < 2; ++i ) {
+            item_location s = dummy.i_add( item( itype_soldering_iron ) );
+            REQUIRE( s->put_in( item( itype_battery_ups ), pocket_type::MOD ).success() );
+            REQUIRE( s->has_flag( json_flag_USE_UPS ) );
+        }
+        WHEN( "querying charges_of via crafting_inventory" ) {
+            const int reported = dummy.crafting_inventory().charges_of( itype_soldering_iron );
+            THEN( "result is the shared UPS pool, not double" ) {
+                CHECK( reported == ups_charges );
+                CHECK( reported != ups_charges * 2 );
+            }
+        }
+    }
+
+    GIVEN( "two UPS-modded arc welders (charges_per_use 20) sharing one UPS" ) {
+        for( int i = 0; i < 2; ++i ) {
+            item_location w = dummy.i_add( item( itype_welder ) );
+            REQUIRE( w->put_in( item( itype_battery_ups ), pocket_type::MOD ).success() );
+            REQUIRE( w->has_flag( json_flag_USE_UPS ) );
+        }
+        WHEN( "querying charges_of via crafting_inventory" ) {
+            const int reported = dummy.crafting_inventory().charges_of( itype_welder );
+            THEN( "legacy returns raw charge count once, not per-tool sum" ) {
+                // Legacy must NOT divide by charges_per_use, must NOT add UPS per tool.
+                CHECK( reported == ups_charges );
+                CHECK( reported != ups_charges * 2 );
+            }
+        }
+    }
 }
 
 TEST_CASE( "tools_use_charge_to_craft", "[crafting][charge]" )

--- a/tests/multimag_test.cpp
+++ b/tests/multimag_test.cpp
@@ -48,6 +48,7 @@ static const item_group_id Item_spawn_data_test_multimag_full_load( "test_multim
 static const itype_id itype_38_special( "38_special" );
 static const itype_id itype_556( "556" );
 static const itype_id itype_9mm( "9mm" );
+static const itype_id itype_UPS_ON( "UPS_ON" );
 static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_battery( "battery" );
 static const itype_id itype_book_binder( "book_binder" );
@@ -56,19 +57,17 @@ static const itype_id itype_glock_19( "glock_19" );
 static const itype_id itype_glockmag( "glockmag" );
 static const itype_id itype_heavy_battery_cell( "heavy_battery_cell" );
 static const itype_id itype_medium_battery_cell( "medium_battery_cell" );
+static const itype_id itype_oxygen( "oxygen" );
 static const itype_id itype_paper( "paper" );
 static const itype_id itype_stanag30( "stanag30" );
 static const itype_id itype_sw_619( "sw_619" );
 static const itype_id itype_test_multimag_gun( "test_multimag_gun" );
 static const itype_id itype_test_multimag_gun_consume( "test_multimag_gun_consume" );
 static const itype_id itype_test_multimag_gun_same_type( "test_multimag_gun_same_type" );
-static const itype_id itype_test_multimag_turret_gun( "test_multimag_turret_gun" );
 static const itype_id itype_test_multimag_tool_consume( "test_multimag_tool_consume" );
 static const itype_id itype_test_multimag_tool_factor( "test_multimag_tool_factor" );
+static const itype_id itype_test_multimag_turret_gun( "test_multimag_turret_gun" );
 static const itype_id itype_test_multimag_vehicle_welder( "test_multimag_vehicle_welder" );
-static const itype_id itype_UPS( "UPS" );
-static const itype_id itype_UPS_ON( "UPS_ON" );
-static const itype_id itype_oxygen( "oxygen" );
 static const itype_id itype_welding_wire_steel( "welding_wire_steel" );
 
 static item make_loaded_glock()

--- a/tests/multimag_test.cpp
+++ b/tests/multimag_test.cpp
@@ -14,12 +14,14 @@
 #include "cata_catch.h"
 #include "cata_utility.h"
 #include "character.h"
+#include "character_attire.h"
 #include "coordinates.h"
 #include "debug.h"
 #include "item.h"
 #include "item_group.h"
 #include "item_location.h"
 #include "item_pocket.h"
+#include "inventory.h"
 #include "inventory_ui.h"
 #include "iteminfo_query.h"
 #include "itype.h"
@@ -33,6 +35,7 @@
 #include "point.h"
 #include "ret_val.h"
 #include "type_id.h"
+#include "units.h"
 #include "visitable.h"
 
 static const gun_mode_id gun_mode_AUTO( "AUTO" );
@@ -60,6 +63,11 @@ static const itype_id itype_test_multimag_gun_consume( "test_multimag_gun_consum
 static const itype_id itype_test_multimag_gun_same_type( "test_multimag_gun_same_type" );
 static const itype_id itype_test_multimag_tool_consume( "test_multimag_tool_consume" );
 static const itype_id itype_test_multimag_tool_factor( "test_multimag_tool_factor" );
+static const itype_id itype_test_multimag_vehicle_welder( "test_multimag_vehicle_welder" );
+static const itype_id itype_UPS( "UPS" );
+static const itype_id itype_UPS_ON( "UPS_ON" );
+static const itype_id itype_oxygen( "oxygen" );
+static const itype_id itype_welding_wire_steel( "welding_wire_steel" );
 
 static item make_loaded_glock()
 {
@@ -1143,6 +1151,26 @@ static item make_multimag_consume_tool( int well_a_charges = 12, int well_b_char
     return tool;
 }
 
+// Multimag USE_UPS welder fixture. power well = battery (heavy_battery_cell mag),
+// oxygen and rod are direct MAGAZINE pockets with ammo_restriction.
+// per_use: power=5, oxygen=2, rod=1.
+static item make_multimag_welder( int batt_charges, int oxygen_qty, int rod_qty )
+{
+    item tool( itype_test_multimag_vehicle_welder );
+    item batt_mag( itype_heavy_battery_cell );
+    batt_mag.put_in( item( itype_battery, calendar::turn, batt_charges ), pocket_type::MAGAZINE );
+    REQUIRE( tool.put_in( batt_mag, pocket_type::MAGAZINE_WELL ).success() );
+    if( oxygen_qty > 0 ) {
+        REQUIRE( tool.put_in( item( itype_oxygen, calendar::turn, oxygen_qty ),
+                              pocket_type::MAGAZINE ).success() );
+    }
+    if( rod_qty > 0 ) {
+        REQUIRE( tool.put_in( item( itype_welding_wire_steel, calendar::turn, rod_qty ),
+                              pocket_type::MAGAZINE ).success() );
+    }
+    return tool;
+}
+
 TEST_CASE( "multimag_predicates",
            "[multimag][consume]" )
 {
@@ -1251,6 +1279,19 @@ TEST_CASE( "consume_shots_and_consume_tool_uses_drain_per_pocket",
         CHECK( got == 1 );
         CHECK( tool.ammo_remaining_in_pocket( "well_a" ) == 10 );
         CHECK( tool.ammo_remaining_in_pocket( "well_b" ) == 0 );
+    }
+
+    SECTION( "direct MAGAZINE oxygen pocket drains alongside MAGAZINE_WELL battery" ) {
+        // Welder per_use: power=5, oxygen=2, rod=1. Single use drains all three.
+        item welder = make_multimag_welder( 100, 20, 5 );
+        REQUIRE( welder.ammo_remaining_in_pocket( "power" ) == 100 );
+        REQUIRE( welder.ammo_remaining_in_pocket( "oxygen" ) == 20 );
+        REQUIRE( welder.ammo_remaining_in_pocket( "rod" ) == 5 );
+        const int got = welder.consume_tool_uses( 1, here, pos, nullptr );
+        CHECK( got == 1 );
+        CHECK( welder.ammo_remaining_in_pocket( "power" ) == 95 );
+        CHECK( welder.ammo_remaining_in_pocket( "oxygen" ) == 18 );
+        CHECK( welder.ammo_remaining_in_pocket( "rod" ) == 4 );
     }
 }
 
@@ -1496,14 +1537,71 @@ TEST_CASE( "charges_of_for_multimag_tool_reports_local_uses",
 {
     clear_avatar();
     Character &chr = get_avatar();
-    // Tool with well_a=12, well_b=30: floor(12/2)=6, 30/1=30 -> 6 uses local.
-    item tool = make_multimag_consume_tool( 12, 30 );
-    item_location loc = chr.i_add( tool );
-    REQUIRE( loc );
 
-    // Inventory aggregation should report the multimag tool's local uses.
-    const int reported = chr.charges_of( itype_test_multimag_tool_consume );
-    CHECK( reported == 6 );
+    SECTION( "no external pool: local-only count" ) {
+        // Tool with well_a=12, well_b=30: floor(12/2)=6, 30/1=30 -> 6 uses local.
+        item tool = make_multimag_consume_tool( 12, 30 );
+        item_location loc = chr.i_add( tool );
+        REQUIRE( loc );
+
+        const int reported = chr.charges_of( itype_test_multimag_tool_consume );
+        CHECK( reported == 6 );
+    }
+
+    SECTION( "routes external UPS pool when item has USE_UPS + battery pocket" ) {
+        // UPS=100 covers 5 uses at per_use=5; oxygen/rod cap at 5.
+        chr.worn.wear_item( chr, item( itype_backpack ), false, false );
+        item_location welder = chr.i_add( make_multimag_welder( 0, 10, 5 ) );
+        REQUIRE( welder );
+
+        item ups( itype_UPS_ON );
+        item ups_mag( ups.magazine_default() );
+        ups_mag.ammo_set( ups_mag.ammo_default(), 100 );
+        REQUIRE( ups.put_in( ups_mag, pocket_type::MAGAZINE_WELL ).success() );
+        chr.i_add( ups );
+        REQUIRE( units::to_kilojoule( chr.available_ups() ) == 100 );
+
+        const int reported = chr.charges_of( itype_test_multimag_vehicle_welder );
+        CHECK( reported == 5 );
+    }
+
+    SECTION( "routes external UPS pool from ground via crafting_inventory" ) {
+        // Ground UPS is not in Character::available_ups(); only the visitable
+        // (crafting_inventory) sees it. apply_external_pools_multimag must
+        // query main, not the character, so a multimag tool reaches it.
+        clear_map();
+        chr.worn.wear_item( chr, item( itype_backpack ), false, false );
+        item_location welder = chr.i_add( make_multimag_welder( 0, 10, 5 ) );
+        REQUIRE( welder );
+        REQUIRE( units::to_kilojoule( chr.available_ups() ) == 0 );
+
+        item ups( itype_UPS_ON );
+        item ups_mag( ups.magazine_default() );
+        ups_mag.ammo_set( ups_mag.ammo_default(), 100 );
+        REQUIRE( ups.put_in( ups_mag, pocket_type::MAGAZINE_WELL ).success() );
+        get_map().add_item_or_charges( chr.pos_bub(), ups );
+
+        const int reported = chr.crafting_inventory().charges_of(
+                                 itype_test_multimag_vehicle_welder );
+        CHECK( reported == 5 );
+    }
+
+    SECTION( "inventory dedup: two multimag USE_UPS welders share one UPS" ) {
+        // Without dedup both tools claim UPS=10 (3+3=6); shared gives 3+1=4.
+        chr.worn.wear_item( chr, item( itype_backpack ), false, false );
+        REQUIRE( chr.i_add( make_multimag_welder( 5, 6, 3 ) ) );
+        REQUIRE( chr.i_add( make_multimag_welder( 5, 6, 3 ) ) );
+
+        item ups( itype_UPS_ON );
+        item ups_mag( ups.magazine_default() );
+        ups_mag.ammo_set( ups_mag.ammo_default(), 10 );
+        REQUIRE( ups.put_in( ups_mag, pocket_type::MAGAZINE_WELL ).success() );
+        chr.i_add( ups );
+        REQUIRE( units::to_kilojoule( chr.available_ups() ) == 10 );
+
+        const int reported = chr.charges_of( itype_test_multimag_vehicle_welder );
+        CHECK( reported == 4 );
+    }
 }
 
 TEST_CASE( "item_action_comparator_ranks_legacy_below_multimag_by_cost",

--- a/tests/multimag_test.cpp
+++ b/tests/multimag_test.cpp
@@ -17,6 +17,7 @@
 #include "character_attire.h"
 #include "coordinates.h"
 #include "debug.h"
+#include "flag.h"
 #include "item.h"
 #include "item_group.h"
 #include "item_location.h"
@@ -61,6 +62,7 @@ static const itype_id itype_sw_619( "sw_619" );
 static const itype_id itype_test_multimag_gun( "test_multimag_gun" );
 static const itype_id itype_test_multimag_gun_consume( "test_multimag_gun_consume" );
 static const itype_id itype_test_multimag_gun_same_type( "test_multimag_gun_same_type" );
+static const itype_id itype_test_multimag_turret_gun( "test_multimag_turret_gun" );
 static const itype_id itype_test_multimag_tool_consume( "test_multimag_tool_consume" );
 static const itype_id itype_test_multimag_tool_factor( "test_multimag_tool_factor" );
 static const itype_id itype_test_multimag_vehicle_welder( "test_multimag_vehicle_welder" );
@@ -1369,14 +1371,18 @@ TEST_CASE( "expected_cost_per_use_sums_effective_qty",
     CHECK( legacy.expected_cost_per_use() == 1 );
 }
 
-TEST_CASE( "vehicle_turret_filter_rejects_multimag_guns",
-           "[multimag][consume]" )
+TEST_CASE( "vehicle_turret_filter_multimag_per_gun_opt_out", "[multimag][consume]" )
 {
-    item gun( itype_test_multimag_gun_consume );
-    REQUIRE( gun.uses_firing_requirements() );
-    // The filter (mountable_gun_filter in veh_type.cpp) is static-private; we
-    // only check the predicate it gates on here. Vehicle install integration
-    // is verified indirectly when no multimag gun appears in turret JSON.
+    SECTION( "NO_TURRET multimag gun keeps the per-gun opt-out" ) {
+        item gun( itype_test_multimag_gun_consume );
+        REQUIRE( gun.uses_firing_requirements() );
+        REQUIRE( gun.has_flag( flag_NO_TURRET ) );
+    }
+    SECTION( "multimag gun without NO_TURRET passes the filter" ) {
+        item gun( itype_test_multimag_turret_gun );
+        REQUIRE( gun.uses_firing_requirements() );
+        REQUIRE_FALSE( gun.has_flag( flag_NO_TURRET ) );
+    }
 }
 
 TEST_CASE( "Character_consume_charges_hard_guards_multimag_tools",

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -45,10 +45,12 @@ static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_fridge_test( "fridge_test" );
 static const itype_id itype_metal_tank_test( "metal_tank_test" );
 static const itype_id itype_oatmeal( "oatmeal" );
+static const itype_id itype_battery( "battery" );
 static const itype_id itype_gasoline( "gasoline" );
 static const itype_id itype_test_multimag_direct_battery( "test_multimag_direct_battery" );
 static const itype_id itype_test_multimag_mixed_battery( "test_multimag_mixed_battery" );
 static const itype_id itype_test_multimag_two_battery( "test_multimag_two_battery" );
+static const itype_id itype_water_purifier( "water_purifier" );
 static const itype_id itype_test_multimag_two_fluid( "test_multimag_two_fluid" );
 static const itype_id itype_test_multimag_vehicle_combo( "test_multimag_vehicle_combo" );
 static const itype_id itype_water_clean( "water_clean" );
@@ -363,6 +365,62 @@ TEST_CASE( "vehicle_prepare_tool_multimag", "[vehicle][multimag]" )
         // Per-use cost: power=5, fluid=2.
         CHECK( static_cast<int>( veh->battery_left( here ) ) == batt_before - 5 );
         CHECK( static_cast<int>( veh->fuel_left( here, itype_gasoline ) ) == gas_before - 2 );
+    }
+}
+
+TEST_CASE( "vehicle_run_legacy_charge_tool_uses_water_purifier",
+           "[vehicle][purifier]" )
+{
+    clear_avatar();
+    clear_map_without_vision();
+    clear_vehicles();
+    map &here = get_map();
+
+    const tripoint_bub_ms test_origin( 60, 60, 0 );
+    REQUIRE_FALSE( here.veh_at( test_origin ).has_value() );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_none, test_origin, 0_degrees, 0, 0 );
+    REQUIRE( veh != nullptr );
+    REQUIRE( veh->install_part( here, point_rel_ms::zero, vpart_frame ) != -1 );
+    REQUIRE( veh->install_part( here, point_rel_ms::zero, vpart_small_storage_battery ) != -1 );
+    veh->refresh();
+    here.add_vehicle_to_cache( veh );
+
+    const int per_use = itype_water_purifier->charges_to_use();
+    REQUIRE( per_use > 0 );
+
+    SECTION( "drains battery exactly per_use * uses on success" ) {
+        veh->discharge_battery( here, 100000 );
+        const int budget = per_use * 3;
+        veh->charge_battery( here, budget );
+        REQUIRE( static_cast<int>( veh->battery_left( here ) ) == budget );
+
+        const int got = veh->run_legacy_charge_tool_uses( here, itype_water_purifier, 3 );
+        CHECK( got == 3 );
+        CHECK( static_cast<int>( veh->battery_left( here ) ) == 0 );
+    }
+
+    SECTION( "caps uses by available battery" ) {
+        veh->discharge_battery( here, 100000 );
+        veh->charge_battery( here, per_use * 2 );
+        const int got = veh->run_legacy_charge_tool_uses( here, itype_water_purifier, 5 );
+        CHECK( got == 2 );
+        CHECK( veh->battery_left( here ) == 0 );
+    }
+
+    SECTION( "zero battery returns zero uses, drains nothing" ) {
+        veh->discharge_battery( here, 100000 );
+        REQUIRE( veh->battery_left( here ) == 0 );
+        const int got = veh->run_legacy_charge_tool_uses( here, itype_water_purifier, 5 );
+        CHECK( got == 0 );
+    }
+
+    SECTION( "menu purify pre-check refuses partial budget without burning power" ) {
+        veh->discharge_battery( here, 100000 );
+        veh->charge_battery( here, per_use * 2 );
+        const int batt_before = static_cast<int>( veh->battery_left( here ) );
+        const int requested = 5;
+        REQUIRE_FALSE( batt_before >= requested * per_use );
+        CHECK( static_cast<int>( veh->battery_left( here ) ) == batt_before );
     }
 }
 

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -254,7 +254,7 @@ TEST_CASE( "vehicle_prepare_tool_multimag", "[vehicle][multimag]" )
         veh->part( tank2_idx ).ammo_set( itype_gasoline, 6 );
 
         item tool( itype_test_multimag_two_fluid );
-        const std::map<std::string, vehicle::multimag_pocket_state> bindings =
+        const std::map<std::string, multimag_pocket_state> bindings =
             vehicle::prepare_multimag_pockets( *veh, here, tool );
         REQUIRE( bindings.count( "left" ) );
         REQUIRE( bindings.count( "right" ) );
@@ -282,7 +282,7 @@ TEST_CASE( "vehicle_prepare_tool_multimag", "[vehicle][multimag]" )
         veh->charge_battery( here, 8 );
         REQUIRE( static_cast<int>( veh->battery_left( here ) ) == 8 );
 
-        const std::map<std::string, vehicle::multimag_pocket_state> bindings =
+        const std::map<std::string, multimag_pocket_state> bindings =
             vehicle::prepare_multimag_pockets( *veh, here, tool );
         const int left = bindings.count( "left" ) ? bindings.at( "left" ).initial_qty : 0;
         const int right = bindings.count( "right" ) ? bindings.at( "right" ).initial_qty : 0;
@@ -298,7 +298,7 @@ TEST_CASE( "vehicle_prepare_tool_multimag", "[vehicle][multimag]" )
         veh->charge_battery( here, 1000 );
         REQUIRE( static_cast<int>( veh->battery_left( here ) ) == 1000 );
 
-        const std::map<std::string, vehicle::multimag_pocket_state> bindings =
+        const std::map<std::string, multimag_pocket_state> bindings =
             vehicle::prepare_multimag_pockets( *veh, here, tool );
         REQUIRE( bindings.count( "core" ) );
         CHECK( bindings.at( "core" ).initial_qty == 40 );
@@ -321,7 +321,7 @@ TEST_CASE( "vehicle_prepare_tool_multimag", "[vehicle][multimag]" )
         veh->charge_battery( here, 350 );
         REQUIRE( static_cast<int>( veh->battery_left( here ) ) == 350 );
 
-        const std::map<std::string, vehicle::multimag_pocket_state> bindings =
+        const std::map<std::string, multimag_pocket_state> bindings =
             vehicle::prepare_multimag_pockets( *veh, here, tool );
         REQUIRE( bindings.count( "well" ) );
         REQUIRE( bindings.count( "direct" ) );
@@ -348,7 +348,7 @@ TEST_CASE( "vehicle_prepare_tool_multimag", "[vehicle][multimag]" )
 
     SECTION( "drain_back_multimag drains battery + tank per pocket" ) {
         item welder( itype_test_multimag_vehicle_combo );
-        const std::map<std::string, vehicle::multimag_pocket_state> bindings =
+        const std::map<std::string, multimag_pocket_state> bindings =
             vehicle::prepare_multimag_pockets( *veh, here, welder );
         REQUIRE( bindings.at( "power" ).initial_qty > 0 );
         REQUIRE( bindings.at( "fluid" ).initial_qty > 0 );

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -45,6 +45,12 @@ static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_fridge_test( "fridge_test" );
 static const itype_id itype_metal_tank_test( "metal_tank_test" );
 static const itype_id itype_oatmeal( "oatmeal" );
+static const itype_id itype_gasoline( "gasoline" );
+static const itype_id itype_test_multimag_direct_battery( "test_multimag_direct_battery" );
+static const itype_id itype_test_multimag_mixed_battery( "test_multimag_mixed_battery" );
+static const itype_id itype_test_multimag_two_battery( "test_multimag_two_battery" );
+static const itype_id itype_test_multimag_two_fluid( "test_multimag_two_fluid" );
+static const itype_id itype_test_multimag_vehicle_combo( "test_multimag_vehicle_combo" );
 static const itype_id itype_water_clean( "water_clean" );
 static const itype_id itype_water_faucet( "water_faucet" );
 
@@ -53,9 +59,12 @@ static const recipe_id recipe_oatmeal_cooked( "oatmeal_cooked" );
 static const trait_id trait_DEBUG_CNF( "DEBUG_CNF" );
 
 static const vpart_id vpart_ap_fridge_test( "ap_fridge_test" );
+static const vpart_id vpart_frame( "frame" );
 static const vpart_id vpart_halfboard( "halfboard" );
+static const vpart_id vpart_small_storage_battery( "small_storage_battery" );
 static const vpart_id vpart_tank_test( "tank_test" );
 
+static const vproto_id vehicle_prototype_none( "none" );
 static const vproto_id vehicle_prototype_test_rv( "test_rv" );
 
 static time_point midnight = calendar::turn_zero;
@@ -200,6 +209,161 @@ static void test_craft_via_rig( const std::vector<item> &items, int give_battery
     CHECK( veh.fuel_left( here, itype_water_clean ) == expect_water );
 
     veh.unboard_all( here );
+}
+
+TEST_CASE( "vehicle_prepare_tool_multimag", "[vehicle][multimag]" )
+{
+    clear_avatar();
+    clear_map_without_vision();
+    clear_vehicles();
+    map &here = get_map();
+
+    const tripoint_bub_ms test_origin( 60, 60, 0 );
+    REQUIRE_FALSE( here.veh_at( test_origin ).has_value() );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_none, test_origin, 0_degrees, 0, 0 );
+    REQUIRE( veh != nullptr );
+    REQUIRE( veh->install_part( here, point_rel_ms::zero, vpart_frame ) != -1 );
+    REQUIRE( veh->install_part( here, point_rel_ms::zero, vpart_small_storage_battery ) != -1 );
+    REQUIRE( veh->install_part( here, point_rel_ms( 1, 0 ), vpart_frame ) != -1 );
+    const int tank_idx = veh->install_part( here, point_rel_ms( 1, 0 ), vpart_tank_test );
+    REQUIRE( tank_idx != -1 );
+    veh->refresh();
+    here.add_vehicle_to_cache( veh );
+
+    veh->charge_battery( here, 1000 );
+    veh->part( tank_idx ).ammo_set( itype_gasoline, 50 );
+
+    SECTION( "prepare_tool populates battery + tank pockets" ) {
+        item welder( itype_test_multimag_vehicle_combo );
+        veh->prepare_tool( here, welder );
+        CHECK( welder.ammo_remaining_in_pocket( "power" ) > 0 );
+        CHECK( welder.ammo_remaining_in_pocket( "fluid" ) > 0 );
+    }
+
+    SECTION( "two same-fuel tanks bind each pocket to its own vpart" ) {
+        // Install a second gasoline tank, partially fill both, give the tool
+        // two same-fuel tank pockets. Each pocket must bind to one specific
+        // tank: prep claims per-vpart, drain-back bills per-vpart.
+        REQUIRE( veh->install_part( here, point_rel_ms( 1, 1 ), vpart_frame ) != -1 );
+        const int tank2_idx = veh->install_part( here, point_rel_ms( 1, 1 ), vpart_tank_test );
+        REQUIRE( tank2_idx != -1 );
+        veh->refresh();
+        veh->part( tank_idx ).ammo_set( itype_gasoline, 6 );
+        veh->part( tank2_idx ).ammo_set( itype_gasoline, 6 );
+
+        item tool( itype_test_multimag_two_fluid );
+        const std::map<std::string, vehicle::multimag_pocket_state> bindings =
+            vehicle::prepare_multimag_pockets( *veh, here, tool );
+        REQUIRE( bindings.count( "left" ) );
+        REQUIRE( bindings.count( "right" ) );
+        // Each pocket must be backed by a distinct vpart_index.
+        CHECK( bindings.at( "left" ).vpart_index != bindings.at( "right" ).vpart_index );
+        // Each pocket gets the per-tank total, not double the global pool.
+        CHECK( bindings.at( "left" ).initial_qty == 6 );
+        CHECK( bindings.at( "right" ).initial_qty == 6 );
+
+        const int tank_a_before = veh->part( tank_idx ).ammo_remaining();
+        const int tank_b_before = veh->part( tank2_idx ).ammo_remaining();
+        REQUIRE( tool.consume_tool_uses( 1, here, test_origin, nullptr ) == 1 );
+        vehicle::drain_back_multimag( *veh, here, tool, bindings );
+        // Drain bills each pocket's bound tank exactly per_use=2.
+        CHECK( veh->part( tank_idx ).ammo_remaining() == tank_a_before - 2 );
+        CHECK( veh->part( tank2_idx ).ammo_remaining() == tank_b_before - 2 );
+    }
+
+    SECTION( "two battery pockets share one network without double-claim" ) {
+        // Two battery wells share one vehicle battery network. Per-use cost
+        // sums to 10, vehicle has 8: load must split, not double-claim, so
+        // feasibility is 0 and pocket totals stay within the network budget.
+        item tool( itype_test_multimag_two_battery );
+        veh->discharge_battery( here, 100000 );
+        veh->charge_battery( here, 8 );
+        REQUIRE( static_cast<int>( veh->battery_left( here ) ) == 8 );
+
+        const std::map<std::string, vehicle::multimag_pocket_state> bindings =
+            vehicle::prepare_multimag_pockets( *veh, here, tool );
+        const int left = bindings.count( "left" ) ? bindings.at( "left" ).initial_qty : 0;
+        const int right = bindings.count( "right" ) ? bindings.at( "right" ).initial_qty : 0;
+        CHECK( left + right <= 8 );
+        CHECK( tool.feasible_tool_uses( /*external_pool=*/0 ) == 0 );
+    }
+
+    SECTION( "direct MAGAZINE battery pocket caps at pocket capacity, not vehicle pool" ) {
+        // Vehicle pool (1000) >> pocket capacity (40). Prep must cap at the
+        // pocket's own ammo_restriction limit; an uncapped insert would fail.
+        item tool( itype_test_multimag_direct_battery );
+        veh->discharge_battery( here, 100000 );
+        veh->charge_battery( here, 1000 );
+        REQUIRE( static_cast<int>( veh->battery_left( here ) ) == 1000 );
+
+        const std::map<std::string, vehicle::multimag_pocket_state> bindings =
+            vehicle::prepare_multimag_pockets( *veh, here, tool );
+        REQUIRE( bindings.count( "core" ) );
+        CHECK( bindings.at( "core" ).initial_qty == 40 );
+        CHECK( tool.ammo_remaining_in_pocket( "core" ) == 40 );
+
+        const int batt_after_prep = static_cast<int>( veh->battery_left( here ) );
+        CHECK( batt_after_prep == 1000 );
+
+        REQUIRE( tool.consume_tool_uses( 1, here, test_origin, nullptr ) == 1 );
+        vehicle::drain_back_multimag( *veh, here, tool, bindings );
+        CHECK( static_cast<int>( veh->battery_left( here ) ) == 1000 - 5 );
+    }
+
+    SECTION( "mixed MAGAZINE_WELL + direct MAGAZINE battery pockets account claims correctly" ) {
+        // Vehicle has 350 battery. Well caps at heavy_battery_cell capacity
+        // (259); direct caps at its own 40 ammo_restriction. Sum (299) fits;
+        // direct must NOT be underfilled by a double-subtract bug.
+        item tool( itype_test_multimag_mixed_battery );
+        veh->discharge_battery( here, 100000 );
+        veh->charge_battery( here, 350 );
+        REQUIRE( static_cast<int>( veh->battery_left( here ) ) == 350 );
+
+        const std::map<std::string, vehicle::multimag_pocket_state> bindings =
+            vehicle::prepare_multimag_pockets( *veh, here, tool );
+        REQUIRE( bindings.count( "well" ) );
+        REQUIRE( bindings.count( "direct" ) );
+        const int well_qty = bindings.at( "well" ).initial_qty;
+        const int direct_qty = bindings.at( "direct" ).initial_qty;
+        CHECK( well_qty == 259 );
+        CHECK( direct_qty == 40 );
+    }
+
+    SECTION( "use_vehicle_tool precheck rejects multimag with no feasible use" ) {
+        // Empty every source: feasible_tool_uses must report 0 and
+        // use_vehicle_tool must refuse without invoking the tool.
+        veh->discharge_battery( here, 100000 );
+        for( const vpart_reference &tvp :
+             veh->get_avail_parts( vpart_bitflags::VPFLAG_FLUIDTANK ) ) {
+            tvp.part().ammo_unset();
+        }
+        REQUIRE( veh->battery_left( here ) == 0 );
+
+        const bool ok = vehicle::use_vehicle_tool( *veh, &here, test_origin,
+                        itype_test_multimag_vehicle_combo, /*no_invoke=*/true );
+        CHECK_FALSE( ok );
+    }
+
+    SECTION( "drain_back_multimag drains battery + tank per pocket" ) {
+        item welder( itype_test_multimag_vehicle_combo );
+        const std::map<std::string, vehicle::multimag_pocket_state> bindings =
+            vehicle::prepare_multimag_pockets( *veh, here, welder );
+        REQUIRE( bindings.at( "power" ).initial_qty > 0 );
+        REQUIRE( bindings.at( "fluid" ).initial_qty > 0 );
+
+        const int batt_before = static_cast<int>( veh->battery_left( here ) );
+        const int gas_before = static_cast<int>( veh->fuel_left( here, itype_gasoline ) );
+        REQUIRE( batt_before > 0 );
+        REQUIRE( gas_before > 0 );
+
+        // No carrier and no cable, so consume_tool_uses pulls from local pockets only.
+        REQUIRE( welder.consume_tool_uses( 1, here, test_origin, nullptr ) == 1 );
+        vehicle::drain_back_multimag( *veh, here, welder, bindings );
+
+        // Per-use cost: power=5, fluid=2.
+        CHECK( static_cast<int>( veh->battery_left( here ) ) == batt_before - 5 );
+        CHECK( static_cast<int>( veh->fuel_left( here, itype_gasoline ) ) == gas_before - 2 );
+    }
 }
 
 TEST_CASE( "faucet_offers_cold_water", "[vehicle][vehicle_parts]" )

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -43,18 +43,18 @@ static const damage_type_id damage_bash( "bash" );
 
 static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_fridge_test( "fridge_test" );
+static const itype_id itype_gasoline( "gasoline" );
 static const itype_id itype_metal_tank_test( "metal_tank_test" );
 static const itype_id itype_oatmeal( "oatmeal" );
-static const itype_id itype_battery( "battery" );
-static const itype_id itype_gasoline( "gasoline" );
 static const itype_id itype_test_multimag_direct_battery( "test_multimag_direct_battery" );
 static const itype_id itype_test_multimag_mixed_battery( "test_multimag_mixed_battery" );
 static const itype_id itype_test_multimag_two_battery( "test_multimag_two_battery" );
-static const itype_id itype_water_purifier( "water_purifier" );
 static const itype_id itype_test_multimag_two_fluid( "test_multimag_two_fluid" );
 static const itype_id itype_test_multimag_vehicle_combo( "test_multimag_vehicle_combo" );
+static const itype_id itype_test_multimag_well_fluid( "test_multimag_well_fluid" );
 static const itype_id itype_water_clean( "water_clean" );
 static const itype_id itype_water_faucet( "water_faucet" );
+static const itype_id itype_water_purifier( "water_purifier" );
 
 static const recipe_id recipe_oatmeal_cooked( "oatmeal_cooked" );
 
@@ -240,6 +240,26 @@ TEST_CASE( "vehicle_prepare_tool_multimag", "[vehicle][multimag]" )
         veh->prepare_tool( here, welder );
         CHECK( welder.ammo_remaining_in_pocket( "power" ) > 0 );
         CHECK( welder.ammo_remaining_in_pocket( "fluid" ) > 0 );
+    }
+
+    SECTION( "MAGAZINE_WELL non-battery pocket synthesizes magazine from vehicle tank fluid" ) {
+        // Vehicle tank holds gasoline; tool's fuel pocket is MAGAZINE_WELL
+        // accepting a fluid magazine. Prep must synthesize the magazine and
+        // fill it from the tank, recording a TANK binding so drain_back
+        // bills the same vpart.
+        item tool( itype_test_multimag_well_fluid );
+        const std::map<std::string, multimag_pocket_state> bindings =
+            vehicle::prepare_multimag_pockets( *veh, here, tool );
+        REQUIRE( bindings.count( "fuel" ) );
+        CHECK( bindings.at( "fuel" ).kind == multimag_pocket_state::source_kind::TANK );
+        CHECK( bindings.at( "fuel" ).vpart_index == tank_idx );
+        CHECK( bindings.at( "fuel" ).initial_qty > 0 );
+
+        const int tank_before = veh->part( tank_idx ).ammo_remaining();
+        REQUIRE( tool.consume_tool_uses( 1, here, test_origin, nullptr ) == 1 );
+        vehicle::drain_back_multimag( *veh, here, tool, bindings );
+        // per_use=3 -> tank drained by exactly 3.
+        CHECK( veh->part( tank_idx ).ammo_remaining() == tank_before - 3 );
     }
 
     SECTION( "two same-fuel tanks bind each pocket to its own vpart" ) {

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -7,6 +7,7 @@
 #include "calendar.h"
 #include "cata_catch.h"
 #include "character.h"
+#include "character_attire.h"
 #include "coordinates.h"
 #include "explosion.h"
 #include "item.h"
@@ -27,19 +28,24 @@
 
 static const ammo_effect_str_id ammo_effect_RECYCLED( "RECYCLED" );
 
-static const vproto_id vehicle_prototype_test_turret_rig( "test_turret_rig" );
+static const gun_mode_id gun_mode_BURST( "BURST" );
 
 static const itype_id itype_9mm( "9mm" );
+static const itype_id itype_UPS_ON( "UPS_ON" );
+static const itype_id itype_backpack( "backpack" );
+static const itype_id itype_gasoline( "gasoline" );
 static const itype_id itype_glockmag( "glockmag" );
-static const itype_id itype_test_multimag_gun_consume( "test_multimag_gun_consume" );
-static const itype_id itype_test_multimag_turret_gun( "test_multimag_turret_gun" );
 
+static const vpart_id vpart_frame( "frame" );
+static const vpart_id vpart_tank( "tank" );
 static const vpart_id vpart_turret_test_multimag_gun_consume( "turret_test_multimag_gun_consume" );
 static const vpart_id vpart_turret_test_multimag_turret_flamethrower(
     "turret_test_multimag_turret_flamethrower" );
 static const vpart_id vpart_turret_test_multimag_turret_gun( "turret_test_multimag_turret_gun" );
+static const vpart_id vpart_turret_test_multimag_turret_gun_ups(
+    "turret_test_multimag_turret_gun_ups" );
 
-static const gun_mode_id gun_mode_BURST( "BURST" );
+static const vproto_id vehicle_prototype_test_turret_rig( "test_turret_rig" );
 
 static std::vector<const vpart_info *> all_turret_types()
 {
@@ -72,6 +78,12 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
     const tripoint_bub_ms veh_pos( 65, 65, 0 );
 
     for( const vpart_info *turret_vpi : all_turret_types() ) {
+        // Multimag guns are turret-installable but covered by
+        // vehicle_turret_multimag; the legacy ammo_set path here cannot
+        // populate per-pocket firing_requirements wells.
+        if( !turret_vpi->base_item->firing_requirements.empty() ) {
+            continue;
+        }
         SECTION( turret_vpi->name() ) {
             vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos, 270_degrees, 0, 2,
                                              false, true );
@@ -251,6 +263,117 @@ TEST_CASE( "vehicle_turret_multimag", "[vehicle][turret][multimag]" )
 
         // Vehicle-bound power well cleared back to empty so next prep starts fresh.
         CHECK( vp.get_base().ammo_remaining_in_pocket( "power" ) == 0 );
+
+        here.destroy_vehicle( veh );
+        explosion_handler::process_explosions();
+        clear_avatar();
+    }
+
+    SECTION( "USE_UPS multimag turret leaves player UPS untouched" ) {
+        vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos,
+                                         270_degrees, 0, 2, false, true );
+        REQUIRE( veh );
+        const int turr_idx = veh->install_part( here, point_rel_ms::zero,
+                                                vpart_turret_test_multimag_turret_gun_ups );
+        REQUIRE( turr_idx >= 0 );
+        vehicle_part &vp = veh->part( turr_idx );
+
+        const auto& [bat_current, bat_capacity] = veh->battery_power_level();
+        veh->charge_battery( here, bat_capacity, /* apply_loss = */ false );
+
+        item mag( itype_glockmag );
+        mag.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+        item base_copy( vp.get_base() );
+        REQUIRE( base_copy.put_in( mag, pocket_type::MAGAZINE_WELL ).success() );
+        vp.set_base( std::move( base_copy ) );
+
+        // Give the player a charged UPS so available_ups returns nonzero.
+        player_character.worn.wear_item( player_character, item( itype_backpack ),
+                                         false, false );
+        item ups( itype_UPS_ON );
+        item ups_mag( ups.magazine_default() );
+        ups_mag.ammo_set( ups_mag.ammo_default(), 100 );
+        REQUIRE( ups.put_in( ups_mag, pocket_type::MAGAZINE_WELL ).success() );
+        player_character.i_add( ups );
+        REQUIRE( units::to_kilojoule( player_character.available_ups() ) == 100 );
+
+        const int batt_before = veh->battery_left( here, /* apply_loss = */ false );
+        const int ups_before = units::to_kilojoule( player_character.available_ups() );
+
+        turret_data qry = veh->turret_query( vp );
+        REQUIRE( qry.query() == turret_data::status::ready );
+        player_character.setpos( here, veh->bub_part_pos( here, vp ) );
+        int shots_fired = 0;
+        for( int attempt = 0; shots_fired == 0 && attempt < 3; attempt++ ) {
+            shots_fired += qry.fire( player_character, &here,
+                                     player_character.pos_bub() + point( qry.range(), 0 ) );
+            clear_faults_from_vp( vp );
+        }
+        REQUIRE( shots_fired > 0 );
+
+        // Vehicle pays the full per_use; player UPS is left alone.
+        const int batt_after = veh->battery_left( here, /* apply_loss = */ false );
+        const int ups_after = units::to_kilojoule( player_character.available_ups() );
+        CHECK( batt_before - batt_after == 5 * shots_fired );
+        CHECK( ups_after == ups_before );
+
+        here.destroy_vehicle( veh );
+        explosion_handler::process_explosions();
+        clear_avatar();
+    }
+
+    SECTION( "tank picker skips insufficient tank in favour of sufficient sibling" ) {
+        vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos,
+                                         270_degrees, 0, 2, false, true );
+        REQUIRE( veh );
+        // test_turret_rig already has a tank at (1,0); install a second frame
+        // + tank at (1,1) so the picker has to choose between two siblings.
+        REQUIRE( veh->install_part( here, point_rel_ms( 1, 1 ), vpart_frame ) != -1 );
+        const int tank2_idx = veh->install_part( here, point_rel_ms( 1, 1 ), vpart_tank );
+        REQUIRE( tank2_idx >= 0 );
+        veh->refresh();
+
+        const int turr_idx = veh->install_part( here, point_rel_ms::zero,
+                                                vpart_turret_test_multimag_turret_flamethrower );
+        REQUIRE( turr_idx >= 0 );
+        vehicle_part &vp = veh->part( turr_idx );
+
+        const auto& [bat_current, bat_capacity] = veh->battery_power_level();
+        veh->charge_battery( here, bat_capacity, /* apply_loss = */ false );
+
+        // Find both tanks; one gets the meager fill, the other the sufficient.
+        int tank_meager = -1;
+        int tank_full = -1;
+        for( const vpart_reference &tvp :
+             veh->get_avail_parts( vpart_bitflags::VPFLAG_FLUIDTANK ) ) {
+            const int idx = static_cast<int>( tvp.part_index() );
+            if( tank_meager == -1 ) {
+                tank_meager = idx;
+            } else if( tank_full == -1 ) {
+                tank_full = idx;
+            }
+        }
+        REQUIRE( tank_meager >= 0 );
+        REQUIRE( tank_full >= 0 );
+        REQUIRE( tank_meager != tank_full );
+        veh->part( tank_meager ).ammo_set( itype_gasoline, 1 );
+        veh->part( tank_full ).ammo_set( itype_gasoline, 50 );
+
+        turret_data qry = veh->turret_query( vp );
+        REQUIRE( qry.query() == turret_data::status::ready );
+
+        player_character.setpos( here, veh->bub_part_pos( here, vp ) );
+        int shots_fired = 0;
+        for( int attempt = 0; shots_fired == 0 && attempt < 3; attempt++ ) {
+            shots_fired += qry.fire( player_character, &here,
+                                     player_character.pos_bub() + point( qry.range(), 0 ) );
+            clear_faults_from_vp( vp );
+        }
+        REQUIRE( shots_fired > 0 );
+
+        // Picker must skip the meager tank; only the sufficient one drains.
+        CHECK( veh->part( tank_meager ).ammo_remaining() == 1 );
+        CHECK( veh->part( tank_full ).ammo_remaining() == 50 - 5 * shots_fired );
 
         here.destroy_vehicle( veh );
         explosion_handler::process_explosions();

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include "calendar.h"
 #include "cata_catch.h"
 #include "character.h"
 #include "coordinates.h"
@@ -13,6 +14,7 @@
 #include "map.h"
 #include "map_helpers.h"
 #include "player_helpers.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "ret_val.h"
 #include "type_id.h"
@@ -26,6 +28,14 @@
 static const ammo_effect_str_id ammo_effect_RECYCLED( "RECYCLED" );
 
 static const vproto_id vehicle_prototype_test_turret_rig( "test_turret_rig" );
+
+static const itype_id itype_9mm( "9mm" );
+static const itype_id itype_glockmag( "glockmag" );
+static const itype_id itype_test_multimag_gun_consume( "test_multimag_gun_consume" );
+static const itype_id itype_test_multimag_turret_gun( "test_multimag_turret_gun" );
+
+static const vpart_id vpart_turret_test_multimag_turret_gun( "turret_test_multimag_turret_gun" );
+static const vpart_id vpart_turret_test_multimag_gun_consume( "turret_test_multimag_gun_consume" );
 
 static std::vector<const vpart_info *> all_turret_types()
 {
@@ -127,5 +137,72 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
             // heal the avatar from explosion damages
             clear_avatar();
         }
+    }
+}
+
+TEST_CASE( "vehicle_turret_multimag", "[vehicle][turret][multimag]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    Character &player_character = get_player_character();
+    const tripoint_bub_ms veh_pos( 65, 65, 0 );
+
+    SECTION( "multimag gun without NO_TURRET has an auto-generated turret vpart" ) {
+        // After dropping the firing_requirements early-return in mountable_gun_filter,
+        // vehicles::parts::finalize() generates `turret_<gun_id>` vparts for any
+        // mountable gun. This is the precondition for everything else below.
+        REQUIRE( vpart_turret_test_multimag_turret_gun.is_valid() );
+        // Per-gun NO_TURRET opt-out still suppresses generation.
+        REQUIRE_FALSE( vpart_turret_test_multimag_gun_consume.is_valid() );
+    }
+
+    SECTION( "install + query + fire happy path" ) {
+        vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos,
+                                         270_degrees, 0, 2, false, true );
+        REQUIRE( veh );
+
+        const int turr_idx = veh->install_part( here, point_rel_ms::zero,
+                                                vpart_turret_test_multimag_turret_gun );
+        REQUIRE( turr_idx >= 0 );
+        vehicle_part &vp = veh->part( turr_idx );
+        CHECK( vp.is_turret() );
+
+        REQUIRE( veh->turret_query( vp ).query() == turret_data::status::no_ammo );
+
+        // Charge battery (vehicle source for power well) but leave 9mm well empty.
+        const auto& [bat_current, bat_capacity] = veh->battery_power_level();
+        CHECK( bat_capacity > 0 );
+        veh->charge_battery( here, bat_capacity, /* apply_loss = */ false );
+        REQUIRE( veh->turret_query( vp ).query() == turret_data::status::no_ammo );
+
+        item mag( itype_glockmag );
+        mag.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+        item base_copy( vp.get_base() );
+        REQUIRE( base_copy.put_in( mag, pocket_type::MAGAZINE_WELL ).success() );
+        vp.set_base( std::move( base_copy ) );
+
+        turret_data qry = veh->turret_query( vp );
+        REQUIRE( qry.query() == turret_data::status::ready );
+        REQUIRE( qry.range() > 0 );
+
+        const int batt_before = veh->battery_left( here, /* apply_loss = */ false );
+
+        player_character.setpos( here, veh->bub_part_pos( here, vp ) );
+        int shots_fired = 0;
+        for( int attempt = 0; shots_fired == 0 && attempt < 3; attempt++ ) {
+            shots_fired += qry.fire( player_character, &here,
+                                     player_character.pos_bub() + point( qry.range(), 0 ) );
+            clear_faults_from_vp( vp );
+        }
+        CHECK( shots_fired > 0 );
+
+        // Vehicle battery drained per power-pocket per_use (5 kJ DEFAULT).
+        const int batt_after = veh->battery_left( here, /* apply_loss = */ false );
+        CHECK( batt_before - batt_after == 5 * shots_fired );
+
+        here.destroy_vehicle( veh );
+        explosion_handler::process_explosions();
+        clear_avatar();
     }
 }

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -34,8 +34,12 @@ static const itype_id itype_glockmag( "glockmag" );
 static const itype_id itype_test_multimag_gun_consume( "test_multimag_gun_consume" );
 static const itype_id itype_test_multimag_turret_gun( "test_multimag_turret_gun" );
 
-static const vpart_id vpart_turret_test_multimag_turret_gun( "turret_test_multimag_turret_gun" );
 static const vpart_id vpart_turret_test_multimag_gun_consume( "turret_test_multimag_gun_consume" );
+static const vpart_id vpart_turret_test_multimag_turret_flamethrower(
+    "turret_test_multimag_turret_flamethrower" );
+static const vpart_id vpart_turret_test_multimag_turret_gun( "turret_test_multimag_turret_gun" );
+
+static const gun_mode_id gun_mode_BURST( "BURST" );
 
 static std::vector<const vpart_info *> all_turret_types()
 {
@@ -149,12 +153,17 @@ TEST_CASE( "vehicle_turret_multimag", "[vehicle][turret][multimag]" )
     const tripoint_bub_ms veh_pos( 65, 65, 0 );
 
     SECTION( "multimag gun without NO_TURRET has an auto-generated turret vpart" ) {
-        // After dropping the firing_requirements early-return in mountable_gun_filter,
-        // vehicles::parts::finalize() generates `turret_<gun_id>` vparts for any
-        // mountable gun. This is the precondition for everything else below.
+        // NO_TURRET on the gun suppresses turret vpart generation.
         REQUIRE( vpart_turret_test_multimag_turret_gun.is_valid() );
-        // Per-gun NO_TURRET opt-out still suppresses generation.
         REQUIRE_FALSE( vpart_turret_test_multimag_gun_consume.is_valid() );
+    }
+
+    SECTION( "flamethrower-shape gun gets USE_TANKS flag from gun_uses_liquid_ammo" ) {
+        // Direct MAGAZINE liquid pocket on the gun must trigger USE_TANKS in
+        // the auto-generated turret vpart so install heuristics treat it as
+        // a fluid-fed turret.
+        REQUIRE( vpart_turret_test_multimag_turret_flamethrower.is_valid() );
+        REQUIRE( vpart_turret_test_multimag_turret_flamethrower.obj().has_flag( "USE_TANKS" ) );
     }
 
     SECTION( "install + query + fire happy path" ) {
@@ -200,6 +209,142 @@ TEST_CASE( "vehicle_turret_multimag", "[vehicle][turret][multimag]" )
         // Vehicle battery drained per power-pocket per_use (5 kJ DEFAULT).
         const int batt_after = veh->battery_left( here, /* apply_loss = */ false );
         CHECK( batt_before - batt_after == 5 * shots_fired );
+
+        here.destroy_vehicle( veh );
+        explosion_handler::process_explosions();
+        clear_avatar();
+    }
+
+    SECTION( "post_fire clears bound power well, leaves player ammo well intact" ) {
+        vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos,
+                                         270_degrees, 0, 2, false, true );
+        REQUIRE( veh );
+        const int turr_idx = veh->install_part( here, point_rel_ms::zero,
+                                                vpart_turret_test_multimag_turret_gun );
+        REQUIRE( turr_idx >= 0 );
+        vehicle_part &vp = veh->part( turr_idx );
+
+        const auto& [bat_current, bat_capacity] = veh->battery_power_level();
+        veh->charge_battery( here, bat_capacity, /* apply_loss = */ false );
+
+        item mag( itype_glockmag );
+        const int mag_initial = 15;
+        mag.put_in( item( itype_9mm, calendar::turn, mag_initial ), pocket_type::MAGAZINE );
+        item base_copy( vp.get_base() );
+        REQUIRE( base_copy.put_in( mag, pocket_type::MAGAZINE_WELL ).success() );
+        vp.set_base( std::move( base_copy ) );
+
+        turret_data qry = veh->turret_query( vp );
+        REQUIRE( qry.query() == turret_data::status::ready );
+        player_character.setpos( here, veh->bub_part_pos( here, vp ) );
+        int shots_fired = 0;
+        for( int attempt = 0; shots_fired == 0 && attempt < 3; attempt++ ) {
+            shots_fired += qry.fire( player_character, &here,
+                                     player_character.pos_bub() + point( qry.range(), 0 ) );
+            clear_faults_from_vp( vp );
+        }
+        REQUIRE( shots_fired > 0 );
+
+        // Player-loaded mag survives post_fire with rounds drawn down by per_use.
+        const int ammo_after = vp.get_base().ammo_remaining_in_pocket( "ammo" );
+        CHECK( ammo_after == mag_initial - shots_fired );
+
+        // Vehicle-bound power well cleared back to empty so next prep starts fresh.
+        CHECK( vp.get_base().ammo_remaining_in_pocket( "power" ) == 0 );
+
+        here.destroy_vehicle( veh );
+        explosion_handler::process_explosions();
+        clear_avatar();
+    }
+
+    SECTION( "BURST mode drains per_use_battery * mode.qty per shot" ) {
+        vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos,
+                                         270_degrees, 0, 2, false, true );
+        REQUIRE( veh );
+        const int turr_idx = veh->install_part( here, point_rel_ms::zero,
+                                                vpart_turret_test_multimag_turret_gun );
+        REQUIRE( turr_idx >= 0 );
+        vehicle_part &vp = veh->part( turr_idx );
+        const auto& [bat_current, bat_capacity] = veh->battery_power_level();
+        veh->charge_battery( here, bat_capacity, /* apply_loss = */ false );
+
+        item mag( itype_glockmag );
+        mag.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+        item base_copy( vp.get_base() );
+        REQUIRE( base_copy.put_in( mag, pocket_type::MAGAZINE_WELL ).success() );
+        vp.set_base( std::move( base_copy ) );
+
+        {
+            item gun_with_mode( vp.get_base() );
+            while( gun_with_mode.gun_get_mode_id() != gun_mode_BURST ) {
+                gun_with_mode.gun_cycle_mode();
+            }
+            vp.set_base( std::move( gun_with_mode ) );
+        }
+        REQUIRE( vp.get_base().gun_get_mode_id() == gun_mode_BURST );
+
+        turret_data qry = veh->turret_query( vp );
+        REQUIRE( qry.query() == turret_data::status::ready );
+        const int batt_before = veh->battery_left( here, /* apply_loss = */ false );
+
+        player_character.setpos( here, veh->bub_part_pos( here, vp ) );
+        int shots_fired = 0;
+        for( int attempt = 0; shots_fired == 0 && attempt < 3; attempt++ ) {
+            shots_fired += qry.fire( player_character, &here,
+                                     player_character.pos_bub() + point( qry.range(), 0 ) );
+            clear_faults_from_vp( vp );
+        }
+        REQUIRE( shots_fired > 0 );
+
+        const int batt_after = veh->battery_left( here, /* apply_loss = */ false );
+        CHECK( batt_before - batt_after == 15 * shots_fired );
+
+        here.destroy_vehicle( veh );
+        explosion_handler::process_explosions();
+        clear_avatar();
+    }
+
+    SECTION( "BURST stops mid-sequence when vehicle battery cannot cover next burst" ) {
+        vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos,
+                                         270_degrees, 0, 2, false, true );
+        REQUIRE( veh );
+        const int turr_idx = veh->install_part( here, point_rel_ms::zero,
+                                                vpart_turret_test_multimag_turret_gun );
+        REQUIRE( turr_idx >= 0 );
+        vehicle_part &vp = veh->part( turr_idx );
+
+        // Charge vehicle to exactly one BURST worth (15 kJ); next burst must fail.
+        veh->discharge_battery( here, 100000 );
+        veh->charge_battery( here, 15, /* apply_loss = */ false );
+        REQUIRE( static_cast<int>( veh->battery_left( here, false ) ) == 15 );
+
+        item mag( itype_glockmag );
+        mag.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+        item base_copy( vp.get_base() );
+        REQUIRE( base_copy.put_in( mag, pocket_type::MAGAZINE_WELL ).success() );
+        vp.set_base( std::move( base_copy ) );
+
+        {
+            item gun_with_mode( vp.get_base() );
+            while( gun_with_mode.gun_get_mode_id() != gun_mode_BURST ) {
+                gun_with_mode.gun_cycle_mode();
+            }
+            vp.set_base( std::move( gun_with_mode ) );
+        }
+
+        turret_data qry = veh->turret_query( vp );
+        REQUIRE( qry.query() == turret_data::status::ready );
+
+        player_character.setpos( here, veh->bub_part_pos( here, vp ) );
+        const int first = qry.fire( player_character, &here,
+                                    player_character.pos_bub() + point( qry.range(), 0 ) );
+        clear_faults_from_vp( vp );
+        CHECK( first > 0 );
+        CHECK( veh->battery_left( here, false ) == 0 );
+
+        // Vehicle empty; subsequent burst must report no_ammo before firing.
+        turret_data qry2 = veh->turret_query( vp );
+        CHECK( qry2.query() == turret_data::status::no_ammo );
 
         here.destroy_vehicle( veh );
         explosion_handler::process_explosions();


### PR DESCRIPTION
#### Summary
Features "Vehicle turrets and tools draw from multimag pockets"

#### Purpose of change

Continues #86808 down the vehicle and crafting paths. UPS-deprecation prep and the vehicle turret gap from the multimag rollout (#85928).

#### Describe the solution

- validator accepts direct MAGAZINE pockets with ammo_restriction in `firing_requirements` (handheld + vehicle paths already supported them; validator was overcautious)
- crafting `charges_of` learns multimag tools and stops double-counting shared UPS across multiple matching tools, including legacy USE_UPS (same dedup gap there too)
- vehicle pseudo-tool prep populates every schema pocket from batteries and tanks instead of one
- `water_purifier` vehicle drain routes through the tool engine instead of hardcoded battery math
- vehicle turret install + fire path supports multimag guns: turret data prepares pockets from vehicle batteries and tanks at fire time, fires through the existing multimag drain, bills sources back at post-fire. Closes the vehicle-turret carve-out from #86808
- aim UI panel and auto-turret targeting prep a temp-copy of the gun so range, ammo data, and AoE reflect what would actually load instead of the empty pre-fire pocket state
- `ammo_select` works on multi-tank multimag turrets so the player picks which fluid feeds (e.g. diesel vs napalm)
- `gun_uses_liquid_ammo` heuristic detects direct MAGAZINE liquid pockets so install metadata picks up `USE_TANKS` correctly

Furniture pseudo-tool path still single-pocket; left for a follow-up.

#### Describe alternatives you've considered

For aim UI display, the temptation was a parallel "what would load" calculator next to the existing readers. Pushed prep into the accessor methods instead so every caller of `range()` / `ammo_data()` / `ammo_effects()` gets the correct answer without each site re-implementing the load.

#### Testing

New tests covering vehicle prep + drain, the tank picker (preferred-ammo + sufficiency), per-pocket ownership vs player-loaded magazines, multimag turret install + query + fire across DEFAULT and BURST including partial-burst depletion, USE_UPS turret leaving player UPS untouched, charges_of dedup math, water_purifier menu + funnel routes. Existing item, pocket, reload, and turret tests pass.

Verified in-game with a debug-spawned multimag coilgun-shape turret on a vehicle with battery + glockmag.

#### Additional context

N/A