### PR TITLE
Fix SDL3 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,6 +233,18 @@ jobs:
           install: >-
             gettext
             make
+      - name: Cache vcpkg packages (Windows, SDL2)
+        if: runner.os == 'Windows' && matrix.sdl3 != 1
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: msvc-full-features/vcpkg_installed
+          key: vcpkg-installed-sdl2-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-c3867e714dd3a51c272826eea77267876517ed99
+      - name: Cache vcpkg packages (Windows, SDL3)
+        if: runner.os == 'Windows' && matrix.sdl3 == 1
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: msvc-full-features/vcpkg_installed
+          key: vcpkg-installed-sdl3-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-c3867e714dd3a51c272826eea77267876517ed99
       - name: Install dependencies (Linux, SDL2)
         if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm && matrix.sdl3 != 1
         run: |
@@ -252,15 +264,53 @@ jobs:
         if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm && matrix.sdl3 == 1
         run: |
           sudo apt-get update
-          sudo apt-get install libsdl3-dev libsdl3-image-dev libsdl3-ttf-dev \
-            libflac-dev libogg-dev libvorbis-dev libmpg123-dev libwavpack-dev \
-            libpulse-dev libncursesw5-dev ccache gettext parallel pkg-config cmake
-      - name: Build SDL3_mixer from source (Linux, SDL3)
+          sudo apt-get install libflac-dev libogg-dev libvorbis-dev libmpg123-dev libwavpack-dev \
+              libfreetype-dev libharfbuzz-dev libjpeg-dev libpng-dev libwebp-dev libtiff-dev \
+              libpulse-dev libncursesw5-dev ccache gettext parallel pkg-config cmake \
+              libx11-dev libxext-dev libxcursor-dev libxi-dev libxfixes-dev libxrandr-dev \
+              libxrender-dev libxss-dev libxtst-dev libxkbcommon-dev libwayland-dev \
+              libdecor-0-dev libdrm-dev libgbm-dev libudev-dev libpipewire-0.3-dev \
+              libdbus-1-dev libibus-1.0-dev
+      - name: Cache SDL3 stack source build (Linux, SDL3)
         if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm && matrix.sdl3 == 1
+        id: cache-sdl3-release
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ runner.workspace }}/sdl3_prefix
+          key: sdl3-stack-sdl-3.4.4-image-3.4.2-ttf-3.2.2-mixer-3.2.0-${{ runner.os }}-v2
+      - name: Build SDL3 stack from source (Linux, SDL3)
+        if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm && matrix.sdl3 == 1 && steps.cache-sdl3-release.outputs.cache-hit != 'true'
         run: |
+          PREFIX=${{ runner.workspace }}/sdl3_prefix
+          export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig:$PREFIX/lib/x86_64-linux-gnu/pkgconfig
+          export CMAKE_PREFIX_PATH=$PREFIX
+          git clone --depth 1 --branch release-3.4.4 https://github.com/libsdl-org/SDL.git sdl3_src
+          cmake -S sdl3_src -B sdl3_build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=$PREFIX \
+              -DBUILD_SHARED_LIBS=ON
+          cmake --build sdl3_build -j$(nproc)
+          cmake --install sdl3_build
+          git clone --depth 1 --branch release-3.4.2 https://github.com/libsdl-org/SDL_image.git sdl3_image_src
+          cmake -S sdl3_image_src -B sdl3_image_build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=$PREFIX \
+              -DSDLIMAGE_VENDORED=OFF \
+              -DBUILD_SHARED_LIBS=ON
+          cmake --build sdl3_image_build -j$(nproc)
+          cmake --install sdl3_image_build
+          git clone --depth 1 --branch release-3.2.2 https://github.com/libsdl-org/SDL_ttf.git sdl3_ttf_src
+          cmake -S sdl3_ttf_src -B sdl3_ttf_build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=$PREFIX \
+              -DSDLTTF_VENDORED=OFF \
+              -DBUILD_SHARED_LIBS=ON
+          cmake --build sdl3_ttf_build -j$(nproc)
+          cmake --install sdl3_ttf_build
           git clone --depth 1 --branch release-3.2.0 https://github.com/libsdl-org/SDL_mixer.git sdl3_mixer_src
           cmake -S sdl3_mixer_src -B sdl3_mixer_build \
               -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=$PREFIX \
               -DSDLMIXER_VENDORED=OFF \
               -DSDLMIXER_FLAC=ON -DSDLMIXER_FLAC_LIBFLAC=ON \
               -DSDLMIXER_MP3=ON -DSDLMIXER_MP3_MPG123=ON \
