### PR TITLE
Move `construction` to generic_factory

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1691,7 +1691,7 @@ _find_alt_construction( tripoint_bub_ms const &loc, construction_id const &idx,
                         std::optional<construction_id> const &part_con_idx,
                         std::function<bool( construction const & )> const &filter )
 {
-    std::vector<construction *> cons = constructions_by_filter( filter );
+    std::vector<const construction *> cons = constructions_by_filter( filter );
     for( construction const *el : cons ) {
         if( _can_construct( loc, idx, *el, part_con_idx ) ) {
             return el;
@@ -1712,7 +1712,7 @@ construction const *_find_prereq( tripoint_bub_ms const &loc, construction_id co
                                   std::optional<construction_id> const &part_con_idx, checked_cache_t &checked_cache )
 {
     construction const *con = nullptr;
-    std::vector<construction *> cons = constructions_by_filter( [&idx, &top_idx](
+    std::vector<const construction *> cons = constructions_by_filter( [&idx, &top_idx](
     construction const & it ) {
         furn_id const f = top_idx->post_is_furniture ? _get_id<furn_id>( top_idx ) : furn_id();
         ter_id const t = top_idx->post_is_furniture ? ter_id() : _get_id<ter_id>( top_idx );

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -232,6 +232,9 @@ construction_id blueprint_options::get_final_construction(
             continue;
         }
         const construction &con_next = list_constructions[i];
+        if( con_next.is_blacklisted() ) {
+            continue;
+        }
         if( con.group == con_next.group &&
             ( con_next.pre_terrain.find( con.post_terrain ) != con_next.pre_terrain.end() ) ) {
             skip_index.insert( idx );

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -91,6 +91,7 @@ static const construction_category_id construction_category_ALL( "ALL" );
 static const construction_category_id construction_category_APPLIANCE( "APPLIANCE" );
 static const construction_category_id construction_category_DECONSTRUCT( "DECONSTRUCT" );
 static const construction_category_id construction_category_FILTER( "FILTER" );
+static const construction_category_id construction_category_OTHER( "OTHER" );
 static const construction_category_id construction_category_REPAIR( "REPAIR" );
 
 static const construction_group_str_id
@@ -1299,13 +1300,10 @@ bool can_construct( const construction &con, const tripoint_bub_ms &p )
     const map &here = get_map();
     const furn_id &f = here.furn( p );
     const ter_id &t = here.ter( p );
-    if( con.pre_specials.size() > 1 ) { // pre-functions
-        for( const auto &special : con.pre_specials ) {
-            if( !special( p ) ) {
-                return false;
-            }
-        }
-    } else if( !con.pre_special( p ) ) { // pre-function
+    // pre-functions
+    if( !std::all_of( con.pre_specials.begin(), con.pre_specials.end(), [&p]( const auto & fn ) {
+    return fn( p );
+    } ) ) {
         return false;
     }
     if( !has_pre_terrain( con, p ) || // terrain type
@@ -1547,12 +1545,8 @@ void build_construction_activity_actor::complete_construction( player_activity &
 
     // This comes after clearing the activity, in case the function interrupts
     // activities
-    if( built.post_specials.size() > 1 ) { // pre-functions
-        for( const auto &special : built.post_specials ) {
-            special( terp, you );
-        }
-    } else {
-        built.post_special( terp, you );
+    for( const auto &special : built.post_specials ) {
+        special( terp, you );
     }
     // Players will not automatically resume backlog, other Characters will.
     if( you.is_avatar() && !you.backlog.empty() &&
@@ -2310,22 +2304,27 @@ void construct::failure_deconstruct( const tripoint_bub_ms & )
     add_msg( m_info, _( "You cannot deconstruct this!" ) );
 }
 
-template <typename T>
-void assign_or_debugmsg( T &dest, const std::string &fun_id,
-                         const std::map<std::string, T> &possible )
-{
-    const auto iter = possible.find( fun_id );
-    if( iter != possible.end() ) {
-        dest = iter->second;
-    } else {
-        dest = possible.find( "" )->second;
-        const std::string list_available = enumerate_as_string( possible.begin(), possible.end(),
-        []( const std::pair<std::string, T> &pr ) {
-            return pr.first;
-        } );
-        debugmsg( "Unknown function: %s, available values are %s", fun_id.c_str(), list_available );
+template <typename Fn>
+struct construction_special_reader : generic_typed_reader<construction_special_reader<Fn>> {
+    const std::map<std::string, Fn> &possible;
+    explicit construction_special_reader( const std::map<std::string, Fn> &lookup ) : possible(
+            lookup ) {}
+
+    Fn get_next( const JsonValue &jv ) const {
+        std::string fun_id = jv.get_string();
+        const auto iter = possible.find( fun_id );
+        if( iter != possible.end() ) {
+            return iter->second;
+        } else {
+            const std::string list_available = enumerate_as_string( possible.begin(), possible.end(),
+            []( const std::pair<std::string, Fn> &pr ) {
+                return pr.first;
+            } );
+            jv.throw_error( string_format( "Unknown function: %s, available values are %s", fun_id.c_str(),
+                                           list_available ) );
+        }
     }
-}
+};
 
 void load_construction( const JsonObject &jo, const std::string &src )
 {
@@ -2334,22 +2333,19 @@ void load_construction( const JsonObject &jo, const std::string &src )
 
 void construction::load( const JsonObject &jo, const std::string_view )
 {
-    jo.get_member( "group" ).read( group );
+    mandatory( jo, was_loaded, "group", group );
     if( jo.has_member( "required_skills" ) ) {
-        for( JsonArray arr : jo.get_array( "required_skills" ) ) {
-            required_skills[skill_id( arr.get_string( 0 ) )] = arr.get_int( 1 );
-        }
-    } else {
-        skill_id legacy_skill( jo.get_string( "skill", skill_fabrication.str() ) );
-        int legacy_diff = jo.get_int( "difficulty" );
+        mandatory( jo, was_loaded, "required_skills", required_skills, pair_reader<skill_id, int> {} );
+    } else if( !was_loaded ) {
+        skill_id legacy_skill;
+        int legacy_diff;
+        optional( jo, was_loaded, "skill", legacy_skill, skill_fabrication );
+        mandatory( jo, was_loaded, "difficulty", legacy_diff );
         required_skills[ legacy_skill ] = legacy_diff;
     }
 
-    category = construction_category_id( jo.get_string( "category", "OTHER" ) );
-    if( jo.has_string( "time" ) ) {
-        time = to_moves<int>( read_from_json_string<time_duration>( jo.get_member( "time" ),
-                              time_duration::units ) );
-    }
+    optional( jo, was_loaded, "category", category, construction_category_OTHER );
+    optional( jo, was_loaded, "time", time, time_duration_as_moves_reader{} );
 
     const requirement_id req_id( "inline_construction_" + id.str() );
     requirement_data::load_requirement( jo, req_id );
@@ -2363,8 +2359,8 @@ void construction::load( const JsonObject &jo, const std::string_view )
         }
     }
 
-    jo.read( "pre_note", pre_note );
-    pre_terrain = jo.get_as_string_set( "pre_terrain" );
+    optional( jo, was_loaded, "pre_note", pre_note );
+    optional( jo, was_loaded, "pre_terrain", pre_terrain, auto_flags_reader<> {} );
     if( !pre_terrain.empty() ) {
         const std::string &first_pre_terrain = *pre_terrain.begin();
         if( first_pre_terrain.size() > 1
@@ -2374,7 +2370,7 @@ void construction::load( const JsonObject &jo, const std::string_view )
         }
     }
 
-    post_terrain = jo.get_string( "post_terrain", "" );
+    optional( jo, was_loaded, "post_terrain", post_terrain );
     if( post_terrain.size() > 1
         && post_terrain[0] == 'f'
         && post_terrain[1] == '_' ) {
@@ -2384,26 +2380,8 @@ void construction::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "activity_level", activity_level,
               activity_level_reader{}, MODERATE_EXERCISE );
 
-    if( jo.has_member( "pre_flags" ) ) {
-        pre_flags.clear();
-        if( jo.has_string( "pre_flags" ) ) {
-            pre_flags.emplace( jo.get_string( "pre_flags" ), false );
-        } else if( jo.has_object( "pre_flags" ) ) {
-            JsonObject jflag = jo.get_object( "pre_flags" );
-            pre_flags.emplace( jflag.get_string( "flag" ), jflag.get_bool( "force_terrain" ) );
-        } else if( jo.has_array( "pre_flags" ) ) {
-            for( JsonValue jval : jo.get_array( "pre_flags" ) ) {
-                if( jval.test_string() ) {
-                    pre_flags.emplace( jval.get_string(), false );
-                } else if( jval.test_object() ) {
-                    JsonObject jflag = jval.get_object();
-                    pre_flags.emplace( jflag.get_string( "flag" ), jflag.get_bool( "force_terrain" ) );
-                }
-            }
-        }
-    }
-
-    post_flags = jo.get_tags( "post_flags" );
+    optional( jo, was_loaded, "pre_flags", pre_flags, named_pair_reader<std::string, bool> { "flag", "force_terrain", false } );
+    optional( jo, was_loaded, "post_flags", post_flags, auto_flags_reader<> {} );
 
     if( jo.has_member( "byproducts" ) ) {
         byproduct_item_group = item_group::load_item_group( jo.get_member( "byproducts" ),
@@ -2472,41 +2450,24 @@ void construction::load( const JsonObject &jo, const std::string_view )
             { "deconstruct", construct::failure_deconstruct },
         }
     };
-    std::string failure_fallback = "standard";
-    if( jo.has_array( "pre_special" ) ) {
-        JsonArray jarr = jo.get_array( "pre_special" );
-        for( std::string special : jarr ) {
-            if( special == "check_deconstruct" ) {
-                failure_fallback =  "deconstruct";
-            }
-            assign_or_debugmsg( pre_special, special, pre_special_map );
-            pre_specials.push_back( pre_special );
-        }
-    } else {
-        const std::string special = jo.get_string( "pre_special", "" );
-        if( special == "check_deconstruct" ) {
-            failure_fallback =  "deconstruct";
-        }
-        assign_or_debugmsg( pre_special, special, pre_special_map );
-    }
-    if( jo.has_array( "post_special" ) ) {
-        JsonArray jarr = jo.get_array( "post_special" );
-        for( std::string special : jarr ) {
-            assign_or_debugmsg( post_special, special, post_special_map );
-            post_specials.push_back( post_special );
-        }
-    } else {
-        assign_or_debugmsg( post_special, jo.get_string( "post_special", "" ), post_special_map );
-    }
-    assign_or_debugmsg( do_turn_special, jo.get_string( "do_turn_special", "" ),
-                        do_turn_special_map );
-    assign_or_debugmsg( explain_failure, jo.get_string( "explain_failure", failure_fallback ),
-                        explain_fail_map );
-    vehicle_start = jo.get_bool( "vehicle_start", false );
+    optional( jo, was_loaded, "pre_special", pre_specials, construction_special_reader{ pre_special_map },
+    { construct::check_nothing } );
+    optional( jo, was_loaded, "post_special", post_specials, construction_special_reader{ post_special_map },
+    { construct::done_nothing } );
+    optional( jo, was_loaded, "do_turn_special", do_turn_special, construction_special_reader{ do_turn_special_map },
+              construct::done_nothing );
 
-    on_display = jo.get_bool( "on_display", true );
-    dark_craftable = jo.get_bool( "dark_craftable", false );
-    strict = jo.get_bool( "strict", false );
+    const bool fallback_deconstruct = std::any_of( pre_specials.begin(),
+    pre_specials.end(), []( const auto fn ) {
+        return fn == construct::check_deconstruct;
+    } );
+    optional( jo, was_loaded, "explain_failure", explain_failure, construction_special_reader{ explain_fail_map },
+              fallback_deconstruct ? construct::failure_deconstruct : construct::failure_standard );
+
+    optional( jo, was_loaded, "vehicle_start", vehicle_start, false );
+    optional( jo, was_loaded, "on_display", on_display, true );
+    optional( jo, was_loaded, "dark_craftable", dark_craftable, false );
+    optional( jo, was_loaded, "strict", strict, false );
 }
 
 void reset_constructions()

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -163,8 +163,6 @@ static const vproto_id vehicle_prototype_none( "none" );
 
 static const std::string flag_WIRING( "WIRING" );
 
-static bool finalized = false;
-
 // Construction functions.
 namespace construct
 {
@@ -231,8 +229,51 @@ static void failure_standard( const tripoint_bub_ms & );
 static void failure_deconstruct( const tripoint_bub_ms & );
 } // namespace construct
 
-static std::vector<construction> constructions;
-static std::map<construction_str_id, construction_id> construction_id_map;
+namespace
+{
+generic_factory<construction> construction_factory( "construction" );
+} // namespace
+
+template<>
+const construction &string_id<construction>::obj() const
+{
+    return construction_factory.obj( *this );
+}
+
+template<>
+int_id<construction> string_id<construction>::id() const
+{
+    return construction_factory.convert( *this, int_id<construction>( -1 ) );
+}
+
+template<>
+bool string_id<construction>::is_valid() const
+{
+    return construction_factory.is_valid( *this );
+}
+
+template<>
+const construction &int_id<construction>::obj() const
+{
+    return construction_factory.obj( *this );
+}
+
+template<>
+const string_id<construction> &int_id<construction>::id() const
+{
+    return construction_factory.convert( *this );
+}
+
+template<>
+bool int_id<construction>::is_valid() const
+{
+    return construction_factory.is_valid( *this );
+}
+
+template<>
+int_id<construction>::int_id( const string_id<construction> &id ) : _id( id.id() ) {}
+
+//static std::map<construction_str_id, construction_id> construction_id_map;
 
 // Helper functions, nobody but us needs to call these.
 static bool can_construct( const construction &con );
@@ -297,10 +338,6 @@ std::vector<const construction *> constructions_by_group( const construction_gro
 std::vector<const construction *>
 constructions_by_filter( std::function<bool( construction const & )> const &filter )
 {
-    if( !finalized ) {
-        debugmsg( "constructions_by_filter called before finalization" );
-        return {};
-    }
     std::vector<const construction *> result;
     for( const construction &constructions_a : get_constructions() ) {
         if( filter( constructions_a ) && !constructions_a.is_blacklisted() ) {
@@ -316,10 +353,7 @@ static void load_available_constructions( std::vector<construction_group_str_id>
 {
     cat_available.clear();
     available.clear();
-    if( !finalized ) {
-        debugmsg( "load_available_constructions called before finalization" );
-        return;
-    }
+
     avatar &player_character = get_avatar();
     for( const construction &it : get_constructions() ) {
         if( !it.on_display || it.is_blacklisted() ) {
@@ -402,12 +436,7 @@ static nc_color construction_color( const construction_group_str_id &group, bool
 
 const std::vector<construction> &get_constructions()
 {
-    if( !finalized ) {
-        debugmsg( "get_constructions called before finalization" );
-        static std::vector<construction> fake_constructions;
-        return fake_constructions;
-    }
-    return constructions;
+    return construction_factory.get_all();
 }
 
 static std::string furniture_qualities_string( const furn_id &fid )
@@ -490,10 +519,6 @@ static std::string has_pre_flags_colorize( const construction &con );
 
 construction_id construction_menu( const bool blueprint )
 {
-    if( !finalized ) {
-        debugmsg( "construction_menu called before finalization" );
-        return construction_id( -1 );
-    }
     // filter_mode: 0 = all, 1 = ready (skills & materials satisfied, but location not satisfied),
     // 2 = buildable here (skills & materials satisfied and location satisfied)
     static int filter_mode = 0;
@@ -1434,10 +1459,6 @@ void place_construction( std::vector<construction_group_str_id> const &groups )
 void build_construction_activity_actor::complete_construction( player_activity &act,
         Character &you )
 {
-    if( !finalized ) {
-        debugmsg( "complete_construction called before finalization" );
-        return;
-    }
     map &here = get_map();
     const tripoint_bub_ms terp = here.get_bub( construction_location );
     partial_con *pc = here.partial_con_at( terp );
@@ -1479,7 +1500,7 @@ void build_construction_activity_actor::complete_construction( player_activity &
     // partial_con contains components for vehicle and appliance construction
     // it's removal is handled in done_appliance() / done_vehicle
     if( pc->id->category != construction_category_APPLIANCE &&
-        pc->id->str_id != construction_constr_veh ) {
+        pc->id->id != construction_constr_veh ) {
         here.partial_con_remove( terp );
     }
 
@@ -2306,93 +2327,87 @@ void assign_or_debugmsg( T &dest, const std::string &fun_id,
     }
 }
 
-void load_construction( const JsonObject &jo )
+void load_construction( const JsonObject &jo, const std::string &src )
 {
-    construction con;
-    // These ids are only temporary. The actual ids are determined in finalize_construction,
-    // after removing blacklisted constructions.
-    con.id = construction_id( -1 );
-    con.str_id = construction_str_id( jo.get_string( "id" ) );
-    if( con.str_id.is_null() ) {
-        jo.throw_error_at( "id", "Null construction id specified" );
-    } else if( construction_id_map.find( con.str_id ) != construction_id_map.end() ) {
-        jo.throw_error_at( "id", "Duplicate construction id" );
-    }
+    construction_factory.load( jo, src );
+}
 
-    jo.get_member( "group" ).read( con.group );
+void construction::load( const JsonObject &jo, const std::string_view )
+{
+    jo.get_member( "group" ).read( group );
     if( jo.has_member( "required_skills" ) ) {
         for( JsonArray arr : jo.get_array( "required_skills" ) ) {
-            con.required_skills[skill_id( arr.get_string( 0 ) )] = arr.get_int( 1 );
+            required_skills[skill_id( arr.get_string( 0 ) )] = arr.get_int( 1 );
         }
     } else {
         skill_id legacy_skill( jo.get_string( "skill", skill_fabrication.str() ) );
         int legacy_diff = jo.get_int( "difficulty" );
-        con.required_skills[ legacy_skill ] = legacy_diff;
+        required_skills[ legacy_skill ] = legacy_diff;
     }
 
-    con.category = construction_category_id( jo.get_string( "category", "OTHER" ) );
+    category = construction_category_id( jo.get_string( "category", "OTHER" ) );
     if( jo.has_string( "time" ) ) {
-        con.time = to_moves<int>( read_from_json_string<time_duration>( jo.get_member( "time" ),
-                                  time_duration::units ) );
+        time = to_moves<int>( read_from_json_string<time_duration>( jo.get_member( "time" ),
+                              time_duration::units ) );
     }
 
-    const requirement_id req_id( "inline_construction_" + con.str_id.str() );
+    const requirement_id req_id( "inline_construction_" + id.str() );
     requirement_data::load_requirement( jo, req_id );
-    con.requirements = req_id;
+    requirements = req_id;
 
     if( jo.has_string( "using" ) ) {
-        con.reqs_using = { { requirement_id( jo.get_string( "using" ) ), 1} };
+        reqs_using = { { requirement_id( jo.get_string( "using" ) ), 1} };
     } else if( jo.has_array( "using" ) ) {
         for( JsonArray cur : jo.get_array( "using" ) ) {
-            con.reqs_using.emplace_back( requirement_id( cur.get_string( 0 ) ), cur.get_int( 1 ) );
+            reqs_using.emplace_back( requirement_id( cur.get_string( 0 ) ), cur.get_int( 1 ) );
         }
     }
 
-    jo.read( "pre_note", con.pre_note );
-    con.pre_terrain = jo.get_as_string_set( "pre_terrain" );
-    if( !con.pre_terrain.empty() ) {
-        const std::string &first_pre_terrain = *con.pre_terrain.begin();
+    jo.read( "pre_note", pre_note );
+    pre_terrain = jo.get_as_string_set( "pre_terrain" );
+    if( !pre_terrain.empty() ) {
+        const std::string &first_pre_terrain = *pre_terrain.begin();
         if( first_pre_terrain.size() > 1
             && first_pre_terrain[0] == 'f'
             && first_pre_terrain[1] == '_' ) {
-            con.pre_is_furniture = true;
+            pre_is_furniture = true;
         }
     }
 
-    con.post_terrain = jo.get_string( "post_terrain", "" );
-    if( con.post_terrain.size() > 1
-        && con.post_terrain[0] == 'f'
-        && con.post_terrain[1] == '_' ) {
-        con.post_is_furniture = true;
+    post_terrain = jo.get_string( "post_terrain", "" );
+    if( post_terrain.size() > 1
+        && post_terrain[0] == 'f'
+        && post_terrain[1] == '_' ) {
+        post_is_furniture = true;
     }
 
-    optional( jo, false/*con.was_loaded*/, "activity_level", con.activity_level,
+    optional( jo, was_loaded, "activity_level", activity_level,
               activity_level_reader{}, MODERATE_EXERCISE );
 
     if( jo.has_member( "pre_flags" ) ) {
-        con.pre_flags.clear();
+        pre_flags.clear();
         if( jo.has_string( "pre_flags" ) ) {
-            con.pre_flags.emplace( jo.get_string( "pre_flags" ), false );
+            pre_flags.emplace( jo.get_string( "pre_flags" ), false );
         } else if( jo.has_object( "pre_flags" ) ) {
             JsonObject jflag = jo.get_object( "pre_flags" );
-            con.pre_flags.emplace( jflag.get_string( "flag" ), jflag.get_bool( "force_terrain" ) );
+            pre_flags.emplace( jflag.get_string( "flag" ), jflag.get_bool( "force_terrain" ) );
         } else if( jo.has_array( "pre_flags" ) ) {
             for( JsonValue jval : jo.get_array( "pre_flags" ) ) {
                 if( jval.test_string() ) {
-                    con.pre_flags.emplace( jval.get_string(), false );
+                    pre_flags.emplace( jval.get_string(), false );
                 } else if( jval.test_object() ) {
                     JsonObject jflag = jval.get_object();
-                    con.pre_flags.emplace( jflag.get_string( "flag" ), jflag.get_bool( "force_terrain" ) );
+                    pre_flags.emplace( jflag.get_string( "flag" ), jflag.get_bool( "force_terrain" ) );
                 }
             }
         }
     }
 
-    con.post_flags = jo.get_tags( "post_flags" );
+    post_flags = jo.get_tags( "post_flags" );
 
     if( jo.has_member( "byproducts" ) ) {
-        con.byproduct_item_group = item_group::load_item_group( jo.get_member( "byproducts" ),
-                                   "collection", "byproducts of construction " + con.str_id.str() );
+        byproduct_item_group = item_group::load_item_group( jo.get_member( "byproducts" ),
+                               "collection", "byproducts of construction " + id.str() );
     }
 
     static const std::map<std::string, bool( * )( const tripoint_bub_ms & )> pre_special_map = {{
@@ -2464,92 +2479,78 @@ void load_construction( const JsonObject &jo )
             if( special == "check_deconstruct" ) {
                 failure_fallback =  "deconstruct";
             }
-            assign_or_debugmsg( con.pre_special, special, pre_special_map );
-            con.pre_specials.push_back( con.pre_special );
+            assign_or_debugmsg( pre_special, special, pre_special_map );
+            pre_specials.push_back( pre_special );
         }
     } else {
         const std::string special = jo.get_string( "pre_special", "" );
         if( special == "check_deconstruct" ) {
             failure_fallback =  "deconstruct";
         }
-        assign_or_debugmsg( con.pre_special, special, pre_special_map );
+        assign_or_debugmsg( pre_special, special, pre_special_map );
     }
     if( jo.has_array( "post_special" ) ) {
         JsonArray jarr = jo.get_array( "post_special" );
         for( std::string special : jarr ) {
-            assign_or_debugmsg( con.post_special, special, post_special_map );
-            con.post_specials.push_back( con.post_special );
+            assign_or_debugmsg( post_special, special, post_special_map );
+            post_specials.push_back( post_special );
         }
     } else {
-        assign_or_debugmsg( con.post_special, jo.get_string( "post_special", "" ), post_special_map );
+        assign_or_debugmsg( post_special, jo.get_string( "post_special", "" ), post_special_map );
     }
-    assign_or_debugmsg( con.do_turn_special, jo.get_string( "do_turn_special", "" ),
+    assign_or_debugmsg( do_turn_special, jo.get_string( "do_turn_special", "" ),
                         do_turn_special_map );
-    assign_or_debugmsg( con.explain_failure, jo.get_string( "explain_failure", failure_fallback ),
+    assign_or_debugmsg( explain_failure, jo.get_string( "explain_failure", failure_fallback ),
                         explain_fail_map );
-    con.vehicle_start = jo.get_bool( "vehicle_start", false );
+    vehicle_start = jo.get_bool( "vehicle_start", false );
 
-    con.on_display = jo.get_bool( "on_display", true );
-    con.dark_craftable = jo.get_bool( "dark_craftable", false );
-    con.strict = jo.get_bool( "strict", false );
-
-    constructions.push_back( con );
-    construction_id_map.emplace( con.str_id, con.id );
+    on_display = jo.get_bool( "on_display", true );
+    dark_craftable = jo.get_bool( "dark_craftable", false );
+    strict = jo.get_bool( "strict", false );
 }
 
 void reset_constructions()
 {
-    constructions.clear();
-    construction_id_map.clear();
-    finalized = false;
+    construction_factory.reset();
 }
 
 void check_constructions()
 {
-    for( size_t i = 0; i < constructions.size(); i++ ) {
-        const construction &c = constructions[ i ];
-        const std::string display_name = "construction " + c.str_id.str();
-        for( const auto &pr : c.required_skills ) {
-            if( !pr.first.is_valid() ) {
-                debugmsg( "Unknown skill %s in %s", pr.first.c_str(), display_name );
-            }
-        }
+    construction_factory.check();
+}
 
-        if( !c.requirements.is_valid() ) {
-            debugmsg( "%s has missing requirement data %s",
-                      display_name, c.requirements.c_str() );
+void construction::check() const
+{
+    const std::string display_name = "construction " + id.str();
+    for( const auto &pr : required_skills ) {
+        if( !pr.first.is_valid() ) {
+            debugmsg( "Unknown skill %s in %s", pr.first.c_str(), display_name );
         }
+    }
 
-        if( !c.pre_terrain.empty() ) {
-            for( const auto &pre_terrain : c.pre_terrain ) {
-                if( c.pre_is_furniture ) {
-                    if( !furn_str_id( pre_terrain ).is_valid() ) {
-                        debugmsg( "Unknown pre_terrain (furniture) %s in %s", pre_terrain, display_name );
-                    }
-                } else if( !ter_str_id( pre_terrain ).is_valid() ) {
-                    debugmsg( "Unknown pre_terrain (terrain) %s in %s", pre_terrain, display_name );
+    if( !requirements.is_valid() ) {
+        debugmsg( "%s has missing requirement data %s",
+                  display_name, requirements.c_str() );
+    }
+
+    if( !pre_terrain.empty() ) {
+        for( const auto &pre_terrain : pre_terrain ) {
+            if( pre_is_furniture ) {
+                if( !furn_str_id( pre_terrain ).is_valid() ) {
+                    debugmsg( "Unknown pre_terrain (furniture) %s in %s", pre_terrain, display_name );
                 }
+            } else if( !ter_str_id( pre_terrain ).is_valid() ) {
+                debugmsg( "Unknown pre_terrain (terrain) %s in %s", pre_terrain, display_name );
             }
         }
-        if( !c.post_terrain.empty() ) {
-            if( c.post_is_furniture ) {
-                if( !furn_str_id( c.post_terrain ).is_valid() ) {
-                    debugmsg( "Unknown post_terrain (furniture) %s in %s", c.post_terrain, display_name );
-                }
-            } else if( !ter_str_id( c.post_terrain ).is_valid() ) {
-                debugmsg( "Unknown post_terrain (terrain) %s in %s", c.post_terrain, display_name );
+    }
+    if( !post_terrain.empty() ) {
+        if( post_is_furniture ) {
+            if( !furn_str_id( post_terrain ).is_valid() ) {
+                debugmsg( "Unknown post_terrain (furniture) %s in %s", post_terrain, display_name );
             }
-        }
-        if( c.id != construction_id( i ) ) {
-            debugmsg( "%s has id %u, but should have %u",
-                      display_name, c.id.to_i(), i );
-        }
-        if( construction_id_map.find( c.str_id ) == construction_id_map.end() ) {
-            debugmsg( "%s is an invalid string id",
-                      display_name );
-        } else if( construction_id_map[c.str_id] != construction_id( i ) ) {
-            debugmsg( "%s points to int id %u, but should point to %u",
-                      display_name, construction_id_map[c.str_id].to_i(), i );
+        } else if( !ter_str_id( post_terrain ).is_valid() ) {
+            debugmsg( "Unknown post_terrain (terrain) %s in %s", post_terrain, display_name );
         }
     }
 }
@@ -2606,9 +2607,11 @@ std::vector<std::string> construction::get_folded_time_string( int width ) const
     return folded_time;
 }
 
+static std::vector<item_comp> frame_items;
+
 void finalize_constructions()
 {
-    std::vector<item_comp> frame_items;
+    frame_items.clear();
     for( const vpart_info &vpi : vehicles::parts::get_all() ) {
         if( !vpi.has_flag( flag_INITIAL_PART.str() ) ) {
             continue;
@@ -2624,40 +2627,35 @@ void finalize_constructions()
         debugmsg( "No valid frames detected for vehicle construction" );
     }
 
-    for( construction &con : constructions ) {
-        if( !con.group.is_valid() ) {
-            debugmsg( "Invalid construction group (%s) defined for construction (%s)",
-                      con.group.str(), con.str_id.str() );
-        }
-        if( con.vehicle_start ) {
-            const_cast<requirement_data &>( con.requirements.obj() ).get_components().push_back( frame_items );
-        }
-        bool is_valid_construction_category = false;
-        for( const construction_category &cc : construction_categories::get_all() ) {
-            if( con.category == cc.id ) {
-                is_valid_construction_category = true;
-                break;
-            }
-        }
-        if( !is_valid_construction_category ) {
-            debugmsg( "Invalid construction category (%s) defined for construction (%s)", con.category.str(),
-                      con.str_id.str() );
-        }
-        requirement_data requirements_ = std::accumulate(
-                                             con.reqs_using.begin(), con.reqs_using.end(), *con.requirements );
+    construction_factory.finalize();
+}
 
-        requirement_data::save_requirement( requirements_, con.requirements );
-        con.reqs_using.clear();
-        inp_mngr.pump_events();
+void construction::finalize()
+{
+    if( !group.is_valid() ) {
+        debugmsg( "Invalid construction group (%s) defined for construction (%s)",
+                  group.str(), id.str() );
     }
-
-    construction_id_map.clear();
-    for( size_t i = 0; i < constructions.size(); i++ ) {
-        constructions[ i ].id = construction_id( i );
-        construction_id_map.emplace( constructions[i].str_id, constructions[i].id );
+    if( vehicle_start ) {
+        const_cast<requirement_data &>( requirements.obj() ).get_components().push_back( frame_items );
     }
+    bool is_valid_construction_category = false;
+    for( const construction_category &cc : construction_categories::get_all() ) {
+        if( category == cc.id ) {
+            is_valid_construction_category = true;
+            break;
+        }
+    }
+    if( !is_valid_construction_category ) {
+        debugmsg( "Invalid construction category (%s) defined for construction (%s)", category.str(),
+                  id.str() );
+    }
+    requirement_data requirements_ = std::accumulate(
+                                         reqs_using.begin(), reqs_using.end(), *requirements );
 
-    finalized = true;
+    requirement_data::save_requirement( requirements_, requirements );
+    reqs_using.clear();
+    inp_mngr.pump_events();
 }
 
 bool construction::is_blacklisted() const
@@ -2737,7 +2735,7 @@ std::vector<construction_id> find_build_sequence( const std::string &target_id,
     while( current_terrain != target_id ) {
         auto it = parent.find( current_terrain );
         const auto& [cons_ptr, next_terrain] = it->second;
-        ret.push_back( cons_ptr->id );
+        ret.emplace_back( cons_ptr->id );
         current_terrain = next_terrain;
     }
     return ret;
@@ -2749,10 +2747,6 @@ build_reqs get_build_reqs_for_furn_ter_ids(
     ter_id const &base_ter = ter_t_dirt.id();
     build_reqs total_reqs;
 
-    if( !finalized ) {
-        debugmsg( "get_build_reqs_for_furn_ter_ids called before finalization" );
-        return total_reqs;
-    }
     std::map<construction_id, int> total_builds;
 
     // find the shortest route to create target terrain from empty or base terrain,
@@ -2805,90 +2799,4 @@ build_reqs get_build_reqs_for_furn_ter_ids(
     }
 
     return total_reqs;
-}
-
-static const construction null_construction {};
-
-template <>
-const construction_str_id &construction_id::id() const
-{
-    if( !finalized ) {
-        debugmsg( "construction_id::id called before finalization" );
-        return construction_str_id::NULL_ID();
-    } else if( is_valid() ) {
-        return constructions[to_i()].str_id;
-    } else {
-        if( to_i() != -1 ) {
-            debugmsg( "Invalid construction id %d", to_i() );
-        }
-        return construction_str_id::NULL_ID();
-    }
-}
-
-template <>
-const construction &construction_id::obj() const
-{
-    if( !finalized ) {
-        debugmsg( "construction_id::obj called before finalization" );
-        return null_construction;
-    } else if( is_valid() ) {
-        return constructions[to_i()];
-    } else {
-        debugmsg( "Invalid construction id %d", to_i() );
-        return null_construction;
-    }
-}
-
-template <>
-bool construction_id::is_valid() const
-{
-    if( !finalized ) {
-        debugmsg( "construction_id::is_valid called before finalization" );
-        return false;
-    }
-    return to_i() >= 0 && static_cast<size_t>( to_i() ) < constructions.size();
-}
-
-template <>
-construction_id construction_str_id::id() const
-{
-    if( !finalized ) {
-        debugmsg( "construction_str_id::id called before finalization" );
-        return construction_id( -1 );
-    }
-    auto it = construction_id_map.find( *this );
-    if( it != construction_id_map.end() ) {
-        return it->second;
-    } else {
-        if( !is_null() ) {
-            debugmsg( "Invalid construction str id %s", str() );
-        }
-        return construction_id( -1 );
-    }
-}
-
-template <>
-const construction &construction_str_id::obj() const
-{
-    if( !finalized ) {
-        debugmsg( "construction_str_id::obj called before finalization" );
-        return null_construction;
-    }
-    auto it = construction_id_map.find( *this );
-    if( it != construction_id_map.end() ) {
-        return it->second.obj();
-    } else {
-        debugmsg( "Invalid construction str id %s", str() );
-        return null_construction;
-    }
-}
-
-template <>
-bool construction_str_id::is_valid() const
-{
-    if( !finalized ) {
-        debugmsg( "construction_str_id::is_valid called before finalization" );
-        return false;
-    }
-    return construction_id_map.find( *this ) != construction_id_map.end();
 }

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -303,7 +303,7 @@ constructions_by_filter( std::function<bool( construction const & )> const &filt
     }
     std::vector<const construction *> result;
     for( const construction &constructions_a : get_constructions() ) {
-        if( filter( constructions_a ) ) {
+        if( filter( constructions_a ) && !constructions_a.is_blacklisted() ) {
             result.push_back( &constructions_a );
         }
     }
@@ -322,7 +322,7 @@ static void load_available_constructions( std::vector<construction_group_str_id>
     }
     avatar &player_character = get_avatar();
     for( const construction &it : get_constructions() ) {
-        if( !it.on_display ) {
+        if( !it.on_display || it.is_blacklisted() ) {
             continue;
         }
         bool ok = false;
@@ -2651,11 +2651,6 @@ void finalize_constructions()
         inp_mngr.pump_events();
     }
 
-    constructions.erase( std::remove_if( constructions.begin(), constructions.end(),
-    [&]( const construction & c ) {
-        return c.requirements->is_blacklisted();
-    } ), constructions.end() );
-
     construction_id_map.clear();
     for( size_t i = 0; i < constructions.size(); i++ ) {
         constructions[ i ].id = construction_id( i );
@@ -2663,6 +2658,11 @@ void finalize_constructions()
     }
 
     finalized = true;
+}
+
+bool construction::is_blacklisted() const
+{
+    return requirements->is_blacklisted();
 }
 
 // Using BFS to find the shortest route to create target terrain from empty or base terrain,
@@ -2673,7 +2673,7 @@ std::vector<construction_id> find_build_sequence( const std::string &target_id,
     // make a post_terrain->construction multimap for speedy search
     std::unordered_multimap<std::string, const construction *> construction_map;
     for( construction const &cons : get_constructions() ) {
-        if( !filter( cons ) ) {
+        if( !filter( cons ) || cons.is_blacklisted() ) {
             continue;
         }
         construction_map.insert( { cons.post_terrain, &cons } );

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -236,7 +236,7 @@ static std::map<construction_str_id, construction_id> construction_id_map;
 
 // Helper functions, nobody but us needs to call these.
 static bool can_construct( const construction &con );
-static std::vector<construction *> player_can_build_valid_constructions( Character &you,
+static std::vector<const construction *> player_can_build_valid_constructions( Character &you,
         const read_only_visitable &inv, const construction_group_str_id &group );
 static bool player_can_build( Character &you, const read_only_visitable &inv,
                               const construction_group_str_id &group );
@@ -286,18 +286,7 @@ static bool has_pre_terrain( const construction &con )
     return false;
 }
 
-void standardize_construction_times( const int time )
-{
-    if( !finalized ) {
-        debugmsg( "standardize_construction_times called before finalization" );
-        return;
-    }
-    for( construction &c : constructions ) {
-        c.time = time;
-    }
-}
-
-std::vector<construction *> constructions_by_group( const construction_group_str_id &group )
+std::vector<const construction *> constructions_by_group( const construction_group_str_id &group )
 {
     return constructions_by_filter(
     [&group]( construction const & it ) {
@@ -305,15 +294,15 @@ std::vector<construction *> constructions_by_group( const construction_group_str
     } );
 }
 
-std::vector<construction *>
+std::vector<const construction *>
 constructions_by_filter( std::function<bool( construction const & )> const &filter )
 {
     if( !finalized ) {
         debugmsg( "constructions_by_filter called before finalization" );
         return {};
     }
-    std::vector<construction *> result;
-    for( construction &constructions_a : constructions ) {
+    std::vector<const construction *> result;
+    for( const construction &constructions_a : get_constructions() ) {
         if( filter( constructions_a ) ) {
             result.push_back( &constructions_a );
         }
@@ -332,7 +321,7 @@ static void load_available_constructions( std::vector<construction_group_str_id>
         return;
     }
     avatar &player_character = get_avatar();
-    for( construction &it : constructions ) {
+    for( const construction &it : get_constructions() ) {
         if( !it.on_display ) {
             continue;
         }
@@ -394,8 +383,8 @@ static nc_color construction_color( const construction_group_str_id &group, bool
     if( player_character.has_trait( trait_DEBUG_HS ) ) {
         col = c_white;
     } else {
-        std::vector<construction *> cons = player_can_build_valid_constructions( player_character,
-                                           player_character.crafting_inventory(), group );
+        std::vector<const construction *> cons = player_can_build_valid_constructions( player_character,
+                player_character.crafting_inventory(), group );
         if( !cons.empty() ) {
             col = c_white;
             for( const auto &pr : cons.front()->required_skills ) {
@@ -438,7 +427,7 @@ static std::string furniture_qualities_string( const furn_id &fid )
     return ret;
 }
 
-static std::pair<std::map<tripoint_bub_ms, const construction *>, std::vector<construction *>>
+static std::pair<std::map<tripoint_bub_ms, const construction *>, std::vector<const construction *>>
         valid_constructions_near_player( const std::vector<construction_group_str_id> &groups,
                 const inventory &total_inv, avatar &player_character );
 
@@ -602,17 +591,17 @@ construction_id construction_menu( const bool blueprint )
             //construct the project list buffer
 
             // Print stages and their requirement.
-            std::vector<construction *> options = constructions_by_group( current_group );
+            std::vector<const construction *> options = constructions_by_group( current_group );
 
             construct_buffers.clear();
             current_construct_breakpoint = 0;
             construct_buffer_breakpoints.clear();
             full_construct_buffer.clear();
             int stage_counter = 0;
-            for( std::vector<construction *>::iterator it = options.begin();
+            for( std::vector<const construction *>::iterator it = options.begin();
                  it != options.end(); ++it ) {
                 stage_counter++;
-                construction *current_con = *it;
+                const construction *current_con = *it;
                 if( filter_mode == 1 ) {
                     // show stages where skills & materials are satisfied but location is not
                     if( !( player_can_build( player_character, total_inv, *current_con, true ) &&
@@ -1140,16 +1129,16 @@ construction_id construction_menu( const bool blueprint )
     return ret;
 }
 
-static std::vector<construction *> player_can_build_valid_constructions( Character &you,
+std::vector<const construction *> player_can_build_valid_constructions( Character &you,
         const read_only_visitable &inv,
         const construction_group_str_id &group )
 {
-    std::vector<construction *> result;
+    std::vector<const construction *> result;
 
     // check all with the same group to see if player can build any
     // if so, it will be added to the result
-    std::vector<construction *> cons = constructions_by_group( group );
-    for( construction *&con : cons ) {
+    std::vector<const construction *> cons = constructions_by_group( group );
+    for( const construction *&con : cons ) {
         if( player_can_build( you, inv, *con ) ) {
             result.push_back( con );
         }
@@ -1161,8 +1150,8 @@ bool player_can_build( Character &you, const read_only_visitable &inv,
                        const construction_group_str_id &group )
 {
     // check all with the same group to see if player can build any
-    std::vector<construction *> cons = constructions_by_group( group );
-    for( construction *&con : cons ) {
+    std::vector<const construction *> cons = constructions_by_group( group );
+    for( const construction *&con : cons ) {
         if( player_can_build( you, inv, *con ) ) {
             return true;
         }
@@ -1192,8 +1181,8 @@ bool player_can_see_to_build( Character &you, const construction_group_str_id &g
     if( you.fine_detail_vision_mod() < 4 || you.has_trait( trait_DEBUG_HS ) ) {
         return true;
     }
-    std::vector<construction *> cons = constructions_by_group( group );
-    for( construction *&con : cons ) {
+    std::vector<const construction *> cons = constructions_by_group( group );
+    for( const construction *&con : cons ) {
         if( con->dark_craftable ) {
             return true;
         }
@@ -1319,16 +1308,16 @@ bool can_construct( const construction &con )
     return false;
 }
 
-std::pair<std::map<tripoint_bub_ms, const construction *>, std::vector<construction *>>
+std::pair<std::map<tripoint_bub_ms, const construction *>, std::vector<const construction *>>
         valid_constructions_near_player( const std::vector<construction_group_str_id> &groups,
                 const inventory &total_inv, avatar &player_character )
 {
-    std::pair<std::map<tripoint_bub_ms, const construction *>, std::vector<construction *>> ret;
+    std::pair<std::map<tripoint_bub_ms, const construction *>, std::vector<const construction *>> ret;
     std::map<tripoint_bub_ms, const construction *> &valid = ret.first;
-    std::vector<construction *> &cons = ret.second;
+    std::vector<const construction *> &cons = ret.second;
     map &here = get_map();
     for( construction_group_str_id const &group : groups ) {
-        std::vector<construction *> const temp = constructions_by_group( group );
+        std::vector<const construction *> const temp = constructions_by_group( group );
         for( const tripoint_bub_ms &p : here.points_in_radius( player_character.pos_bub(), 1 ) ) {
             for( const auto *con : temp ) {
                 if( p != player_character.pos_bub() && can_construct( *con, p ) &&
@@ -1347,10 +1336,10 @@ void place_construction( std::vector<construction_group_str_id> const &groups )
     avatar &player_character = get_avatar();
     const inventory &total_inv = player_character.crafting_inventory();
 
-    std::pair<std::map<tripoint_bub_ms, const construction *>, std::vector<construction *>>
+    std::pair<std::map<tripoint_bub_ms, const construction *>, std::vector<const construction *>>
             valid_pair = valid_constructions_near_player( groups, total_inv, player_character );
     std::map<tripoint_bub_ms, const construction *> &valid = valid_pair.first;
-    std::vector<construction *> &cons = valid_pair.second;
+    std::vector<const construction *> &cons = valid_pair.second;
     map &here = get_map();
 
     bool blink = true;
@@ -2683,7 +2672,7 @@ std::vector<construction_id> find_build_sequence( const std::string &target_id,
 {
     // make a post_terrain->construction multimap for speedy search
     std::unordered_multimap<std::string, const construction *> construction_map;
-    for( construction const &cons : constructions ) {
+    for( construction const &cons : get_constructions() ) {
         if( !filter( cons ) ) {
             continue;
         }

--- a/src/construction.h
+++ b/src/construction.h
@@ -79,12 +79,10 @@ struct construction {
         bool vehicle_start = false;
 
         // Custom constructibility check
-        bool ( *pre_special )( const tripoint_bub_ms & );
         std::vector<bool ( * )( const tripoint_bub_ms & )> pre_specials;
         // Custom while constructing effects
         void ( *do_turn_special )( const tripoint_bub_ms &, Character & );
         // Custom after-effects
-        void ( *post_special )( const tripoint_bub_ms &, Character & );
         std::vector<void ( * )( const tripoint_bub_ms &, Character & )> post_specials;
         // Custom error message display
         void ( *explain_failure )( const tripoint_bub_ms & );

--- a/src/construction.h
+++ b/src/construction.h
@@ -8,6 +8,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -19,7 +20,6 @@
 
 class Character;
 class read_only_visitable;
-struct construction;
 struct point;
 
 namespace catacurses
@@ -34,11 +34,6 @@ struct partial_con {
     std::list<item> components;
     construction_id id = construction_id( -1 );
 };
-
-template <>
-const construction &construction_id::obj() const;
-template <>
-bool construction_id::is_valid() const;
 
 struct construction {
         // Construction type category
@@ -71,12 +66,15 @@ struct construction {
         bool is_blacklisted() const;
 
         // Index in construction vector
-        construction_id id = construction_id( -1 );
-        construction_str_id str_id = construction_str_id::NULL_ID();
+        construction_str_id id;
+        void load( const JsonObject &jo, std::string_view );
+        void check() const;
+        void finalize();
 
         // Time in moves
         int time = 0;
 
+        bool was_loaded = false;
         // If true, the requirements are generated during finalization
         bool vehicle_start = false;
 
@@ -119,7 +117,7 @@ struct construction {
 const std::vector<construction> &get_constructions();
 
 void place_construction( std::vector<construction_group_str_id> const &groups );
-void load_construction( const JsonObject &jo );
+void load_construction( const JsonObject &jo, const std::string &src );
 void reset_constructions();
 construction_id construction_menu( bool blueprint );
 bool has_pre_flags( const construction &con, furn_id const &f, ter_id const &t );

--- a/src/construction.h
+++ b/src/construction.h
@@ -68,6 +68,8 @@ struct construction {
         std::vector<std::pair<requirement_id, int>> reqs_using;
         requirement_id requirements;
 
+        bool is_blacklisted() const;
+
         // Index in construction vector
         construction_id id = construction_id( -1 );
         construction_str_id str_id = construction_str_id::NULL_ID();

--- a/src/construction.h
+++ b/src/construction.h
@@ -116,9 +116,6 @@ struct construction {
 
 const std::vector<construction> &get_constructions();
 
-//! Set all constructions to take the specified time.
-void standardize_construction_times( int time );
-
 void place_construction( std::vector<construction_group_str_id> const &groups );
 void load_construction( const JsonObject &jo );
 void reset_constructions();
@@ -127,9 +124,10 @@ bool has_pre_flags( const construction &con, furn_id const &f, ter_id const &t )
 bool can_construct( const construction &con, const tripoint_bub_ms &p );
 bool player_can_build( Character &you, const read_only_visitable &inv, const construction &con,
                        bool can_construct_skip = false );
-std::vector<construction *> constructions_by_group( const construction_group_str_id &group );
-std::vector<construction *> constructions_by_filter( std::function<bool( construction const & )>
-        const &filter );
+std::vector<const construction *> constructions_by_group( const construction_group_str_id &group );
+std::vector<const construction *> constructions_by_filter(
+    std::function<bool( construction const & )>
+    const &filter );
 void check_constructions();
 void finalize_constructions();
 std::vector<construction_id> find_build_sequence( const std::string &target_id,

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -2256,6 +2256,14 @@ class text_style_check_reader : public generic_typed_reader<text_style_check_rea
         allow_object object_allowed;
 };
 
+struct time_duration_as_moves_reader : public generic_typed_reader<time_duration_as_moves_reader> {
+    int64_t get_next( const JsonValue &jv ) const {
+        time_duration ret;
+        jv.read( ret );
+        return to_moves<int64_t>( ret );
+    }
+};
+
 class activity_level_reader : public generic_typed_reader<activity_level_reader>
 {
     public:

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2952,10 +2952,10 @@ std::optional<int> iuse::dig( Character *p, item *it, const tripoint_bub_ms & )
 
     std::vector<construction> const &cnstr = get_constructions();
     auto const build = std::find_if( cnstr.begin(), cnstr.end(), []( const construction & it ) {
-        return it.str_id == construction_constr_pit;
+        return it.id == construction_constr_pit;
     } );
     auto const build_shallow = std::find_if( cnstr.begin(), cnstr.end(), []( const construction & it ) {
-        return it.str_id == construction_constr_pit_shallow;
+        return it.id == construction_constr_pit_shallow;
     } );
 
     place_construction( { build->group, build_shallow->group } );
@@ -2976,7 +2976,7 @@ std::optional<int> iuse::dig_channel( Character *p, item *it, const tripoint_bub
 
     std::vector<construction> const &cnstr = get_constructions();
     auto const build = std::find_if( cnstr.begin(), cnstr.end(), []( const construction & it ) {
-        return it.str_id == construction_constr_water_channel;
+        return it.id == construction_constr_water_channel;
     } );
 
     place_construction( { build->group } );
@@ -2996,7 +2996,7 @@ std::optional<int> iuse::fill_pit( Character *p, item *it, const tripoint_bub_ms
 
     std::vector<construction> const &cnstr = get_constructions();
     auto const build = std::find_if( cnstr.begin(), cnstr.end(), []( const construction & it ) {
-        return it.str_id == construction_constr_fill_pit;
+        return it.id == construction_constr_fill_pit;
     } );
 
     place_construction( { build->group } );
@@ -3016,7 +3016,7 @@ std::optional<int> iuse::clear_rubble( Character *p, item *it, const tripoint_bu
 
     std::vector<construction> const &cnstr = get_constructions();
     auto const build = std::find_if( cnstr.begin(), cnstr.end(), []( const construction & it ) {
-        return it.str_id == construction_constr_clear_rubble;
+        return it.id == construction_constr_clear_rubble;
     } );
 
     place_construction( { build->group } );

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -233,14 +233,6 @@ bool recipe::has_flag( const std::string &flag_name ) const
     return flags.count( flag_name );
 }
 
-struct time_duration_as_moves_reader : public generic_typed_reader<time_duration_as_moves_reader> {
-    int64_t get_next( const JsonValue &jv ) const {
-        time_duration ret;
-        jv.read( ret );
-        return to_moves<int64_t>( ret );
-    }
-};
-
 void recipe::load( const JsonObject &jo, const std::string_view src )
 {
     abstract = jo.has_string( "abstract" );

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -112,7 +112,7 @@ construction get_construction( std::string const &name )
 {
     std::vector<construction> const &cnstr = get_constructions();
     auto const build = std::find_if( cnstr.begin(), cnstr.end(), [&name]( const construction & it ) {
-        return it.str_id == construction_str_id( name );
+        return it.id == construction_str_id( name );
     } );
     return *build;
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Support copy-from and other JSON inheritance features for constructions"

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/86859

#### Describe the solution
Move `construction` to `generic_factory` and update it's load function to use `optional` and `mandatory` for most items.

This involved removing the extra function pointer for `pre`/`post` functions and just always using the `vector` values.

Requirements and byproducts are not using `optional`/`mandatory` because there isn't plug-in support for it.

#### Testing
Tests pass, all mods load correctly.

Construction in game seems to be working normally, and the menu is displaying normal values.

Digging a water channel (exercising pre) works correctly.
Placing appliance (exercising post) works correctly.