### PR TITLE
Add item-targeted wakeup scheduler

### DIFF
--- a/data/mods/TEST_DATA/item_wakeup_test_items.json
+++ b/data/mods/TEST_DATA/item_wakeup_test_items.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "test_wakeup_dummy",
+    "type": "ITEM",
+    "subtypes": [ "GENERIC" ],
+    "category": "spare_parts",
+    "name": { "str": "wakeup test dummy" },
+    "description": "A test item used by the item-wakeup test suite.  Tests register a C++ handler against this id.",
+    "material": [ "test_material" ],
+    "weight": "1 g",
+    "volume": "1 ml",
+    "symbol": "*",
+    "color": "white"
+  },
+  {
+    "id": "test_wakeup_no_handler",
+    "type": "ITEM",
+    "subtypes": [ "GENERIC" ],
+    "category": "spare_parts",
+    "name": { "str": "wakeup test (no handler)" },
+    "description": "A test item with no registered wakeup handler.  Used to exercise the dispatcher's no-op path.",
+    "material": [ "test_material" ],
+    "weight": "1 g",
+    "volume": "1 ml",
+    "symbol": "*",
+    "color": "white"
+  }
+]

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -41,6 +41,7 @@
 #include "help.h"
 #include "input.h"
 #include "input_context.h"
+#include "item_wakeup.h"
 #include "magic_enchantment.h"
 #include "map.h"
 #include "map_iterator.h"
@@ -501,6 +502,7 @@ bool do_turn()
 
     timed_event_manager &timed_events = get_timed_events();
     timed_events.process();
+    get_item_wakeups().process( calendar::turn );
     mission::process_all();
     avatar &u = get_avatar();
     map &m = get_map();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -128,6 +128,7 @@
 #include "item_pocket.h"
 #include "item_search.h"
 #include "item_stack.h"
+#include "item_wakeup.h"
 #include "iteminfo_query.h"
 #include "itype.h"
 #include "iuse.h"
@@ -11559,6 +11560,11 @@ stats_tracker &get_stats()
 timed_event_manager &get_timed_events()
 {
     return g->timed_events;
+}
+
+item_wakeup_manager &get_item_wakeups()
+{
+    return *g->item_wakeup_manager_ptr;
 }
 
 weather_manager &get_weather()

--- a/src/game.h
+++ b/src/game.h
@@ -93,6 +93,7 @@ class spell_events;
 class static_popup;
 class stats_tracker;
 class timed_event_manager;
+class item_wakeup_manager;
 class ui_adaptor;
 class uilist;
 class vehicle;
@@ -190,6 +191,7 @@ class game
         friend stats_tracker &get_stats();
         friend scent_map &get_scent();
         friend timed_event_manager &get_timed_events();
+        friend item_wakeup_manager &get_item_wakeups();
         friend memorial_logger &get_memorial();
         friend bool do_turn();
         friend bool turn_handler::cleanup_at_end();
@@ -1148,6 +1150,7 @@ class game
         live_view &liveview; // NOLINT(cata-serialize)
         pimpl<scent_map> scent_ptr; // NOLINT(cata-serialize)
         pimpl<timed_event_manager> timed_event_manager_ptr; // NOLINT(cata-serialize)
+        pimpl<item_wakeup_manager> item_wakeup_manager_ptr;
         pimpl<event_bus> event_bus_ptr; // NOLINT(cata-serialize)
         pimpl<stats_tracker> stats_tracker_ptr;
         pimpl<achievements_tracker> achievements_tracker_ptr;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4580,11 +4580,12 @@ bool item::process_wet( Character *carrier, const tripoint_bub_ms & /*pos*/ )
 
 std::vector<desired_wakeup> item::enumerate_scheduled_wakeups() const
 {
-    return {};
+    return enumerate_scheduled_dispatch( *this );
 }
 
-void item::actualize_scheduled( item_wakeup_kind /*kind*/, time_point /*now*/ )
+void item::actualize_scheduled( item_wakeup_kind kind, time_point now )
 {
+    actualize_scheduled_dispatch( *this, kind, now );
 }
 
 bool item::process( map &here, Character *carrier, const tripoint_bub_ms &pos, float insulation,

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -44,6 +44,7 @@
 #include "item_group.h"
 #include "item_tname.h"
 #include "item_transformation.h"
+#include "item_wakeup.h"
 #include "itype.h"
 #include "iuse.h"
 #include "iuse_actor.h"
@@ -4575,6 +4576,15 @@ bool item::process_wet( Character *carrier, const tripoint_bub_ms & /*pos*/ )
     }
     // Always return true so our caller will bail out instead of processing us as a tool.
     return true;
