### PR TITLE
Sidebar headers for various game objects

### DIFF
--- a/src/game_ui_tile_info.cpp
+++ b/src/game_ui_tile_info.cpp
@@ -332,6 +332,13 @@ void game::print_fields_info( const tripoint_bub_ms &lp, const catacurses::windo
     map &here = get_map();
 
     const field &tmpfield = here.field_at( lp );
+    int size = std::distance( tmpfield.begin(), tmpfield.end() );
+    if( size == 0 ) {
+        return;
+    }
+
+    // Header.
+    mvwprintz( w_look, point( column, ++line ), c_light_blue, _( "-----FIELDS-----" ) );
     for( const auto &fld : tmpfield ) {
         const field_entry &cur = fld.second;
         if( fld.first.obj().has_fire && ( here.has_flag( ter_furn_flag::TFLAG_FIRE_CONTAINER, lp ) ||
@@ -345,10 +352,8 @@ void game::print_fields_info( const tripoint_bub_ms &lp, const catacurses::windo
         }
     }
 
-    int size = std::distance( tmpfield.begin(), tmpfield.end() );
-    if( size > 0 ) {
-        mvwprintz( w_look, point( column, ++line ), c_white, "\n" );
-    }
+    // Padding for whatever comes afterwards. Not sure why it needs to be in this function!
+    mvwprintz( w_look, point( column, ++line ), c_white, "\n" );
 }
 
 void game::print_trap_info( const tripoint_bub_ms &lp, const catacurses::window &w_look,
@@ -358,12 +363,19 @@ void game::print_trap_info( const tripoint_bub_ms &lp, const catacurses::window 
     map &here = get_map();
 
     const trap &tr = here.tr_at( lp );
-    if( tr.can_see( lp, u ) ) {
-        std::string tr_name = tr.name();
-        mvwprintz( w_look, point( column, ++line ), tr.color, tr_name );
+    if( tr.is_null() ) {
+        return; // Nothing here!
     }
 
-    ++line;
+    if( tr.can_see( lp, u ) ) {
+        // Header. Only printed if we actually know there's a trap there. ;)
+        mvwprintz( w_look, point( column, ++line ), c_light_blue, _( "-----TRAP-----" ) );
+
+        mvwprintz( w_look, point( column, ++line ), tr.color, tr.name() );
+
+        // Padding for whatever comes afterwards. Not sure why it needs to be in this function!
+        ++line;
+    }
 }
 
 void game::print_part_con_info( const tripoint_bub_ms &lp, const catacurses::window &w_look,
@@ -402,9 +414,12 @@ void game::print_vehicle_info( const vehicle *veh, int veh_part, const catacurse
 {
     if( veh ) {
         // Print the name of the vehicle.
-        mvwprintz( w_look, point( column, ++line ), c_light_gray, _( "Vehicle: " ) );
-        mvwprintz( w_look, point( column + utf8_width( _( "Vehicle: " ) ), line ), c_white, "%s",
-                   veh->name );
+        if( veh->is_appliance() ) {
+            mvwprintz( w_look, point( column, ++line ), c_light_blue, _( "-----APPLIANCE-----" ) );
+        } else {
+            mvwprintz( w_look, point( column, ++line ), c_light_blue, _( "-----VEHICLE-----" ) );
+        }
+        mvwprintz( w_look, point( column, ++line ), c_white, "%s", veh->name );
         // Then the list of parts on that tile.
         line = veh->print_part_list( w_look, ++line, last_line, getmaxx( w_look ), veh_part );
     }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -860,6 +860,11 @@ int monster::print_info( const catacurses::window &w, int vStart, int vLines, in
     const int max_width = getmaxx( w ) - column - 1;
     std::ostringstream oss;
 
+    // This header specifically refers to them as a somewhat-misleading "Creatures" instead of "Monsters".
+    // This is because many of our "Monster" objects do not represent things that are pejorative monsters.
+    // Therefore the header is intentionally *neutral* on the language.
+    mvwprintz( w, point( column, vStart++ ), c_light_blue, _( "-----CREATURE-----" ) );
+
     oss << get_tag_from_color( c_white ) << get_origin( type->src ) << "</color>" << "\n";
 
     if( debug_mode ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2961,6 +2961,9 @@ int npc::print_info( const catacurses::window &w, int line, int vLines, int colu
     // because it's a border as well; so we have lines 6 through 11.
     // w is also 53 characters wide - 2 characters for border = 51 characters for us
 
+    // Header.
+    mvwprintz( w, point( column, line++ ), c_light_blue, _( "-----CHARACTER-----" ) );
+
     // Print health bar and NPC name on the first line.
     std::pair<std::string, nc_color> bar = get_hp_bar( hp_percentage(), 100 );
     mvwprintz( w, point( column, line ), bar.second, bar.first );


### PR DESCRIPTION
#### Summary
Interface "Sidebar headers for various game objects"

#### Purpose of change
* Followup to #84698

#### Describe the solution
Since these headers were introduced I haven't seen any issues with them. They seem to be doing their job, but there's some cases where people still get confused. (e.g. someone earlier mistook a fridge furniture for a fridge *appliance*)

So, let's go ahead and add headers for the rest of the things.

Includes headers for:
Terrain (pre-existing)
Furniture (pre-existing)
NPCs
Monsters (referred to as "Creature"s, see code comment)
Traps (Only if you know they're there 😉 )
Fields
Vehicles (split by appliance/regular vehicle)

#### Describe alternatives you've considered
Imgui sidebar?

The NPC header calls them a "PERSON". This may grow out of date as we get more exotic NPCs (like robots in aftershock). Perhaps there is a different neutral term we could use.

#### Testing
Quick little video showing all the different ones

https://github.com/user-attachments/assets/35376485-1032-4f0c-a964-171dd1cbc6d6

#### Additional context

Note: No header for items, do we need one?