### PR TITLE
 Cache highway lake test results to avoid O(a billion) noise calculations

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -2097,11 +2097,14 @@ bool overmap::guess_has_lake( const point_abs_om &p, const double noise_threshol
     const om_noise::om_noise_layer_lake noise_func( origin, g->get_seed() );
 
     int lake_tiles = 0;
-    for( int i = 0; i < OMAPX; i++ ) {
+    for( int i = 0; i < OMAPX && lake_tiles < max_tile_count; i++ ) {
         for( int j = 0; j < OMAPY; j++ ) {
             const point_om_omt seed_point( i, j );
             if( omt_lake_noise_threshold( origin, seed_point, noise_threshold ) ) {
                 lake_tiles++;
+                if( lake_tiles >= max_tile_count ) {
+                    break;
+                }
             }
         }
     }

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -394,6 +394,8 @@ class highway_intersection_grid : public overmap_feature_grid
         // cannot be placed in constructor because options are loaded after overmapbuffer
         void set_options();
         void generate_offset( overmap_feature_grid_node &node ) override;
+    private:
+        std::unordered_map<point_abs_om, bool> om_has_lake_cache;
 };
 
 /*

--- a/src/overmap_highway.cpp
+++ b/src/overmap_highway.cpp
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -1063,14 +1064,23 @@ void highway_intersection_grid::set_options()
 void highway_intersection_grid::generate_offset( overmap_feature_grid_node &node )
 {
     const int max_offset_variance = this->max_offset_variance;
-    auto no_lakes = []( const point_abs_om & pt ) {
+    auto no_lakes = [this]( const point_abs_om & pt ) {
         const region_settings &settings = overmap_buffer.get_default_settings( pt );
         if( !settings.overmap_lake ) {
             return true;
         }
-        const region_settings_lake &lake_settings = settings.get_settings_lake();
-        return !overmap::guess_has_lake( pt, lake_settings.noise_threshold_lake,
-                                         lake_settings.lake_size_min );
+        auto val_emplaced = om_has_lake_cache.emplace( pt, false );
+        // A little trickery, instead of doing find/emplace/set, we just use a single
+        // emplace which returns the existing entry if it was already set. the .second
+        // member is true if emplacement happened, which means it was *not* set, so
+        // we have to actually test it for lakeness.
+        if( val_emplaced.second ) {
+            const region_settings_lake &lake_settings = settings.get_settings_lake();
+            val_emplaced.first->second =
+                !overmap::guess_has_lake( pt, lake_settings.noise_threshold_lake,
+                                          lake_settings.lake_size_min );
+        }
+        return val_emplaced.first->second;
     };
     const point_abs_om grid_pos = node.get_grid_pos();
     tripoint_abs_om as_tripoint( grid_pos, 0 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Performance "Speedup highway placement by caching expensive math"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Some postprocess tests revealed a hotspot related to highway generation. There was a ton of cpu time being spent in `raw_noise_3d`. Specifically, this was calculating whether OMTs contained water to determine if a particular OM was a 'lake' or not and thus could or couldn't support a highway node or something idk. Looking into the algorithm I realized it was iterating every OMT of an OM testing if it would turn into a lake, and then every OM was being tested repeatedly because the higher level algorithm was testing a radius of OMs around each given one. So much redundant math.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Cache the 'lake'ness of an OM inside the `highway_intersection_grid` object, which narrowly scopes the calculations and avoids potentially mixing results across loads or anything. Also, short circuit inside the inner loop once we've hit enough tiles anyway so we don't iterate the entire OM once it's enough to classify it as a lake.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Look ma, no ~~hands~~ `raw_noise_3d`! before/after
<img width="820" height="450" alt="image" src="https://github.com/user-attachments/assets/ddce642c-2ec8-47e1-b329-44faff08ccac" />


The `postprocess_*` tests should be much faster on this PR now. They print their durations to the logs so we can compare them to historical runs after they finish.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