+}
+
+std::vector<desired_wakeup> item::enumerate_scheduled_wakeups() const
+{
+    return {};
+}
+
+void item::actualize_scheduled( item_wakeup_kind /*kind*/, time_point /*now*/ )
+{
 }
 
 bool item::process( map &here, Character *carrier, const tripoint_bub_ms &pos, float insulation,

--- a/src/item.h
+++ b/src/item.h
@@ -47,6 +47,8 @@ class Character;
 class Creature;
 class JsonObject;
 class JsonOut;
+struct desired_wakeup;
+enum class item_wakeup_kind : uint8_t;
 class book_proficiency_bonuses;
 class enchant_cache;
 class enchantment;
@@ -1582,6 +1584,15 @@ class item : public visitable
 
         bool leak( map &here, Character *carrier, const tripoint_bub_ms &pos,
                    item_pocket *pocke = nullptr );
+
+        // Producer contract for the item wakeup scheduler.  Returns the
+        // (kind, when) pairs this item currently wants scheduled.  Default
+        // empty; only items with their own time-based state override.
+        std::vector<desired_wakeup> enumerate_scheduled_wakeups() const;
+
+        // Consumer for a fired wakeup.  Must be idempotent: receiving the
+        // same (kind, now) twice must not corrupt state.
+        void actualize_scheduled( item_wakeup_kind kind, time_point now );
 
         struct link_data {
             /// State of the link's source connection, the end usually represented by the device/cable item itself. @ref link_state.

--- a/src/item.h
+++ b/src/item.h
@@ -1585,13 +1585,10 @@ class item : public visitable
         bool leak( map &here, Character *carrier, const tripoint_bub_ms &pos,
                    item_pocket *pocke = nullptr );
 
-        // Producer contract for the item wakeup scheduler.  Returns the
-        // (kind, when) pairs this item currently wants scheduled.  Default
-        // empty; only items with their own time-based state override.
+        // Producer for the wakeup scheduler.  Default empty.
         std::vector<desired_wakeup> enumerate_scheduled_wakeups() const;
 
-        // Consumer for a fired wakeup.  Must be idempotent: receiving the
-        // same (kind, now) twice must not corrupt state.
+        // Idempotent: receiving (kind, now) twice must not corrupt state.
         void actualize_scheduled( item_wakeup_kind kind, time_point now );
 
         struct link_data {

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -1403,3 +1403,8 @@ int item_location::get_quality( const std::string &quality, bool strict_boiling 
     quality_id qualityid( quality );
     return tool->get_quality_nonrecursive( qualityid, strict_boiling );
 }
+
+item_location find_item_by_uid( int64_t /*uid*/, const item_locator_hint &/*hint*/ )
+{
+    return item_location::nowhere;
+}

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -49,6 +49,7 @@
 #include "vehicle_selector.h"
 #include "visitable.h"
 #include "vpart_position.h"
+#include "vpart_range.h"
 
 // Legacy: positional index lookup, used only for serializing idx (kept for old-save compat
 // from before #85905) and vehicle base items. Once legacy save support is dropped, this can

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -10,6 +10,7 @@
 #include <optional>
 #include <ostream>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include "character.h"
@@ -24,12 +25,15 @@
 #include "item.h"
 #include "item_pocket.h"
 #include "item_uid.h"
+#include "item_wakeup.h"
 #include "itype.h"
 #include "json.h"
 #include "line.h"
 #include "magic_enchantment.h"
 #include "map.h"
+#include "map_iterator.h"
 #include "map_selector.h"
+#include "npc.h"
 #include "pimpl.h"
 #include "point.h"
 #include "ret_val.h"
@@ -1404,7 +1408,152 @@ int item_location::get_quality( const std::string &quality, bool strict_boiling 
     return tool->get_quality_nonrecursive( qualityid, strict_boiling );
 }
 
-item_location find_item_by_uid( int64_t /*uid*/, const item_locator_hint &/*hint*/ )
+// Hint-driven uid resolution with bounded fallback.  No world-wide scan.
+// Returns invalid for items in monster stomachs, portals, or off-bubble.
+item_location find_item_by_uid( int64_t uid, const item_locator_hint &hint )
 {
+    if( uid <= 0 ) {
+        return item_location::nowhere;
+    }
+
+    map &here = get_map();
+
+    auto try_character = [uid]( Character * c ) -> item_location {
+        if( c == nullptr )
+        {
+            return item_location::nowhere;
+        }
+        item *found = retrieve_by_uid( *c, uid );
+        if( found == nullptr )
+        {
+            return item_location::nowhere;
+        }
+        return item_location( *c, found );
+    };
+
+    // Off-bubble would wrap a pointer into a temporary tinymap; gate to
+    // in-bounds.  Owners must call rebuild_for_item once back in range.
+    auto try_map_at = [uid, &here]( const tripoint_abs_ms & abs ) -> item_location {
+        if( !here.inbounds( here.get_bub( abs ) ) )
+        {
+            return item_location::nowhere;
+        }
+        map_cursor mc( abs );
+        item *found = retrieve_by_uid( mc, uid );
+        if( found == nullptr )
+        {
+            return item_location::nowhere;
+        }
+        return item_location( mc, found );
+    };
+
+    switch( hint.where ) {
+        case item_locator_hint::place::character: {
+            const character_id *cid = std::get_if<character_id>( &hint.location );
+            if( cid != nullptr && cid->is_valid() ) {
+                Character &u = get_player_character();
+                if( u.getID() == *cid ) {
+                    item_location loc = try_character( &u );
+                    if( loc ) {
+                        return loc;
+                    }
+                }
+                npc *n = g->find_npc( *cid );
+                if( n != nullptr ) {
+                    item_location loc = try_character( n );
+                    if( loc ) {
+                        return loc;
+                    }
+                }
+            }
+            break;
+        }
+        case item_locator_hint::place::map: {
+            const tripoint_abs_ms *p = std::get_if<tripoint_abs_ms>( &hint.location );
+            if( p != nullptr ) {
+                item_location loc = try_map_at( *p );
+                if( loc ) {
+                    return loc;
+                }
+            }
+            break;
+        }
+        case item_locator_hint::place::vehicle: {
+            const vehicle_hint *vh = std::get_if<vehicle_hint>( &hint.location );
+            if( vh != nullptr && here.inbounds( here.get_bub( vh->cargo_square ) ) ) {
+                const optional_vpart_position vp = here.veh_at( vh->cargo_square );
+                if( vp ) {
+                    vehicle &veh = vp->vehicle();
+                    // Try in order: stored part_index (if in range), then
+                    // mount_offset lookup, then the cargo-square part.
+                    std::vector<int> candidates;
+                    if( vh->part_index >= 0 && vh->part_index < veh.part_count() ) {
+                        candidates.push_back( vh->part_index );
+                    }
+                    const std::vector<int> at_mount = veh.parts_at_relative(
+                                                          vh->mount_offset, true, false );
+                    for( int p : at_mount ) {
+                        if( p != vh->part_index ) {
+                            candidates.push_back( p );
+                        }
+                    }
+                    const int square_part = static_cast<int>( vp->part_index() );
+                    if( std::find( candidates.begin(), candidates.end(),
+                                   square_part ) == candidates.end() ) {
+                        candidates.push_back( square_part );
+                    }
+                    for( int part : candidates ) {
+                        if( part < 0 || part >= veh.part_count() ) {
+                            continue;
+                        }
+                        vehicle_cursor vc( veh, part );
+                        item *found = retrieve_by_uid( vc, uid );
+                        if( found != nullptr ) {
+                            return item_location( vc, found );
+                        }
+                    }
+                }
+            }
+            break;
+        }
+        case item_locator_hint::place::unknown:
+            break;
+    }
+
+    // Bounded fallback: avatar + nearby NPCs + loaded vehicles + map tiles.
+    // No world-wide scan.
+    item_location loc = try_character( &get_player_character() );
+    if( loc ) {
+        return loc;
+    }
+    for( npc &n : g->all_npcs() ) {
+        item_location l2 = try_character( &n );
+        if( l2 ) {
+            return l2;
+        }
+    }
+    for( const wrapped_vehicle &wv : here.get_vehicles() ) {
+        if( wv.v == nullptr ) {
+            continue;
+        }
+        for( const vpart_reference &vpr : wv.v->get_all_parts() ) {
+            vehicle_cursor vc( *wv.v, vpr.part_index() );
+            item *found = retrieve_by_uid( vc, uid );
+            if( found != nullptr ) {
+                return item_location( vc, found );
+            }
+        }
+    }
+    for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
+        if( !here.has_items( p ) ) {
+            continue;
+        }
+        map_cursor mc( here.get_abs( p ) );
+        item *found = retrieve_by_uid( mc, uid );
+        if( found != nullptr ) {
+            return item_location( mc, found );
+        }
+    }
+
     return item_location::nowhere;
 }

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_ITEM_LOCATION_H
 #define CATA_SRC_ITEM_LOCATION_H
 
+#include <cstdint>
 #include <list>
 #include <memory>
 #include <string>
@@ -198,6 +199,12 @@ class item_location
 std::unique_ptr<talker> get_talker_for( item_location &it );
 std::unique_ptr<const_talker> get_const_talker_for( const item_location &it );
 std::unique_ptr<talker> get_talker_for( item_location *it );
+
+struct item_locator_hint;
+
+// Resolve an item by its uid, starting from the hint.  Returns invalid
+// item_location if not found within the accepted resolution boundary.
+item_location find_item_by_uid( int64_t uid, const item_locator_hint &hint );
 
 using drop_location = std::pair<item_location, int>;
 using drop_locations = std::list<drop_location>;

--- a/src/item_wakeup.cpp
+++ b/src/item_wakeup.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <map>
+#include <queue>
 #include <string>
 #include <utility>
 
@@ -214,40 +215,63 @@ static void dispatch_actualize( item &it, item_wakeup_kind kind, time_point now 
     }
 }
 
+// Min-heap comparator: top is smallest by (when, uid, kind).  push_heap and
+// friends produce a max-heap, so this returns true when `a` should sink
+// below `b`, i.e. `a` is greater.
+bool item_wakeup_manager::heap_greater( const entry_iter &a, const entry_iter &b )
+{
+    if( a->when != b->when ) {
+        return a->when > b->when;
+    }
+    if( a->uid != b->uid ) {
+        return a->uid > b->uid;
+    }
+    return static_cast<int>( a->kind ) > static_cast<int>( b->kind );
+}
+
+bool item_wakeup_manager::is_live( const entry_iter &it ) const
+{
+    const auto map_it = by_key_.find( {it->uid, it->kind} );
+    return map_it != by_key_.end() && map_it->second == it;
+}
+
+void item_wakeup_manager::clean_heap_top()
+{
+    while( !heap_.empty() && !is_live( heap_.front() ) ) {
+        const entry_iter top = heap_.front();
+        std::pop_heap( heap_.begin(), heap_.end(), heap_greater );
+        heap_.pop_back();
+        entries_.erase( top );
+    }
+}
+
 void item_wakeup_manager::schedule_or_update( int64_t uid, time_point when,
         item_wakeup_kind kind, item_locator_hint hint )
 {
-    auto match = std::find_if( entries_.begin(), entries_.end(),
-    [uid, kind]( const entry & e ) {
-        return e.uid == uid && e.kind == kind;
-    } );
-    if( match != entries_.end() ) {
-        match->when = when;
-        match->hint = hint;
-        return;
-    }
     entry e;
     e.uid = uid;
     e.kind = kind;
     e.when = when;
     e.hint = hint;
-    entries_.push_back( e );
+    const entry_iter new_it = entries_.insert( e );
+    by_key_[ {uid, kind}] = new_it;
+    heap_.push_back( new_it );
+    std::push_heap( heap_.begin(), heap_.end(), heap_greater );
+    clean_heap_top();
 }
 
 void item_wakeup_manager::cancel( int64_t uid, item_wakeup_kind kind )
 {
-    entries_.erase( std::remove_if( entries_.begin(), entries_.end(),
-    [uid, kind]( const entry & e ) {
-        return e.uid == uid && e.kind == kind;
-    } ), entries_.end() );
+    by_key_.erase( {uid, kind} );
+    clean_heap_top();
 }
 
 void item_wakeup_manager::cancel_all( int64_t uid )
 {
-    entries_.erase( std::remove_if( entries_.begin(), entries_.end(),
-    [uid]( const entry & e ) {
-        return e.uid == uid;
-    } ), entries_.end() );
+    for( int k = 0; k < static_cast<int>( item_wakeup_kind::last ); ++k ) {
+        by_key_.erase( {uid, static_cast<item_wakeup_kind>( k )} );
+    }
+    clean_heap_top();
 }
 
 void item_wakeup_manager::rebuild_for_item( item &it, item_locator_hint hint )
@@ -255,66 +279,62 @@ void item_wakeup_manager::rebuild_for_item( item &it, item_locator_hint hint )
     const int64_t uid = it.uid().get_value();
     const std::vector<desired_wakeup> desired = it.enumerate_scheduled_wakeups();
 
-    // Cancel kinds the item no longer wants.
-    entries_.erase( std::remove_if( entries_.begin(), entries_.end(),
-    [uid, &desired]( const entry & e ) {
-        if( e.uid != uid ) {
-            return false;
+    for( int k = 0; k < static_cast<int>( item_wakeup_kind::last ); ++k ) {
+        const item_wakeup_kind kind = static_cast<item_wakeup_kind>( k );
+        const bool wanted = std::any_of( desired.begin(), desired.end(),
+        [kind]( const desired_wakeup & d ) {
+            return d.kind == kind;
+        } );
+        if( !wanted ) {
+            by_key_.erase( {uid, kind} );
         }
-        for( const desired_wakeup &d : desired ) {
-            if( d.kind == e.kind ) {
-                return false;
-            }
-        }
-        return true;
-    } ), entries_.end() );
-
-    // Add or update each desired wakeup.
+    }
     for( const desired_wakeup &d : desired ) {
         schedule_or_update( uid, d.when, d.kind, hint );
     }
+    clean_heap_top();
 }
 
 bool item_wakeup_manager::is_scheduled( int64_t uid, item_wakeup_kind kind ) const
 {
-    return std::any_of( entries_.begin(), entries_.end(),
-    [uid, kind]( const entry & e ) {
-        return e.uid == uid && e.kind == kind;
-    } );
+    return by_key_.count( {uid, kind} ) > 0;
 }
 
 std::optional<time_point> item_wakeup_manager::get( int64_t uid,
         item_wakeup_kind kind ) const
 {
-    auto match = std::find_if( entries_.begin(), entries_.end(),
-    [uid, kind]( const entry & e ) {
-        return e.uid == uid && e.kind == kind;
-    } );
-    if( match == entries_.end() ) {
+    const auto map_it = by_key_.find( {uid, kind} );
+    if( map_it == by_key_.end() ) {
         return std::nullopt;
     }
-    return match->when;
+    return map_it->second->when;
 }
 
 std::optional<scheduled_wakeup_info> item_wakeup_manager::peek_next_wakeup() const
 {
-    std::vector<scheduled_wakeup_info> all = dump();
-    if( all.empty() ) {
+    if( heap_.empty() ) {
         return std::nullopt;
     }
-    return all.front();
+    const entry_iter top = heap_.front();
+    scheduled_wakeup_info info;
+    info.uid = top->uid;
+    info.kind = top->kind;
+    info.when = top->when;
+    info.hint = top->hint;
+    return info;
 }
 
 std::vector<scheduled_wakeup_info> item_wakeup_manager::dump() const
 {
     std::vector<scheduled_wakeup_info> out;
-    out.reserve( entries_.size() );
-    for( const entry &e : entries_ ) {
+    out.reserve( by_key_.size() );
+    for( const auto &kv : by_key_ ) {
+        const entry_iter it = kv.second;
         scheduled_wakeup_info info;
-        info.uid = e.uid;
-        info.kind = e.kind;
-        info.when = e.when;
-        info.hint = e.hint;
+        info.uid = it->uid;
+        info.kind = it->kind;
+        info.when = it->when;
+        info.hint = it->hint;
         out.push_back( info );
     }
     std::sort( out.begin(), out.end(),
@@ -333,7 +353,7 @@ std::vector<scheduled_wakeup_info> item_wakeup_manager::dump() const
 item_wakeup_manager::stats item_wakeup_manager::get_stats() const
 {
     stats s = stats_;
-    s.total_pending = static_cast<int>( entries_.size() );
+    s.total_pending = static_cast<int>( by_key_.size() );
     return s;
 }
 
@@ -342,28 +362,25 @@ void item_wakeup_manager::process( time_point now )
     cata_assert( !processing_active );
     processing_active = true;
 
-    // Snapshot expired entries in deterministic order, erase from live queue.
     std::vector<entry> snapshot;
-    snapshot.reserve( entries_.size() );
-    auto first_pending = std::partition( entries_.begin(), entries_.end(),
-    [now]( const entry & e ) {
-        return e.when > now;
-    } );
-    snapshot.assign( first_pending, entries_.end() );
-    entries_.erase( first_pending, entries_.end() );
-    std::sort( snapshot.begin(), snapshot.end(),
-    []( const entry & a, const entry & b ) {
-        if( a.when != b.when ) {
-            return a.when < b.when;
+    while( !heap_.empty() ) {
+        const entry_iter top = heap_.front();
+        if( !is_live( top ) ) {
+            std::pop_heap( heap_.begin(), heap_.end(), heap_greater );
+            heap_.pop_back();
+            entries_.erase( top );
+            continue;
         }
-        if( a.uid != b.uid ) {
-            return a.uid < b.uid;
+        if( top->when > now ) {
+            break;
         }
-        return static_cast<int>( a.kind ) < static_cast<int>( b.kind );
-    } );
+        snapshot.push_back( *top );
+        std::pop_heap( heap_.begin(), heap_.end(), heap_greater );
+        heap_.pop_back();
+        by_key_.erase( {top->uid, top->kind} );
+        entries_.erase( top );
+    }
 
-    // Dispatch each.  Stale uids increment the counter; threshold breach
-    // emits a single debugmsg per manager lifetime (reset by clear()).
     for( const entry &e : snapshot ) {
         item_location loc = find_item_by_uid( e.uid, e.hint );
         if( !loc ) {
@@ -379,12 +396,15 @@ void item_wakeup_manager::process( time_point now )
         loc->actualize_scheduled( e.kind, now );
     }
 
+    clean_heap_top();
     processing_active = false;
 }
 
 void item_wakeup_manager::clear()
 {
     entries_.clear();
+    by_key_.clear();
+    heap_.clear();
     stats_ = stats{};
     stale_seen_uids_ = 0;
     stale_msg_emitted_ = false;
@@ -396,18 +416,24 @@ void item_wakeup_manager::serialize( JsonOut &jsout ) const
     jsout.member( "version", CURRENT_VERSION );
     jsout.member( "wakeups" );
     jsout.start_array();
-    std::vector<entry> sorted = entries_;
-    std::sort( sorted.begin(), sorted.end(),
-    []( const entry & a, const entry & b ) {
-        if( a.when != b.when ) {
-            return a.when < b.when;
+    std::vector<entry_iter> live;
+    live.reserve( by_key_.size() );
+    for( const std::pair<const key_t, entry_iter> &kv : by_key_ ) {
+        live.push_back( kv.second );
+    }
+    std::sort( live.begin(), live.end(),
+    []( const entry_iter & a, const entry_iter & b ) {
+        if( a->when != b->when ) {
+            return a->when < b->when;
         }
-        if( a.uid != b.uid ) {
-            return a.uid < b.uid;
+        if( a->uid != b->uid ) {
+            return a->uid < b->uid;
         }
-        return static_cast<int>( a.kind ) < static_cast<int>( b.kind );
+        return static_cast<int>( a->kind ) < static_cast<int>( b->kind );
     } );
-    for( const entry &e : sorted ) {
+    cata_assert( entries_.size() >= live.size() );
+    for( const entry_iter &it : live ) {
+        const entry &e = *it;
         jsout.start_object();
         jsout.member( "uid", e.uid );
         jsout.member( "kind", kind_to_string( e.kind ) );
@@ -422,10 +448,7 @@ void item_wakeup_manager::serialize( JsonOut &jsout ) const
 
 void item_wakeup_manager::deserialize( const JsonObject &jo )
 {
-    entries_.clear();
-    stats_ = stats{};
-    stale_seen_uids_ = 0;
-    stale_msg_emitted_ = false;
+    clear();
 
     int version = 0;
     if( !jo.read( "version", version ) ) {
@@ -443,8 +466,6 @@ void item_wakeup_manager::deserialize( const JsonObject &jo )
     std::map<std::pair<int64_t, item_wakeup_kind>, entry> dedup;
     int dropped = 0;
     for( JsonObject row : jo.get_array( "wakeups" ) ) {
-        // Consume every field unconditionally so the strict JSON parser
-        // does not flag unread members on bad entries.
         row.allow_omitted_members();
         int64_t uid = 0;
         std::string kind_str;
@@ -470,9 +491,9 @@ void item_wakeup_manager::deserialize( const JsonObject &jo )
         e.kind = kind;
         e.when = when;
         e.hint = hint;
-        // Dedupe by (uid, kind), keeping the latest when.
-        auto key = std::make_pair( uid, kind );
-        auto existing = dedup.find( key );
+        const std::pair<int64_t, item_wakeup_kind> key{ uid, kind };
+        const std::map<std::pair<int64_t, item_wakeup_kind>, entry>::const_iterator existing
+            = dedup.find( key );
         if( existing == dedup.end() ) {
             dedup[key] = e;
         } else {
@@ -482,10 +503,12 @@ void item_wakeup_manager::deserialize( const JsonObject &jo )
             }
         }
     }
-    entries_.reserve( dedup.size() );
     for( const auto &kv : dedup ) {
-        entries_.push_back( kv.second );
+        const entry_iter it = entries_.insert( kv.second );
+        by_key_[kv.first] = it;
+        heap_.push_back( it );
     }
+    std::make_heap( heap_.begin(), heap_.end(), heap_greater );
     stats_.dropped_on_load = dropped;
 }
 

--- a/src/item_wakeup.cpp
+++ b/src/item_wakeup.cpp
@@ -1,0 +1,94 @@
+#include "item_wakeup.h"
+
+#include <map>
+
+#include "json.h"
+#include "type_id.h"
+
+void item_wakeup_manager::schedule_or_update( int64_t /*uid*/, time_point /*when*/,
+        item_wakeup_kind /*kind*/, item_locator_hint /*hint*/ )
+{
+}
+
+void item_wakeup_manager::cancel( int64_t /*uid*/, item_wakeup_kind /*kind*/ )
+{
+}
+
+void item_wakeup_manager::cancel_all( int64_t /*uid*/ )
+{
+}
+
+void item_wakeup_manager::rebuild_for_item( item &/*it*/, item_locator_hint /*hint*/ )
+{
+}
+
+bool item_wakeup_manager::is_scheduled( int64_t /*uid*/, item_wakeup_kind /*kind*/ ) const
+{
+    return false;
+}
+
+std::optional<time_point> item_wakeup_manager::get( int64_t /*uid*/,
+        item_wakeup_kind /*kind*/ ) const
+{
+    return std::nullopt;
+}
+
+std::optional<scheduled_wakeup_info> item_wakeup_manager::peek_next_wakeup() const
+{
+    return std::nullopt;
+}
+
+std::vector<scheduled_wakeup_info> item_wakeup_manager::dump() const
+{
+    return {};
+}
+
+item_wakeup_manager::stats item_wakeup_manager::get_stats() const
+{
+    return stats_;
+}
+
+void item_wakeup_manager::process( time_point /*now*/ )
+{
+}
+
+void item_wakeup_manager::clear()
+{
+    entries_.clear();
+    stats_ = stats{};
+}
+
+void item_wakeup_manager::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.member( "version", 1 );
+    jsout.member( "wakeups" );
+    jsout.start_array();
+    jsout.end_array();
+    jsout.end_object();
+}
+
+void item_wakeup_manager::deserialize( const JsonObject &/*jo*/ )
+{
+}
+
+#ifdef CATA_TESTS
+namespace
+{
+std::map<itype_id, item_wakeup_test_handler> &test_handler_registry()
+{
+    static std::map<itype_id, item_wakeup_test_handler> registry;
+    return registry;
+}
+}  // namespace
+
+void register_test_wakeup_handler( const itype_id &id, item_wakeup_test_handler fn )
+{
+    test_handler_registry()[id] = fn;
+}
+
+void clear_test_wakeup_handlers()
+{
+    test_handler_registry().clear();
+}
+#endif

--- a/src/item_wakeup.cpp
+++ b/src/item_wakeup.cpp
@@ -1,85 +1,177 @@
 #include "item_wakeup.h"
 
+#include <algorithm>
 #include <map>
+#include <string>
+#include <utility>
 
+#include "cata_assert.h"
+#include "character_id.h"
+#include "debug.h"
+#include "flexbuffer_json.h"
+#include "item.h"
+#include "item_location.h"
+#include "item_uid.h"
 #include "json.h"
 #include "type_id.h"
 
-void item_wakeup_manager::schedule_or_update( int64_t /*uid*/, time_point /*when*/,
-        item_wakeup_kind /*kind*/, item_locator_hint /*hint*/ )
+namespace
 {
+
+constexpr int CURRENT_VERSION = 1;
+
+// Stale dispatches before a single noise-control debugmsg fires.
+// Reset by clear() and deserialize().
+constexpr int STALE_DEBUGMSG_THRESHOLD = 32;
+
+const char *kind_to_string( item_wakeup_kind k )
+{
+    switch( k ) {
+        case item_wakeup_kind::alarm:
+            return "alarm";
+        case item_wakeup_kind::ready_check:
+            return "ready_check";
+        case item_wakeup_kind::fail_check:
+            return "fail_check";
+        case item_wakeup_kind::last:
+            break;
+    }
+    return "invalid";
 }
 
-void item_wakeup_manager::cancel( int64_t /*uid*/, item_wakeup_kind /*kind*/ )
+bool string_to_kind( const std::string &s, item_wakeup_kind &out )
 {
-}
-
-void item_wakeup_manager::cancel_all( int64_t /*uid*/ )
-{
-}
-
-void item_wakeup_manager::rebuild_for_item( item &/*it*/, item_locator_hint /*hint*/ )
-{
-}
-
-bool item_wakeup_manager::is_scheduled( int64_t /*uid*/, item_wakeup_kind /*kind*/ ) const
-{
+    if( s == "alarm" ) {
+        out = item_wakeup_kind::alarm;
+        return true;
+    }
+    if( s == "ready_check" ) {
+        out = item_wakeup_kind::ready_check;
+        return true;
+    }
+    if( s == "fail_check" ) {
+        out = item_wakeup_kind::fail_check;
+        return true;
+    }
     return false;
 }
 
-std::optional<time_point> item_wakeup_manager::get( int64_t /*uid*/,
-        item_wakeup_kind /*kind*/ ) const
+const char *place_to_string( item_locator_hint::place p )
 {
-    return std::nullopt;
+    switch( p ) {
+        case item_locator_hint::place::map:
+            return "map";
+        case item_locator_hint::place::vehicle:
+            return "vehicle";
+        case item_locator_hint::place::character:
+            return "character";
+        case item_locator_hint::place::unknown:
+            break;
+    }
+    return "unknown";
 }
 
-std::optional<scheduled_wakeup_info> item_wakeup_manager::peek_next_wakeup() const
+bool string_to_place( const std::string &s, item_locator_hint::place &out )
 {
-    return std::nullopt;
+    if( s == "map" ) {
+        out = item_locator_hint::place::map;
+        return true;
+    }
+    if( s == "vehicle" ) {
+        out = item_locator_hint::place::vehicle;
+        return true;
+    }
+    if( s == "character" ) {
+        out = item_locator_hint::place::character;
+        return true;
+    }
+    if( s == "unknown" ) {
+        out = item_locator_hint::place::unknown;
+        return true;
+    }
+    return false;
 }
 
-std::vector<scheduled_wakeup_info> item_wakeup_manager::dump() const
-{
-    return {};
-}
-
-item_wakeup_manager::stats item_wakeup_manager::get_stats() const
-{
-    return stats_;
-}
-
-void item_wakeup_manager::process( time_point /*now*/ )
-{
-}
-
-void item_wakeup_manager::clear()
-{
-    entries_.clear();
-    stats_ = stats{};
-}
-
-void item_wakeup_manager::serialize( JsonOut &jsout ) const
+void serialize_hint( JsonOut &jsout, const item_locator_hint &hint )
 {
     jsout.start_object();
-    jsout.member( "version", 1 );
-    jsout.member( "wakeups" );
-    jsout.start_array();
-    jsout.end_array();
+    jsout.member( "where", place_to_string( hint.where ) );
+    if( hint.where == item_locator_hint::place::map ) {
+        const tripoint_abs_ms *p = std::get_if<tripoint_abs_ms>( &hint.location );
+        if( p != nullptr ) {
+            jsout.member( "abs_ms", *p );
+        }
+    } else if( hint.where == item_locator_hint::place::vehicle ) {
+        const vehicle_hint *v = std::get_if<vehicle_hint>( &hint.location );
+        if( v != nullptr ) {
+            jsout.member( "cargo_square", v->cargo_square );
+            jsout.member( "part_index", v->part_index );
+            jsout.member( "mount_offset", v->mount_offset );
+        }
+    } else if( hint.where == item_locator_hint::place::character ) {
+        const character_id *c = std::get_if<character_id>( &hint.location );
+        if( c != nullptr ) {
+            jsout.member( "character", c->get_value() );
+        }
+    }
     jsout.end_object();
 }
 
-void item_wakeup_manager::deserialize( const JsonObject &/*jo*/ )
+bool deserialize_hint( const JsonObject &jo, item_locator_hint &hint )
 {
+    std::string where_str;
+    if( !jo.read( "where", where_str ) ) {
+        return false;
+    }
+    if( !string_to_place( where_str, hint.where ) ) {
+        return false;
+    }
+    if( hint.where == item_locator_hint::place::map ) {
+        tripoint_abs_ms p;
+        if( !jo.read( "abs_ms", p ) ) {
+            hint.where = item_locator_hint::place::unknown;
+            hint.location = std::monostate{};
+            return true;
+        }
+        hint.location = p;
+    } else if( hint.where == item_locator_hint::place::vehicle ) {
+        vehicle_hint v;
+        if( !jo.read( "cargo_square", v.cargo_square ) ) {
+            hint.where = item_locator_hint::place::unknown;
+            hint.location = std::monostate{};
+            return true;
+        }
+        jo.read( "part_index", v.part_index );
+        jo.read( "mount_offset", v.mount_offset );
+        hint.location = v;
+    } else if( hint.where == item_locator_hint::place::character ) {
+        int64_t cid = 0;
+        if( !jo.read( "character", cid ) ) {
+            hint.where = item_locator_hint::place::unknown;
+            hint.location = std::monostate{};
+            return true;
+        }
+        hint.location = character_id( static_cast<int>( cid ) );
+    } else {
+        hint.location = std::monostate{};
+    }
+    return true;
 }
 
-#ifdef CATA_TESTS
-namespace
-{
 std::map<itype_id, item_wakeup_test_handler> &test_handler_registry()
 {
     static std::map<itype_id, item_wakeup_test_handler> registry;
     return registry;
 }
+
+std::map<itype_id, item_wakeup_test_enumerator> &test_enumerator_registry()
+{
+    static std::map<itype_id, item_wakeup_test_enumerator> registry;
+    return registry;
+}
+
+bool processing_active = false;
+
 }  // namespace
 
 void register_test_wakeup_handler( const itype_id &id, item_wakeup_test_handler fn )
@@ -91,4 +183,314 @@ void clear_test_wakeup_handlers()
 {
     test_handler_registry().clear();
 }
-#endif
+
+void register_test_enumerate_handler( const itype_id &id, item_wakeup_test_enumerator fn )
+{
+    test_enumerator_registry()[id] = fn;
+}
+
+void clear_test_enumerate_handlers()
+{
+    test_enumerator_registry().clear();
+}
+
+std::vector<desired_wakeup> enumerate_scheduled_dispatch( const item &it )
+{
+    const std::map<itype_id, item_wakeup_test_enumerator> &reg = test_enumerator_registry();
+    const auto entry = reg.find( it.typeId() );
+    if( entry != reg.end() ) {
+        return entry->second( it );
+    }
+    return {};
+}
+
+// Dispatcher called from item::actualize_scheduled.
+static void dispatch_actualize( item &it, item_wakeup_kind kind, time_point now )
+{
+    const std::map<itype_id, item_wakeup_test_handler> &reg = test_handler_registry();
+    const auto it_handler = reg.find( it.typeId() );
+    if( it_handler != reg.end() ) {
+        it_handler->second( it, kind, now );
+    }
+}
+
+void item_wakeup_manager::schedule_or_update( int64_t uid, time_point when,
+        item_wakeup_kind kind, item_locator_hint hint )
+{
+    auto match = std::find_if( entries_.begin(), entries_.end(),
+    [uid, kind]( const entry & e ) {
+        return e.uid == uid && e.kind == kind;
+    } );
+    if( match != entries_.end() ) {
+        match->when = when;
+        match->hint = hint;
+        return;
+    }
+    entry e;
+    e.uid = uid;
+    e.kind = kind;
+    e.when = when;
+    e.hint = hint;
+    entries_.push_back( e );
+}
+
+void item_wakeup_manager::cancel( int64_t uid, item_wakeup_kind kind )
+{
+    entries_.erase( std::remove_if( entries_.begin(), entries_.end(),
+    [uid, kind]( const entry & e ) {
+        return e.uid == uid && e.kind == kind;
+    } ), entries_.end() );
+}
+
+void item_wakeup_manager::cancel_all( int64_t uid )
+{
+    entries_.erase( std::remove_if( entries_.begin(), entries_.end(),
+    [uid]( const entry & e ) {
+        return e.uid == uid;
+    } ), entries_.end() );
+}
+
+void item_wakeup_manager::rebuild_for_item( item &it, item_locator_hint hint )
+{
+    const int64_t uid = it.uid().get_value();
+    const std::vector<desired_wakeup> desired = it.enumerate_scheduled_wakeups();
+
+    // Cancel kinds the item no longer wants.
+    entries_.erase( std::remove_if( entries_.begin(), entries_.end(),
+    [uid, &desired]( const entry & e ) {
+        if( e.uid != uid ) {
+            return false;
+        }
+        for( const desired_wakeup &d : desired ) {
+            if( d.kind == e.kind ) {
+                return false;
+            }
+        }
+        return true;
+    } ), entries_.end() );
+
+    // Add or update each desired wakeup.
+    for( const desired_wakeup &d : desired ) {
+        schedule_or_update( uid, d.when, d.kind, hint );
+    }
+}
+
+bool item_wakeup_manager::is_scheduled( int64_t uid, item_wakeup_kind kind ) const
+{
+    return std::any_of( entries_.begin(), entries_.end(),
+    [uid, kind]( const entry & e ) {
+        return e.uid == uid && e.kind == kind;
+    } );
+}
+
+std::optional<time_point> item_wakeup_manager::get( int64_t uid,
+        item_wakeup_kind kind ) const
+{
+    auto match = std::find_if( entries_.begin(), entries_.end(),
+    [uid, kind]( const entry & e ) {
+        return e.uid == uid && e.kind == kind;
+    } );
+    if( match == entries_.end() ) {
+        return std::nullopt;
+    }
+    return match->when;
+}
+
+std::optional<scheduled_wakeup_info> item_wakeup_manager::peek_next_wakeup() const
+{
+    std::vector<scheduled_wakeup_info> all = dump();
+    if( all.empty() ) {
+        return std::nullopt;
+    }
+    return all.front();
+}
+
+std::vector<scheduled_wakeup_info> item_wakeup_manager::dump() const
+{
+    std::vector<scheduled_wakeup_info> out;
+    out.reserve( entries_.size() );
+    for( const entry &e : entries_ ) {
+        scheduled_wakeup_info info;
+        info.uid = e.uid;
+        info.kind = e.kind;
+        info.when = e.when;
+        info.hint = e.hint;
+        out.push_back( info );
+    }
+    std::sort( out.begin(), out.end(),
+    []( const scheduled_wakeup_info & a, const scheduled_wakeup_info & b ) {
+        if( a.when != b.when ) {
+            return a.when < b.when;
+        }
+        if( a.uid != b.uid ) {
+            return a.uid < b.uid;
+        }
+        return static_cast<int>( a.kind ) < static_cast<int>( b.kind );
+    } );
+    return out;
+}
+
+item_wakeup_manager::stats item_wakeup_manager::get_stats() const
+{
+    stats s = stats_;
+    s.total_pending = static_cast<int>( entries_.size() );
+    return s;
+}
+
+void item_wakeup_manager::process( time_point now )
+{
+    cata_assert( !processing_active );
+    processing_active = true;
+
+    // Snapshot expired entries in deterministic order, erase from live queue.
+    std::vector<entry> snapshot;
+    snapshot.reserve( entries_.size() );
+    auto first_pending = std::partition( entries_.begin(), entries_.end(),
+    [now]( const entry & e ) {
+        return e.when > now;
+    } );
+    snapshot.assign( first_pending, entries_.end() );
+    entries_.erase( first_pending, entries_.end() );
+    std::sort( snapshot.begin(), snapshot.end(),
+    []( const entry & a, const entry & b ) {
+        if( a.when != b.when ) {
+            return a.when < b.when;
+        }
+        if( a.uid != b.uid ) {
+            return a.uid < b.uid;
+        }
+        return static_cast<int>( a.kind ) < static_cast<int>( b.kind );
+    } );
+
+    // Dispatch each.  Stale uids increment the counter; threshold breach
+    // emits a single debugmsg per manager lifetime (reset by clear()).
+    for( const entry &e : snapshot ) {
+        item_location loc = find_item_by_uid( e.uid, e.hint );
+        if( !loc ) {
+            stats_.stale_resolution++;
+            stale_seen_uids_++;
+            if( stale_seen_uids_ >= STALE_DEBUGMSG_THRESHOLD && !stale_msg_emitted_ ) {
+                debugmsg( "item_wakeup_manager: %d stale uids unresolved",
+                          stale_seen_uids_ );
+                stale_msg_emitted_ = true;
+            }
+            continue;
+        }
+        loc->actualize_scheduled( e.kind, now );
+    }
+
+    processing_active = false;
+}
+
+void item_wakeup_manager::clear()
+{
+    entries_.clear();
+    stats_ = stats{};
+    stale_seen_uids_ = 0;
+    stale_msg_emitted_ = false;
+}
+
+void item_wakeup_manager::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.member( "version", CURRENT_VERSION );
+    jsout.member( "wakeups" );
+    jsout.start_array();
+    std::vector<entry> sorted = entries_;
+    std::sort( sorted.begin(), sorted.end(),
+    []( const entry & a, const entry & b ) {
+        if( a.when != b.when ) {
+            return a.when < b.when;
+        }
+        if( a.uid != b.uid ) {
+            return a.uid < b.uid;
+        }
+        return static_cast<int>( a.kind ) < static_cast<int>( b.kind );
+    } );
+    for( const entry &e : sorted ) {
+        jsout.start_object();
+        jsout.member( "uid", e.uid );
+        jsout.member( "kind", kind_to_string( e.kind ) );
+        jsout.member( "when", e.when );
+        jsout.member( "hint" );
+        serialize_hint( jsout, e.hint );
+        jsout.end_object();
+    }
+    jsout.end_array();
+    jsout.end_object();
+}
+
+void item_wakeup_manager::deserialize( const JsonObject &jo )
+{
+    entries_.clear();
+    stats_ = stats{};
+    stale_seen_uids_ = 0;
+    stale_msg_emitted_ = false;
+
+    int version = 0;
+    if( !jo.read( "version", version ) ) {
+        debugmsg( "item_wakeup_manager: save without version, treating as v1" );
+    } else if( version != CURRENT_VERSION ) {
+        debugmsg( "item_wakeup_manager: unknown save version %d, dropping queue",
+                  version );
+        return;
+    }
+
+    if( !jo.has_array( "wakeups" ) ) {
+        return;
+    }
+
+    std::map<std::pair<int64_t, item_wakeup_kind>, entry> dedup;
+    int dropped = 0;
+    for( JsonObject row : jo.get_array( "wakeups" ) ) {
+        // Consume every field unconditionally so the strict JSON parser
+        // does not flag unread members on bad entries.
+        row.allow_omitted_members();
+        int64_t uid = 0;
+        std::string kind_str;
+        time_point when;
+        item_wakeup_kind kind = item_wakeup_kind::alarm;
+        const bool got_uid = row.read( "uid", uid );
+        const bool got_kind = row.read( "kind", kind_str );
+        const bool got_when = row.read( "when", when );
+        item_locator_hint hint;
+        if( row.has_object( "hint" ) ) {
+            JsonObject hint_obj = row.get_object( "hint" );
+            if( !deserialize_hint( hint_obj, hint ) ) {
+                hint = item_locator_hint{};
+            }
+        }
+        if( !got_uid || uid <= 0 || !got_kind || !string_to_kind( kind_str, kind )
+            || !got_when ) {
+            dropped++;
+            continue;
+        }
+        entry e;
+        e.uid = uid;
+        e.kind = kind;
+        e.when = when;
+        e.hint = hint;
+        // Dedupe by (uid, kind), keeping the latest when.
+        auto key = std::make_pair( uid, kind );
+        auto existing = dedup.find( key );
+        if( existing == dedup.end() ) {
+            dedup[key] = e;
+        } else {
+            stats_.duplicate_event++;
+            if( existing->second.when < when ) {
+                dedup[key] = e;
+            }
+        }
+    }
+    entries_.reserve( dedup.size() );
+    for( const auto &kv : dedup ) {
+        entries_.push_back( kv.second );
+    }
+    stats_.dropped_on_load = dropped;
+}
+
+// Item-side dispatch entry called from item.cpp.
+void actualize_scheduled_dispatch( item &it, item_wakeup_kind kind, time_point now )
+{
+    dispatch_actualize( it, kind, now );
+}

--- a/src/item_wakeup.h
+++ b/src/item_wakeup.h
@@ -18,8 +18,7 @@ class JsonObject;
 class JsonOut;
 class item;
 
-// Categorizes what a scheduled wakeup is for.  Distinct kinds for one item
-// coexist independently.
+// Distinct kinds coexist per item.
 enum class item_wakeup_kind : uint8_t {
     alarm = 0,
     ready_check,
@@ -27,18 +26,15 @@ enum class item_wakeup_kind : uint8_t {
     last
 };
 
-// Persisted vehicle hint.  vpart_reference is a runtime handle and must
-// not appear on disk; this struct stores only stable values.  The cargo
-// square is authoritative; part_index/mount_offset are fallback hints
-// that may be stale after vehicle moves or repairs.
+// Persisted vehicle hint.  cargo_square is authoritative; part_index and
+// mount_offset are fallbacks that may be stale across moves or repairs.
 struct vehicle_hint {
     tripoint_abs_ms cargo_square;
     int part_index = -1;
     point_rel_ms mount_offset;
 };
 
-// Hint for resolving an item by uid.  Drives the lookup order in
-// find_item_by_uid; never the source of truth for item identity.
+// Hint for find_item_by_uid lookup; never authoritative.
 struct item_locator_hint {
     enum class place : uint8_t { map, vehicle, character, unknown };
     place where = place::unknown;
@@ -47,9 +43,7 @@ struct item_locator_hint {
     item_locator_hint() = default;
 };
 
-// Producer record returned by item::enumerate_scheduled_wakeups.  Items
-// describe their desired wakeups by (kind, when); the manager stamps the
-// caller-supplied hint when (re)scheduling.
+// Producer record.  Manager stamps the caller-supplied hint when scheduling.
 struct desired_wakeup {
     item_wakeup_kind kind;
     time_point when;
@@ -63,9 +57,8 @@ struct scheduled_wakeup_info {
     item_locator_hint hint;
 };
 
-// Item-targeted wakeup scheduler.  Items remain authoritative for runtime
-// state; this queue is advisory and can be reconstructed via
-// rebuild_for_item from item state.
+// Item-targeted wakeup scheduler.  Items are authoritative; this queue is
+// advisory and reconstructible via rebuild_for_item.
 class item_wakeup_manager
 {
     public:
@@ -82,10 +75,8 @@ class item_wakeup_manager
         void cancel( int64_t uid, item_wakeup_kind kind );
         void cancel_all( int64_t uid );
 
-        // Reconcile the manager's queue for a single item against the item's
-        // own enumerate_scheduled_wakeups().  Items the manager has but the
-        // item no longer wants are cancelled; new desires are scheduled.
-        // Idempotent.  Hint is stamped onto every (re)scheduled entry.
+        // Reconcile this item's entries against its enumerate_scheduled_wakeups().
+        // Idempotent.
         void rebuild_for_item( item &it, item_locator_hint hint );
 
         bool is_scheduled( int64_t uid, item_wakeup_kind kind ) const;
@@ -95,11 +86,8 @@ class item_wakeup_manager
         std::vector<scheduled_wakeup_info> dump() const;
         stats get_stats() const;
 
-        // Two-phase, non-reentrant.  Snapshot all entries with when <= now,
-        // erase from live queue, then dispatch handlers from the snapshot.
-        // Recursion guard asserts process() is not called from a handler.
-        // Wakeups newly scheduled for <= now during a handler do NOT fire
-        // again in the same pass.
+        // Two-phase: snapshot expired entries, erase, dispatch from snapshot.
+        // Asserts non-reentrant.  Same-pass reschedule does not double-fire.
         void process( time_point now );
 
         // Test isolation only.  Drops every entry and zeroes stats.
@@ -117,20 +105,31 @@ class item_wakeup_manager
         };
 
         std::vector<entry> entries_;
-        stats stats_;
+        stats stats_; // NOLINT(cata-serialize)
+        int stale_seen_uids_ = 0; // NOLINT(cata-serialize)
+        bool stale_msg_emitted_ = false; // NOLINT(cata-serialize)
 };
 
-// Game-owned accessor.
 item_wakeup_manager &get_item_wakeups();
 
-// find_item_by_uid is declared in item_location.h.
-
-// Test-only handler registry.  Production builds compile this out.
-#ifdef CATA_TESTS
+// Test handler registry.  Always compiled in; production cost is one
+// empty-map lookup per dispatch.
 using item_wakeup_test_handler =
     void( * )( item &it, item_wakeup_kind kind, time_point now );
 void register_test_wakeup_handler( const itype_id &id, item_wakeup_test_handler fn );
 void clear_test_wakeup_handlers();
-#endif
+
+// Dispatch entry called from item::actualize_scheduled.
+void actualize_scheduled_dispatch( item &it, item_wakeup_kind kind, time_point now );
+
+// Test producer registry.  See test handler registry note above.
+using item_wakeup_test_enumerator =
+    std::vector<desired_wakeup>( * )( const item &it );
+void register_test_enumerate_handler( const itype_id &id,
+                                      item_wakeup_test_enumerator fn );
+void clear_test_enumerate_handlers();
+
+// Dispatch entry called from item::enumerate_scheduled_wakeups.
+std::vector<desired_wakeup> enumerate_scheduled_dispatch( const item &it );
 
 #endif // CATA_SRC_ITEM_WAKEUP_H

--- a/src/item_wakeup.h
+++ b/src/item_wakeup.h
@@ -1,0 +1,136 @@
+#pragma once
+#ifndef CATA_SRC_ITEM_WAKEUP_H
+#define CATA_SRC_ITEM_WAKEUP_H
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "calendar.h"
+#include "character_id.h"
+#include "coordinates.h"
+#include "point.h"
+#include "type_id.h"
+
+class JsonObject;
+class JsonOut;
+class item;
+
+// Categorizes what a scheduled wakeup is for.  Distinct kinds for one item
+// coexist independently.
+enum class item_wakeup_kind : uint8_t {
+    alarm = 0,
+    ready_check,
+    fail_check,
+    last
+};
+
+// Persisted vehicle hint.  vpart_reference is a runtime handle and must
+// not appear on disk; this struct stores only stable values.  The cargo
+// square is authoritative; part_index/mount_offset are fallback hints
+// that may be stale after vehicle moves or repairs.
+struct vehicle_hint {
+    tripoint_abs_ms cargo_square;
+    int part_index = -1;
+    point_rel_ms mount_offset;
+};
+
+// Hint for resolving an item by uid.  Drives the lookup order in
+// find_item_by_uid; never the source of truth for item identity.
+struct item_locator_hint {
+    enum class place : uint8_t { map, vehicle, character, unknown };
+    place where = place::unknown;
+    std::variant<std::monostate, tripoint_abs_ms, vehicle_hint, character_id> location;
+
+    item_locator_hint() = default;
+};
+
+// Producer record returned by item::enumerate_scheduled_wakeups.  Items
+// describe their desired wakeups by (kind, when); the manager stamps the
+// caller-supplied hint when (re)scheduling.
+struct desired_wakeup {
+    item_wakeup_kind kind;
+    time_point when;
+};
+
+// Diagnostics row.
+struct scheduled_wakeup_info {
+    int64_t uid;
+    item_wakeup_kind kind;
+    time_point when;
+    item_locator_hint hint;
+};
+
+// Item-targeted wakeup scheduler.  Items remain authoritative for runtime
+// state; this queue is advisory and can be reconstructed via
+// rebuild_for_item from item state.
+class item_wakeup_manager
+{
+    public:
+        struct stats {
+            int total_pending = 0;
+            int stale_resolution = 0;
+            int duplicate_event = 0;
+            int dropped_on_load = 0;
+        };
+
+        // Insert or replace the (uid, kind) entry.  Newer when always wins.
+        void schedule_or_update( int64_t uid, time_point when,
+                                 item_wakeup_kind kind, item_locator_hint hint );
+        void cancel( int64_t uid, item_wakeup_kind kind );
+        void cancel_all( int64_t uid );
+
+        // Reconcile the manager's queue for a single item against the item's
+        // own enumerate_scheduled_wakeups().  Items the manager has but the
+        // item no longer wants are cancelled; new desires are scheduled.
+        // Idempotent.  Hint is stamped onto every (re)scheduled entry.
+        void rebuild_for_item( item &it, item_locator_hint hint );
+
+        bool is_scheduled( int64_t uid, item_wakeup_kind kind ) const;
+        std::optional<time_point> get( int64_t uid, item_wakeup_kind kind ) const;
+        std::optional<scheduled_wakeup_info> peek_next_wakeup() const;
+        // Sorted by (when, uid, kind).
+        std::vector<scheduled_wakeup_info> dump() const;
+        stats get_stats() const;
+
+        // Two-phase, non-reentrant.  Snapshot all entries with when <= now,
+        // erase from live queue, then dispatch handlers from the snapshot.
+        // Recursion guard asserts process() is not called from a handler.
+        // Wakeups newly scheduled for <= now during a handler do NOT fire
+        // again in the same pass.
+        void process( time_point now );
+
+        // Test isolation only.  Drops every entry and zeroes stats.
+        void clear();
+
+        void serialize( JsonOut &jsout ) const;
+        void deserialize( const JsonObject &jo );
+
+    private:
+        struct entry {
+            int64_t uid = 0;
+            item_wakeup_kind kind = item_wakeup_kind::alarm;
+            time_point when = calendar::before_time_starts;
+            item_locator_hint hint;
+        };
+
+        std::vector<entry> entries_;
+        stats stats_;
+};
+
+// Game-owned accessor.
+item_wakeup_manager &get_item_wakeups();
+
+// find_item_by_uid is declared in item_location.h.
+
+// Test-only handler registry.  Production builds compile this out.
+#ifdef CATA_TESTS
+using item_wakeup_test_handler =
+    void( * )( item &it, item_wakeup_kind kind, time_point now );
+void register_test_wakeup_handler( const itype_id &id, item_wakeup_test_handler fn );
+void clear_test_wakeup_handlers();
+#endif
+
+#endif // CATA_SRC_ITEM_WAKEUP_H

--- a/src/item_wakeup.h
+++ b/src/item_wakeup.h
@@ -3,13 +3,15 @@
 #define CATA_SRC_ITEM_WAKEUP_H
 
 #include <cstdint>
+#include <map>
 #include <optional>
 #include <utility>
 #include <variant>
 #include <vector>
 
 #include "calendar.h"
-#include "character_id.h"
+#include "character_id.h" // IWYU pragma: keep
+#include "colony.h"
 #include "coordinates.h"
 #include "point.h"
 #include "type_id.h"
@@ -104,7 +106,22 @@ class item_wakeup_manager
             item_locator_hint hint;
         };
 
-        std::vector<entry> entries_;
+        using entry_iter = cata::colony<entry>::iterator;
+        using key_t = std::pair<int64_t, item_wakeup_kind>;
+
+        // Pop tombstoned entries off heap_ until top points to a live node.
+        void clean_heap_top();
+        bool is_live( const entry_iter &it ) const;
+        static bool heap_greater( const entry_iter &a, const entry_iter &b );
+
+        cata::colony<entry> entries_;
+        // Source of liveness truth.  An entry_iter is live iff
+        // by_key_[{uid, kind}] == iter.  Stale heap nodes are reaped on
+        // pop or via clean_heap_top.
+        std::map<key_t, entry_iter> by_key_;
+        // Min-heap by (when, uid, kind), maintained via push_heap/pop_heap.
+        // Pure cache, reconstructible from entries_ + by_key_ on load.
+        std::vector<entry_iter> heap_; // NOLINT(cata-serialize)
         stats stats_; // NOLINT(cata-serialize)
         int stale_seen_uids_ = 0; // NOLINT(cata-serialize)
         bool stale_msg_emitted_ = false; // NOLINT(cata-serialize)

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -25,6 +25,7 @@
 #include "hash_utils.h"
 #include "horde_entity.h"
 #include "input.h"
+#include "item_wakeup.h"
 #include "json.h"
 #include "json_loader.h"
 #include "kill_tracker.h"
@@ -1695,6 +1696,9 @@ void game::unserialize_master( const cata_path &file_name, std::istream &fin )
 
 void game::unserialize_master( const JsonValue &jv )
 {
+    // Reset state that has no clear-on-load hook of its own; otherwise a
+    // save without the field inherits the previous game's queue.
+    get_item_wakeups().clear();
     JsonObject game_json = jv;
     for( JsonMember jsin : game_json ) {
         std::string name = jsin.name();
@@ -1714,6 +1718,8 @@ void game::unserialize_master( const JsonValue &jv )
             weather_manager::unserialize_all( jsin );
         } else if( name == "timed_events" ) {
             timed_event_manager::unserialize_all( jsin );
+        } else if( name == "item_wakeups" ) {
+            get_item_wakeups().deserialize( jsin );
         } else if( name == "overmapbuffer" ) {
             overmap_buffer.global_state.deserialize( jsin );
         } else if( name == "placed_unique_specials" ) {
@@ -1915,6 +1921,9 @@ void game::serialize_master( std::ostream &fout )
 
         json.member( "timed_events" );
         timed_event_manager::serialize_all( json );
+
+        json.member( "item_wakeups" );
+        get_item_wakeups().serialize( json );
 
         json.member( "factions", *faction_manager_ptr );
         json.member( "seed", seed );

--- a/tests/item_wakeup_test.cpp
+++ b/tests/item_wakeup_test.cpp
@@ -1,0 +1,847 @@
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "avatar.h"
+#include "calendar.h"
+#include "cata_catch.h"
+#include "character_id.h"
+#include "coordinates.h"
+#include "debug.h"
+#include "flexbuffer_json.h"
+#include "item.h"
+#include "item_location.h"
+#include "item_uid.h"
+#include "item_wakeup.h"
+#include "json.h"
+#include "json_loader.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "player_helpers.h"
+#include "point.h"
+#include "type_id.h"
+#include "units.h"
+#include "vehicle.h"
+#include "vpart_position.h"
+#include "vpart_range.h"
+
+static const itype_id itype_test_wakeup_dummy( "test_wakeup_dummy" );
+static const itype_id itype_test_wakeup_no_handler( "test_wakeup_no_handler" );
+static const vproto_id vehicle_prototype_bicycle( "bicycle" );
+
+namespace
+{
+
+struct fire_record {
+    int64_t uid;
+    item_wakeup_kind kind;
+    time_point when;
+};
+
+std::vector<fire_record> &fire_log()
+{
+    static std::vector<fire_record> log;
+    return log;
+}
+
+void dummy_handler( item &it, item_wakeup_kind kind, time_point now )
+{
+    fire_log().push_back( fire_record{ it.uid().get_value(), kind, now } );
+}
+
+void install_test_handler()
+{
+    clear_test_wakeup_handlers();
+    fire_log().clear();
+    register_test_wakeup_handler( itype_test_wakeup_dummy, &dummy_handler );
+}
+
+item_locator_hint hint_for_map( const tripoint_abs_ms &p )
+{
+    item_locator_hint h;
+    h.where = item_locator_hint::place::map;
+    h.location = p;
+    return h;
+}
+
+item_locator_hint hint_unknown()
+{
+    return item_locator_hint{};
+}
+
+}  // namespace
+
+
+TEST_CASE( "item_wakeup_lifecycle_basic", "[item_wakeup][lifecycle]" )
+{
+    item_wakeup_manager mgr;
+    const time_point t = calendar::turn_zero + 5_minutes;
+    mgr.schedule_or_update( 1, t, item_wakeup_kind::ready_check, hint_unknown() );
+
+    SECTION( "scheduled item appears in dump" ) {
+        REQUIRE( mgr.dump().size() == 1 );
+        CHECK( mgr.dump().front().uid == 1 );
+        CHECK( mgr.dump().front().kind == item_wakeup_kind::ready_check );
+        CHECK( mgr.dump().front().when == t );
+    }
+
+    SECTION( "is_scheduled and get reflect the entry" ) {
+        CHECK( mgr.is_scheduled( 1, item_wakeup_kind::ready_check ) );
+        CHECK_FALSE( mgr.is_scheduled( 1, item_wakeup_kind::alarm ) );
+        CHECK( mgr.get( 1, item_wakeup_kind::ready_check ).value() == t );
+        CHECK_FALSE( mgr.get( 2, item_wakeup_kind::ready_check ).has_value() );
+    }
+
+    SECTION( "cancel removes only matching kind" ) {
+        mgr.schedule_or_update( 1, t + 1_minutes, item_wakeup_kind::alarm, hint_unknown() );
+        mgr.cancel( 1, item_wakeup_kind::ready_check );
+        CHECK_FALSE( mgr.is_scheduled( 1, item_wakeup_kind::ready_check ) );
+        CHECK( mgr.is_scheduled( 1, item_wakeup_kind::alarm ) );
+    }
+
+    SECTION( "cancel_all removes every kind for uid" ) {
+        mgr.schedule_or_update( 1, t + 1_minutes, item_wakeup_kind::alarm, hint_unknown() );
+        mgr.schedule_or_update( 2, t, item_wakeup_kind::ready_check, hint_unknown() );
+        mgr.cancel_all( 1 );
+        CHECK_FALSE( mgr.is_scheduled( 1, item_wakeup_kind::ready_check ) );
+        CHECK_FALSE( mgr.is_scheduled( 1, item_wakeup_kind::alarm ) );
+        CHECK( mgr.is_scheduled( 2, item_wakeup_kind::ready_check ) );
+    }
+}
+
+TEST_CASE( "item_wakeup_schedule_or_update_overwrites", "[item_wakeup][lifecycle]" )
+{
+    item_wakeup_manager mgr;
+    const time_point t1 = calendar::turn_zero + 5_minutes;
+    const time_point t2 = calendar::turn_zero + 10_minutes;
+    mgr.schedule_or_update( 1, t1, item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.schedule_or_update( 1, t2, item_wakeup_kind::ready_check, hint_unknown() );
+
+    REQUIRE( mgr.dump().size() == 1 );
+    CHECK( mgr.dump().front().when == t2 );
+}
+
+TEST_CASE( "item_wakeup_clear_resets_state", "[item_wakeup][lifecycle]" )
+{
+    item_wakeup_manager mgr;
+    mgr.schedule_or_update( 1, calendar::turn_zero + 5_minutes,
+                            item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.clear();
+    CHECK( mgr.dump().empty() );
+    CHECK( mgr.get_stats().total_pending == 0 );
+}
+
+
+TEST_CASE( "item_wakeup_fires_at_or_after_when", "[item_wakeup][firing]" )
+{
+    clear_map();
+    install_test_handler();
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item placed = item( itype_test_wakeup_dummy, calendar::turn );
+    item &on_map = here.add_item( origin, placed );
+    const int64_t uid = on_map.uid().get_value();
+
+    item_wakeup_manager mgr;
+    const time_point fire_at = calendar::turn + 5_minutes;
+    mgr.schedule_or_update( uid, fire_at, item_wakeup_kind::ready_check,
+                            hint_for_map( here.get_abs( origin ) ) );
+
+    SECTION( "before fire time, nothing fires" ) {
+        mgr.process( fire_at - 1_minutes );
+        CHECK( fire_log().empty() );
+        CHECK( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
+    }
+
+    SECTION( "at fire time, handler fires once and entry is consumed" ) {
+        mgr.process( fire_at );
+        REQUIRE( fire_log().size() == 1 );
+        CHECK( fire_log().front().uid == uid );
+        CHECK( fire_log().front().kind == item_wakeup_kind::ready_check );
+        CHECK_FALSE( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
+    }
+
+    SECTION( "process well after fire time still fires once" ) {
+        mgr.process( fire_at + 1_hours );
+        CHECK( fire_log().size() == 1 );
+    }
+}
+
+TEST_CASE( "item_wakeup_fires_in_time_order", "[item_wakeup][firing]" )
+{
+    clear_map();
+    install_test_handler();
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &a = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    item &b = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid_a = a.uid().get_value();
+    const int64_t uid_b = b.uid().get_value();
+
+    item_wakeup_manager mgr;
+    const time_point t1 = calendar::turn + 1_minutes;
+    const time_point t2 = calendar::turn + 2_minutes;
+    const item_locator_hint h = hint_for_map( here.get_abs( origin ) );
+    mgr.schedule_or_update( uid_b, t2, item_wakeup_kind::ready_check, h );
+    mgr.schedule_or_update( uid_a, t1, item_wakeup_kind::ready_check, h );
+
+    mgr.process( t2 );
+    REQUIRE( fire_log().size() == 2 );
+    // Handlers receive `now`, not the original wakeup time, so uid order is
+    // the contract: earlier-scheduled wakeups dispatch first.
+    CHECK( fire_log()[0].uid == uid_a );
+    CHECK( fire_log()[1].uid == uid_b );
+}
+
+TEST_CASE( "item_wakeup_same_pass_reschedule_does_not_double_fire",
+           "[item_wakeup][firing]" )
+{
+    clear_map();
+    clear_test_wakeup_handlers();
+    fire_log().clear();
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    item_wakeup_manager *mgr_ptr = nullptr;
+    auto rescheduling_handler = []( item & it, item_wakeup_kind kind, time_point now ) {
+        fire_log().push_back( fire_record{ it.uid().get_value(), kind, now } );
+        // Item handler reschedules itself for "now"; this MUST NOT fire again
+        // in the same process pass.
+        get_item_wakeups().schedule_or_update( it.uid().get_value(), now,
+                                               item_wakeup_kind::ready_check, hint_unknown() );
+    };
+    register_test_wakeup_handler( itype_test_wakeup_dummy, rescheduling_handler );
+
+    item_wakeup_manager &mgr = get_item_wakeups();
+    mgr.clear();
+    mgr_ptr = &mgr;
+    const time_point t = calendar::turn + 1_minutes;
+    mgr.schedule_or_update( uid, t, item_wakeup_kind::ready_check,
+                            hint_for_map( here.get_abs( origin ) ) );
+
+    mgr.process( t );
+    CHECK( fire_log().size() == 1 );
+    // Re-scheduled entry remains pending until the next process pass.
+    CHECK( mgr_ptr->is_scheduled( uid, item_wakeup_kind::ready_check ) );
+    mgr.clear();
+    clear_test_wakeup_handlers();
+}
+
+
+TEST_CASE( "item_wakeup_handler_called_once_per_fire", "[item_wakeup][idempotency]" )
+{
+    clear_map();
+    install_test_handler();
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    item_wakeup_manager mgr;
+    const time_point t = calendar::turn + 1_minutes;
+    mgr.schedule_or_update( uid, t, item_wakeup_kind::ready_check,
+                            hint_for_map( here.get_abs( origin ) ) );
+    mgr.process( t );
+    mgr.process( t + 1_hours );
+
+    CHECK( fire_log().size() == 1 );
+}
+
+
+TEST_CASE( "item_wakeup_default_enumerate_is_empty", "[item_wakeup][rebuild]" )
+{
+    item it( itype_test_wakeup_dummy, calendar::turn );
+    CHECK( it.enumerate_scheduled_wakeups().empty() );
+}
+
+TEST_CASE( "item_wakeup_rebuild_schedules_from_item", "[item_wakeup][rebuild]" )
+{
+    // Default-enumerate is empty, so rebuild_for_item must cancel any
+    // pre-existing entry for the item's uid.
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    item_wakeup_manager mgr;
+    mgr.schedule_or_update( uid, calendar::turn + 5_minutes,
+                            item_wakeup_kind::ready_check,
+                            hint_for_map( here.get_abs( origin ) ) );
+    REQUIRE( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
+
+    mgr.rebuild_for_item( on_map, hint_for_map( here.get_abs( origin ) ) );
+    CHECK_FALSE( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
+}
+
+
+TEST_CASE( "item_wakeup_resolve_on_map", "[item_wakeup][resolve]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    item_location loc = find_item_by_uid( uid, hint_for_map( here.get_abs( origin ) ) );
+    REQUIRE( loc );
+    CHECK( loc.get_item()->uid().get_value() == uid );
+}
+
+TEST_CASE( "item_wakeup_resolve_on_character", "[item_wakeup][resolve]" )
+{
+    clear_avatar();
+    avatar &u = get_avatar();
+    item carried( itype_test_wakeup_dummy, calendar::turn );
+    item_location placed = u.i_add( carried );
+    REQUIRE( placed );
+    const int64_t uid = placed->uid().get_value();
+
+    item_locator_hint hint;
+    hint.where = item_locator_hint::place::character;
+    hint.location = u.getID();
+
+    item_location loc = find_item_by_uid( uid, hint );
+    REQUIRE( loc );
+    CHECK( loc.get_item()->uid().get_value() == uid );
+}
+
+TEST_CASE( "item_wakeup_resolve_destroyed_item_returns_invalid", "[item_wakeup][resolve]" )
+{
+    clear_map();
+    item_location loc = find_item_by_uid( 999999999, hint_unknown() );
+    CHECK_FALSE( loc );
+}
+
+TEST_CASE( "item_wakeup_resolve_invalid_uid_returns_invalid", "[item_wakeup][resolve]" )
+{
+    item_location loc = find_item_by_uid( 0, hint_unknown() );
+    CHECK_FALSE( loc );
+}
+
+TEST_CASE( "item_wakeup_resolve_falls_back_to_loaded_map", "[item_wakeup][resolve]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    const tripoint_bub_ms elsewhere( 65, 65, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( elsewhere,
+                                  item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    // Hint is wrong (points to origin, item is at elsewhere).  Map fallback
+    // should still resolve via reality-bubble scan.
+    item_location loc = find_item_by_uid( uid, hint_for_map( here.get_abs( origin ) ) );
+    REQUIRE( loc );
+    CHECK( loc.get_item()->uid().get_value() == uid );
+}
+
+TEST_CASE( "item_wakeup_wrong_hint_falls_back_to_avatar", "[item_wakeup][resolve]" )
+{
+    clear_avatar();
+    avatar &u = get_avatar();
+    item carried( itype_test_wakeup_dummy, calendar::turn );
+    item_location placed = u.i_add( carried );
+    REQUIRE( placed );
+    const int64_t uid = placed->uid().get_value();
+
+    // Hint says map, but item is in inventory.  Fallback should find it.
+    item_location loc = find_item_by_uid( uid,
+                                          hint_for_map( tripoint_abs_ms{ 1, 1, 0 } ) );
+    REQUIRE( loc );
+    CHECK( loc.get_item()->uid().get_value() == uid );
+}
+
+
+TEST_CASE( "item_wakeup_save_load_roundtrip", "[item_wakeup][persistence]" )
+{
+    item_wakeup_manager src;
+    const time_point t = calendar::turn_zero + 10_minutes;
+    src.schedule_or_update( 100, t, item_wakeup_kind::ready_check,
+                            hint_for_map( tripoint_abs_ms{ 1, 2, 0 } ) );
+    src.schedule_or_update( 100, t + 1_minutes, item_wakeup_kind::alarm, hint_unknown() );
+    src.schedule_or_update( 200, t + 2_minutes, item_wakeup_kind::fail_check, hint_unknown() );
+
+    std::ostringstream os;
+    JsonOut jsout( os );
+    src.serialize( jsout );
+
+    item_wakeup_manager dst;
+    JsonValue jv = json_loader::from_string( os.str() );
+    JsonObject jo = jv.get_object();
+    dst.deserialize( jo );
+
+    REQUIRE( dst.dump().size() == 3 );
+    CHECK( dst.is_scheduled( 100, item_wakeup_kind::ready_check ) );
+    CHECK( dst.is_scheduled( 100, item_wakeup_kind::alarm ) );
+    CHECK( dst.is_scheduled( 200, item_wakeup_kind::fail_check ) );
+}
+
+TEST_CASE( "item_wakeup_save_load_character_hint", "[item_wakeup][persistence]" )
+{
+    item_wakeup_manager src;
+    item_locator_hint hint;
+    hint.where = item_locator_hint::place::character;
+    hint.location = character_id( 42 );
+    src.schedule_or_update( 7, calendar::turn_zero + 1_minutes,
+                            item_wakeup_kind::alarm, hint );
+
+    std::ostringstream os;
+    JsonOut jsout( os );
+    src.serialize( jsout );
+
+    item_wakeup_manager dst;
+    JsonValue jv = json_loader::from_string( os.str() );
+    JsonObject jo = jv.get_object();
+    dst.deserialize( jo );
+
+    REQUIRE( dst.is_scheduled( 7, item_wakeup_kind::alarm ) );
+}
+
+TEST_CASE( "item_wakeup_save_load_vehicle_hint", "[item_wakeup][persistence]" )
+{
+    item_wakeup_manager src;
+    vehicle_hint vh;
+    vh.cargo_square = tripoint_abs_ms{ 10, 20, 0 };
+    vh.part_index = 3;
+    vh.mount_offset = point_rel_ms{ 1, 0 };
+    item_locator_hint hint;
+    hint.where = item_locator_hint::place::vehicle;
+    hint.location = vh;
+    src.schedule_or_update( 99, calendar::turn_zero + 5_minutes,
+                            item_wakeup_kind::ready_check, hint );
+
+    std::ostringstream os;
+    JsonOut jsout( os );
+    src.serialize( jsout );
+
+    item_wakeup_manager dst;
+    JsonValue jv = json_loader::from_string( os.str() );
+    JsonObject jo = jv.get_object();
+    dst.deserialize( jo );
+
+    REQUIRE( dst.is_scheduled( 99, item_wakeup_kind::ready_check ) );
+}
+
+TEST_CASE( "item_wakeup_load_absent_version_treats_as_v1",
+           "[item_wakeup][persistence]" )
+{
+    const std::string raw = R"(
+        {
+            "wakeups": [
+                { "uid": 5, "kind": "ready_check", "when": 100 }
+            ]
+        }
+    )";
+
+    item_wakeup_manager mgr;
+    const std::string dmsg = capture_debugmsg_during( [&]() {
+        JsonValue jv = json_loader::from_string( raw );
+        JsonObject jo = jv.get_object();
+        mgr.deserialize( jo );
+    } );
+    CHECK_FALSE( dmsg.empty() );
+    CHECK( mgr.is_scheduled( 5, item_wakeup_kind::ready_check ) );
+}
+
+TEST_CASE( "item_wakeup_load_dedupe_increments_duplicate_event_counter",
+           "[item_wakeup][persistence]" )
+{
+    const std::string raw = R"(
+        {
+            "version": 1,
+            "wakeups": [
+                { "uid": 5, "kind": "ready_check", "when": 100 },
+                { "uid": 5, "kind": "ready_check", "when": 200 }
+            ]
+        }
+    )";
+
+    item_wakeup_manager mgr;
+    JsonValue jv = json_loader::from_string( raw );
+    JsonObject jo = jv.get_object();
+    mgr.deserialize( jo );
+
+    CHECK( mgr.dump().size() == 1 );
+    CHECK( mgr.get_stats().duplicate_event == 1 );
+}
+
+TEST_CASE( "item_wakeup_load_drops_bad_entries", "[item_wakeup][persistence]" )
+{
+    const std::string raw = R"(
+        {
+            "version": 1,
+            "wakeups": [
+                { "uid": 0, "kind": "alarm", "when": 100 },
+                { "uid": 5, "kind": "ready_check", "when": 100 },
+                { "uid": 7, "kind": "garbage_kind", "when": 100 }
+            ]
+        }
+    )";
+
+    item_wakeup_manager mgr;
+    JsonValue jv = json_loader::from_string( raw );
+    JsonObject jo = jv.get_object();
+    mgr.deserialize( jo );
+
+    CHECK( mgr.dump().size() == 1 );
+    CHECK( mgr.is_scheduled( 5, item_wakeup_kind::ready_check ) );
+    CHECK( mgr.get_stats().dropped_on_load == 2 );
+}
+
+TEST_CASE( "item_wakeup_load_unknown_version_drops_queue",
+           "[item_wakeup][persistence]" )
+{
+    const std::string raw = R"(
+        {
+            "version": 999,
+            "wakeups": [
+                { "uid": 5, "kind": "ready_check", "when": 100 }
+            ]
+        }
+    )";
+
+    item_wakeup_manager mgr;
+    const std::string dmsg = capture_debugmsg_during( [&]() {
+        JsonValue jv = json_loader::from_string( raw );
+        JsonObject jo = jv.get_object();
+        mgr.deserialize( jo );
+    } );
+    CHECK_FALSE( dmsg.empty() );
+    CHECK( mgr.dump().empty() );
+}
+
+TEST_CASE( "item_wakeup_load_dedupes_uid_kind_keeping_latest",
+           "[item_wakeup][persistence]" )
+{
+    const std::string raw = R"(
+        {
+            "version": 1,
+            "wakeups": [
+                { "uid": 5, "kind": "ready_check", "when": 100 },
+                { "uid": 5, "kind": "ready_check", "when": 200 }
+            ]
+        }
+    )";
+
+    item_wakeup_manager mgr;
+    JsonValue jv = json_loader::from_string( raw );
+    JsonObject jo = jv.get_object();
+    mgr.deserialize( jo );
+
+    REQUIRE( mgr.dump().size() == 1 );
+    const time_point persisted = mgr.get( 5, item_wakeup_kind::ready_check ).value();
+    CHECK( to_turn<int>( persisted ) == 200 );
+}
+
+
+TEST_CASE( "item_wakeup_dump_is_sorted_deterministically", "[item_wakeup][diag]" )
+{
+    item_wakeup_manager mgr;
+    const time_point t = calendar::turn_zero + 5_minutes;
+    mgr.schedule_or_update( 3, t + 1_minutes, item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.schedule_or_update( 1, t + 1_minutes, item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.schedule_or_update( 2, t, item_wakeup_kind::alarm, hint_unknown() );
+    mgr.schedule_or_update( 2, t, item_wakeup_kind::ready_check, hint_unknown() );
+
+    std::vector<scheduled_wakeup_info> d = mgr.dump();
+    REQUIRE( d.size() == 4 );
+    // Sorted by (when, uid, kind)
+    CHECK( d[0].uid == 2 );
+    CHECK( d[0].kind == item_wakeup_kind::alarm );
+    CHECK( d[1].uid == 2 );
+    CHECK( d[1].kind == item_wakeup_kind::ready_check );
+    CHECK( d[2].uid == 1 );
+    CHECK( d[3].uid == 3 );
+}
+
+TEST_CASE( "item_wakeup_peek_matches_dump_front", "[item_wakeup][diag]" )
+{
+    item_wakeup_manager mgr;
+    const time_point t = calendar::turn_zero + 5_minutes;
+
+    SECTION( "empty manager returns nullopt" ) {
+        CHECK_FALSE( mgr.peek_next_wakeup().has_value() );
+    }
+
+    SECTION( "non-empty manager matches dump front" ) {
+        mgr.schedule_or_update( 5, t, item_wakeup_kind::ready_check, hint_unknown() );
+        mgr.schedule_or_update( 3, t + 1_minutes, item_wakeup_kind::alarm, hint_unknown() );
+        std::optional<scheduled_wakeup_info> peek = mgr.peek_next_wakeup();
+        REQUIRE( peek.has_value() );
+        CHECK( peek->uid == mgr.dump().front().uid );
+        CHECK( peek->kind == mgr.dump().front().kind );
+        CHECK( peek->when == mgr.dump().front().when );
+    }
+}
+
+TEST_CASE( "item_wakeup_total_pending_tracks_entry_count", "[item_wakeup][diag]" )
+{
+    item_wakeup_manager mgr;
+    CHECK( mgr.get_stats().total_pending == 0 );
+    mgr.schedule_or_update( 1, calendar::turn_zero + 1_minutes,
+                            item_wakeup_kind::alarm, hint_unknown() );
+    CHECK( mgr.get_stats().total_pending == 1 );
+    mgr.schedule_or_update( 2, calendar::turn_zero + 2_minutes,
+                            item_wakeup_kind::alarm, hint_unknown() );
+    CHECK( mgr.get_stats().total_pending == 2 );
+    mgr.cancel( 1, item_wakeup_kind::alarm );
+    CHECK( mgr.get_stats().total_pending == 1 );
+}
+
+
+TEST_CASE( "item_wakeup_no_registered_handler_is_noop",
+           "[item_wakeup][firing]" )
+{
+    clear_map();
+    clear_test_wakeup_handlers();
+    fire_log().clear();
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin,
+                                  item( itype_test_wakeup_no_handler, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    item_wakeup_manager mgr;
+    mgr.schedule_or_update( uid, calendar::turn + 1_minutes,
+                            item_wakeup_kind::ready_check,
+                            hint_for_map( here.get_abs( origin ) ) );
+    mgr.process( calendar::turn + 5_minutes );
+
+    CHECK( fire_log().empty() );
+    CHECK_FALSE( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
+}
+
+
+namespace
+{
+std::vector<desired_wakeup> dummy_enumerator( const item &/*it*/ )
+{
+    return {
+        desired_wakeup{ item_wakeup_kind::ready_check, calendar::turn_zero + 5_minutes },
+        desired_wakeup{ item_wakeup_kind::fail_check, calendar::turn_zero + 10_minutes },
+    };
+}
+}  // namespace
+
+TEST_CASE( "item_wakeup_rebuild_schedules_from_producer", "[item_wakeup][rebuild]" )
+{
+    clear_map();
+    clear_test_enumerate_handlers();
+    register_test_enumerate_handler( itype_test_wakeup_dummy, &dummy_enumerator );
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    item_wakeup_manager mgr;
+    mgr.rebuild_for_item( on_map, hint_for_map( here.get_abs( origin ) ) );
+
+    CHECK( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
+    CHECK( mgr.is_scheduled( uid, item_wakeup_kind::fail_check ) );
+    CHECK( mgr.get( uid, item_wakeup_kind::ready_check ).value()
+           == calendar::turn_zero + 5_minutes );
+
+    clear_test_enumerate_handlers();
+}
+
+TEST_CASE( "item_wakeup_rebuild_updates_existing_when", "[item_wakeup][rebuild]" )
+{
+    clear_map();
+    clear_test_enumerate_handlers();
+    register_test_enumerate_handler( itype_test_wakeup_dummy, &dummy_enumerator );
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    item_wakeup_manager mgr;
+    // Pre-existing entry with a different time.
+    mgr.schedule_or_update( uid, calendar::turn_zero + 1_minutes,
+                            item_wakeup_kind::ready_check,
+                            hint_for_map( here.get_abs( origin ) ) );
+
+    mgr.rebuild_for_item( on_map, hint_for_map( here.get_abs( origin ) ) );
+
+    CHECK( mgr.get( uid, item_wakeup_kind::ready_check ).value()
+           == calendar::turn_zero + 5_minutes );
+    clear_test_enumerate_handlers();
+}
+
+TEST_CASE( "item_wakeup_resolve_on_vehicle_cargo", "[item_wakeup][resolve][vehicle]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    const tripoint_bub_ms veh_pos( 65, 65, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, veh_pos, 0_degrees, -1, 100 );
+    REQUIRE( veh != nullptr );
+
+    int cargo_part_idx = -1;
+    for( const vpart_reference &vpr : veh->get_all_parts() ) {
+        if( vpr.has_feature( "CARGO" ) ) {
+            cargo_part_idx = vpr.part_index();
+            break;
+        }
+    }
+    REQUIRE( cargo_part_idx >= 0 );
+
+    vehicle_part &cargo_part = veh->part( cargo_part_idx );
+    item dummy( itype_test_wakeup_dummy, calendar::turn );
+    std::optional<vehicle_stack::iterator> added =
+        veh->add_item( here, cargo_part, dummy );
+    REQUIRE( added.has_value() );
+    const int64_t uid = ( *added )->uid().get_value();
+
+    vehicle_hint vh;
+    vh.cargo_square = here.get_abs( veh->bub_part_pos( here, cargo_part ) );
+    vh.part_index = cargo_part_idx;
+    vh.mount_offset = cargo_part.mount;
+    item_locator_hint hint;
+    hint.where = item_locator_hint::place::vehicle;
+    hint.location = vh;
+
+    item_location loc = find_item_by_uid( uid, hint );
+    REQUIRE( loc );
+    CHECK( loc.get_item()->uid().get_value() == uid );
+}
+
+TEST_CASE( "item_wakeup_resolve_vehicle_stale_part_index_uses_mount",
+           "[item_wakeup][resolve][vehicle]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    const tripoint_bub_ms veh_pos( 65, 65, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, veh_pos, 0_degrees, -1, 100 );
+    REQUIRE( veh != nullptr );
+
+    int cargo_part_idx = -1;
+    for( const vpart_reference &vpr : veh->get_all_parts() ) {
+        if( vpr.has_feature( "CARGO" ) ) {
+            cargo_part_idx = vpr.part_index();
+            break;
+        }
+    }
+    REQUIRE( cargo_part_idx >= 0 );
+
+    vehicle_part &cargo_part = veh->part( cargo_part_idx );
+    const point_rel_ms saved_mount = cargo_part.mount;
+    std::optional<vehicle_stack::iterator> added =
+        veh->add_item( here, cargo_part,
+                       item( itype_test_wakeup_dummy, calendar::turn ) );
+    REQUIRE( added.has_value() );
+    const int64_t uid = ( *added )->uid().get_value();
+
+    vehicle_hint vh;
+    vh.cargo_square = here.get_abs( veh->bub_part_pos( here, cargo_part ) );
+    // Deliberately wrong part_index but valid mount_offset.
+    vh.part_index = veh->part_count() + 100;
+    vh.mount_offset = saved_mount;
+    item_locator_hint hint;
+    hint.where = item_locator_hint::place::vehicle;
+    hint.location = vh;
+
+    item_location loc = find_item_by_uid( uid, hint );
+    REQUIRE( loc );
+    CHECK( loc.get_item()->uid().get_value() == uid );
+}
+
+TEST_CASE( "item_wakeup_resolve_vehicle_moved_uses_loaded_scan",
+           "[item_wakeup][resolve][vehicle]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    const tripoint_bub_ms initial_pos( 65, 65, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, initial_pos,
+                                     0_degrees, -1, 100 );
+    REQUIRE( veh != nullptr );
+
+    int cargo_part_idx = -1;
+    for( const vpart_reference &vpr : veh->get_all_parts() ) {
+        if( vpr.has_feature( "CARGO" ) ) {
+            cargo_part_idx = vpr.part_index();
+            break;
+        }
+    }
+    REQUIRE( cargo_part_idx >= 0 );
+
+    vehicle_part &cargo_part = veh->part( cargo_part_idx );
+    const tripoint_abs_ms saved_square = here.get_abs(
+            veh->bub_part_pos( here, cargo_part ) );
+    std::optional<vehicle_stack::iterator> added =
+        veh->add_item( here, cargo_part,
+                       item( itype_test_wakeup_dummy, calendar::turn ) );
+    REQUIRE( added.has_value() );
+    const int64_t uid = ( *added )->uid().get_value();
+
+    // Move the vehicle one tile so the saved cargo_square no longer matches.
+    here.displace_vehicle( *veh, tripoint_rel_ms{ 1, 0, 0 } );
+
+    vehicle_hint vh;
+    vh.cargo_square = saved_square;
+    vh.part_index = cargo_part_idx;
+    vh.mount_offset = cargo_part.mount;
+    item_locator_hint hint;
+    hint.where = item_locator_hint::place::vehicle;
+    hint.location = vh;
+
+    item_location loc = find_item_by_uid( uid, hint );
+    REQUIRE( loc );
+    CHECK( loc.get_item()->uid().get_value() == uid );
+}
+
+
+TEST_CASE( "item_wakeup_resolve_off_bubble_returns_invalid",
+           "[item_wakeup][resolve]" )
+{
+    clear_map();
+    // tripoint_abs_ms far from the reality bubble origin.  inbounds() must
+    // reject it; resolution returns invalid without crashing.
+    const tripoint_abs_ms far_away{ 1000000, 1000000, 0 };
+    item_location loc = find_item_by_uid( 12345, hint_for_map( far_away ) );
+    CHECK_FALSE( loc );
+}

--- a/tests/item_wakeup_test.cpp
+++ b/tests/item_wakeup_test.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstdint>
 #include <functional>
 #include <optional>
@@ -844,4 +845,131 @@ TEST_CASE( "item_wakeup_resolve_off_bubble_returns_invalid",
     const tripoint_abs_ms far_away{ 1000000, 1000000, 0 };
     item_location loc = find_item_by_uid( 12345, hint_for_map( far_away ) );
     CHECK_FALSE( loc );
+}
+
+TEST_CASE( "item_wakeup_update_displaces_top", "[item_wakeup][heap]" )
+{
+    item_wakeup_manager mgr;
+    const time_point t_early = calendar::turn_zero + 1_minutes;
+    const time_point t_late = calendar::turn_zero + 10_minutes;
+
+    mgr.schedule_or_update( 5, t_early, item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.schedule_or_update( 9, t_early + 1_minutes, item_wakeup_kind::ready_check,
+                            hint_unknown() );
+    mgr.schedule_or_update( 5, t_late, item_wakeup_kind::ready_check, hint_unknown() );
+
+    std::optional<scheduled_wakeup_info> top = mgr.peek_next_wakeup();
+    REQUIRE( top.has_value() );
+    CHECK( top->uid == 9 );
+    CHECK( top->when == t_early + 1_minutes );
+    CHECK( mgr.get_stats().total_pending == 2 );
+}
+
+TEST_CASE( "item_wakeup_cancel_top_lets_next_fire", "[item_wakeup][heap]" )
+{
+    item_wakeup_manager mgr;
+    const time_point t_early = calendar::turn_zero + 1_minutes;
+    const time_point t_late = calendar::turn_zero + 5_minutes;
+
+    mgr.schedule_or_update( 1, t_early, item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.schedule_or_update( 2, t_late, item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.cancel( 1, item_wakeup_kind::ready_check );
+
+    std::optional<scheduled_wakeup_info> top = mgr.peek_next_wakeup();
+    REQUIRE( top.has_value() );
+    CHECK( top->uid == 2 );
+    CHECK( top->when == t_late );
+}
+
+TEST_CASE( "item_wakeup_serialize_after_update_drops_tombstones",
+           "[item_wakeup][heap][persistence]" )
+{
+    item_wakeup_manager src;
+    src.schedule_or_update( 5, calendar::turn_zero + 1_minutes,
+                            item_wakeup_kind::ready_check, hint_unknown() );
+    src.schedule_or_update( 5, calendar::turn_zero + 10_minutes,
+                            item_wakeup_kind::ready_check, hint_unknown() );
+    src.cancel( 5, item_wakeup_kind::ready_check );
+
+    std::ostringstream os;
+    JsonOut jsout( os );
+    src.serialize( jsout );
+
+    item_wakeup_manager dst;
+    JsonValue jv = json_loader::from_string( os.str() );
+    JsonObject jo = jv.get_object();
+    dst.deserialize( jo );
+
+    CHECK( dst.get_stats().total_pending == 0 );
+    CHECK_FALSE( dst.is_scheduled( 5, item_wakeup_kind::ready_check ) );
+}
+
+TEST_CASE( "item_wakeup_peek_tiebreak_matches_dump_order", "[item_wakeup][heap]" )
+{
+    item_wakeup_manager mgr;
+    const time_point t = calendar::turn_zero + 5_minutes;
+    mgr.schedule_or_update( 5, t, item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.schedule_or_update( 5, t, item_wakeup_kind::alarm, hint_unknown() );
+    mgr.schedule_or_update( 3, t, item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.schedule_or_update( 3, t, item_wakeup_kind::alarm, hint_unknown() );
+
+    const std::vector<scheduled_wakeup_info> sorted = mgr.dump();
+    REQUIRE( sorted.size() == 4 );
+    const std::optional<scheduled_wakeup_info> top = mgr.peek_next_wakeup();
+    REQUIRE( top.has_value() );
+    CHECK( top->uid == sorted.front().uid );
+    CHECK( top->kind == sorted.front().kind );
+    CHECK( top->when == sorted.front().when );
+}
+
+TEST_CASE( "item_wakeup_dispatch_order_with_equal_when", "[item_wakeup][heap]" )
+{
+    clear_map();
+    install_test_handler();
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &a = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    item &b = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid_a = a.uid().get_value();
+    const int64_t uid_b = b.uid().get_value();
+    const int64_t small_uid = std::min( uid_a, uid_b );
+    const int64_t large_uid = std::max( uid_a, uid_b );
+
+    item_wakeup_manager mgr;
+    const time_point fire_at = calendar::turn + 1_minutes;
+    const item_locator_hint h = hint_for_map( here.get_abs( origin ) );
+    mgr.schedule_or_update( large_uid, fire_at, item_wakeup_kind::ready_check, h );
+    mgr.schedule_or_update( small_uid, fire_at, item_wakeup_kind::ready_check, h );
+
+    mgr.process( fire_at );
+    REQUIRE( fire_log().size() == 2 );
+    CHECK( fire_log()[0].uid == small_uid );
+    CHECK( fire_log()[1].uid == large_uid );
+}
+
+TEST_CASE( "item_wakeup_deserialize_restores_heap_invariant",
+           "[item_wakeup][heap][persistence]" )
+{
+    item_wakeup_manager src;
+    src.schedule_or_update( 9, calendar::turn_zero + 5_minutes,
+                            item_wakeup_kind::ready_check, hint_unknown() );
+    src.schedule_or_update( 1, calendar::turn_zero + 1_minutes,
+                            item_wakeup_kind::ready_check, hint_unknown() );
+
+    std::ostringstream os;
+    JsonOut jsout( os );
+    src.serialize( jsout );
+
+    item_wakeup_manager dst;
+    JsonValue jv = json_loader::from_string( os.str() );
+    JsonObject jo = jv.get_object();
+    dst.deserialize( jo );
+
+    std::optional<scheduled_wakeup_info> top = dst.peek_next_wakeup();
+    REQUIRE( top.has_value() );
+    CHECK( top->uid == 1 );
+    CHECK( top->when == calendar::turn_zero + 1_minutes );
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Add item-targeted wakeup scheduler"

#### Purpose of change

New engine primitive for scheduling per-item state changes at specific calendar times, with persistence across save/load. Lives alongside `timed_event_manager` but is item-keyed instead of world-location-keyed, so events follow the item across moves (map, inventory, vehicle).

#### Describe the solution

New `item_wakeup_manager` owned by `game`. Items expose two hooks: `enumerate_scheduled_wakeups()` (producer, default empty) and `actualize_scheduled()` (consumer, default no-op). The manager keeps a flat queue keyed by `int64_t` uid; `process()` is two-phase and non-reentrant. Resolution goes through `find_item_by_uid` in `item_location.cpp`, walking map/character/vehicle hints with a bounded fallback through avatar, NPCs, loaded vehicles, and map tiles. Off-bubble items return invalid; owners reconcile via `rebuild_for_item` once reachable again. Persistence is versioned with per-entry recovery.

Item identity uses raw `int64_t` keys, not `item_uid` directly, since `item_uid` mints a fresh value on copy.

#### Describe alternatives you've considered

Extending `timed_event_manager` to carry an item uid mixes item-specific state into a world-event subsystem. Bolting onto `active_item_cache` only fires when the submap is actualized, which is the wrong shape for "ring at calendar time T even off-bubble."

#### Testing

33 new test cases under `[item_wakeup]` cover lifecycle, firing, persistence, resolution paths including vehicle mount-offset fallback and within-bubble vehicle movement, and idempotency.

#### Additional context

N/A