### PR TITLE
Restore gravity for birds

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -760,7 +760,22 @@ void monster::plan()
             set_dest( dest );
         } else if( mon_plan.fleeing ) {
             tripoint_abs_ms away = pos_abs() - dest + pos_abs();
-            away.z() = posz();
+            // Aloft fliers descend, grounded fliers take off; non-fliers stay
+            // at current z. Mirror in monster::hear_sound.
+            int chosen_z = posz();
+            if( flies() ) {
+                map &here = get_map();
+                const tripoint_bub_ms here_bub = pos_bub();
+                const bool grounded = here.has_floor_or_water( here_bub );
+                if( !grounded &&
+                    here.valid_move( here_bub, here_bub + tripoint::below, false, true ) ) {
+                    chosen_z = posz() - 1;
+                } else if( grounded &&
+                           here.valid_move( here_bub, here_bub + tripoint::above, false, true ) ) {
+                    chosen_z = posz() + 1;
+                }
+            }
+            away.z() = chosen_z;
             set_dest( away );
         }
         if( ( mon_plan.angers_hostile_weak || mon_plan.fears_hostile_weak ||
@@ -2431,9 +2446,16 @@ void monster::stumble_base( const bool is_voluntary )
     // The same-z radius scan above cannot produce straight-up or straight-down
     // candidates; add them here, gated by stair / climb / swim / fly rules.
     if( is_voluntary ) {
+        // Supported fliers can take off, aloft fliers prefer to settle and
+        // don't get a stumble path upward.
+        const bool flier_supported = flies() && here.has_floor_or_water( pos_bub() );
+        const bool flier_aloft = flies() && !here.has_floor_or_water( pos_bub() );
         const tripoint_bub_ms below( pos_bub() + tripoint::below );
         if( here.valid_move( pos_bub(), below, false, true ) ) {
             valid_stumbles.push_back( below );
+            if( flier_aloft ) {
+                valid_stumbles.push_back( below );
+            }
         }
         const tripoint_bub_ms above( pos_bub() + tripoint::above );
         const bool stair_up = here.has_flag( ter_furn_flag::TFLAG_GOES_UP, pos_bub() ) &&
@@ -2444,7 +2466,7 @@ void monster::stumble_base( const bool is_voluntary )
         const bool swim_up = swims() &&
                              here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub() ) &&
                              here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, above );
-        if( ( flies() || stair_up || ladder_up || swim_up ) &&
+        if( ( flier_supported || stair_up || ladder_up || swim_up ) &&
             here.valid_move( pos_bub(), above, false, flies() ) ) {
             valid_stumbles.push_back( above );
         }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1647,7 +1647,23 @@ bool monster::is_fleeing( Character &u ) const
         return false;
     }
     monster_attitude att = attitude( &u );
-    return att == MATT_FLEE || ( att == MATT_FOLLOW && rl_dist( pos_bub(), u.pos_bub() ) <= 4 );
+    if( att == MATT_FLEE ) {
+        return true;
+    }
+    if( att != MATT_FOLLOW ) {
+        return false;
+    }
+    // Scale vertical separation for fliers (one z is roughly four meters).
+    constexpr int FLIER_Z_PENALTY = 4;
+    int effective;
+    if( flies() ) {
+        const int xy = rl_dist( pos_bub().xy(), u.pos_bub().xy() );
+        const int z_diff = std::abs( pos_abs().z() - u.pos_abs().z() );
+        effective = xy + z_diff * FLIER_Z_PENALTY;
+    } else {
+        effective = rl_dist( pos_bub(), u.pos_bub() );
+    }
+    return effective <= 4;
 }
 
 Creature::Attitude monster::attitude_to( const Creature &other ) const
@@ -4079,7 +4095,22 @@ void monster::hear_sound( const tripoint_bub_ms &source, const int vol, const in
         // TODO: make the destination scale with the sound and handle
         // the case when (x,y) is the same by picking a random direction
         tripoint_abs_ms away = pos_abs() + ( pos_abs() - target );
-        away.z() = posz();
+        // Aloft fliers descend, grounded fliers take off; non-fliers stay at
+        // current z. Mirror in monster::plan.
+        int chosen_z = posz();
+        if( flies() ) {
+            map &here = get_map();
+            const tripoint_bub_ms here_bub = pos_bub();
+            const bool grounded = here.has_floor_or_water( here_bub );
+            if( !grounded &&
+                here.valid_move( here_bub, here_bub + tripoint::below, false, true ) ) {
+                chosen_z = posz() - 1;
+            } else if( grounded &&
+                       here.valid_move( here_bub, here_bub + tripoint::above, false, true ) ) {
+                chosen_z = posz() + 1;
+            }
+        }
+        away.z() = chosen_z;
         wander_to( away, wander_turns );
     }
 }

