### PR TITLE
Pass item_location through item wakeup dispatch

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4578,14 +4578,15 @@ bool item::process_wet( Character *carrier, const tripoint_bub_ms & /*pos*/ )
     return true;
 }
 
-std::vector<desired_wakeup> item::enumerate_scheduled_wakeups() const
+std::vector<desired_wakeup> item::enumerate_scheduled_wakeups( const item_location &loc ) const
 {
-    return enumerate_scheduled_dispatch( *this );
+    return enumerate_scheduled_dispatch( *this, loc );
 }
 
-void item::actualize_scheduled( item_wakeup_kind kind, time_point now )
+void item::actualize_scheduled( item_wakeup_kind kind, time_point now,
+                                const item_location &loc )
 {
-    actualize_scheduled_dispatch( *this, kind, now );
+    actualize_scheduled_dispatch( *this, kind, now, loc );
 }
 
 bool item::process( map &here, Character *carrier, const tripoint_bub_ms &pos, float insulation,

--- a/src/item.h
+++ b/src/item.h
@@ -1585,11 +1585,13 @@ class item : public visitable
         bool leak( map &here, Character *carrier, const tripoint_bub_ms &pos,
                    item_pocket *pocke = nullptr );
 
-        // Producer for the wakeup scheduler.  Default empty.
-        std::vector<desired_wakeup> enumerate_scheduled_wakeups() const;
+        // Producer for the wakeup scheduler.  Default empty.  `loc` lets
+        // producers vary their wakeups by where the item lives.
+        std::vector<desired_wakeup> enumerate_scheduled_wakeups( const item_location &loc ) const;
 
         // Idempotent: receiving (kind, now) twice must not corrupt state.
-        void actualize_scheduled( item_wakeup_kind kind, time_point now );
+        void actualize_scheduled( item_wakeup_kind kind, time_point now,
+                                  const item_location &loc );
 
         struct link_data {
             /// State of the link's source connection, the end usually represented by the device/cable item itself. @ref link_state.

--- a/src/item_wakeup.cpp
+++ b/src/item_wakeup.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "cata_assert.h"
+#include "character.h"
 #include "character_id.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
@@ -15,6 +16,8 @@
 #include "item_uid.h"
 #include "json.h"
 #include "type_id.h"
+#include "vehicle.h"
+#include "vehicle_selector.h"
 
 namespace
 {
@@ -195,24 +198,75 @@ void clear_test_enumerate_handlers()
     test_enumerator_registry().clear();
 }
 
-std::vector<desired_wakeup> enumerate_scheduled_dispatch( const item &it )
+std::vector<desired_wakeup> enumerate_scheduled_dispatch( const item &it,
+        const item_location &loc )
 {
     const std::map<itype_id, item_wakeup_test_enumerator> &reg = test_enumerator_registry();
     const auto entry = reg.find( it.typeId() );
     if( entry != reg.end() ) {
-        return entry->second( it );
+        return entry->second( it, loc );
     }
     return {};
 }
 
 // Dispatcher called from item::actualize_scheduled.
-static void dispatch_actualize( item &it, item_wakeup_kind kind, time_point now )
+static void dispatch_actualize( item &it, item_wakeup_kind kind, time_point now,
+                                const item_location &loc )
 {
     const std::map<itype_id, item_wakeup_test_handler> &reg = test_handler_registry();
     const auto it_handler = reg.find( it.typeId() );
     if( it_handler != reg.end() ) {
-        it_handler->second( it, kind, now );
+        it_handler->second( it, kind, now, loc );
     }
+}
+
+// Persistable hint for find_item_by_uid on next dispatch.  Walks parent
+// containers to the topmost holder so uid lookup can recurse from there.
+static item_locator_hint hint_from_location( const item_location &loc )
+{
+    item_locator_hint h;
+    if( !loc ) {
+        return h;
+    }
+    item_location top = loc;
+    while( top.has_parent() ) {
+        top = top.parent_item();
+    }
+    switch( top.where() ) {
+        case item_location::type::character: {
+            Character *c = top.carrier();
+            if( c != nullptr ) {
+                h.where = item_locator_hint::place::character;
+                h.location = c->getID();
+            }
+            break;
+        }
+        case item_location::type::map:
+            h.where = item_locator_hint::place::map;
+            h.location = top.pos_abs();
+            break;
+        case item_location::type::vehicle: {
+            const vehicle_cursor *vc = top.veh_cursor();
+            if( vc != nullptr ) {
+                h.where = item_locator_hint::place::vehicle;
+                vehicle_hint vh;
+                vh.cargo_square = top.pos_abs();
+                vh.part_index = static_cast<int>( vc->part );
+                if( vh.part_index >= 0 && vh.part_index < vc->veh.part_count() ) {
+                    vh.mount_offset = vc->veh.part( vh.part_index ).mount;
+                }
+                h.location = vh;
+            } else {
+                h.where = item_locator_hint::place::map;
+                h.location = top.pos_abs();
+            }
+            break;
+        }
+        case item_location::type::container:
+        case item_location::type::invalid:
+            break;
+    }
+    return h;
 }
 
 // Min-heap comparator: top is smallest by (when, uid, kind).  push_heap and
@@ -274,10 +328,18 @@ void item_wakeup_manager::cancel_all( int64_t uid )
     clean_heap_top();
 }
 
-void item_wakeup_manager::rebuild_for_item( item &it, item_locator_hint hint )
+void item_wakeup_manager::rebuild_for_item( const item_location &loc )
 {
-    const int64_t uid = it.uid().get_value();
-    const std::vector<desired_wakeup> desired = it.enumerate_scheduled_wakeups();
+    if( !loc ) {
+        return;
+    }
+    const item *it = loc.get_item();
+    if( it == nullptr ) {
+        return;
+    }
+    const int64_t uid = it->uid().get_value();
+    const item_locator_hint hint = hint_from_location( loc );
+    const std::vector<desired_wakeup> desired = it->enumerate_scheduled_wakeups( loc );
 
     for( int k = 0; k < static_cast<int>( item_wakeup_kind::last ); ++k ) {
         const item_wakeup_kind kind = static_cast<item_wakeup_kind>( k );
@@ -393,7 +455,7 @@ void item_wakeup_manager::process( time_point now )
             }
             continue;
         }
-        loc->actualize_scheduled( e.kind, now );
+        loc->actualize_scheduled( e.kind, now, loc );
     }
 
     clean_heap_top();