@@ -268,9 +318,16 @@ jobs:
               -DSDLMIXER_WAVPACK=ON \
               -DSDLMIXER_OPUS=OFF -DSDLMIXER_MOD=OFF -DSDLMIXER_MIDI=OFF \
               -DBUILD_SHARED_LIBS=ON
-          cmake --build sdl3_mixer_build -j$((`nproc`+0))
-          sudo cmake --install sdl3_mixer_build
-          cp sdl3_mixer_src/LICENSE.txt ${{ github.workspace }}/LICENSE-SDL3_mixer.txt
+          cmake --build sdl3_mixer_build -j$(nproc)
+          cmake --install sdl3_mixer_build
+          mkdir -p $PREFIX/share
+          cp sdl3_src/LICENSE.txt $PREFIX/share/LICENSE-SDL.txt
+          cp sdl3_mixer_src/LICENSE.txt $PREFIX/share/LICENSE-SDL3_mixer.txt
+      - name: Stage SDL3 license files (Linux, SDL3)
+        if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm && matrix.sdl3 == 1
+        run: |
+          cp ${{ runner.workspace }}/sdl3_prefix/share/LICENSE-SDL.txt ${{ github.workspace }}/LICENSE-SDL.txt
+          cp ${{ runner.workspace }}/sdl3_prefix/share/LICENSE-SDL3_mixer.txt ${{ github.workspace }}/LICENSE-SDL3_mixer.txt
       - name: Install Emscripten (WebAssembly)
         if: matrix.wasm
         uses: mymindstorm/setup-emsdk@d233ac12b0102f74ca199f5dad7a4e2c13a8a745 # v13
@@ -294,11 +351,69 @@ jobs:
         if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 != 1
         run: |
           sudo port install freetype +universal pkgconfig +universal
-      - name: install brew packages (mac, SDL3)
+      - name: install macports (mac, SDL3)
+        if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 == 1
+        uses: melusina-org/setup-macports@c7eb59386def259a274627092566a7f7b8d219b1 # v1
+      - name: install macports packages (mac, SDL3)
         if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 == 1
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes \
-            brew install pkgconf sdl3 sdl3_image sdl3_ttf sdl3_mixer freetype
+          sudo port install freetype +universal pkgconfig +universal
+      - name: Cache SDL3 stack source build (mac, SDL3)
+        if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 == 1
+        id: cache-sdl3-release-macos
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ runner.workspace }}/sdl3_prefix
+          key: sdl3-stack-universal-sdl-3.4.4-image-3.4.2-ttf-3.2.2-mixer-3.2.0-${{ runner.os }}-v1
+      - name: Build SDL3 stack from source (mac, SDL3, universal)
+        if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 == 1 && steps.cache-sdl3-release-macos.outputs.cache-hit != 'true'
+        run: |
+          PREFIX=${{ runner.workspace }}/sdl3_prefix
+          export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig:/opt/local/lib/pkgconfig
+          export CMAKE_PREFIX_PATH=$PREFIX
+          ARCH_ARG='-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64'
+          git clone --depth 1 --branch release-3.4.4 https://github.com/libsdl-org/SDL.git sdl3_src
+          cmake -S sdl3_src -B sdl3_build "$ARCH_ARG" \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=$PREFIX \
+              -DBUILD_SHARED_LIBS=ON
+          cmake --build sdl3_build -j$(sysctl -n hw.ncpu)
+          cmake --install sdl3_build
+          git clone --depth 1 --branch release-3.4.2 --recurse-submodules --shallow-submodules https://github.com/libsdl-org/SDL_image.git sdl3_image_src
+          cmake -S sdl3_image_src -B sdl3_image_build "$ARCH_ARG" \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=$PREFIX \
+              -DSDLIMAGE_VENDORED=ON \
+              -DSDLIMAGE_AVIF=OFF -DSDLIMAGE_JXL=OFF -DSDLIMAGE_WEBP=OFF \
+              -DPNG_ARM_NEON=off \
+              -DBUILD_SHARED_LIBS=ON
+          cmake --build sdl3_image_build -j$(sysctl -n hw.ncpu)
+          cmake --install sdl3_image_build
+          git clone --depth 1 --branch release-3.2.2 --recurse-submodules --shallow-submodules https://github.com/libsdl-org/SDL_ttf.git sdl3_ttf_src
+          cmake -S sdl3_ttf_src -B sdl3_ttf_build "$ARCH_ARG" \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=$PREFIX \
+              -DSDLTTF_VENDORED=ON \
+              -DBUILD_SHARED_LIBS=ON
+          cmake --build sdl3_ttf_build -j$(sysctl -n hw.ncpu)
+          cmake --install sdl3_ttf_build
+          git clone --depth 1 --branch release-3.2.0 --recurse-submodules --shallow-submodules https://github.com/libsdl-org/SDL_mixer.git sdl3_mixer_src
+          cmake -S sdl3_mixer_src -B sdl3_mixer_build "$ARCH_ARG" \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=$PREFIX \
+              -DSDLMIXER_VENDORED=ON \
+              -DSDLMIXER_OPUS=OFF -DSDLMIXER_MOD=OFF -DSDLMIXER_MIDI=OFF \
+              -DBUILD_SHARED_LIBS=ON
+          cmake --build sdl3_mixer_build -j$(sysctl -n hw.ncpu)
+          cmake --install sdl3_mixer_build
+          mkdir -p $PREFIX/share
+          cp sdl3_src/LICENSE.txt $PREFIX/share/LICENSE-SDL.txt
+          cp sdl3_mixer_src/LICENSE.txt $PREFIX/share/LICENSE-SDL3_mixer.txt
+      - name: Stage SDL3 license files (mac, SDL3)
+        if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 == 1
+        run: |
+          cp ${{ runner.workspace }}/sdl3_prefix/share/LICENSE-SDL.txt ${{ github.workspace }}/LICENSE-SDL.txt
+          cp ${{ runner.workspace }}/sdl3_prefix/share/LICENSE-SDL3_mixer.txt ${{ github.workspace }}/LICENSE-SDL3_mixer.txt
       - name: Create VERSION.TXT
         shell: bash
         run: |
