### PR TITLE
Speed up `post_process` tests through a combination of optimizations

### DIFF
--- a/src/field_type.h
+++ b/src/field_type.h
@@ -118,7 +118,7 @@ struct field_intensity_level {
     int monster_spawn_radius = 0;
     mongroup_id monster_spawn_group;
     float light_emitted = 0.0f;
-    light_color_rgb light_color;
+    light_color_rgb light_color{};
     float local_light_override = -1.0f;
     float translucency = 0.0f;
     int concentration = 0;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3569,7 +3569,7 @@ float game::natural_light_level( const int zlev ) const
         return LIGHT_AMBIENT_MINIMAL;
     }
 
-    if( latest_lightlevels[zlev] > -std::numeric_limits<float>::max() ) {
+    if( latest_lightlevels[zlev] > std::numeric_limits<float>::lowest() ) {
         // Already found the light level for now?
         return latest_lightlevels[zlev];
     }
@@ -3628,7 +3628,7 @@ unsigned char game::light_level( const int zlev ) const
 void game::reset_light_level()
 {
     for( float &lev : latest_lightlevels ) {
-        lev = -std::numeric_limits<float>::max();
+        lev = std::numeric_limits<float>::lowest();
     }
 }
 

--- a/src/level_cache.cpp
+++ b/src/level_cache.cpp
@@ -1,28 +1,38 @@
 #include "level_cache.h"
 
-#include <algorithm>
-
-#include "lightmap.h"
-#include "shadowcasting.h"
+#include <cstring>
 
 level_cache::level_cache()
 {
-    const int map_dimensions = MAPSIZE_X * MAPSIZE_Y;
+    clear();
+}
+
+void level_cache::clear()
+{
+    // Blast zeroes over the entire region. Some compilers, looking at you msvc, aren't smart enough
+    // to turn this into a single fused memset. Sometimes it doesn't even optimize fill_n into memset
+    // but emits scalar loops. This murders map test performance.
+#pragma GCC diagnostic push
+    // It's safe to disable this because we static_assert that level_cache_default_zero_members is
+    // trivially copyable, and we know all zeros bit pattern is a legal representation for the type.
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+    std::memset( static_cast<level_cache_default_zero_members *>( this ), 0,
+                 sizeof( level_cache_default_zero_members ) );
+#pragma GCC diagnostic pop
+
     transparency_cache_dirty.set();
     outside_cache_dirty = true;
     floor_cache_dirty = false;
-    constexpr four_quadrants four_zeros( 0.0f );
-    std::fill_n( &lm[0][0], map_dimensions, four_zeros );
-    std::fill_n( &sm[0][0], map_dimensions, 0.0f );
-    std::fill_n( &light_color_cache[0][0], map_dimensions, light_color_rgb{} );
-    std::fill_n( &light_source_buffer[0][0], map_dimensions, buffered_light_source{} );
-    std::fill_n( &outside_cache[0][0], map_dimensions, false );
-    std::fill_n( &floor_cache[0][0], map_dimensions, false );
-    std::fill_n( &transparency_cache[0][0], map_dimensions, 0.0f );
-    std::fill_n( &vision_transparency_cache[0][0], map_dimensions, 0.0f );
-    std::fill_n( &seen_cache[0][0], map_dimensions, 0.0f );
-    std::fill_n( &camera_cache[0][0], map_dimensions, 0.0f );
-    std::fill_n( &visibility_cache[0][0], map_dimensions, lit_level::DARK );
+    seen_cache_dirty = false;
+    lightmap_dirty = true;
+    has_colored_lights = false;
+    no_floor_gaps = false;
+
+    natural_light_level_cache = 0.0f;
+
+    vehicle_list.clear();
+    zone_vehicles.clear();
+
     clear_vehicle_cache();
 }
 

--- a/src/level_cache.h
+++ b/src/level_cache.h
@@ -5,6 +5,7 @@
 #include <array>
 #include <bitset>
 #include <set>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 
@@ -17,11 +18,73 @@
 // IWYU pragma: no_forward_declare four_quadrants
 class vehicle;
 
-struct level_cache {
+// level_cache is a huge struct and some compilers need help to zero these
+// members efficiently. Break them into a separate struct which can be memset
+// in a single call instead of a bunch of fill_n which don't optimize well.
+struct level_cache_default_zero_members {
+    cata::mdarray<four_quadrants, point_bub_ms> lm;
+    cata::mdarray<float, point_bub_ms> sm;
+    // Accumulated colored light energy per tile. Populated during generate_lightmap
+    // alongside lm/sm. Zero = uncolored (white) light only.
+    cata::mdarray<light_color_rgb, point_bub_ms> light_color_cache;
+    // Bulk light source buffer. Scalar luminance uses max() for dedup;
+    // color accumulates additively. Only valid during generate_lightmap.
+    struct buffered_light_source {
+        buffered_light_source() = default;
+        float luminance;
+        light_color_rgb color;
+    };
+    cata::mdarray<buffered_light_source, point_bub_ms> light_source_buffer;
+    // if false, means tile is under the roof ("inside"), true means tile is "outside"
+    // "inside" tiles are protected from sun, rain, etc. (see ter_furn_flag::TFLAG_INDOORS flag)
+    cata::mdarray<bool, point_bub_ms> outside_cache;
+
+    // true when vehicle below has "ROOF" or "OPAQUE" part, furniture below has ter_furn_flag::TFLAG_SUN_ROOF_ABOVE
+    //      or terrain doesn't have ter_furn_flag::TFLAG_NO_FLOOR flag
+    // false otherwise
+    // i.e. true == has floor
+    cata::mdarray<bool, point_bub_ms> floor_cache;
+
+    // stores cached transparency of the tiles
+    // units: "transparency" (see LIGHT_TRANSPARENCY_OPEN_AIR)
+    cata::mdarray<float, point_bub_ms>transparency_cache;
+
+    // materialized  (transparency_cache[i][j] > LIGHT_TRANSPARENCY_SOLID)
+    // doesn't consider fields (i.e. if tile is covered in thick smoke, it's still
+    // considered transparent for the purpuses of this cache)
+    // true, if tile is not opaque
+    std::array<std::bitset<MAPSIZE_Y>, MAPSIZE_X> transparent_cache_wo_fields;
+
+    // stores "adjusted transparency" of the tiles
+    // initial values derived from transparency_cache, uses same units
+    // examples of adjustment: changed transparency on player's tile and special case for crouching
+    cata::mdarray<float, point_bub_ms> vision_transparency_cache;
+
+    // stores "visibility" of the tiles to the player
+    // values range from 1 (fully visible to player) to 0 (not visible)
+    cata::mdarray<float, point_bub_ms> seen_cache;
+
+    // same as `seen_cache` (same units) but contains values for cameras and mirrors
+    // effective "visibility_cache" is calculated as "max(seen_cache, camera_cache)"
+    cata::mdarray<float, point_bub_ms> camera_cache;
+
+    // stores resulting apparent brightness to player, calculated by map::apparent_light_at
+    cata::mdarray<lit_level, point_bub_ms> visibility_cache;
+    std::bitset<MAPSIZE_X *MAPSIZE_Y> map_memory_cache_dec;
+    std::bitset<MAPSIZE_X *MAPSIZE_Y> map_memory_cache_ter;
+    std::bitset<MAPSIZE *MAPSIZE> field_cache;
+};
+// The only way to memset the above without UB is if it is trivially copyable
+// and that all zeros is a valid representation. We can't assert the latter.
+static_assert( std::is_trivially_copyable_v<level_cache_default_zero_members> );
+
+struct level_cache : level_cache_default_zero_members {
     public:
         // Zeros all relevant values
         level_cache();
         level_cache( const level_cache &other ) = default;
+
+        void clear();
 
         std::bitset<MAPSIZE *MAPSIZE> transparency_cache_dirty;
         bool outside_cache_dirty = false;
@@ -34,60 +97,8 @@ struct level_cache {
         // This is a single value indicating that the entire level is floored.
         bool no_floor_gaps = false;
 
-        cata::mdarray<four_quadrants, point_bub_ms> lm;
-        cata::mdarray<float, point_bub_ms> sm;
-        // Accumulated colored light energy per tile. Populated during generate_lightmap
-        // alongside lm/sm. Zero = uncolored (white) light only.
-        cata::mdarray<light_color_rgb, point_bub_ms> light_color_cache;
-        // Bulk light source buffer. Scalar luminance uses max() for dedup;
-        // color accumulates additively. Only valid during generate_lightmap.
-        struct buffered_light_source {
-            float luminance = 0.0f;
-            light_color_rgb color;
-        };
-        cata::mdarray<buffered_light_source, point_bub_ms> light_source_buffer;
-
         // Cache of natural light level is useful if it needs to be in sync with the light cache.
-        float natural_light_level_cache;
-
-        // if false, means tile is under the roof ("inside"), true means tile is "outside"
-        // "inside" tiles are protected from sun, rain, etc. (see ter_furn_flag::TFLAG_INDOORS flag)
-        cata::mdarray<bool, point_bub_ms> outside_cache;
-
-        // true when vehicle below has "ROOF" or "OPAQUE" part, furniture below has ter_furn_flag::TFLAG_SUN_ROOF_ABOVE
-        //      or terrain doesn't have ter_furn_flag::TFLAG_NO_FLOOR flag
-        // false otherwise
-        // i.e. true == has floor
-        cata::mdarray<bool, point_bub_ms> floor_cache;
-
-        // stores cached transparency of the tiles
-        // units: "transparency" (see LIGHT_TRANSPARENCY_OPEN_AIR)
-        cata::mdarray<float, point_bub_ms>transparency_cache;
-
-        // materialized  (transparency_cache[i][j] > LIGHT_TRANSPARENCY_SOLID)
-        // doesn't consider fields (i.e. if tile is covered in thick smoke, it's still
-        // considered transparent for the purpuses of this cache)
-        // true, if tile is not opaque
-        std::array<std::bitset<MAPSIZE_Y>, MAPSIZE_X> transparent_cache_wo_fields;
-
-        // stores "adjusted transparency" of the tiles
-        // initial values derived from transparency_cache, uses same units
-        // examples of adjustment: changed transparency on player's tile and special case for crouching
-        cata::mdarray<float, point_bub_ms> vision_transparency_cache;
-
-        // stores "visibility" of the tiles to the player
-        // values range from 1 (fully visible to player) to 0 (not visible)
-        cata::mdarray<float, point_bub_ms> seen_cache;
-
-        // same as `seen_cache` (same units) but contains values for cameras and mirrors
-        // effective "visibility_cache" is calculated as "max(seen_cache, camera_cache)"
-        cata::mdarray<float, point_bub_ms> camera_cache;
-
-        // stores resulting apparent brightness to player, calculated by map::apparent_light_at
-        cata::mdarray<lit_level, point_bub_ms> visibility_cache;
-        std::bitset<MAPSIZE_X *MAPSIZE_Y> map_memory_cache_dec;
-        std::bitset<MAPSIZE_X *MAPSIZE_Y> map_memory_cache_ter;
-        std::bitset<MAPSIZE *MAPSIZE> field_cache;
+        float natural_light_level_cache = 0.0f;
 
         std::set<vehicle *> vehicle_list;
         std::set<vehicle *> zone_vehicles;

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -74,7 +74,7 @@ std::string four_quadrants::to_string() const
 static light_color_rgb cached_twilight_color()
 {
     static time_point cached_turn = calendar::before_time_starts;
-    static light_color_rgb cached_color;
+    static light_color_rgb cached_color{};
     if( cached_turn == calendar::turn ) {
         return cached_color;
     }
@@ -759,7 +759,7 @@ void map::generate_lightmap( const int zlev )
                 if( !light_color_cache[x][y].is_colored() ) {
                     continue;
                 }
-                light_color_rgb sum;
+                light_color_rgb sum{};
                 int count = 0;
                 for( int dx = -1; dx <= 1; ++dx ) {
                     for( int dy = -1; dy <= 1; ++dy ) {

--- a/src/lightmap.h
+++ b/src/lightmap.h
@@ -58,9 +58,10 @@ constexpr inline int LIGHT_RANGE( float b )
 // Per-tile accumulated light color energy (float RGB).
 // Stored as raw energy, not display-ready; the renderer converts to uint8.
 struct light_color_rgb {
-    float r = 0.0f;
-    float g = 0.0f;
-    float b = 0.0f;
+    light_color_rgb() = default;
+    float r;
+    float g;
+    float b;
     bool is_colored() const {
         return r > 0.0f || g > 0.0f || b > 0.0f;
     }
@@ -83,6 +84,7 @@ struct light_color_rgb {
     // Create from HSV. h in [0,360), s and v in [0,1].
     static light_color_rgb from_hsv( float h, float s, float v );
 };
+static_assert( std::is_trivially_default_constructible_v<light_color_rgb> );
 
 // Returns the warm dawn/dusk tint color, or empty when not applicable
 // (alternate dimension, outside twilight). Cached per turn.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8942,8 +8942,8 @@ void map::loadn( const point_bub_sm &grid, bool update_vehicles )
 
     // It might be possible to just check the (0, 0) submap as we should never have
     // a case where only one submap is missing from an OMT level.
-    for( int gridx = 0; gridx <= 1; gridx++ ) {
-        for( int gridy = 0; gridy <= 1; gridy++ ) {
+    for( int gridx = 0; !map_incomplete && gridx <= 1; gridx++ ) {
+        for( int gridy = 0; !map_incomplete && gridy <= 1; gridy++ ) {
             for( int gridz = -OVERMAP_DEPTH; gridz <= OVERMAP_HEIGHT; gridz++ ) {
                 const tripoint grid_pos( gridx, gridy, gridz );
                 if( !MAPBUFFER.submap_exists( grid_sm_base.xy() + grid_pos ) ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -339,6 +339,21 @@ map &map::operator=( map && ) = default;
 
 static submap null_submap;
 
+std::list<std::unique_ptr<level_cache>> map::free_cache_pool;
+
+std::unique_ptr<level_cache, map::level_cache_free> map::alloc_cache()
+{
+    std::unique_ptr<level_cache, level_cache_free> cache;
+    if( !free_cache_pool.empty() ) {
+        cache.reset( free_cache_pool.front().release() );
+        free_cache_pool.pop_front();
+        cache->clear();
+    } else {
+        cache.reset( new level_cache{} );
+    }
+    return cache;
+}
+
 void map::set_transparency_cache_dirty( const int zlev )
 {
     if( inbounds_z( zlev ) ) {
@@ -11310,9 +11325,9 @@ std::list<Creature *> map::get_creatures_in_radius_circ( const tripoint_bub_ms &
 level_cache &map::access_cache( int zlev )
 {
     if( zlev >= -OVERMAP_DEPTH && zlev <= OVERMAP_HEIGHT ) {
-        std::unique_ptr<level_cache> &cache = caches[zlev + OVERMAP_DEPTH];
+        std::unique_ptr<level_cache, level_cache_free> &cache = caches[zlev + OVERMAP_DEPTH];
         if( !cache ) {
-            cache = std::make_unique<level_cache>();
+            cache = alloc_cache();
         }
         return *cache;
     }
@@ -11324,9 +11339,9 @@ level_cache &map::access_cache( int zlev )
 const level_cache &map::access_cache( int zlev ) const
 {
     if( zlev >= -OVERMAP_DEPTH && zlev <= OVERMAP_HEIGHT ) {
-        std::unique_ptr<level_cache> &cache = caches[zlev + OVERMAP_DEPTH];
+        std::unique_ptr<level_cache, level_cache_free> &cache = caches[zlev + OVERMAP_DEPTH];
         if( !cache ) {
-            cache = std::make_unique<level_cache>();
+            cache = alloc_cache();
         }
         return *cache;
     }

--- a/src/map.h
+++ b/src/map.h
@@ -2260,9 +2260,18 @@ class map
          */
         std::vector<tripoint_bub_ms> field_ter_locs;
         /**
+         * Holds free'd caches because we probably don't have to return the memory to the OS.
+         */
+        static std::list<std::unique_ptr<level_cache>> free_cache_pool;
+        struct level_cache_free {
+            void operator()( level_cache *cache ) {
+                free_cache_pool.emplace_back( cache );
+            }
+        };
+        /**
          * Holds caches for visibility, light, transparency and vehicles
          */
-        mutable std::array< std::unique_ptr<level_cache>, OVERMAP_LAYERS > caches;
+        mutable std::array< std::unique_ptr<level_cache, level_cache_free>, OVERMAP_LAYERS > caches;
 
         mutable std::array< std::unique_ptr<pathfinding_cache>, OVERMAP_LAYERS > pathfinding_caches;
         /**
@@ -2280,12 +2289,14 @@ class map
 
         // Note: no bounds check
         level_cache &get_cache( int zlev ) const {
-            std::unique_ptr<level_cache> &cache = caches[zlev + OVERMAP_DEPTH];
+            std::unique_ptr<level_cache, level_cache_free> &cache = caches[zlev + OVERMAP_DEPTH];
             if( !cache ) {
-                cache = std::make_unique<level_cache>();
+                cache = alloc_cache();
             }
             return *cache;
         }
+
+        static std::unique_ptr<level_cache, level_cache_free> alloc_cache();
 
         level_cache *get_cache_lazy( int zlev ) const {
             return caches[zlev + OVERMAP_DEPTH].get();

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -559,7 +559,7 @@ struct map_data_common_t {
         void examine( Character &, const tripoint_bub_ms & ) const;
 
         int light_emitted = 0;
-        light_color_rgb light_color;
+        light_color_rgb light_color{};
         // The amount of movement points required to pass this terrain by default.
         int movecost = 0;
         int heat_radiation = 0;

--- a/src/shadowcasting.h
+++ b/src/shadowcasting.h
@@ -87,6 +87,7 @@ struct four_quadrants {
         return result;
     }
 };
+static_assert( std::is_trivially_copyable_v<four_quadrants> );
 
 // Hoisted to header and inlined so the test in tests/shadowcasting_test.cpp can use it.
 // Beer-Lambert law says attenuation is going to be equal to

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -485,7 +485,7 @@ class vpart_info
         // recharging (charging speed in watts)
         // funnel (water collection area in mm^2)
         int bonus = 0;
-        light_color_rgb light_color;
+        light_color_rgb light_color{};
 
         /** cargo weight modifier (percentage) */
         int cargo_weight_modifier = 100;

--- a/tests/mapgen_post_process_test.cpp
+++ b/tests/mapgen_post_process_test.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "avatar.h"
 #include "calendar.h"
 #include "cata_catch.h"
 #include "coordinates.h"
@@ -124,6 +125,21 @@ static pp_scan_result scan_omt( map &m, int z_level )
     return result;
 }
 
+static void clear_map_and_reset_player()
+{
+    // The ordering here is very specific.
+    // clear_avatar() moves the player to the center of the bubble.
+    // clear_overmaps will regenerate everything from the origin to the player's current position.
+    // So first we move the avatar to the origin
+    // then clear overmaps to minimize excess regeneration
+    // then reset the avatar to the middle of the bubble which is conveniently around them.
+    // Some tests leave the avatar off in the sticks which makes clear_overmaps take astoundingly long
+    get_avatar().move_to( tripoint_abs_ms::zero );
+    clear_overmaps();
+    clear_map();
+    clear_avatar();
+}
+
 // Smoke tests: exercise post-process generators through the full map::generate() pipeline
 // using a controlled test OMT with trivial mapgen (seeded RNG gives deterministic output).
 //
@@ -131,9 +147,7 @@ static pp_scan_result scan_omt( map &m, int z_level )
 
 TEST_CASE( "post_process_riot_damage_seeded_smoke", "[mapgen][post_process]" )
 {
-    clear_overmaps();
-    clear_map();
-    clear_avatar();
+    clear_map_and_reset_player();
     const tripoint_abs_omt pos( 50, 50, 0 );
     overmap_buffer.ter_set( pos, oter_test_pp_riot_building.id() );
     // Set surrounding tiles to field to avoid neighbor-dependent behavior
@@ -220,9 +234,7 @@ static std::vector<tile_state> snapshot_omt( map &m, int z_level )
 
 TEST_CASE( "post_process_non_rerun_guard", "[mapgen][post_process]" )
 {
-    clear_overmaps();
-    clear_map();
-    clear_avatar();
+    clear_map_and_reset_player();
     const tripoint_abs_omt pos( 50, 50, 0 );
     overmap_buffer.ter_set( pos, oter_test_pp_riot_building.id() );
     for( int dx = -1; dx <= 1; dx++ ) {
@@ -323,9 +335,7 @@ TEST_CASE( "post_process_riot_road_vs_building", "[mapgen][post_process][charact
     // Road mode (is_a_road=true) skips pre_burn.
     // Building mode (is_a_road=false) runs pre_burn.
     // Use a seed + day count where pre_burn fires for building mode.
-    clear_overmaps();
-    clear_map();
-    clear_avatar();
+    clear_map_and_reset_player();
     map &here = get_map();
     const tripoint_abs_omt pos = project_to<coords::omt>( here.get_abs_sub() );
 
@@ -371,9 +381,7 @@ TEST_CASE( "post_process_riot_road_vs_building", "[mapgen][post_process][charact
 
 TEST_CASE( "post_process_natural_underground_skip", "[mapgen][post_process][characterization]" )
 {
-    clear_overmaps();
-    clear_map();
-    clear_avatar();
+    clear_map_and_reset_player();
     map &here = get_map();
     const tripoint_abs_omt pos = project_to<coords::omt>( here.get_abs_sub() );
 
@@ -394,9 +402,7 @@ TEST_CASE( "post_process_natural_underground_skip", "[mapgen][post_process][char
 TEST_CASE( "post_process_stair_preservation", "[mapgen][post_process][characterization]" )
 {
     // When pre_burn fires, stairs (GOES_UP/GOES_DOWN) must survive.
-    clear_overmaps();
-    clear_map();
-    clear_avatar();
+    clear_map_and_reset_player();
     map &here = get_map();
     const tripoint_abs_omt pos = project_to<coords::omt>( here.get_abs_sub() );
 
@@ -435,9 +441,7 @@ TEST_CASE( "post_process_stair_preservation", "[mapgen][post_process][characteri
 
 TEST_CASE( "post_process_fire_decay", "[mapgen][post_process][characterization]" )
 {
-    clear_overmaps();
-    clear_map();
-    clear_avatar();
+    clear_map_and_reset_player();
     map &here = get_map();
     const tripoint_abs_omt pos = project_to<coords::omt>( here.get_abs_sub() );
 
@@ -457,9 +461,7 @@ TEST_CASE( "post_process_item_move_planter_preservation",
            "[mapgen][post_process][characterization]" )
 {
     // Seeds in SEALED+CONTAINER+PLANT furniture must not be moved by GENERATOR_move_items.
-    clear_overmaps();
-    clear_map();
-    clear_avatar();
+    clear_map_and_reset_player();
     map &here = get_map();
     const tripoint_abs_omt pos = project_to<coords::omt>( here.get_abs_sub() );
 
@@ -563,9 +565,7 @@ static void build_pre_burn_immunity_layout( map &m, int z_level )
 
 TEST_CASE( "post_process_pre_burn_material_immunity", "[mapgen][post_process]" )
 {
-    clear_overmaps();
-    clear_map();
-    clear_avatar();
+    clear_map_and_reset_player();
     map &here = get_map();
     const tripoint_abs_omt pos = project_to<coords::omt>( here.get_abs_sub() );
 
@@ -686,9 +686,7 @@ TEST_CASE( "post_process_oter_field_dispatch", "[mapgen][post_process]" )
 {
     // test_pp_field_building has post_process_generators: ["test_pp_riot"], no flag.
     // Field-based dispatch should execute the generator.
-    clear_overmaps();
-    clear_map();
-    clear_avatar();
+    clear_map_and_reset_player();
     const tripoint_abs_omt pos( 50, 50, 0 );
     overmap_buffer.ter_set( pos, oter_test_pp_field_building.id() );
     for( int dx = -1; dx <= 1; dx++ ) {
@@ -726,9 +724,7 @@ TEST_CASE( "post_process_field_over_flag", "[mapgen][post_process]" )
     //
     // Both test OMTs share the same mapgen definition, so the RNG path
     // through map::generate() is identical for the same seed.
-    clear_overmaps();
-    clear_map();
-    clear_avatar();
+    clear_map_and_reset_player();
 
     const tripoint_abs_omt pos( 50, 50, 0 );
     calendar::turn = calendar::start_of_cataclysm + 14_days;
@@ -805,9 +801,7 @@ TEST_CASE( "post_process_real_core_inherited_riot", "[mapgen][post_process]" )
 {
     // s_pharm inherits riot_damage from generic_city_building -> generic_city_building_no_sidewalk.
     // After migration, the abstract has post_process_generators: ["riot_damage"].
-    clear_overmaps();
-    clear_map();
-    clear_avatar();
+    clear_map_and_reset_player();
     const tripoint_abs_omt pos( 50, 50, 0 );
     overmap_buffer.ter_set( pos, oter_s_pharm_north.id() );
     for( int dx = -1; dx <= 1; dx++ ) {
@@ -839,9 +833,7 @@ TEST_CASE( "post_process_real_core_exempt", "[mapgen][post_process]" )
 {
     // s_gas_rural explicitly deletes riot_damage via post_process_generators.
     // No PP should run on this OMT.
-    clear_overmaps();
-    clear_map();
-    clear_avatar();
+    clear_map_and_reset_player();
     const tripoint_abs_omt pos( 50, 50, 0 );
     overmap_buffer.ter_set( pos, oter_s_gas_rural_north.id() );
     for( int dx = -1; dx <= 1; dx++ ) {
@@ -1032,9 +1024,7 @@ TEST_CASE( "post_process_resolved_generator_empty_sub_decisions", "[mapgen][post
 // not silently noop or unconditionally apply.
 TEST_CASE( "post_process_null_decisions_falls_back_to_fresh_roll", "[mapgen][post_process]" )
 {
-    clear_overmaps();
-    clear_map();
-    clear_avatar();
+    clear_map_and_reset_player();
     map &here = get_map();
     const tripoint_abs_omt pos = project_to<coords::omt>( here.get_abs_sub() );
 
@@ -1061,9 +1051,7 @@ TEST_CASE( "post_process_null_decisions_falls_back_to_fresh_roll", "[mapgen][pos
 TEST_CASE( "post_process_pre_burn_skipped_is_noop_and_preserves_others",
            "[mapgen][post_process]" )
 {
-    clear_overmaps();
-    clear_map();
-    clear_avatar();
+    clear_map_and_reset_player();
     map &here = get_map();
     const tripoint_abs_omt pos = project_to<coords::omt>( here.get_abs_sub() );
 
@@ -1099,9 +1087,7 @@ TEST_CASE( "post_process_pre_burn_skipped_is_noop_and_preserves_others",
 TEST_CASE( "post_process_pre_burn_applied_runs_unconditionally",
            "[mapgen][post_process]" )
 {
-    clear_overmaps();
-    clear_map();
-    clear_avatar();
+    clear_map_and_reset_player();
     map &here = get_map();
     const tripoint_abs_omt pos = project_to<coords::omt>( here.get_abs_sub() );
 

--- a/tests/mapgen_post_process_test.cpp
+++ b/tests/mapgen_post_process_test.cpp
@@ -576,7 +576,8 @@ TEST_CASE( "post_process_pre_burn_material_immunity", "[mapgen][post_process]" )
     rng_set_engine_seed( 42424242 );
     pp_generator_test_pp_pre_burn_only.obj().execute( here, pos );
 
-    SECTION( "walls: flammable burn, non-flammable survive" ) {
+    {
+        INFO( "walls: flammable burn, non-flammable survive" );
         // Wood walls -> t_wall_burnt
         CHECK( here.ter( tripoint_bub_ms( 1, 1, 0 ) ) == ter_t_wall_burnt.id() );
         CHECK( here.ter( tripoint_bub_ms( 3, 1, 0 ) ) == ter_t_wall_burnt.id() );
@@ -585,14 +586,16 @@ TEST_CASE( "post_process_pre_burn_material_immunity", "[mapgen][post_process]" )
         CHECK( here.ter( tripoint_bub_ms( 7, 1, 0 ) ) == ter_t_wall_metal.id() );
     }
 
-    SECTION( "closed doors: flammable burn, non-flammable survive" ) {
+    {
+        INFO( "closed doors: flammable burn, non-flammable survive" );
         // Wood door -> t_floor_burnt (has DOOR flag + FLAMMABLE)
         CHECK( here.ter( tripoint_bub_ms( 1, 3, 0 ) ) == ter_t_floor_burnt.id() );
         // Metal door unchanged (has DOOR flag, no FLAMMABLE)
         CHECK( here.ter( tripoint_bub_ms( 3, 3, 0 ) ) == ter_t_door_metal_c.id() );
     }
 
-    SECTION( "open/locked doors: flammable burn to dirt, non-flammable survive" ) {
+    {
+        INFO( "open/locked doors: flammable burn to dirt, non-flammable survive" );
         // Open wood door -> t_dirt (no DOOR flag, flammable outdoor)
         CHECK( here.ter( tripoint_bub_ms( 1, 5, 0 ) ) == ter_t_dirt.id() );
         // Open metal door unchanged (no DOOR flag, not flammable)
@@ -603,25 +606,29 @@ TEST_CASE( "post_process_pre_burn_material_immunity", "[mapgen][post_process]" )
         CHECK( here.ter( tripoint_bub_ms( 7, 5, 0 ) ) == ter_t_dirt.id() );
     }
 
-    SECTION( "floors: flammable burn, non-flammable survive" ) {
+    {
+        INFO( "floors: flammable burn, non-flammable survive" );
         CHECK( here.ter( tripoint_bub_ms( 1, 7, 0 ) ) == ter_t_floor_burnt.id() );
         CHECK( here.ter( tripoint_bub_ms( 3, 7, 0 ) ) == ter_t_thconc_floor.id() );
     }
 
-    SECTION( "outdoor: grass to dirt, pavement and water survive" ) {
+    {
+        INFO( "outdoor: grass to dirt, pavement and water survive" );
         CHECK( here.ter( tripoint_bub_ms( 1, 9, 0 ) ) == ter_t_dirt.id() );
         CHECK( here.ter( tripoint_bub_ms( 3, 9, 0 ) ) == ter_t_pavement.id() );
         CHECK( here.ter( tripoint_bub_ms( 5, 9, 0 ) ) == ter_t_water_dp.id() );
     }
 
-    SECTION( "furniture: flammable destroyed, non-flammable survives" ) {
+    {
+        INFO( "furniture: flammable destroyed, non-flammable survives" );
         // Metal locker on concrete floor: locker survives
         CHECK( here.furn( tripoint_bub_ms( 1, 11, 0 ) ) == furn_f_locker.id() );
         // Wood table on concrete floor: table destroyed (terrain immunity != furniture immunity)
         CHECK( here.furn( tripoint_bub_ms( 3, 11, 0 ) ) == furn_str_id::NULL_ID().id() );
     }
 
-    SECTION( "items: cleared on non-water tiles, preserved in water" ) {
+    {
+        INFO( "items: cleared on non-water tiles, preserved in water" );
         // Items on concrete floor: cleared (fire chaos destroys contents)
         CHECK( here.i_at( tripoint_bub_ms( 1, 13, 0 ) ).empty() );
         // Items in water: preserved


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Performance "`level_cache` isn't dogshit slow anymore, and other level headed wins"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Windows test execution time is multiple hours now. A lot of it is attributable to map `[post_process]` tests. Not all of it, but a lot. They were slow for a couple reasons. One, `level_cache` is huge and constantly allocating and deallocating it was expensive because those huge allocations always come from and return to the OS directly. Two, `level_cache`'s initializer was bad on Windows due to a combination of bad stl optimizations and bad compiler optimizations. The two together meant that instead of cleanly blasting zeroes across the entire ~1.1MB struct, it was falling back to some extremely slow 8 or 16 byte-at-a-time loops setting each individual `mdarray` and `bitset` to zero. Finally, there was a bad interaction with an earlier test leaving the avatar off in the sticks somewhere, causing bad behavior in clear_overmaps() which makes it regenerate like the entire world from the origin to the player's position. We only hit this on Windows because of the way the test sharding worked out (namely, we don't shard them on Windows).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Refactor `level_cache` so all the zero-able members are in a separate struct which `level_cache` inherits from. `memset` it to 0 in a new `reset` function. The C++ standard has an explicit carveout that you're allowed to memset a trivially copyable type, and it is allowed here because all zero bits is a valid representation. We can `static_assert` that it is trivially copyable. To make it trivially copyable we had to add explicitly defaulted constructors to a couple other structs (which are in turn asserted to be trivially copyable) and add explicit `{}` initializers to a few places where they were previously default initialized only.
- Create an object pool for `level_cache` where we save old caches so we don't have to slosh 2MB of ram back and forth from the kernel. Free'd `level_cache` objects are instead pushed into this list and are `reset()` when popping off it.
- Change one particularly bad actor test from using `SECTION`, which reruns the init and teardown code before/after each one, to just scoped `INFO` blocks, because the setup and teardown are identical each time and each `SECTION` was just reading the result. This single test was ~1/3rd the runtime of all the tests combined, after the other optimization.
- Move the player back to the world origin before calling clear_overmaps so it only regenerates the origin instead of a huge diagonal line across the planet.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I ran a lot of tests locally, I could post screenshots but you know what they'll look like.

Ok fine you can have an unexpected one. This is a `perf` report for `[post_process]` tests after all my fixes in this PR + the linked one. IDK if I did it right but `level_cache::level_cache` was a lot higher before.
<img width="1355" height="835" alt="image" src="https://github.com/user-attachments/assets/fe1494c2-2f14-4d8a-8e92-392b52eead9f" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
CPUs have hardware support for fast blasting of bytes (like zero) but you have to actually get the compiler to emit calls to those specific instructions (`rep stosb`), which typically happens in memset, but the standard library has to actually attempt to call memset. libc++/libstdc++ would optimize fill_n calls to memset and then identify they're memsetting identical ranges and combine it into one call, but msvc's stl didn't. It only optimizes for single scalar value fills and not struct fills like `four_quadrants`. So we have to do this dance to make the single fused memset call explicit. It's a neat trick.

Combo-wombo's with #86886 for best results.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