@@ -513,7 +575,8 @@ void item_wakeup_manager::deserialize( const JsonObject &jo )
 }
 
 // Item-side dispatch entry called from item.cpp.
-void actualize_scheduled_dispatch( item &it, item_wakeup_kind kind, time_point now )
+void actualize_scheduled_dispatch( item &it, item_wakeup_kind kind, time_point now,
+                                   const item_location &loc )
 {
-    dispatch_actualize( it, kind, now );
+    dispatch_actualize( it, kind, now, loc );
 }

--- a/src/item_wakeup.h
+++ b/src/item_wakeup.h
@@ -19,6 +19,7 @@
 class JsonObject;
 class JsonOut;
 class item;
+class item_location;
 
 // Distinct kinds coexist per item.
 enum class item_wakeup_kind : uint8_t {
@@ -78,8 +79,8 @@ class item_wakeup_manager
         void cancel_all( int64_t uid );
 
         // Reconcile this item's entries against its enumerate_scheduled_wakeups().
-        // Idempotent.
-        void rebuild_for_item( item &it, item_locator_hint hint );
+        // Idempotent.  Hint is derived from the location internally.
+        void rebuild_for_item( const item_location &loc );
 
         bool is_scheduled( int64_t uid, item_wakeup_kind kind ) const;
         std::optional<time_point> get( int64_t uid, item_wakeup_kind kind ) const;
@@ -132,21 +133,24 @@ item_wakeup_manager &get_item_wakeups();
 // Test handler registry.  Always compiled in; production cost is one
 // empty-map lookup per dispatch.
 using item_wakeup_test_handler =
-    void( * )( item &it, item_wakeup_kind kind, time_point now );
+    void( * )( item &it, item_wakeup_kind kind, time_point now,
+               const item_location &loc );
 void register_test_wakeup_handler( const itype_id &id, item_wakeup_test_handler fn );
 void clear_test_wakeup_handlers();
 
 // Dispatch entry called from item::actualize_scheduled.
-void actualize_scheduled_dispatch( item &it, item_wakeup_kind kind, time_point now );
+void actualize_scheduled_dispatch( item &it, item_wakeup_kind kind, time_point now,
+                                   const item_location &loc );
 
 // Test producer registry.  See test handler registry note above.
 using item_wakeup_test_enumerator =
-    std::vector<desired_wakeup>( * )( const item &it );
+    std::vector<desired_wakeup>( * )( const item &it, const item_location &loc );
 void register_test_enumerate_handler( const itype_id &id,
                                       item_wakeup_test_enumerator fn );
 void clear_test_enumerate_handlers();
 
 // Dispatch entry called from item::enumerate_scheduled_wakeups.
-std::vector<desired_wakeup> enumerate_scheduled_dispatch( const item &it );
+std::vector<desired_wakeup> enumerate_scheduled_dispatch( const item &it,
+        const item_location &loc );
 
 #endif // CATA_SRC_ITEM_WAKEUP_H

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -56,6 +56,7 @@
 #include "item_factory.h"
 #include "item_group.h"
 #include "item_location.h"
+#include "item_wakeup.h"
 #include "itype.h"
 #include "iuse.h"
 #include "iuse_actor.h"
@@ -8627,6 +8628,69 @@ void map::load( const tripoint_abs_sm &w, const bool update_vehicle,
             }
         }
     }
