### PR TITLE
swap stab and bash damage on war hammers, fix material

### DIFF
--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -1978,7 +1978,7 @@
     "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
     "price": "160 USD",
     "qualities": [ [ "HAMMER", 1 ] ],
-    "melee_damage": { "bash": 22, "stab": 23 }
+    "melee_damage": { "bash": 23, "stab": 22 }
   },
   {
     "id": "warhammer_fake",
@@ -2029,7 +2029,7 @@
     "description": "A medieval hammer with a spike on one end, made for battle.  Its odd shape and balance make it an excellent weapon, but an ineffective tool.  This one is custom-made with high steel and is a solid, dependable weapon.",
     "proportional": { "price_postapoc": 1.05, "price": 1.05 },
     "replace_materials": { "mc_steel": "hc_steel" },
-    "relative": { "melee_damage": { "stab": 1 } }
+    "relative": { "melee_damage": { "bash": 1 } }
   },
   {
     "id": "ch_warhammer",
@@ -2039,7 +2039,7 @@
     "description": "A medieval hammer with a spike on one end, made for battle.  Its odd shape and balance make it an excellent weapon, but an ineffective tool.  This one is custom-made with hardened steel and can pulverize bones.",
     "proportional": { "price_postapoc": 1.1, "price": 1.1 },
     "replace_materials": { "mc_steel": "ch_steel" },
-    "relative": { "melee_damage": { "stab": 2 } }
+    "relative": { "melee_damage": { "bash": 2 } }
   },
   {
     "id": "qt_warhammer",
@@ -2048,8 +2048,8 @@
     "name": { "str": "tempered steel war hammer" },
     "description": "A medieval hammer with a spike on one end, made for battle.  Its odd shape and balance make it an excellent weapon, but an ineffective tool.  This one is custom-made with tempered steel and will crack skulls like watermelons.",
     "proportional": { "price_postapoc": 1.15, "price": 1.15 },
-    "replace_materials": { "mc_steel": "ch_steel" },
-    "relative": { "melee_damage": { "stab": 3 } }
+    "replace_materials": { "mc_steel": "qt_steel" },
+    "relative": { "melee_damage": { "bash": 3 } }
   },
   {
     "id": "exodii_prybar",

--- a/data/mods/TEST_DATA/expected_dps_data.json
+++ b/data/mods/TEST_DATA/expected_dps_data.json
@@ -237,7 +237,7 @@
       "lc_warhammer": 30.6,
       "hc_warhammer": 35.95,
       "ch_warhammer": 36.66,
-      "qt_warhammer": 37.10
+      "qt_warhammer": 37.1
     }
   },
   {

--- a/data/mods/TEST_DATA/expected_dps_data.json
+++ b/data/mods/TEST_DATA/expected_dps_data.json
@@ -233,11 +233,11 @@
       "hammer_sledge": 20.0,
       "2h_club_kanabo_studded": 25.16,
       "2h_club_kanabo_spiked": 25.65,
-      "warhammer": 36.33,
+      "warhammer": 35.64,
       "lc_warhammer": 30.6,
-      "hc_warhammer": 37.39,
-      "ch_warhammer": 38.5,
-      "qt_warhammer": 39.44
+      "hc_warhammer": 35.95,
+      "ch_warhammer": 36.66,
+      "qt_warhammer": 37.10
     }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Swap bash and stab damage on war hammers"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

War hammers had slightly higher stab than bash.  This caused them to be treated as stabbing weapons primarily, and thus they got messages using verbs like "poke."  Odd.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Swaps bash damage and stab damage.  Now they're primarily blunt weapons.

Also, fixed tempered steel war hammer material (ch_steel -> qt_steel)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Leaving it as is, as it's arguable that the spike described is doing crippling stab damage.  Not mad if that's how it stays.  This just seemed more believable to me, and makes for better combat messaging.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked in game.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
