### PR TITLE
Display some items by volume or weight, instead of count

### DIFF
--- a/data/json/items/comestibles/drink.json
+++ b/data/json/items/comestibles/drink.json
@@ -1638,6 +1638,7 @@
     "quench": 50,
     "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE", "DECAYS_IN_AIR" ],
     "name": { "str_sp": "clean water" },
+    "display_type": "BY_VOLUME",
     "description": "Fresh, clean water.  Truly the best thing to quench your thirst.",
     "container": "bottle_plastic",
     "sealed": true,

--- a/data/json/items/comestibles/spice.json
+++ b/data/json/items/comestibles/spice.json
@@ -92,6 +92,7 @@
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "salt" },
+    "display_type": "BY_WEIGHT",
     "description": "Yuck!  You surely wouldn't want to eat this.  It's good for preserving meat and cooking, though.",
     "material": [ "salt" ],
     "color": "white"

--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -109,6 +109,7 @@ These fields can be read by any ITEM regardless of subtypes:
     "condition": "leather",       // The condition to check for.
     "name": { "str": "pair of leather socks", "str_pl": "pairs of leather socks" } // Name field, same rules as above.
 } ],
+"display_type": "BY_WEIGHT",      // (Optional) Whether this item should be displayed by weight or volume instead of count. Valid entries are `DEFAULT`(no need to put anything), `BY_VOLUME`, and `BY_WEIGHT`.
 "container": "null",             // What container (if any) this item should spawn within
 "repairs_like": "scarf",          // If this item does not have recipe, what item to look for a recipe for when repairing it.
 "color": "blue",                 // Color of the item symbol.

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -784,7 +784,8 @@ std::string inventory_selector_preset::get_caption( const inventory_entry &entry
         disp_name = entry.any_item()->display_name( count );
     }
 
-    return ( count > 1 ) ? string_format( "%d %s", count, disp_name ) : disp_name;
+    return ( count > 1 ) ? string_format( "%s %s",
+                                          entry.any_item()->type->count_or_volume_or_weight_prefix( count ), disp_name ) : disp_name;
 }
 
 std::string inventory_selector_preset::get_denial( const inventory_entry &entry ) const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1738,7 +1738,7 @@ std::string item::display_name( unsigned int quantity ) const
                     amt = string_format( " (%s%s)", colorize( string_format( "%i/%i", amount, max_amount ),
                                          charges_color ),
                                          ammotext );
-                } else {
+                } else if( !type->dont_display_count_or_charges() )  {
                     amt = string_format( " (%i%s)", amount, ammotext );
                 }
             }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4168,6 +4168,22 @@ std::string enum_to_string<link_state>( link_state data )
 }
 
 template<>