@@ -328,6 +443,10 @@ jobs:
       - name: Build CDDA (linux)
         if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm
         run: |
+          if [ "${{ matrix.sdl3 }}" = "1" ]; then
+            export PKG_CONFIG_PATH="$RUNNER_WORKSPACE/sdl3_prefix/lib/pkgconfig:$RUNNER_WORKSPACE/sdl3_prefix/lib/x86_64-linux-gnu/pkgconfig"
+            export LD_LIBRARY_PATH="$RUNNER_WORKSPACE/sdl3_prefix/lib:$RUNNER_WORKSPACE/sdl3_prefix/lib/x86_64-linux-gnu"
+          fi
           make COMPILER=clang++-18 -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} SDL3=${{ matrix.sdl3 == 1 && '1' || '0' }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 LIBBACKTRACE=${{ matrix.libbacktrace }} WARN_STALE_DATA=1 PCH=0 bindist
           mv cataclysmdda-0.J.tar.gz cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.tar.gz
       - name: Build CDDA (WebAssembly)
@@ -365,7 +484,8 @@ jobs:
       - name: Build CDDA (osx, SDL3)
         if: runner.os == 'macOS' && matrix.sdl3 == 1
         env:
-          PKG_CONFIG_PATH: /opt/homebrew/lib/pkgconfig
+          PKG_CONFIG_PATH: ${{ runner.workspace }}/sdl3_prefix/lib/pkgconfig:/opt/local/lib/pkgconfig
+          DYLIBBUNDLER_SEARCH_PATHS: ${{ runner.workspace }}/sdl3_prefix/lib
         run: |
           make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} SDL3=1 RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 UNIVERSAL_BINARY=1 WARN_STALE_DATA=1 dmgdist
           mv Cataclysm.dmg cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg

--- a/Makefile
+++ b/Makefile
@@ -1011,9 +1011,18 @@ ifeq ($(TARGETSYSTEM),LINUX)
   CXXFLAGS += -mcx16
   BINDIST_EXTRAS += cataclysm-launcher
   ifneq ("$(wildcard LICENSE-SDL.txt)","")
-    SDL2_solib = $(shell ldd $(TARGET) | grep libSDL2-2\.0 | cut -d ' ' -f 3)
-    INSTALL_EXTRAS += $(SDL2_solib)
+    ifeq ($(SDL3),1)
+      SDL_solibs = $(shell ldd $(TARGET) | awk '/libSDL3/ {print $$3}')
+    else
+      SDL_solibs = $(shell ldd $(TARGET) | grep libSDL2-2\.0 | cut -d ' ' -f 3)
+    endif
+    INSTALL_EXTRAS += $(SDL_solibs)
     BINDIST_EXTRAS += LICENSE-SDL.txt