--- a/tests/flying_creature_test.cpp
+++ b/tests/flying_creature_test.cpp
@@ -1,0 +1,178 @@
+#include <memory>
+#include <set>
+
+#include "cata_catch.h"
+#include "character.h"
+#include "coordinates.h"
+#include "game.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "monster.h"
+#include "player_helpers.h"
+#include "point.h"
+#include "type_id.h"
+
+static const mtype_id mon_crow( "mon_crow" );
+
+static const ter_str_id ter_t_floor( "t_floor" );
+static const ter_str_id ter_t_open_air( "t_open_air" );
+static const ter_str_id ter_t_wall( "t_wall" );
+
+// Floor at z=0, single open-air column straight up; walls everywhere else on
+// the 3x3 z=1,2 footprint. Aloft fliers have no lateral candidates here.
+static void build_narrow_shaft( map &here, const point_bub_ms &origin )
+{
+    for( int dx = -1; dx <= 1; ++dx ) {
+        for( int dy = -1; dy <= 1; ++dy ) {
+            const bool center = dx == 0 && dy == 0;
+            const tripoint_bub_ms p0( origin.x() + dx, origin.y() + dy, 0 );
+            const tripoint_bub_ms p1( origin.x() + dx, origin.y() + dy, 1 );
+            const tripoint_bub_ms p2( origin.x() + dx, origin.y() + dy, 2 );
+            here.ter_set( p0, ter_t_floor.id() );
+            here.ter_set( p1, center ? ter_t_open_air.id() : ter_t_wall.id() );
+            here.ter_set( p2, center ? ter_t_open_air.id() : ter_t_wall.id() );
+        }
+    }
+    for( int z = 0; z <= 2; ++z ) {
+        here.invalidate_map_cache( z );
+        here.build_map_cache( z, true );
+    }
+}
+
+// Force MATT_FLEE attitude toward the player.
+static void force_flee_state( monster &mon )
+{
+    mon.aggro_character = true;
+    mon.anger = 0;
+    mon.morale = -100;
+}
+
+static std::set<int> run_and_collect_z( monster &mon, int turns )
+{
+    std::set<int> visited_z;
+    visited_z.insert( mon.posz() );
+    for( int turn = 0; turn < turns; ++turn ) {
+        mon.mod_moves( mon.get_speed() );
+        while( mon.get_moves() > 0 ) {
+            const int prev = mon.posz();
+            mon.move();
+            visited_z.insert( mon.posz() );
+            if( mon.posz() == prev && mon.get_moves() <= 0 ) {
+                break;
+            }
+        }
+    }
+    return visited_z;
+}
+
+TEST_CASE( "aloft_idle_flier_settles_downward", "[monster][z-level][stumble]" )
+{
+    clear_avatar();
+    clear_map( 0, 2 );
+    map &here = get_map();
+    Character &player = get_player_character();
+    player.setpos( here, tripoint_bub_ms( 100, 100, 0 ) );
+
+    const point_bub_ms origin( 30, 30 );
+    build_narrow_shaft( here, origin );
+
+    const tripoint_bub_ms spawn_pos( origin.x(), origin.y(), 2 );
+    monster &mon = spawn_test_monster( mon_crow.str(), spawn_pos, false );
+    mon.anger = 0;
+    mon.morale = 0;
+    REQUIRE( mon.flies() );
+    REQUIRE( mon.is_wandering() );
+
+    constexpr int budget_turns = 1500;
+    const std::set<int> visited = run_and_collect_z( mon, budget_turns );
+
+    g->remove_zombie( mon );
+
+    CAPTURE( visited );
+    CHECK( visited.count( 0 ) + visited.count( 1 ) >= 1 );
+}
+
+TEST_CASE( "aloft_flier_descends_when_fleeing", "[monster][z-level][flee]" )
+{
+    clear_avatar();
+    clear_map( 0, 2 );
+    map &here = get_map();
+    Character &player = get_player_character();
+
+    const point_bub_ms origin( 30, 30 );
+    build_narrow_shaft( here, origin );
+
+    player.setpos( here, tripoint_bub_ms( origin.x(), origin.y(), 0 ) );
+    const tripoint_bub_ms spawn_pos( origin.x(), origin.y(), 2 );
+    monster &mon = spawn_test_monster( mon_crow.str(), spawn_pos, false );
+    REQUIRE( mon.flies() );
+    force_flee_state( mon );
+
+    constexpr int budget_turns = 600;
+    const std::set<int> visited = run_and_collect_z( mon, budget_turns );
+    const int final_z = mon.posz();
+
+    g->remove_zombie( mon );
+
+    CAPTURE( visited );
+    CHECK( ( visited.count( 0 ) == 1 || visited.count( 1 ) == 1 ) );
+    CHECK( final_z < 2 );
+}
+
+TEST_CASE( "grounded_flier_takes_off_when_fleeing", "[monster][z-level][flee]" )
+{
+    clear_avatar();
+    clear_map( 0, 2 );
+    map &here = get_map();
+    Character &player = get_player_character();
+
+    const point_bub_ms origin( 30, 30 );
+    build_narrow_shaft( here, origin );
+
+    const tripoint_bub_ms spawn_pos( origin.x(), origin.y(), 0 );
+    player.setpos( here, tripoint_bub_ms( origin.x() + 1, origin.y(), 0 ) );
+    monster &mon = spawn_test_monster( mon_crow.str(), spawn_pos, false );
+    REQUIRE( mon.flies() );
+    force_flee_state( mon );
+
+    constexpr int budget_turns = 600;
+    const std::set<int> visited = run_and_collect_z( mon, budget_turns );
+
+    g->remove_zombie( mon );
+
+    CAPTURE( visited );
+    CHECK( visited.count( 1 ) == 1 );
+}
+
+TEST_CASE( "skittish_flier_ignores_distant_z_threat", "[monster][z-level][skittish]" )
+{
+    clear_avatar();
+    clear_map( 0, 2 );
+    map &here = get_map();
+    Character &player = get_player_character();
+
+    const point_bub_ms origin( 30, 30 );
+    build_narrow_shaft( here, origin );
+
+    // xy dist 0, z dist 2: unscaled would trip skittish flee at <=4;
+    // scaled effective is 8.
+    player.setpos( here, tripoint_bub_ms( origin.x(), origin.y(), 0 ) );
+    const tripoint_bub_ms spawn_pos( origin.x(), origin.y(), 2 );
+    monster &mon = spawn_test_monster( mon_crow.str(), spawn_pos, false );
+    REQUIRE( mon.flies() );
+    // attitude() returns MATT_FOLLOW when morale < 0 and morale + anger > 0.
+    mon.aggro_character = true;
+    mon.anger = 5;
+    mon.morale = -3;
+
+    CHECK_FALSE( mon.is_fleeing( player ) );
+
+    g->remove_zombie( mon );
+    monster &mon_close = spawn_test_monster( mon_crow.str(),
+                         tripoint_bub_ms( origin.x() + 1, origin.y(), 0 ), false );
+    mon_close.aggro_character = true;
+    mon_close.anger = 5;
+    mon_close.morale = -3;
+    CHECK( mon_close.is_fleeing( player ) );
+    g->remove_zombie( mon_close );
+}