+
+    reconcile_item_wakeups();
+}
+
+void map::reconcile_item_wakeups()
+{
+    item_wakeup_manager &wakeups = get_item_wakeups();
+    auto reconcile_recursive = [&wakeups]( auto & self, item_location loc ) -> void {
+        if( !loc )
+        {
+            return;
+        }
+        item *outer = loc.get_item();
+        if( outer == nullptr )
+        {
+            return;
+        }
+        wakeups.rebuild_for_item( loc );
+        for( item *child : outer->all_items_top() )
+        {
+            item_location child_loc( loc, child );
+            self( self, child_loc );
+        }
+    };
+
+    for( int gridx = 0; gridx < my_MAPSIZE; gridx++ ) {
+        for( int gridy = 0; gridy < my_MAPSIZE; gridy++ ) {
+            const int zmin = zlevels ? -OVERMAP_DEPTH : abs_sub.z();
+            const int zmax = zlevels ? OVERMAP_HEIGHT : abs_sub.z();
+            for( int gridz = zmin; gridz <= zmax; gridz++ ) {
+                const tripoint_rel_sm grid( gridx, gridy, gridz );
+                submap *const sm = get_submap_at_grid( grid );
+                if( sm == nullptr ) {
+                    continue;
+                }
+                for( int sx = 0; sx < SEEX; ++sx ) {
+                    for( int sy = 0; sy < SEEY; ++sy ) {
+                        for( item &it : sm->get_items( { sx, sy } ) ) {
+                            const tripoint_bub_ms p( sx + gridx * SEEX,
+                                                     sy + gridy * SEEY, gridz );
+                            const tripoint_abs_ms abs = get_abs( p );
+                            item_location loc( map_cursor( abs ), &it );
+                            reconcile_recursive( reconcile_recursive, loc );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    for( wrapped_vehicle &wv : get_vehicles() ) {
+        if( wv.v == nullptr ) {
+            continue;
+        }
+        for( const vpart_reference &vpr : wv.v->get_all_parts() ) {
+            vehicle_part &vp = wv.v->part( vpr.part_index() );
+            for( item &it : wv.v->get_items( vp ) ) {
+                vehicle_cursor vc( *wv.v, vpr.part_index() );
+                item_location loc( vc, &it );
+                reconcile_recursive( reconcile_recursive, loc );
+            }
+        }
+    }
 }
 
 void map::shift_traps( const point_rel_sm &shift )
@@ -8817,6 +8881,9 @@ void map::shift( const point_rel_sm &sp )
     // with entities at the edges
     for( tripoint_rel_sm loaded_grid : loaded_grids ) {
         actualize( loaded_grid );
+    }
+    if( !loaded_grids.empty() ) {
+        reconcile_item_wakeups();
     }
 }
 

--- a/src/map.h
+++ b/src/map.h
@@ -1961,6 +1961,13 @@ class map
         void saven( const tripoint_bub_sm &grid );
         void loadn( const point_bub_sm &grid, bool update_vehicles );
         /**
+         * Walk all items currently in the bubble (map tiles + vehicle cargo,
+         * recursing into containers) and call rebuild_for_item on each.  Run
+         * after submaps come back into range so item-targeted wakeups re-arm
+         * from authoritative item state.
+         */
+        void reconcile_item_wakeups();
+        /**
          * Fast forward a submap that has just been loading into this map.
          * This is used to rot and remove rotten items, grow plants, fill funnels etc.
          */

--- a/tests/item_wakeup_test.cpp
+++ b/tests/item_wakeup_test.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <functional>
+#include <list>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -22,14 +23,18 @@
 #include "json_loader.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "map_selector.h"
 #include "player_helpers.h"
+#include "pocket_type.h"
 #include "point.h"
+#include "ret_val.h"
 #include "type_id.h"
 #include "units.h"
 #include "vehicle.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
 
+static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_test_wakeup_dummy( "test_wakeup_dummy" );
 static const itype_id itype_test_wakeup_no_handler( "test_wakeup_no_handler" );
 static const vproto_id vehicle_prototype_bicycle( "bicycle" );
@@ -49,7 +54,8 @@ std::vector<fire_record> &fire_log()
     return log;
 }
 
-void dummy_handler( item &it, item_wakeup_kind kind, time_point now )
+void dummy_handler( item &it, item_wakeup_kind kind, time_point now,
+                    const item_location &/*loc*/ )
 {
     fire_log().push_back( fire_record{ it.uid().get_value(), kind, now } );
 }
@@ -219,7 +225,8 @@ TEST_CASE( "item_wakeup_same_pass_reschedule_does_not_double_fire",
     const int64_t uid = on_map.uid().get_value();
 
     item_wakeup_manager *mgr_ptr = nullptr;
-    auto rescheduling_handler = []( item & it, item_wakeup_kind kind, time_point now ) {
+    auto rescheduling_handler = []( item & it, item_wakeup_kind kind, time_point now,
+    const item_location & /*loc*/ ) {
         fire_log().push_back( fire_record{ it.uid().get_value(), kind, now } );
         // Item handler reschedules itself for "now"; this MUST NOT fire again
         // in the same process pass.
@@ -270,7 +277,7 @@ TEST_CASE( "item_wakeup_handler_called_once_per_fire", "[item_wakeup][idempotenc
 TEST_CASE( "item_wakeup_default_enumerate_is_empty", "[item_wakeup][rebuild]" )
 {
     item it( itype_test_wakeup_dummy, calendar::turn );
-    CHECK( it.enumerate_scheduled_wakeups().empty() );
+    CHECK( it.enumerate_scheduled_wakeups( item_location() ).empty() );
 }
 
 TEST_CASE( "item_wakeup_rebuild_schedules_from_item", "[item_wakeup][rebuild]" )
@@ -291,7 +298,7 @@ TEST_CASE( "item_wakeup_rebuild_schedules_from_item", "[item_wakeup][rebuild]" )
                             hint_for_map( here.get_abs( origin ) ) );
     REQUIRE( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
 
-    mgr.rebuild_for_item( on_map, hint_for_map( here.get_abs( origin ) ) );
+    mgr.rebuild_for_item( item_location( map_cursor( here.get_abs( origin ) ), &on_map ) );
     CHECK_FALSE( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
 }
 
@@ -643,7 +650,8 @@ TEST_CASE( "item_wakeup_no_registered_handler_is_noop",
 
 namespace
 {
-std::vector<desired_wakeup> dummy_enumerator( const item &/*it*/ )
+std::vector<desired_wakeup> dummy_enumerator( const item &/*it*/,
+        const item_location &/*loc*/ )
 {
     return {
         desired_wakeup{ item_wakeup_kind::ready_check, calendar::turn_zero + 5_minutes },
@@ -666,7 +674,7 @@ TEST_CASE( "item_wakeup_rebuild_schedules_from_producer", "[item_wakeup][rebuild
     const int64_t uid = on_map.uid().get_value();
 
     item_wakeup_manager mgr;
-    mgr.rebuild_for_item( on_map, hint_for_map( here.get_abs( origin ) ) );
+    mgr.rebuild_for_item( item_location( map_cursor( here.get_abs( origin ) ), &on_map ) );
 
     CHECK( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
     CHECK( mgr.is_scheduled( uid, item_wakeup_kind::fail_check ) );
@@ -695,7 +703,7 @@ TEST_CASE( "item_wakeup_rebuild_updates_existing_when", "[item_wakeup][rebuild]"
                             item_wakeup_kind::ready_check,
                             hint_for_map( here.get_abs( origin ) ) );
 
-    mgr.rebuild_for_item( on_map, hint_for_map( here.get_abs( origin ) ) );
+    mgr.rebuild_for_item( item_location( map_cursor( here.get_abs( origin ) ), &on_map ) );
 
     CHECK( mgr.get( uid, item_wakeup_kind::ready_check ).value()
            == calendar::turn_zero + 5_minutes );
@@ -711,7 +719,7 @@ TEST_CASE( "item_wakeup_resolve_on_vehicle_cargo", "[item_wakeup][resolve][vehic
     u.setpos( here, origin );
 
     const tripoint_bub_ms veh_pos( 65, 65, 0 );
-    vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, veh_pos, 0_degrees, -1, 100 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, veh_pos, 0_degrees, -1, 2 );
     REQUIRE( veh != nullptr );
 
     int cargo_part_idx = -1;
@@ -753,7 +761,7 @@ TEST_CASE( "item_wakeup_resolve_vehicle_stale_part_index_uses_mount",
     u.setpos( here, origin );
 
     const tripoint_bub_ms veh_pos( 65, 65, 0 );
-    vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, veh_pos, 0_degrees, -1, 100 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, veh_pos, 0_degrees, -1, 2 );
     REQUIRE( veh != nullptr );
 
     int cargo_part_idx = -1;
@@ -798,7 +806,7 @@ TEST_CASE( "item_wakeup_resolve_vehicle_moved_uses_loaded_scan",
 
     const tripoint_bub_ms initial_pos( 65, 65, 0 );
     vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, initial_pos,
-                                     0_degrees, -1, 100 );
+                                     0_degrees, -1, 2 );
     REQUIRE( veh != nullptr );
 
     int cargo_part_idx = -1;
@@ -972,4 +980,209 @@ TEST_CASE( "item_wakeup_deserialize_restores_heap_invariant",
     REQUIRE( top.has_value() );
     CHECK( top->uid == 1 );
     CHECK( top->when == calendar::turn_zero + 1_minutes );
+}
+
+namespace
+{
+struct location_record {
+    int64_t uid = 0;
+    item_location::type where = item_location::type::invalid;
+    tripoint_abs_ms abs;
+};
+
+std::vector<location_record> &location_log()
+{
+    static std::vector<location_record> log;
+    return log;
+}
+
+void location_capturing_handler( item &it, item_wakeup_kind /*kind*/,
+                                 time_point /*now*/, const item_location &loc )
+{
+    location_record r;
+    r.uid = it.uid().get_value();
+    if( loc ) {
+        r.where = loc.where();
+        r.abs = loc.pos_abs();
+    }
+    location_log().push_back( r );
+}
+}  // namespace
+
+TEST_CASE( "item_wakeup_handler_observes_resolved_location",
+           "[item_wakeup][location]" )
+{
+    clear_map();
+    clear_test_wakeup_handlers();
+    location_log().clear();
+    register_test_wakeup_handler( itype_test_wakeup_dummy, &location_capturing_handler );
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+    const tripoint_abs_ms expected_abs = here.get_abs( origin );
+
+    item_wakeup_manager mgr;
+    const time_point t = calendar::turn + 1_minutes;
+    mgr.schedule_or_update( uid, t, item_wakeup_kind::ready_check,
+                            hint_for_map( expected_abs ) );
+    mgr.process( t );
+
+    REQUIRE( location_log().size() == 1 );
+    CHECK( location_log()[0].uid == uid );
+    CHECK( location_log()[0].where == item_location::type::map );
+    CHECK( location_log()[0].abs == expected_abs );
+
+    clear_test_wakeup_handlers();
+}
+
+TEST_CASE( "item_wakeup_enumerator_observes_resolved_location",
+           "[item_wakeup][location][rebuild]" )
+{
+    static std::vector<tripoint_abs_ms> seen_locs;
+    seen_locs.clear();
+    auto loc_enumerator = []( const item & /*it*/, const item_location & loc )
+    -> std::vector<desired_wakeup> {
+        if( loc )
+        {
+            seen_locs.push_back( loc.pos_abs() );
+        }
+        return {
+            desired_wakeup{ item_wakeup_kind::ready_check, calendar::turn_zero + 5_minutes },
+        };
+    };
+
+    clear_map();
+    clear_test_enumerate_handlers();
+    register_test_enumerate_handler( itype_test_wakeup_dummy, loc_enumerator );
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const tripoint_abs_ms expected_abs = here.get_abs( origin );
+
+    item_wakeup_manager mgr;
+    mgr.rebuild_for_item( item_location( map_cursor( expected_abs ), &on_map ) );
+
+    REQUIRE( seen_locs.size() == 1 );
+    CHECK( seen_locs[0] == expected_abs );
+
+    clear_test_enumerate_handlers();
+}
+
+TEST_CASE( "item_wakeup_map_load_reconciles_dropped_entries",
+           "[item_wakeup][reconcile]" )
+{
+    auto reconcile_enumerator = []( const item & /*it*/, const item_location & /*loc*/ )
+    -> std::vector<desired_wakeup> {
+        return {
+            desired_wakeup{ item_wakeup_kind::ready_check, calendar::turn_zero + 30_minutes },
+        };
+    };
+
+    clear_test_enumerate_handlers();
+    register_test_enumerate_handler( itype_test_wakeup_dummy, reconcile_enumerator );
+
+    item_wakeup_manager &mgr = get_item_wakeups();
+    mgr.clear();
+
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    mgr.clear();
+    REQUIRE_FALSE( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
+
+    here.load( here.get_abs_sub(), /*update_vehicles=*/false, /*pump_events=*/false );
+
+    CHECK( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
+    if( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) ) {
+        CHECK( mgr.get( uid, item_wakeup_kind::ready_check ).value()
+               == calendar::turn_zero + 30_minutes );
+    }
+
+    mgr.clear();
+    clear_test_enumerate_handlers();
+}
+
+TEST_CASE( "item_wakeup_shift_reconciles_dropped_entries",
+           "[item_wakeup][reconcile][shift]" )
+{
+    auto enumerator = []( const item & /*it*/, const item_location & /*loc*/ )
+    -> std::vector<desired_wakeup> {
+        return {
+            desired_wakeup{ item_wakeup_kind::ready_check, calendar::turn_zero + 30_minutes },
+        };
+    };
+
+    clear_test_enumerate_handlers();
+    register_test_enumerate_handler( itype_test_wakeup_dummy, enumerator );
+
+    item_wakeup_manager &mgr = get_item_wakeups();
+    mgr.clear();
+
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    mgr.clear();
+    REQUIRE_FALSE( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
+
+    here.shift( point_rel_sm::east );
+
+    CHECK( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
+
+    mgr.clear();
+    clear_test_enumerate_handlers();
+}
+
+TEST_CASE( "item_wakeup_map_load_recurses_into_containers",
+           "[item_wakeup][reconcile][container]" )
+{
+    auto enumerator = []( const item & /*it*/, const item_location & /*loc*/ )
+    -> std::vector<desired_wakeup> {
+        return {
+            desired_wakeup{ item_wakeup_kind::ready_check, calendar::turn_zero + 30_minutes },
+        };
+    };
+
+    clear_test_enumerate_handlers();
+    register_test_enumerate_handler( itype_test_wakeup_dummy, enumerator );
+
+    item_wakeup_manager &mgr = get_item_wakeups();
+    mgr.clear();
+
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    item box( itype_backpack, calendar::turn );
+    REQUIRE( box.put_in( item( itype_test_wakeup_dummy, calendar::turn ),
+                         pocket_type::CONTAINER ).success() );
+    item &placed_box = here.add_item( origin, box );
+    REQUIRE( !placed_box.all_items_top().empty() );
+    const int64_t inner_uid = placed_box.all_items_top().front()->uid().get_value();
+
+    mgr.clear();
+    here.load( here.get_abs_sub(), /*update_vehicles=*/false, /*pump_events=*/false );
+
+    CHECK( mgr.is_scheduled( inner_uid, item_wakeup_kind::ready_check ) );
+
+    mgr.clear();
+    clear_test_enumerate_handlers();
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Pass item_location through item wakeup dispatch"

#### Purpose of change

The wakeup manager already resolves an `item_location` via `find_item_by_uid` before invoking each handler, then drops it. Any handler that needs to inspect surroundings (env-check, vehicle cargo, character carrying) had to re-resolve from scratch. Plumb the resolved location through the dispatch contract so it's available to producers and consumers without redundant lookups.

#### Describe the solution

`item::actualize_scheduled` and `item::enumerate_scheduled_wakeups` gain a `const item_location &loc` parameter. Same for the dispatch trampolines and test handler/enumerator signatures. `item_wakeup_manager::process` passes the resolved location it already had.

`rebuild_for_item` now takes `const item_location &` and derives the persisted hint internally; the old `(item &, item_locator_hint)` form is gone.

`map::load` gets a reconciliation pass at the end: walks items in the loaded grids and calls `rebuild_for_item` on each. Items with empty enumerate output return immediately. Cheap fast-path for the common case; re-arms wakeups for items that were off-bubble while their submap was unloaded.

#### Describe alternatives you've considered

Re-resolving inside every handler via `find_item_by_uid` works but does the same scan twice for no reason.

Storing `item_location` directly on queue entries is a foot-gun: items move, the stored handle goes stale, and `item_location` is documented as not safe to keep across turns.

#### Testing

Three new test cases under `[item_wakeup][location]` and `[item_wakeup][reconcile]` cover handler/enumerator location observation and the `map::load` reconciliation flow. Existing wakeup tests pass.

#### Additional context

Builds on #86899.