+    ifeq ($(SDL3),1)
+      ifneq ("$(wildcard LICENSE-SDL3_mixer.txt)","")
+        BINDIST_EXTRAS += LICENSE-SDL3_mixer.txt
+      endif
+    endif
   endif
   ifeq ($(BACKTRACE),1)
     # -rdynamic needed for symbols in backtraces
@@ -1425,7 +1434,7 @@ ifeq ($(SOUND), 1)
 endif  # ifeq ($(SOUND), 1)
 endif  # ifeq ($(SDL3), 1)
 endif  # ifdef FRAMEWORK
-	dylibbundler -of -b -x $(APPRESOURCESDIR)/$(APPTARGET) -d $(APPRESOURCESDIR)/ -p @executable_path/
+	dylibbundler -of -b -x $(APPRESOURCESDIR)/$(APPTARGET) -d $(APPRESOURCESDIR)/ -p @executable_path/ $(addprefix -s ,$(DYLIBBUNDLER_SEARCH_PATHS))
 
 dmgdistclean:
 	rm -rf Cataclysm
@@ -1452,7 +1461,7 @@ endif  # ifeq ($(NATIVE), osx)
 $(BINDIST): distclean version $(TARGET) $(ZZIP_BIN) $(L10N) $(BINDIST_EXTRAS) $(BINDIST_LOCALE)
 	mkdir -p $(BINDIST_DIR)
 	cp -R $(TARGET) $(ZZIP_BIN) $(BINDIST_EXTRAS) $(BINDIST_DIR)
-	$(foreach lib,$(INSTALL_EXTRAS), install --strip $(lib) $(BINDIST_DIR))
+	$(foreach lib,$(INSTALL_EXTRAS),install --strip $(lib) $(BINDIST_DIR);)
 ifdef LANGUAGES
 	cp -R --parents lang/mo $(BINDIST_DIR)
 endif

--- a/doc/c++/COMPILING-VS-VCPKG.md
+++ b/doc/c++/COMPILING-VS-VCPKG.md
@@ -38,7 +38,7 @@ Steps from current guide were tested on Windows 11 (64 bit), Visual Studio 2022 
 
 2. Install `Git for Windows` (installer can be downloaded from [Git homepage](https://git-scm.com/)).
 
-3. Install and configure `vcpkg`. If you already have `vcpkg` installed, you should update it to at least commit `3b57fb2e1ff55613db14d2aaf0a30529289c7050` (the most recent tested good revision) and rerun `.\bootstrap-vcpkg.bat` as described:
+3. Install and configure `vcpkg`. If you already have `vcpkg` installed, you should update it to at least commit `c3867e714dd3a51c272826eea77267876517ed99` (the most recent tested good revision) and rerun `.\bootstrap-vcpkg.bat` as described:
 
 ***WARNING: It is important that, wherever you decide to clone this repo, the path does not include whitespace or special symbols. That is, `C:/dev/vcpkg` is acceptable, but `C:/dev test/vcpkg` and `C:/C++Projects/vcpkg` is not.***
 


### PR DESCRIPTION
#### Summary
Build "Fix SDL3 release artifacts for Linux, macOS, Windows"

#### Purpose of change
SDL3 release macOS/Linux lanes failed because I didn't update them along with sdl3-matrix. Hotfix porting the matrix setup over to release.

#### Describe the solution
Linux SDL3: source-build the SDL3 stack into a cached prefix, set PKG_CONFIG_PATH/LD_LIBRARY_PATH at make time. Linux bindist bundles libSDL3*.so via ldd.

macOS SDL3: source-build SDL3 stack universal (arm64+x86_64) with vendored codecs (AVIF/JXL/WEBP/PNG-NEON disabled, those don't build clean as universal). dylibbundler search path threaded through so the .app bundle picks them up. Tried macports SDL3 ports first but their libcxx binary archive signature broke mid-day, source-build is more deterministic anyway.

Windows: port vcpkg_installed cache from SDL3 matrix, keyed per feature.

Doc bump for the tested vcpkg commit.

#### Describe alternatives you've considered
Lipo-combine of brew arm64+intel bottles -- works but min-version mismatches between bottle tags. Not worth the fragility.

#### Testing
Verified in my fork: https://github.com/dobbry-vechur/Cataclysm-DDA/actions/runs/25359855896

#### Additional context
N/A