### PR DESCRIPTION
#### Summary
Bugfixes "Flying creatures land more, flee toward ground, and ignore distant z threats"

#### Purpose of change
After #86262 and #86618 fliers stay airborne too much. Birds drift up via stumble, never descend when fleeing, and panic at the player from one z up.

#### Describe the solution
Stumble is now state-aware for fliers. A flier on floor or water can take off. An aloft flier gets no upward stumble and is biased to drift down. Stairs, ladders, and swim columns work as before.

The flee vector in `monster::plan` and the fear-of-sound branch in `monster::hear_sound` no longer pin the flier to its current z. Aloft fliers descend, grounded fliers take off, non-fliers unchanged.

The skittish radius in `monster::is_fleeing` now scales vertical separation for fliers (xy + z*4 instead of 3D Chebyshev). A bird one z above goes from effective 1 to 4, two z above from 2 to 8. Non-fliers and non-skittish attitudes unaffected.

#### Describe alternatives you've considered
A serialized landing timer with per-mtype \`flight_endurance\` was tempting but adds a state machine for a regression that local heuristics already cover. Constants stay local, easy to tune later.

A blanket altitude penalty in \`calc_movecost\` would silently regress permanent-hover designs (drones, nether fliers) where staying aloft is the point.

#### Testing
Four new cases in \`tests/flying_creature_test.cpp\`: aloft idle flier settles down, aloft flier descends when fleeing, grounded flier takes off when fleeing, skittish flier two z above ignores the player. Existing monster tests still pass. Verified in-game, birds behave better.

#### Additional context
Builds on #86262 and #86618. Those were correct for ground creatures but turned fliers into drift balloons; this counterbalances the flier-only path.