### PR TITLE
Show input context to player

### DIFF
--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -666,9 +666,19 @@ keybindings_ui::keybindings_ui( bool permit_execute_action,
 {
     this->ctxt = parent;
 
-    legend.push_back( colorize( _( "Unbound keys" ), unbound_key ) );
-    legend.push_back( colorize( _( "Keybinding active only on this screen" ), local_key ) );
-    legend.push_back( colorize( _( "Keybinding active globally" ), global_key ) );
+    // FIXME? These categories aren't translated. It's still useful to display them, even if the viewer can't understand them.
+    if( parent->category == "DEFAULTMODE" ) {
+        legend.emplace_back( _( "Currently showing keys for the main game." ) );
+    } else {
+        legend.push_back( string_format( _( "Currently showing keys ONLY for the last opened window: %s!" ),
+                                         parent->category ) );
+    }
+
+    legend.push_back( colorize( _( "Unbound keys are colored like this." ), unbound_key ) );
+    legend.push_back( colorize( _( "Keybinding active only on this screen are colored like this." ),
+                                local_key ) );
+    legend.push_back( colorize( _( "Keybinding active globally are colored like this." ),
+                                global_key ) );
     legend.push_back( colorize( _( "* User customized" ), global_key ) );
     if( permit_execute_action ) {
         legend.push_back( string_format(

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -104,7 +104,7 @@ class mission_ui_impl : public cataimgui::window
 
 void mission_ui::draw_mission_ui()
 {
-    input_context ctxt;
+    input_context ctxt( "MISSION_UI" );
     mission_ui_impl p_impl;
 
     ctxt.register_navigate_ui_list();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
We have a great many UIs and with it, we have input contexts... this means that pressing `w` during main gameplay is different than pressing `w` in any of our many, many windows.

Despite this, that isn't clearly conveyed to the player: It's only *suggested* by the phrase "Keybindings active only on this screen".

#### Describe the solution
Add a notice, and print the input context we're working with.

(Also, embarrassingly discover that the mission UI is the only place not categorizing its input context. So fixed that while I was here.)

#### Describe alternatives you've considered


#### Testing
<img width="553" height="61" alt="image" src="https://github.com/user-attachments/assets/20254f41-a30a-4cc5-b70e-44f2f569bc1c" />

#### Additional context
These categories aren't translated. It's still useful to display them, even if the viewer can't understand them.

We COULD translate them by marking them as `to_translation("foo")` and then calling for the translated string here in the keybindings UI. But I am not sure that's necessary.