+std::string enum_to_string<item_display_type>( item_display_type data )
+{
+    switch( data ) {
+        case item_display_type::DEFAULT:
+            return "DEFAULT";
+        case item_display_type::BY_WEIGHT:
+            return "BY_WEIGHT";
+        case item_display_type::BY_VOLUME:
+            return "BY_VOLUME";
+        case item_display_type::LAST:
+            break;
+    }
+    cata_fatal( "Invalid item_display_type" );
+}
+
+template<>
 std::string enum_to_string<grip_val>( grip_val val )
 {
     switch( val ) {
@@ -4366,6 +4382,7 @@ void itype::load( const JsonObject &jo, std::string_view src )
     optional( jo, was_loaded, "integral_weight", integral_weight, not_negative_mass, -1_gram );
     optional( jo, was_loaded, "volume", volume );
     optional( jo, was_loaded, "longest_side", longest_side, -1_mm );
+    optional( jo, was_loaded, "display_type", display_type, item_display_type::DEFAULT );
     optional( jo, was_loaded, "price", price, not_negative_money, 0_cent );
     optional( jo, was_loaded, "price_postapoc", price_post, not_negative_money, -1_cent );
     optional( jo, was_loaded, "stackable", stackable_ );

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -35,13 +35,13 @@
 #include "point.h"
 #include "recipe.h"
 #include "relic.h"
+#include "string_formatter.h"
 #include "text_snippets.h"
 #include "translation.h"
 #include "translation_cache.h"
 #include "translations.h"
 #include "type_id.h"
 #include "units.h"
-#include "units_utility.h"
 #include "value_ptr.h"
 
 static const flag_id json_flag_HINT_THE_LOCATION( "HINT_THE_LOCATION" );
@@ -61,28 +61,6 @@ std::string noop( item const & /* it */, unsigned int /* quantity */,
                   segment_bitset const & /* segments */ )
 {
     return {};
-}
-
-std::string amount_weight( item const &it, unsigned int quantity,
-                           segment_bitset const &/* segments */ )
-{
-    std::string prefix;
-    if( it.type->display_type == item_display_type::BY_WEIGHT ) {
-        prefix = it.type->count_or_volume_or_weight_prefix( quantity );
-    }
-
-    return prefix;
-}
-
-std::string amount_volume( item const &it, unsigned int quantity,
-                           segment_bitset const &/* segments */ )
-{
-    std::string prefix;
-    if( it.type->display_type == item_display_type::BY_VOLUME ) {
-        prefix = it.type->count_or_volume_or_weight_prefix( quantity );
-    }
-
-    return prefix;
 }
 
 std::string faults( item const &it, unsigned int /* quantity */,
@@ -715,8 +693,6 @@ constexpr std::array<decl_f_print_segment *, num_segments> get_segs_array()
 {
     std::array<decl_f_print_segment *, num_segments> arr{};
     arr[static_cast<size_t>( tname::segments::FAULTS ) ] = faults;
-    arr[static_cast<size_t>( tname::segments::WEIGHT ) ] = amount_weight;
-    arr[static_cast<size_t>( tname::segments::VOLUME ) ] = amount_volume;
     arr[static_cast<size_t>( tname::segments::FAULTS_SUFFIX ) ] = faults_suffix;
     arr[static_cast<size_t>( tname::segments::DIRT ) ] = dirt_symbol;
     arr[static_cast<size_t>( tname::segments::OVERHEAT ) ] = overheat_symbol;

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -35,13 +35,13 @@
 #include "point.h"
 #include "recipe.h"
 #include "relic.h"
-#include "string_formatter.h"
 #include "text_snippets.h"
 #include "translation.h"
 #include "translation_cache.h"
 #include "translations.h"
 #include "type_id.h"
 #include "units.h"
+#include "units_utility.h"
 #include "value_ptr.h"
 
 static const flag_id json_flag_HINT_THE_LOCATION( "HINT_THE_LOCATION" );
@@ -61,6 +61,28 @@ std::string noop( item const & /* it */, unsigned int /* quantity */,
                   segment_bitset const & /* segments */ )
 {
     return {};
+}
+
+std::string amount_weight( item const &it, unsigned int quantity,
+                           segment_bitset const &/* segments */ )
+{
+    std::string prefix;
+    if( it.type->display_type == item_display_type::BY_WEIGHT ) {
+        prefix = it.type->count_or_volume_or_weight_prefix( quantity );
+    }
+
+    return prefix;
+}
+
+std::string amount_volume( item const &it, unsigned int quantity,
+                           segment_bitset const &/* segments */ )
+{
+    std::string prefix;
+    if( it.type->display_type == item_display_type::BY_VOLUME ) {
+        prefix = it.type->count_or_volume_or_weight_prefix( quantity );
+    }
+
+    return prefix;
 }
 
 std::string faults( item const &it, unsigned int /* quantity */,
@@ -222,7 +244,7 @@ std::string craft( item const &it, unsigned int /* quantity */,
         } else {
             maintext = string_format( _( "in progress %s" ), it.get_making().result_name() );
         }
-        if( it.charges > 1 ) {
+        if( it.charges > 1 && !it.type->dont_display_count_or_charges() ) {
             maintext += string_format( " (%d)", it.charges );
         }
         const int percent_progress = it.item_counter / 100000;
@@ -283,10 +305,11 @@ std::string contents( item const &it, unsigned int /* quantity */,
             if( total_count == aggi_count ) {
                 return string_format(
                            segments[tname::segments::CONTENTS_COUNT]
-                           //~ [container item name] " > [count] [type]"
-                           ? npgettext( "item name", " > %1$zd %2$s", " > %1$zd %2$s", total_count )
+                           //~ [container item name] " > [count or volume or weight (depending on type)] [type]"
+                           ? npgettext( "item name", " > %1$s %2$s", " > %1$s %2$s", total_count )
                            : " > %2$s",
-                           total_count, ctnc );
+                           contents_item.type->count_or_volume_or_weight_prefix( total_count ),
+                           ctnc );
             }
             return string_format(
                        segments[tname::segments::CONTENTS_COUNT]
@@ -692,6 +715,8 @@ constexpr std::array<decl_f_print_segment *, num_segments> get_segs_array()
 {
     std::array<decl_f_print_segment *, num_segments> arr{};
     arr[static_cast<size_t>( tname::segments::FAULTS ) ] = faults;
+    arr[static_cast<size_t>( tname::segments::WEIGHT ) ] = amount_weight;
+    arr[static_cast<size_t>( tname::segments::VOLUME ) ] = amount_volume;
     arr[static_cast<size_t>( tname::segments::FAULTS_SUFFIX ) ] = faults_suffix;
     arr[static_cast<size_t>( tname::segments::DIRT ) ] = dirt_symbol;
     arr[static_cast<size_t>( tname::segments::OVERHEAT ) ] = overheat_symbol;

--- a/src/item_tname.h
+++ b/src/item_tname.h
@@ -20,8 +20,6 @@ namespace tname
 // Each element is checked individually for stacking in item::stacks_with(), and all elements much stack for any 2 items to stack
 enum class segments : std::size_t {
     FAULTS = 0,
-    WEIGHT,
-    VOLUME,
     DIRT,
     OVERHEAT,
     FAVORITE_PRE,

--- a/src/item_tname.h
+++ b/src/item_tname.h
@@ -20,6 +20,8 @@ namespace tname
 // Each element is checked individually for stacking in item::stacks_with(), and all elements much stack for any 2 items to stack
 enum class segments : std::size_t {
     FAULTS = 0,
+    WEIGHT,
+    VOLUME,
     DIRT,
     OVERHEAT,
     FAVORITE_PRE,

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -15,8 +15,10 @@
 #include "material.h"
 #include "recipe.h"
 #include "ret_val.h"
+#include "string_formatter.h"
 #include "subbodypart.h"
 #include "translations.h"
+#include "units_utility.h"
 
 static const flag_id json_flag_CAN_HAVE_CHARGES( "CAN_HAVE_CHARGES" );
 
@@ -123,6 +125,22 @@ std::string itype::get_item_type_string() const
         return "AMMO";
     }
     return "misc";
+}
+
+bool itype::dont_display_count_or_charges() const
+{
+    return display_type != item_display_type::DEFAULT;
+}
+
+std::string itype::count_or_volume_or_weight_prefix( unsigned int quantity ) const
+{
+    // Extra space required to avoid string concatenation in our myriad of UIs :(
+    if( display_type == item_display_type::BY_WEIGHT ) {
+        return string_format( _( "%1$s " ), weight_to_string( weight * quantity, true, true ) );
+    } else if( display_type == item_display_type::BY_VOLUME ) {
+        return string_format( _( "%1$s " ), vol_to_string( volume * quantity, true, true ) );
+    }
+    return std::to_string( quantity );
 }
 
 std::string itype::nname( unsigned int quantity ) const

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -134,11 +134,10 @@ bool itype::dont_display_count_or_charges() const
 
 std::string itype::count_or_volume_or_weight_prefix( unsigned int quantity ) const
 {
-    // Extra space required to avoid string concatenation in our myriad of UIs :(
     if( display_type == item_display_type::BY_WEIGHT ) {
-        return string_format( _( "%1$s " ), weight_to_string( weight * quantity, true, true ) );
+        return string_format( _( "%1$s" ), weight_to_string( weight * quantity, true, true ) );
     } else if( display_type == item_display_type::BY_VOLUME ) {
-        return string_format( _( "%1$s " ), vol_to_string( volume * quantity, true, true ) );
+        return string_format( _( "%1$s" ), vol_to_string( volume * quantity, true, true ) );
     }
     return std::to_string( quantity );
 }

--- a/src/itype.h
+++ b/src/itype.h
@@ -348,6 +348,18 @@ enum class encumbrance_modifier_type : int {
     last
 };
 
+enum class item_display_type {
+    DEFAULT, // count, charges, etc.
+    BY_WEIGHT, // e.g. "12lbs of salt"
+    BY_VOLUME, // e.g. "4 liters of water"
+    LAST
+};
+
+template<>
+struct enum_traits<item_display_type> {
+    static constexpr item_display_type last = item_display_type::LAST;
+};
+
 struct armor_portion_data {
 
     // The base volume for an item
@@ -1579,6 +1591,9 @@ struct itype {
         /** Value after the Cataclysm, dependent upon practical usages. Price given is for a default-sized stack. */
         units::money price_post = -1_cent;
 
+        /** How should this display? */
+        item_display_type display_type = item_display_type::DEFAULT;
+
         // TODO: Add some very basic unwieldiness calc for non specified to_hit?
         int m_to_hit = -2;  // To-hit bonus for melee combat, see GAME_BALANCE.md#to-hit-value
         // itype specifies a legacy raw int to_hit, for use with for item_new_to_hit_enforcement TEST_CASE
@@ -1660,6 +1675,10 @@ struct itype {
         fuel_explosion_data get_explosion_data() const;
 
         std::string get_item_type_string() const;
+
+        std::string count_or_volume_or_weight_prefix( unsigned int quantity ) const;
+
+        bool dont_display_count_or_charges() const;
 
         // Returns the name of the item type in the correct language and with respect to its grammatical number,
         // based on quantity (example: item type "anvil", nname(4) would return "anvils" (as in "4 anvils").

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -180,43 +180,50 @@ std::string tool_comp::to_string( const int batch, const int ) const
 
 std::string item_comp::to_string( const int batch, const int avail ) const
 {
-    const int c = std::abs( count ) * batch;
+    const int num_wanted = std::abs( count ) * batch;
     const item item_temp = item( type );
     if( item_temp.count_by_charges() ) {
         // Count-by-charge
 
         if( avail == item::INFINITE_CHARGES ) {
-            //~ %1$s: item name, %2$d: charge requirement
-            return string_format( npgettext( "requirement", "%2$d %1$s (have infinite)",
-                                             "%2$d %1$s (have infinite)",
-                                             c ),
-                                  item_temp.tname( 1, tname::base_item_name ), c );
+            //~ %1$s: item name, %2$s: charge requirement (number or weight or volume of item, depending on type)
+            return string_format( npgettext( "requirement", "%2$s %1$s (have infinite)",
+                                             "%2$s %1$s (have infinite)",
+                                             num_wanted ),
+                                  item_temp.tname( 1, tname::base_item_name ),
+                                  type->count_or_volume_or_weight_prefix( num_wanted ) );
         } else if( avail > 0 ) {
-            //~ %1$s: item name, %2$d: charge requirement, %3%d: available charges
-            return string_format( npgettext( "requirement", "%2$d %1$s (have %3$d)",
-                                             "%2$d %1$s (have %3$d)", c ),
-                                  item_temp.tname( 1, tname::base_item_name ), c, avail );
+            //~ %1$s: item name, %2$s: charge requirement (number or weight or volume of item, depending on type), %3%s: available charges (number or weight or volume of item, depending on type)
+            return string_format( npgettext( "requirement", "%2$s %1$s (have %3$s)",
+                                             "%2$s %1$s (have %3$s)", num_wanted ),
+                                  item_temp.tname( 1, tname::base_item_name ),
+                                  type->count_or_volume_or_weight_prefix( num_wanted ),
+                                  type->count_or_volume_or_weight_prefix( avail ) );
         } else {
-            //~ %1$s: item name, %2$d: charge requirement
-            return string_format( npgettext( "requirement", "%2$d %1$s", "%2$d %1$s", c ),
-                                  item_temp.tname( 1, tname::base_item_name ), c );
+            //~ %1$s: item name, %2$s: charge requirement (number or weight or volume of item, depending on type)
+            return string_format( npgettext( "requirement", "%2$s %1$s", "%2$s %1$s", num_wanted ),
+                                  item_temp.tname( 1, tname::base_item_name ), type->count_or_volume_or_weight_prefix( num_wanted ) );
         }
     } else {
         if( avail == item::INFINITE_CHARGES ) {
-            //~ %1$s: item name, %2$d: required count
-            return string_format( npgettext( "requirement", "%2$d %1$s (have infinite)",
-                                             "%2$d %1$s (have infinite)",
-                                             c ),
-                                  item_temp.tname( c, tname::base_item_name ), c );
+            //~ %1$s: item name, %2$s: required count (number or weight or volume of item, depending on type)
+            return string_format( npgettext( "requirement", "%2$s %1$s (have infinite)",
+                                             "%2$s %1$s (have infinite)",
+                                             num_wanted ),
+                                  item_temp.tname( num_wanted, tname::base_item_name ),
+                                  type->count_or_volume_or_weight_prefix( num_wanted ) );
         } else if( avail > 0 ) {
-            //~ %1$s: item name, %2$d: required count, %3%d: available count
-            return string_format( npgettext( "requirement", "%2$d %1$s (have %3$d)",
-                                             "%2$d %1$s (have %3$d)", c ),
-                                  item_temp.tname( c, tname::base_item_name ), c, avail );
+            //~ %1$s: item name, %2$s: required count (number or weight or volume of item, depending on type), %3%d: available count (number or weight or volume of item, depending on type)
+            return string_format( npgettext( "requirement", "%2$s %1$s (have %3$s)",
+                                             "%2$s %1$s (have %3$s)", num_wanted ),
+                                  item_temp.tname( num_wanted, tname::base_item_name ),
+                                  type->count_or_volume_or_weight_prefix( num_wanted ),
+                                  type->count_or_volume_or_weight_prefix( avail ) );
         } else {
-            //~ %1$s: item name, %2$d: required count
-            return string_format( npgettext( "requirement", "%2$d %1$s", "%2$d %1$s", c ),
-                                  item_temp.tname( c, tname::base_item_name ), c );
+            //~ %1$s: item name, %2$s: required count (number or weight or volume of item, depending on type)
+            return string_format( npgettext( "requirement", "%2$s %1$s", "%2$s %1$s", num_wanted ),
+                                  item_temp.tname( num_wanted, tname::base_item_name ),
+                                  type->count_or_volume_or_weight_prefix( num_wanted ) );
         }
     }
 }


### PR DESCRIPTION
#### Summary
Interface "Display some items by volume or weight, instead of count"

#### Purpose of change
What is `1200 salt`? 

I don't know. Is that a lot of salt? Is it a little bit of salt?

I DO know what `12kg of salt` is (a lot of salt!). When discussing something like salt, which does not come in discrete 'units', you would refer to it by its volume or weight. We don't currently represent that. That leads to some oddities

#### Describe the solution
Allow items to be shown by volume or weight, instead of count.

<img width="1861" height="803" alt="image" src="https://github.com/user-attachments/assets/7a2abed1-eb54-4c65-8867-3147bae80241" />

This is handled by an enum on the itype, defaulting to er... DEFAULT. For 99.9% of items nothing will change. Only a handful of common items (water, and salt) have currently been changed.

#### Describe alternatives you've considered


#### Testing
Crafting window:
<img width="951" height="339" alt="image" src="https://github.com/user-attachments/assets/a3132653-0065-49fc-b2ee-678db5ac8792" />

<img width="943" height="345" alt="image" src="https://github.com/user-attachments/assets/3448d5a9-aea5-4d35-9c50-ae90ab247e38" />


Message log (after drinking water)
<img width="272" height="23" alt="image" src="https://github.com/user-attachments/assets/4922966f-c701-4fd5-9329-79696a022078" />

AIM:
<img width="930" height="180" alt="image" src="https://github.com/user-attachments/assets/274c21ee-8b02-4a24-a315-5b86c97edfce" />


Inventory:
<img width="662" height="380" alt="image" src="https://github.com/user-attachments/assets/58d8f705-b91a-45fc-9faa-6c40d7c6d56a" />


~~During testing all my clean water was falling out of my water bottles.... I'm unsure how my changes could have caused this, I hope it was just a temporary thing from being based on old master? (If this gets merged and all the water falls out of all the things, I would like the world to know I am not responsible)~~ This was in fact my fault, but it should be resolved with Andrei's commit.

#### Additional context

Known issues:
~~We are still printing number of items/number of charges *in addition to* volume/weight for these items. There are UI concerns with removing that number. It's not the prettiest thing, maybe we can change where/how this is printed to make it better.~~ Mergers suggested that this is a blocker, so the number/amount has been removed.

~~I don't have a clear understanding of how all of our supported languages work, I suspect that this may be rough for several of them. Depending on where issues appear we could change these generic strings (e.g. `"%1$s of %2$s"`) to use a specific context, which should give the translators more flexibility in dealing with them.~~ Since it was moved out of tname this should no longer be a significant issue.

Only two items have been tagged, clean water (BY_VOLUME) and salt (BY_WEIGHT). (Technically regular `water` copies from water_clean and is also BY_VOLUME, so three items). I have not taken any sort of audit to add it to all relevant items, I want to shake out any potential issues first.