### PR TITLE
behold: the rising dough

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -259,6 +259,17 @@
     "auto_needs": true
   },
   {
+    "id": "ACT_CRAFT_WAIT",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "waiting for craft step",
+    "rooted": true,
+    "based_on": "time",
+    "can_resume": false,
+    "refuel_fires": true,
+    "auto_needs": true
+  },
+  {
     "id": "ACT_DISASSEMBLE",
     "type": "activity_type",
     "activity_level": "MODERATE_EXERCISE",

--- a/data/json/recipes/food/bread.json
+++ b/data/json/recipes/food/bread.json
@@ -103,15 +103,22 @@
     "components": [ [ [ "flour", 22 ], [ "bread_flour", 5 ] ], [ [ "yeast", 1 ] ], [ [ "water_clean", 2 ] ], [ [ "sugar", 4 ] ] ],
     "steps": [
       {
-        "name": "Mix dough",
+        "name": "mixing the dough",
         "time": "5 m",
         "activity_level": "MODERATE_EXERCISE",
         "batch_time_factors": [ 25, 4 ],
         "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_baking" }, { "proficiency": "prof_baking_bread" } ]
       },
-      { "name": "Let dough rise", "time": "10 m", "activity_level": "NO_EXERCISE", "batch_time_factors": [ 5, 4 ] },
       {
-        "name": "Bake",
+        "name": "letting the dough rise",
+        "time": "10 m",
+        "activity_level": "NO_EXERCISE",
+        "batch_time_factors": [ 5, 4 ],
+        "attention": "unattended",
+        "unattend_message": "The dough has finished rising."
+      },
+      {
+        "name": "baking",
         "time": "5 m",
         "activity_level": "LIGHT_EXERCISE",
         "batch_time_factors": [ 50, 4 ],

--- a/data/mods/TEST_DATA/recipes.json
+++ b/data/mods/TEST_DATA/recipes.json
@@ -449,6 +449,125 @@
     ]
   },
   {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_unattended_simple",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "steps": [
+      { "name": "Shape", "time": "5 m", "activity_level": "MODERATE_EXERCISE" },
+      { "name": "Cure", "time": "10 m", "activity_level": "NO_EXERCISE", "attention": "unattended" }
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_timeout_recipe",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "steps": [
+      { "name": "Shape", "time": "5 m", "activity_level": "MODERATE_EXERCISE" },
+      {
+        "name": "Cure",
+        "time": "10 m",
+        "activity_level": "NO_EXERCISE",
+        "attention": "unattended",
+        "max_time": "20 m",
+        "grace_period": "5 m"
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_consecutive_unattended",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "steps": [
+      { "name": "Shape", "time": "5 m", "activity_level": "MODERATE_EXERCISE" },
+      { "name": "Cure A", "time": "10 m", "activity_level": "NO_EXERCISE", "attention": "unattended" },
+      { "name": "Cure B", "time": "10 m", "activity_level": "NO_EXERCISE", "attention": "unattended" },
+      { "name": "Finish", "time": "5 m", "activity_level": "LIGHT_EXERCISE" }
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_terminal_unattended",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "steps": [
+      { "name": "Shape", "time": "5 m", "activity_level": "MODERATE_EXERCISE" },
+      { "name": "Sand", "time": "5 m", "activity_level": "LIGHT_EXERCISE" },
+      { "name": "Cure", "time": "10 m", "activity_level": "NO_EXERCISE", "attention": "unattended" }
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_first_step_unattended",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "steps": [
+      { "name": "Soak", "time": "10 m", "activity_level": "NO_EXERCISE", "attention": "unattended" },
+      { "name": "Shape", "time": "5 m", "activity_level": "MODERATE_EXERCISE" },
+      { "name": "Sand", "time": "5 m", "activity_level": "LIGHT_EXERCISE" }
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_only_unattended",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "steps": [ { "name": "Cure", "time": "10 m", "activity_level": "NO_EXERCISE", "attention": "unattended" } ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_unattended_with_qual",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "steps": [
+      { "name": "Shape", "time": "5 m", "activity_level": "MODERATE_EXERCISE" },
+      {
+        "name": "Bake",
+        "time": "10 m",
+        "activity_level": "NO_EXERCISE",
+        "attention": "unattended",
+        "qualities": [ { "id": "OVEN", "level": 1 } ]
+      }
+    ]
+  },
+  {
     "id": "test_nested_weapons",
     "type": "nested_category",
     "activity_level": "NO_EXERCISE",

--- a/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
+++ b/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
@@ -171,6 +171,12 @@ Each entry in the `"steps"` array is an object with these fields:
 "qualities":          // (Optional)  Same format as recipe-level.
 "using":              // (Optional)  Same format as recipe-level.  Merges into this step's requirements.
 "batch_time_factors": // (Optional)  Same format as recipe-level.
+"attention":          // (Optional)  Either "none" (default) or "unattended".  See "Unattended steps".
+"max_time":           // (Optional)  Duration.  Hard deadline for an unattended step.  Must be > "time".
+"grace_period":       // (Optional)  Duration.  Extra time past "max_time" before the craft is destroyed.
+                      //             Only allowed when "max_time" is set.
+"unattend_message":   // (Optional)  Translatable string.  Shown when an unattended step finishes
+                      //             while the player is elsewhere.  Has a generic fallback.
 ```
 
 `"components"` at step level is not allowed.
@@ -231,6 +237,46 @@ Each entry in the `"steps"` array is an object with these fields:
 - Batch savings are applied per-step and summed.
 - The current step name appears in the crafting progress message.
 - Tool speed modifiers (see `"speed"` in item quality definitions) apply per-step: a tool with `"speed": 0.5` on a quality halves the time of steps requiring that quality, without affecting other steps.
+
+### Unattended steps
+
+A step marked `"attention": "unattended"` is wall-clock time the crafter does not actively work through (rising, marinating, curing).  Starting or resuming such a recipe shows a planning modal per unattended step:
+
+- Wait: player roots under `ACT_CRAFT_WAIT`, time passes, activity flips back to active mode when the step finishes (or ends entirely if the step was the last one).
+- Do something else: activity ends, craft stays where it landed, player is free.
+- Set a timer: like "do something else" plus an alarm clock at a chosen offset.  Only offered with a watch, smartphone, or alarm-clock bionic.
+
+Choices persist across save/load.  On resume the modal asks only about the in-flight unattended step and any later unattended steps; already-completed steps are skipped.  The item name shows live percentage progress projected from counter snapshots taken at step entry, even when no actor is running.
+
+When the wall-clock deadline elapses:
+
+- Non-terminal: step advances, distraction fires with `unattend_message` (or a vague log line without a timepiece).  Suppressed if the player is already on this craft.
+- Terminal: craft auto-finalizes at the deadline, so morale, EOCs, heat, and birthday use in-game completion time.
+- `max_time + grace_period` past start: craft is destroyed.
+
+If the step's tools or qualities become unavailable, the step pauses and the deadline slides forward once the env is restored.  `crafter_id` is remembered so env-check picks up the crafter's pseudo-tools, bionics, and trait qualities when they are next to the craft.
+
+NPCs do not see the planning modal and behave as if implicitly waiting; the unattended block in the craft activity actor still drives their craft forward.
+
+Schema:
+
+- `"max_time"`, when set, must be strictly greater than `"time"`.
+- `"grace_period"` requires `"max_time"`.
+- `"attention": "supervised"` is rejected at load (reserved).
+- An unattended step cannot list charged tools yet (charge debit during wallclock pause/resume not implemented).
+
+Example:
+
+```jsonc
+{
+  "name": "Let dough rise",
+  "time": "10 m",
+  "activity_level": "NO_EXERCISE",
+  "batch_time_factors": [ 5, 4 ],
+  "attention": "unattended",
+  "unattend_message": "The dough has finished rising."
+}
+```
 
 ## Practice recipes
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -45,6 +45,7 @@
 #include "coordinates.h"
 #include "craft_command.h"
 #include "crafting.h"
+#include "crafting_enums.h"
 #include "creature.h"
 #include "creature_tracker.h"
 #include "debug.h"
@@ -75,6 +76,7 @@
 #include "item_contents.h"
 #include "item_group.h"
 #include "item_location.h"
+#include "item_wakeup.h"
 #include "itype.h"
 #include "iuse.h"
 #include "iuse_actor.h"
@@ -6276,6 +6278,73 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
                 break;
             }
             accumulated -= budget;
+        }
+    }
+
+    // Mode is derived from craft state every turn so wakeup handlers that
+    // advance current_step do not need to reach into the live actor.
+    auto derive_mode = [&]() -> mode {
+        if( !rec.has_steps() )
+        {
+            return mode::active;
+        }
+        const recipe_step &s = rec.steps()[craft.get_current_step()];
+        if( s.attention != step_attention::unattended )
+        {
+            return mode::active;
+        }
+        if( craft.get_passive_started_at() == calendar::before_time_starts )
+        {
+            return mode::active;
+        }
+        const std::vector<attention_plan> &plans = craft.get_step_plans();
+        const int idx = craft.get_current_step();
+        if( idx >= static_cast<int>( plans.size() ) )
+        {
+            return mode::waiting;
+        }
+        return plans[idx].choice == step_choice::do_wait ? mode::waiting : mode::active;
+    };
+    mode_ = derive_mode();
+
+    if( rec.has_steps() ) {
+        const recipe_step &cur_step = rec.steps()[craft.get_current_step()];
+        if( cur_step.attention == step_attention::unattended ) {
+            const std::vector<attention_plan> &plans = craft.get_step_plans();
+            const int idx = craft.get_current_step();
+            const attention_plan plan = idx < static_cast<int>( plans.size() ) ? plans[idx] :
+                                        attention_plan{};
+
+            if( craft.get_passive_started_at() == calendar::before_time_starts ) {
+                craft.set_passive_started_at( calendar::turn );
+                const crafting_cost_context passive_ctx{ crafter.book_bonuses_nearby(),
+                        compute_tool_speeds( rec, crafter ) };
+                const int64_t step_moves = static_cast<int64_t>( rec.step_budget_moves(
+                                               crafter, idx, craft.get_making_batch_size(),
+                                               passive_ctx, recipe_time_flag::ignore_proficiencies ) );
+                craft.set_ready_at( calendar::turn + time_duration::from_moves( step_moves ) );
+                if( cur_step.max_time.has_value() ) {
+                    time_duration fail_dur = *cur_step.max_time;
+                    if( cur_step.grace_period.has_value() ) {
+                        fail_dur += *cur_step.grace_period;
+                    }
+                    craft.set_fail_at( calendar::turn + fail_dur );
+                }
+                if( plan.choice == step_choice::set_timer && plan.alarm_offset.has_value() ) {
+                    craft.set_alarm_at( calendar::turn + *plan.alarm_offset );
+                }
+                mode_ = derive_mode();
+                get_item_wakeups().rebuild_for_item( craft_item );
+            }
+
+            if( plan.choice == step_choice::do_wait ) {
+                crafter.set_moves( 0 );
+                return;
+            }
+            // do_something / set_timer: end activity without backlog.
+            act.set_to_null();
+            crafter.set_moves( 0 );
+            return;
         }
     }
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -161,6 +161,7 @@ static const activity_id ACT_CLEAR_RUBBLE( "ACT_CLEAR_RUBBLE" );
 static const activity_id ACT_CONSUME( "ACT_CONSUME" );
 static const activity_id ACT_CRACKING( "ACT_CRACKING" );
 static const activity_id ACT_CRAFT( "ACT_CRAFT" );
+static const activity_id ACT_CRAFT_WAIT( "ACT_CRAFT_WAIT" );
 static const activity_id ACT_DISABLE( "ACT_DISABLE" );
 static const activity_id ACT_DISASSEMBLE( "ACT_DISASSEMBLE" );
 static const activity_id ACT_DISMEMBER( "ACT_DISMEMBER" );
@@ -6493,6 +6494,9 @@ void craft_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "craft_loc", craft_item );
     jsout.member( "long", is_long );
     jsout.member( "activity_override", activity_override );
+    if( mode_ == mode::waiting ) {
+        jsout.member( "mode", "waiting" );
+    }
 
     jsout.end_object();
 }
@@ -6506,6 +6510,10 @@ std::unique_ptr<activity_actor> craft_activity_actor::deserialize( JsonValue &js
     data.read( "craft_loc", actor.craft_item );
     data.read( "long", actor.is_long );
     data.read( "activity_override", actor.activity_override );
+    std::string mode_str;
+    if( data.read( "mode", mode_str ) && mode_str == "waiting" ) {
+        actor.mode_ = mode::waiting;
+    }
 
     return actor.clone();
 }
@@ -14735,6 +14743,7 @@ deserialize_functions = {
     { ACT_CONSUME, &consume_activity_actor::deserialize },
     { ACT_CRACKING, &safecracking_activity_actor::deserialize },
     { ACT_CRAFT, &craft_activity_actor::deserialize },
+    { ACT_CRAFT_WAIT, &craft_activity_actor::deserialize },
     { ACT_DISABLE, &disable_activity_actor::deserialize },
     { ACT_DISASSEMBLE, &disassemble_activity_actor::deserialize },
     { ACT_DISMEMBER, &butchery_activity_actor::deserialize },

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6315,50 +6315,18 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
             const attention_plan plan = idx < static_cast<int>( plans.size() ) ? plans[idx] :
                                         attention_plan{};
 
+            // Past-due wakeup (off-bubble drop or same-turn race): advance inline.
+            if( craft.get_passive_started_at() != calendar::before_time_starts &&
+                craft.get_ready_at() != calendar::before_time_starts &&
+                calendar::turn >= craft.get_ready_at() ) {
+                craft_actualize_scheduled( craft, item_wakeup_kind::ready_check,
+                                           calendar::turn, craft_item );
+                return;
+            }
+
             if( craft.get_passive_started_at() == calendar::before_time_starts ) {
-                craft.set_passive_started_at( calendar::turn );
-                const crafting_cost_context passive_ctx{ crafter.book_bonuses_nearby(),
-                        compute_tool_speeds( rec, crafter ) };
-                const int64_t step_moves = static_cast<int64_t>( rec.step_budget_moves(
-                                               crafter, idx, craft.get_making_batch_size(),
-                                               passive_ctx, recipe_time_flag::ignore_proficiencies ) );
-                craft.set_ready_at( calendar::turn + time_duration::from_moves( step_moves ) );
-                if( cur_step.max_time.has_value() ) {
-                    time_duration fail_dur = *cur_step.max_time;
-                    if( cur_step.grace_period.has_value() ) {
-                        fail_dur += *cur_step.grace_period;
-                    }
-                    craft.set_fail_at( calendar::turn + fail_dur );
-                }
-                if( plan.choice == step_choice::set_timer && plan.alarm_offset.has_value() ) {
-                    craft.set_alarm_at( calendar::turn + *plan.alarm_offset );
-                }
-                // Snapshot counter bounds so item_tname can project without mutation.
-                // Bounds derive from prior steps' budgets to drop any active-step
-                // overshoot in item_counter from carrying into this passive step.
-                double prior_moves = 0.0;
-                double base_default = 0.0;
-                double step_default = 0.0;
-                for( size_t i = 0; i < rec.steps().size(); ++i ) {
-                    const double budget = rec.step_budget_moves(
-                                              crafter, i, craft.get_making_batch_size(), passive_ctx );
-                    base_default += budget;
-                    if( static_cast<int>( i ) < idx ) {
-                        prior_moves += budget;
-                    } else if( static_cast<int>( i ) == idx ) {
-                        step_default = budget;
-                    }
-                }
-                base_default = std::max( 1.0, base_default );
-                const int start_counter = static_cast<int>( std::round(
-                                              prior_moves / base_default * 10000000.0 ) );
-                const int end_counter = std::min( 10000000,
-                                                  static_cast<int>( std::round(
-                                                          ( prior_moves + step_default ) / base_default * 10000000.0 ) ) );
-                craft.set_passive_start_counter( start_counter );
-                craft.set_passive_end_counter( end_counter );
+                craft_stamp_passive_entry( craft, crafter, calendar::turn, craft_item );
                 mode_ = derive_mode();
-                get_item_wakeups().rebuild_for_item( craft_item );
             }
 
             if( plan.choice == step_choice::do_wait ) {

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6333,6 +6333,30 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
                 if( plan.choice == step_choice::set_timer && plan.alarm_offset.has_value() ) {
                     craft.set_alarm_at( calendar::turn + *plan.alarm_offset );
                 }
+                // Snapshot counter bounds so item_tname can project without mutation.
+                // Bounds derive from prior steps' budgets to drop any active-step
+                // overshoot in item_counter from carrying into this passive step.
+                double prior_moves = 0.0;
+                double base_default = 0.0;
+                double step_default = 0.0;
+                for( size_t i = 0; i < rec.steps().size(); ++i ) {
+                    const double budget = rec.step_budget_moves(
+                                              crafter, i, craft.get_making_batch_size(), passive_ctx );
+                    base_default += budget;
+                    if( static_cast<int>( i ) < idx ) {
+                        prior_moves += budget;
+                    } else if( static_cast<int>( i ) == idx ) {
+                        step_default = budget;
+                    }
+                }
+                base_default = std::max( 1.0, base_default );
+                const int start_counter = static_cast<int>( std::round(
+                                              prior_moves / base_default * 10000000.0 ) );
+                const int end_counter = std::min( 10000000,
+                                                  static_cast<int>( std::round(
+                                                          ( prior_moves + step_default ) / base_default * 10000000.0 ) ) );
+                craft.set_passive_start_counter( start_counter );
+                craft.set_passive_end_counter( end_counter );
                 mode_ = derive_mode();
                 get_item_wakeups().rebuild_for_item( craft_item );
             }

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1958,11 +1958,14 @@ class unload_activity_actor : public activity_actor
 
 class craft_activity_actor : public activity_actor
 {
+    public:
+        enum class mode : uint8_t { active, waiting };
     private:
         craft_activity_actor() = default;
 
         item_location craft_item;
         bool is_long;
+        mode mode_ = mode::active;
 
         float activity_override = NO_EXERCISE;
         std::optional<requirement_data> cached_continuation_requirements; // NOLINT(cata-serialize)
@@ -1979,7 +1982,8 @@ class craft_activity_actor : public activity_actor
 
         const activity_id &get_type() const override {
             static const activity_id ACT_CRAFT( "ACT_CRAFT" );
-            return ACT_CRAFT;
+            static const activity_id ACT_CRAFT_WAIT( "ACT_CRAFT_WAIT" );
+            return mode_ == mode::waiting ? ACT_CRAFT_WAIT : ACT_CRAFT;
         }
 
         void start( player_activity &act, Character &crafter ) override;

--- a/src/activity_type.cpp
+++ b/src/activity_type.cpp
@@ -77,6 +77,7 @@ std::string enum_to_string<distraction_type>( distraction_type data )
         case distraction_type::mutation: return "mutation";
         case distraction_type::oxygen: return "oxygen";
         case distraction_type::withdrawal: return "withdrawal";
+        case distraction_type::craft_step_complete: return "craft_step_complete";
         // *INDENT-ON*
         default:
             cata_fatal( "Invalid distraction_type in enum_to_string" );

--- a/src/character.h
+++ b/src/character.h
@@ -99,6 +99,7 @@ enum action_id : int;
 enum class recipe_filter_flags : int;
 enum class steed_type : int;
 enum npc_attitude : int;
+struct attention_plan;
 struct bionic;
 struct construction;
 struct dealt_projectile_attack;
@@ -3737,7 +3738,8 @@ class Character : public Creature, public visitable
         void make_all_craft( const recipe_id &id, int batch_size,
                              const std::optional<tripoint_bub_ms> &loc );
         /** consume components and create an active, in progress craft containing them */
-        void start_craft( craft_command &command, const std::optional<tripoint_bub_ms> &loc );
+        void start_craft( craft_command &command, const std::optional<tripoint_bub_ms> &loc,
+                          std::vector<attention_plan> plans = {} );
 
         struct craft_roll_data {
             float center;

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -214,7 +214,7 @@ void craft_command::execute( bool only_cache_comps )
     std::vector<attention_plan> plans;
     if( rec->has_attention_steps() && crafter->is_avatar() ) {
         std::optional<std::vector<attention_plan>> chosen =
-                show_craft_planning_modal( *rec, *crafter, batch_size, {} );
+                show_craft_planning_modal( *rec, *crafter, batch_size, /*from_step=*/0, {} );
         if( !chosen ) {
             return;
         }

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -12,6 +12,7 @@
 #include "activity_actor_definitions.h"
 #include "character.h"
 #include "crafting.h"
+#include "crafting_enums.h"
 #include "debug.h"
 #include "enum_conversions.h"
 #include "enum_traits.h"
@@ -210,7 +211,16 @@ void craft_command::execute( bool only_cache_comps )
         return;
     }
 
-    crafter->start_craft( *this, loc );
+    std::vector<attention_plan> plans;
+    if( rec->has_attention_steps() && crafter->is_avatar() ) {
+        std::optional<std::vector<attention_plan>> chosen =
+                show_craft_planning_modal( *rec, *crafter, batch_size, {} );
+        if( !chosen ) {
+            return;
+        }
+        plans = std::move( *chosen );
+    }
+    crafter->start_craft( *this, loc, std::move( plans ) );
     crafter->last_batch = batch_size;
     crafter->lastrecipe = rec->ident();
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -976,7 +976,79 @@ static item_location place_craft_or_disassembly(
     return craft_in_world;
 }
 
-void Character::start_craft( craft_command &command, const std::optional<tripoint_bub_ms> &loc )
+std::optional<std::vector<attention_plan>> show_craft_planning_modal(
+        const recipe &rec, const Character &crafter, int batch,
+        const std::vector<attention_plan> &existing )
+{
+    const std::vector<recipe_step> &steps = rec.steps();
+    std::vector<attention_plan> plans( steps.size() );
+    for( size_t i = 0; i < std::min( existing.size(), plans.size() ); ++i ) {
+        plans[i] = existing[i];
+    }
+
+    const bool has_timepiece = crafter.has_watch() || crafter.has_alarm_clock();
+    const crafting_cost_context ctx{ crafter.book_bonuses_nearby(),
+                                     compute_tool_speeds( rec, crafter ) };
+
+    for( size_t i = 0; i < steps.size(); ++i ) {
+        const recipe_step &step = steps[i];
+        if( step.attention != step_attention::unattended ) {
+            continue;
+        }
+
+        const time_duration step_dur = time_duration::from_moves(
+                                           rec.step_budget_moves( crafter, i, batch, ctx,
+                                                   recipe_time_flag::ignore_proficiencies ) );
+
+        uilist menu;
+        menu.text = string_format(
+                        _( "Step: %s (%s)\nWhat do you want to do?" ),
+                        step.name.translated(),
+                        to_string_approx( step_dur ) );
+        menu.addentry( 0, true, 'w', _( "Wait for it to finish" ) );
+        menu.addentry( 1, true, 'd', _( "Do something else" ) );
+        if( has_timepiece ) {
+            menu.addentry( 2, true, 't', _( "Set a timer" ) );
+        }
+        menu.query();
+
+        if( menu.ret == UILIST_CANCEL ) {
+            return std::nullopt;
+        }
+
+        if( menu.ret == 0 ) {
+            plans[i].choice = step_choice::do_wait;
+            plans[i].alarm_offset.reset();
+        } else if( menu.ret == 1 ) {
+            plans[i].choice = step_choice::do_something;
+            plans[i].alarm_offset.reset();
+        } else if( menu.ret == 2 ) {
+            uilist alarm;
+            alarm.text = _( "Set an alarm for when?" );
+            alarm.addentry( 1, true, '1',
+                            string_format( _( "When the step finishes (%s)" ),
+                                           to_string( step_dur ) ) );
+            alarm.addentry( 2, step_dur > 5_minutes, '2',
+                            string_format( _( "5 minutes before (%s in)" ),
+                                           to_string( step_dur - 5_minutes ) ) );
+            alarm.query();
+            if( alarm.ret == UILIST_CANCEL ) {
+                return std::nullopt;
+            }
+            plans[i].choice = step_choice::set_timer;
+            if( alarm.ret == 2 ) {
+                plans[i].alarm_offset = step_dur - 5_minutes;
+            } else {
+                plans[i].alarm_offset = step_dur;
+            }
+        }
+    }
+
+    return plans;
+}
+
+void Character::start_craft( craft_command &command, const std::optional<tripoint_bub_ms> &loc,
+                             std::vector<attention_plan> plans )
 {
     if( command.empty() ) {
         debugmsg( "Attempted to start craft with empty command" );
@@ -990,6 +1062,13 @@ void Character::start_craft( craft_command &command, const std::optional<tripoin
     const recipe &making = craft.get_making();
     if( static_cast<int>( get_skill_level( command.get_skill_id() ) ) > making.get_skill_cap() ) {
         handle_skill_warning( command.get_skill_id(), true );
+    }
+
+    if( making.has_attention_steps() ) {
+        craft.set_crafter_id( getID() );
+    }
+    if( !plans.empty() ) {
+        craft.set_step_plans( std::move( plans ) );
     }
 
     // In case we were wearing something just consumed

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1148,6 +1148,9 @@ static std::string compose_unattend_message( const item &craft, const recipe_ste
 
 static void advance_passive_step( item &craft )
 {
+    if( craft.get_passive_end_counter() > craft.item_counter ) {
+        craft.item_counter = std::min( 10000000, craft.get_passive_end_counter() );
+    }
     craft.set_passive_started_at( calendar::before_time_starts );
     craft.set_ready_at( calendar::before_time_starts );
     craft.set_alarm_at( calendar::before_time_starts );
@@ -1156,6 +1159,8 @@ static void advance_passive_step( item &craft )
     craft.set_saved_ready_at( calendar::before_time_starts );
     craft.set_saved_alarm_at( calendar::before_time_starts );
     craft.set_saved_fail_at( calendar::before_time_starts );
+    craft.set_passive_start_counter( 0 );
+    craft.set_passive_end_counter( 0 );
     craft.set_current_step( craft.get_current_step() + 1 );
     craft.set_step_progress( 0.0 );
 }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -86,6 +86,7 @@
 #include "weather.h"
 
 static const activity_id ACT_CRAFT( "ACT_CRAFT" );
+static const activity_id ACT_CRAFT_WAIT( "ACT_CRAFT_WAIT" );
 static const activity_id ACT_DISASSEMBLE( "ACT_DISASSEMBLE" );
 
 static const efftype_id effect_contacts( "contacts" );
@@ -974,6 +975,25 @@ static item_location place_craft_or_disassembly(
     }
 
     return craft_in_world;
+}
+
+void fire_step_complete_distraction( const std::string &msg, const item_location &loc )
+{
+    avatar &u = get_avatar();
+    if( ( u.activity.id() == ACT_CRAFT || u.activity.id() == ACT_CRAFT_WAIT )
+        && !u.activity.targets.empty()
+        && u.activity.targets.back() == loc ) {
+        return;
+    }
+    if( !uistate.distraction_craft_step_complete ) {
+        add_msg( m_info, msg );
+        return;
+    }
+    const bool interrupted =
+        g->cancel_activity_or_ignore_query( distraction_type::craft_step_complete, msg );
+    if( !interrupted && u.activity.id().is_null() && !u.has_destination() ) {
+        add_msg( m_info, msg );
+    }
 }
 
 std::optional<std::vector<attention_plan>> show_craft_planning_modal(

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -28,6 +28,7 @@
 #include "color.h"
 #include "coordinates.h"
 #include "craft_command.h"
+#include "crafting_enums.h"
 #include "crafting_gui.h"
 #include "creature.h"
 #include "debug.h"
@@ -73,9 +74,11 @@
 #include "skill.h"
 #include "string_formatter.h"
 #include "talker.h"
+#include "translation.h"
 #include "translations.h"
 #include "type_id.h"
 #include "uilist.h"
+#include "uistate.h"
 #include "units.h"
 #include "value_ptr.h"
 #include "veh_type.h"
@@ -1065,6 +1068,270 @@ std::optional<std::vector<attention_plan>> show_craft_planning_modal(
     }
 
     return plans;
+}
+
+std::vector<desired_wakeup> craft_enumerate_scheduled_wakeups(
+    const item &craft, const item_location & /*loc*/ )
+{
+    std::vector<desired_wakeup> result;
+    if( !craft.is_craft() ) {
+        return result;
+    }
+    const time_point ready_at = craft.get_ready_at();
+    const time_point alarm_at = craft.get_alarm_at();
+    const time_point fail_at = craft.get_fail_at();
+    if( ready_at != calendar::before_time_starts ) {
+        result.push_back( desired_wakeup{ item_wakeup_kind::ready_check, ready_at } );
+    }
+    if( alarm_at != calendar::before_time_starts ) {
+        result.push_back( desired_wakeup{ item_wakeup_kind::alarm, alarm_at } );
+    }
+    if( fail_at != calendar::before_time_starts ) {
+        result.push_back( desired_wakeup{ item_wakeup_kind::fail_check, fail_at } );
+    }
+    return result;
+}
+
+static bool step_has_env_requirements( const recipe_step &step )
+{
+    return !step.requirements.get_tools().empty()
+           || !step.requirements.get_qualities().empty();
+}
+
+static Character *resolve_crafter( const character_id &cid )
+{
+    if( !cid.is_valid() ) {
+        return nullptr;
+    }
+    avatar &u = get_avatar();
+    if( u.getID() == cid ) {
+        return &u;
+    }
+    return g->find_npc( cid );
+}
+
+static bool env_satisfied_for_step( const recipe_step &step, const item &craft,
+                                    const item_location &loc )
+{
+    if( !step_has_env_requirements( step ) ) {
+        return true;
+    }
+    map &m = get_map();
+    const tripoint_bub_ms craft_pos = m.get_bub( loc.pos_abs() );
+
+    inventory inv;
+    if( loc.where() == item_location::type::character ) {
+        Character *holder = loc.carrier();
+        if( holder != nullptr ) {
+            inv = holder->crafting_inventory( craft_pos, PICKUP_RANGE );
+        }
+    } else {
+        Character *crafter = resolve_crafter( craft.get_crafter_id() );
+        if( crafter != nullptr
+            && rl_dist( crafter->pos_bub( m ), craft_pos ) <= PICKUP_RANGE ) {
+            inv = crafter->crafting_inventory( craft_pos, PICKUP_RANGE );
+        } else {
+            inv.form_from_map( &m, craft_pos, PICKUP_RANGE, /*pl=*/nullptr );
+        }
+    }
+    return step.requirements.can_make_with_inventory(
+               inv, return_true<item>, /*batch=*/1, craft_flags::start_only );
+}
+
+static std::string compose_unattend_message( const item &craft, const recipe_step &step )
+{
+    if( !step.unattend_message.empty() ) {
+        return step.unattend_message.translated();
+    }
+    return string_format( _( "%s is ready." ), craft.get_making().result_name() );
+}
+
+static void advance_passive_step( item &craft )
+{
+    craft.set_passive_started_at( calendar::before_time_starts );
+    craft.set_ready_at( calendar::before_time_starts );
+    craft.set_alarm_at( calendar::before_time_starts );
+    craft.set_fail_at( calendar::before_time_starts );
+    craft.set_pause_started_at( calendar::before_time_starts );
+    craft.set_saved_ready_at( calendar::before_time_starts );
+    craft.set_saved_alarm_at( calendar::before_time_starts );
+    craft.set_saved_fail_at( calendar::before_time_starts );
+    craft.set_current_step( craft.get_current_step() + 1 );
+    craft.set_step_progress( 0.0 );
+}
+
+static void craft_actualize_alarm( item &craft, time_point now, const item_location &loc )
+{
+    if( craft.get_alarm_at() == calendar::before_time_starts ) {
+        return;
+    }
+    // Same-turn collision: ready_check fires next in (kind, when, uid) order
+    // and will produce its own distraction.  Suppress redundant alarm.
+    if( craft.get_ready_at() != calendar::before_time_starts
+        && now >= craft.get_ready_at() ) {
+        craft.set_alarm_at( calendar::before_time_starts );
+        get_item_wakeups().rebuild_for_item( loc );
+        return;
+    }
+    craft.set_alarm_at( calendar::before_time_starts );
+
+    const recipe &rec = craft.get_making();
+    const int step_idx = craft.get_current_step();
+    std::string msg;
+    if( step_idx >= 0 && step_idx < static_cast<int>( rec.steps().size() ) ) {
+        msg = compose_unattend_message( craft, rec.steps()[step_idx] );
+    } else {
+        msg = string_format( _( "%s is ready." ), rec.result_name() );
+    }
+    fire_step_complete_distraction( msg, loc );
+    get_item_wakeups().rebuild_for_item( loc );
+}
+
+static bool activity_targets_loc( const Character &c, const item_location &loc )
+{
+    return ( c.activity.id() == ACT_CRAFT || c.activity.id() == ACT_CRAFT_WAIT )
+           && !c.activity.targets.empty()
+           && c.activity.targets.back() == loc;
+}
+
+static void end_live_wait_for( const item_location &loc )
+{
+    avatar &u = get_avatar();
+    if( activity_targets_loc( u, loc ) ) {
+        u.activity.set_to_null();
+    }
+    for( npc &n : g->all_npcs() ) {
+        if( activity_targets_loc( n, loc ) ) {
+            n.activity.set_to_null();
+        }
+    }
+}
+
+static std::optional<tripoint_bub_ms> craft_loc_for_complete( const item_location &loc )
+{
+    if( loc.where() == item_location::type::character ) {
+        return std::nullopt;
+    }
+    return get_map().get_bub( loc.pos_abs() );
+}
+
+static void craft_actualize_fail( item &craft, time_point now,
+                                  const item_location &loc )
+{
+    if( craft.get_fail_at() == calendar::before_time_starts ) {
+        return;
+    }
+    if( now < craft.get_fail_at() ) {
+        return;
+    }
+    end_live_wait_for( loc );
+    item_location mut_loc = loc;
+    mut_loc.remove_item();
+}
+
+static void finalize_passive_craft( item &craft, const item_location &loc )
+{
+    Character *crafter = resolve_crafter( craft.get_crafter_id() );
+    if( crafter == nullptr ) {
+        debugmsg( "crafter %d gone before terminal unattended step finalized; "
+                  "destroying craft for recipe %s",
+                  craft.get_crafter_id().get_value(),
+                  craft.get_making().ident().str() );
+        item_location mut_loc = loc;
+        mut_loc.remove_item();
+        return;
+    }
+    end_live_wait_for( loc );
+    item craft_copy = craft;
+    const std::optional<tripoint_bub_ms> finalize_loc = craft_loc_for_complete( loc );
+    item_location mut_loc = loc;
+    mut_loc.remove_item();
+    crafter->complete_craft( craft_copy, finalize_loc );
+}
+
+static void craft_actualize_ready( item &craft, time_point now, const item_location &loc )
+{
+    if( craft.get_ready_at() == calendar::before_time_starts ) {
+        return;
+    }
+    if( now < craft.get_ready_at() ) {
+        return;
+    }
+    const recipe &rec = craft.get_making();
+    const int step_idx = craft.get_current_step();
+    if( step_idx < 0 || step_idx >= static_cast<int>( rec.steps().size() ) ) {
+        return;
+    }
+    const recipe_step &step = rec.steps()[step_idx];
+
+    if( !env_satisfied_for_step( step, craft, loc ) ) {
+        if( craft.get_pause_started_at() == calendar::before_time_starts ) {
+            craft.set_pause_started_at( now );
+            craft.set_saved_ready_at( craft.get_ready_at() );
+            craft.set_saved_alarm_at( craft.get_alarm_at() );
+            craft.set_saved_fail_at( craft.get_fail_at() );
+            craft.set_alarm_at( calendar::before_time_starts );
+            craft.set_fail_at( calendar::before_time_starts );
+        }
+        craft.set_ready_at( now + 1_minutes );
+        get_item_wakeups().rebuild_for_item( loc );
+        return;
+    }
+
+    if( craft.get_pause_started_at() != calendar::before_time_starts ) {
+        const time_duration paused_for = now - craft.get_pause_started_at();
+        craft.set_ready_at( craft.get_saved_ready_at() + paused_for );
+        if( craft.get_saved_alarm_at() != calendar::before_time_starts ) {
+            craft.set_alarm_at( craft.get_saved_alarm_at() + paused_for );
+        }
+        if( craft.get_saved_fail_at() != calendar::before_time_starts ) {
+            craft.set_fail_at( craft.get_saved_fail_at() + paused_for );
+        }
+        craft.set_pause_started_at( calendar::before_time_starts );
+        craft.set_saved_ready_at( calendar::before_time_starts );
+        craft.set_saved_alarm_at( calendar::before_time_starts );
+        craft.set_saved_fail_at( calendar::before_time_starts );
+        if( now < craft.get_ready_at() ) {
+            get_item_wakeups().rebuild_for_item( loc );
+            return;
+        }
+    }
+
+    const std::string completion_msg = compose_unattend_message( craft, step );
+    const bool was_last_step = step_idx == static_cast<int>( rec.steps().size() ) - 1;
+
+    if( was_last_step ) {
+        const bool was_on_craft = activity_targets_loc( get_avatar(), loc );
+        finalize_passive_craft( craft, loc );
+        if( !was_on_craft ) {
+            fire_step_complete_distraction( completion_msg, loc );
+        }
+        return;
+    }
+    advance_passive_step( craft );
+    get_item_wakeups().rebuild_for_item( loc );
+    fire_step_complete_distraction( completion_msg, loc );
+}
+
+void craft_actualize_scheduled( item &craft, item_wakeup_kind kind, time_point now,
+                                const item_location &loc )
+{
+    if( !craft.is_craft() ) {
+        return;
+    }
+    switch( kind ) {
+        case item_wakeup_kind::alarm:
+            craft_actualize_alarm( craft, now, loc );
+            return;
+        case item_wakeup_kind::ready_check:
+            craft_actualize_ready( craft, now, loc );
+            return;
+        case item_wakeup_kind::fail_check:
+            craft_actualize_fail( craft, now, loc );
+            return;
+        case item_wakeup_kind::last:
+            return;
+    }
 }
 
 void Character::start_craft( craft_command &command, const std::optional<tripoint_bub_ms> &loc,

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -72,6 +72,7 @@
 #include "ret_val.h"
 #include "rng.h"
 #include "skill.h"
+#include "sounds.h"
 #include "string_formatter.h"
 #include "talker.h"
 #include "translation.h"
@@ -980,7 +981,9 @@ static item_location place_craft_or_disassembly(
     return craft_in_world;
 }
 
-void fire_step_complete_distraction( const std::string &msg, const item_location &loc )
+void fire_step_complete_distraction( const std::string &interrupt_msg,
+                                     const std::string &no_watch_msg,
+                                     const item_location &loc )
 {
     avatar &u = get_avatar();
     if( ( u.activity.id() == ACT_CRAFT || u.activity.id() == ACT_CRAFT_WAIT )
@@ -988,19 +991,23 @@ void fire_step_complete_distraction( const std::string &msg, const item_location
         && u.activity.targets.back() == loc ) {
         return;
     }
+    if( !u.has_watch() && !u.has_alarm_clock() ) {
+        add_msg( m_info, no_watch_msg );
+        return;
+    }
     if( !uistate.distraction_craft_step_complete ) {
-        add_msg( m_info, msg );
+        add_msg( m_info, interrupt_msg );
         return;
     }
     const bool interrupted =
-        g->cancel_activity_or_ignore_query( distraction_type::craft_step_complete, msg );
+        g->cancel_activity_or_ignore_query( distraction_type::craft_step_complete, interrupt_msg );
     if( !interrupted && u.activity.id().is_null() && !u.has_destination() ) {
-        add_msg( m_info, msg );
+        add_msg( m_info, interrupt_msg );
     }
 }
 
 std::optional<std::vector<attention_plan>> show_craft_planning_modal(
-        const recipe &rec, const Character &crafter, int batch,
+        const recipe &rec, const Character &crafter, int batch, int from_step,
         const std::vector<attention_plan> &existing )
 {
     const std::vector<recipe_step> &steps = rec.steps();
@@ -1013,7 +1020,8 @@ std::optional<std::vector<attention_plan>> show_craft_planning_modal(
     const crafting_cost_context ctx{ crafter.book_bonuses_nearby(),
                                      compute_tool_speeds( rec, crafter ) };
 
-    for( size_t i = 0; i < steps.size(); ++i ) {
+    const size_t start_idx = from_step < 0 ? 0 : static_cast<size_t>( from_step );
+    for( size_t i = start_idx; i < steps.size(); ++i ) {
         const recipe_step &step = steps[i];
         if( step.attention != step_attention::unattended ) {
             continue;
@@ -1182,13 +1190,19 @@ static void craft_actualize_alarm( item &craft, time_point now, const item_locat
 
     const recipe &rec = craft.get_making();
     const int step_idx = craft.get_current_step();
-    std::string msg;
-    if( step_idx >= 0 && step_idx < static_cast<int>( rec.steps().size() ) ) {
-        msg = compose_unattend_message( craft, rec.steps()[step_idx] );
-    } else {
-        msg = string_format( _( "%s is ready." ), rec.result_name() );
+    const std::string ready_msg = step_idx >= 0 && step_idx < static_cast<int>( rec.steps().size() )
+                                  ? compose_unattend_message( craft, rec.steps()[step_idx] )
+                                  : string_format( _( "%s is ready." ), rec.result_name() );
+    const std::string alarm_msg = string_format( _( "Your timer goes off: %s" ), ready_msg );
+
+    avatar &u = get_avatar();
+    sounds::sound( u.pos_bub(), 16, sounds::sound_t::alarm,
+                   _( "beep-beep-beep!" ), false, "tool", "alarm_clock" );
+    if( !u.activity.id().is_null() ) {
+        g->cancel_activity_or_ignore_query( distraction_type::noise, alarm_msg );
+    } else if( !u.has_destination() ) {
+        add_msg( m_info, alarm_msg );
     }
-    fire_step_complete_distraction( msg, loc );
     get_item_wakeups().rebuild_for_item( loc );
 }
 
@@ -1268,6 +1282,22 @@ static void craft_actualize_ready( item &craft, time_point now, const item_locat
         return;
     }
     const recipe_step &step = rec.steps()[step_idx];
+    // Recipe-edit migration: stale passive state on what is now an active step
+    // would otherwise advance/finalize the wrong step.  Clear and bail.
+    if( step.attention != step_attention::unattended ) {
+        craft.set_passive_started_at( calendar::before_time_starts );
+        craft.set_ready_at( calendar::before_time_starts );
+        craft.set_alarm_at( calendar::before_time_starts );
+        craft.set_fail_at( calendar::before_time_starts );
+        craft.set_pause_started_at( calendar::before_time_starts );
+        craft.set_saved_ready_at( calendar::before_time_starts );
+        craft.set_saved_alarm_at( calendar::before_time_starts );
+        craft.set_saved_fail_at( calendar::before_time_starts );
+        craft.set_passive_start_counter( 0 );
+        craft.set_passive_end_counter( 0 );
+        get_item_wakeups().rebuild_for_item( loc );
+        return;
+    }
 
     if( !env_satisfied_for_step( step, craft, loc ) ) {
         if( craft.get_pause_started_at() == calendar::before_time_starts ) {
@@ -1303,19 +1333,172 @@ static void craft_actualize_ready( item &craft, time_point now, const item_locat
     }
 
     const std::string completion_msg = compose_unattend_message( craft, step );
+    const std::string flavor_msg = string_format(
+                                       _( "You suddenly remember that the %s may have finished %s." ),
+                                       rec.result_name(), step.name.translated() );
     const bool was_last_step = step_idx == static_cast<int>( rec.steps().size() ) - 1;
 
     if( was_last_step ) {
         const bool was_on_craft = activity_targets_loc( get_avatar(), loc );
         finalize_passive_craft( craft, loc );
         if( !was_on_craft ) {
-            fire_step_complete_distraction( completion_msg, loc );
+            fire_step_complete_distraction( completion_msg, flavor_msg, loc );
         }
         return;
     }
+    // Stamp consecutive unattended step at the just-consumed ready_at so a
+    // chain catches up without losing wall-clock between them.
+    const time_point step_end = craft.get_ready_at();
     advance_passive_step( craft );
+    const int new_idx = craft.get_current_step();
+    bool wakeups_rebuilt = false;
+    if( new_idx < static_cast<int>( rec.steps().size() ) &&
+        rec.steps()[new_idx].attention == step_attention::unattended ) {
+        Character *next_crafter = resolve_crafter( craft.get_crafter_id() );
+        if( next_crafter != nullptr ) {
+            craft_stamp_passive_entry( craft, *next_crafter, step_end, loc );
+            wakeups_rebuilt = true;
+        }
+    }
+    if( !wakeups_rebuilt ) {
+        get_item_wakeups().rebuild_for_item( loc );
+    }
+    fire_step_complete_distraction( completion_msg, flavor_msg, loc );
+}
+
+void craft_resolve_overdue_passive( item &craft, time_point now, item_location &loc )
+{
+    if( !craft.is_craft() ) {
+        return;
+    }
+    // Each iteration either advances the step (and the ready handler chains
+    // the next unattended step inline) or terminates.  Bounded by step count.
+    const int max_iters = static_cast<int>( craft.get_making().steps().size() ) + 1;
+    item *cur = &craft;
+    for( int i = 0; i < max_iters; ++i ) {
+        if( cur->get_passive_started_at() == calendar::before_time_starts ) {
+            return;
+        }
+        if( cur->get_ready_at() == calendar::before_time_starts ) {
+            return;
+        }
+        if( now < cur->get_ready_at() ) {
+            return;
+        }
+        craft_actualize_scheduled( *cur, item_wakeup_kind::ready_check, now, loc );
+        // Terminal step finalization removes the craft via complete_craft.
+        cur = loc.get_item();
+        if( cur == nullptr ) {
+            return;
+        }
+    }
+}
+
+void craft_stamp_passive_entry( item &craft, const Character &crafter, time_point now,
+                                const item_location &loc )
+{
+    if( !craft.is_craft() ) {
+        return;
+    }
+    const recipe &rec = craft.get_making();
+    if( !rec.has_steps() ) {
+        return;
+    }
+    const int idx = craft.get_current_step();
+    if( idx < 0 || idx >= static_cast<int>( rec.steps().size() ) ) {
+        return;
+    }
+    const recipe_step &cur_step = rec.steps()[idx];
+    if( cur_step.attention != step_attention::unattended ) {
+        return;
+    }
+    const std::vector<attention_plan> &plans = craft.get_step_plans();
+    const attention_plan plan = idx < static_cast<int>( plans.size() ) ? plans[idx] :
+                                attention_plan{};
+
+    craft.set_passive_started_at( now );
+    const crafting_cost_context passive_ctx{ crafter.book_bonuses_nearby(),
+            compute_tool_speeds( rec, crafter ) };
+    const int64_t step_moves = static_cast<int64_t>( rec.step_budget_moves(
+                                   crafter, idx, craft.get_making_batch_size(),
+                                   passive_ctx, recipe_time_flag::ignore_proficiencies ) );
+    craft.set_ready_at( now + time_duration::from_moves( step_moves ) );
+    if( cur_step.max_time.has_value() ) {
+        time_duration fail_dur = *cur_step.max_time;
+        if( cur_step.grace_period.has_value() ) {
+            fail_dur += *cur_step.grace_period;
+        }
+        craft.set_fail_at( now + fail_dur );
+    }
+    if( plan.choice == step_choice::set_timer && plan.alarm_offset.has_value() ) {
+        craft.set_alarm_at( now + *plan.alarm_offset );
+    }
+    // Counter bounds derive from prior steps' budgets (default flags) so any
+    // active-step overshoot in item_counter does not carry into this passive
+    // step.  Matches the active accumulator's batch_time(default) basis.
+    double prior_moves = 0.0;
+    double base_default = 0.0;
+    double step_default = 0.0;
+    for( size_t i = 0; i < rec.steps().size(); ++i ) {
+        const double budget = rec.step_budget_moves(
+                                  crafter, i, craft.get_making_batch_size(), passive_ctx );
+        base_default += budget;
+        if( static_cast<int>( i ) < idx ) {
+            prior_moves += budget;
+        } else if( static_cast<int>( i ) == idx ) {
+            step_default = budget;
+        }
+    }
+    // Truncate the denominator the same way batch_time() does so passive
+    // boundary identity matches the active accumulator's normalization.
+    const double base_total = std::max( 1.0,
+                                        static_cast<double>( static_cast<int64_t>( base_default ) ) );
+    const int start_counter = static_cast<int>( std::round(
+                                  prior_moves / base_total * 10000000.0 ) );
+    const int end_counter = std::min( 10000000,
+                                      static_cast<int>( std::round(
+                                              ( prior_moves + step_default ) / base_total * 10000000.0 ) ) );
+    craft.set_passive_start_counter( start_counter );
+    craft.set_passive_end_counter( end_counter );
     get_item_wakeups().rebuild_for_item( loc );
-    fire_step_complete_distraction( completion_msg, loc );
+}
+
+void craft_apply_resume_replan( item_location &loc )
+{
+    item *craft = loc.get_item();
+    if( craft == nullptr || !craft->is_craft() ) {
+        return;
+    }
+    if( craft->get_passive_started_at() == calendar::before_time_starts ) {
+        return;
+    }
+    const recipe &rec = craft->get_making();
+    const int idx = craft->get_current_step();
+    if( idx < 0 || idx >= static_cast<int>( rec.steps().size() ) ) {
+        return;
+    }
+    if( rec.steps()[idx].attention != step_attention::unattended ) {
+        return;
+    }
+    const std::vector<attention_plan> &plans = craft->get_step_plans();
+    const attention_plan plan = idx < static_cast<int>( plans.size() ) ? plans[idx] :
+                                attention_plan{};
+    // While env-paused, alarm_at is zeroed and saved_alarm_at carries the
+    // authoritative deadline restored on unpause.  Edit whichever is live so
+    // the replan survives the restore.
+    const bool paused = craft->get_saved_ready_at() != calendar::before_time_starts;
+    if( plan.choice == step_choice::set_timer && plan.alarm_offset.has_value() ) {
+        const time_point alarm_at = craft->get_passive_started_at() + *plan.alarm_offset;
+        if( paused ) {
+            craft->set_saved_alarm_at( alarm_at );
+        } else {
+            craft->set_alarm_at( alarm_at );
+        }
+    } else {
+        craft->set_alarm_at( calendar::before_time_starts );
+        craft->set_saved_alarm_at( calendar::before_time_starts );
+    }
+    get_item_wakeups().rebuild_for_item( loc );
 }
 
 void craft_actualize_scheduled( item &craft, item_wakeup_kind kind, time_point now,

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -7,10 +7,13 @@
 #include <string>
 #include <vector>
 
+#include "item_wakeup.h"
+
 class Character;
 class item;
 class item_location;
 class recipe;
+class time_point;
 struct attention_plan;
 template <typename E> struct enum_traits;
 
@@ -44,5 +47,12 @@ std::optional<std::vector<attention_plan>> show_craft_planning_modal(
 // auto-traveling.
 void fire_step_complete_distraction( const std::string &msg,
                                      const item_location &loc );
+
+// Wakeup hooks for in-progress craft items.  Called by item_wakeup
+// dispatchers when the item is a craft.
+std::vector<desired_wakeup> craft_enumerate_scheduled_wakeups(
+    const item &craft, const item_location &loc );
+void craft_actualize_scheduled( item &craft, item_wakeup_kind kind,
+                                time_point now, const item_location &loc );
 
 #endif // CATA_SRC_CRAFTING_H

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -4,10 +4,12 @@
 
 #include <list>
 #include <optional>
+#include <string>
 #include <vector>
 
 class Character;
 class item;
+class item_location;
 class recipe;
 struct attention_plan;
 template <typename E> struct enum_traits;
@@ -35,5 +37,12 @@ void drop_or_handle( const item &newit, Character &p );
 std::optional<std::vector<attention_plan>> show_craft_planning_modal(
         const recipe &rec, const Character &crafter, int batch,
         const std::vector<attention_plan> &existing );
+
+// Interrupts the avatar's current activity with a craft_step_complete
+// distraction.  Suppresses if the avatar is already engaged on this same
+// craft.  Falls back to a log message if the avatar is idle and not
+// auto-traveling.
+void fire_step_complete_distraction( const std::string &msg,
+                                     const item_location &loc );
 
 #endif // CATA_SRC_CRAFTING_H

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -3,9 +3,13 @@
 #define CATA_SRC_CRAFTING_H
 
 #include <list>
+#include <optional>
+#include <vector>
 
 class Character;
 class item;
+class recipe;
+struct attention_plan;
 template <typename E> struct enum_traits;
 
 enum class craft_flags : int {
@@ -25,4 +29,11 @@ void remove_ammo( item &dis_item, Character &p );
 void remove_ammo( std::list<item> &dis_items, Character &p );
 
 void drop_or_handle( const item &newit, Character &p );
+
+// Asks the avatar what to do at each attention step.  Returns nullopt if the
+// avatar cancelled.  `existing` pre-fills choices on resume.
+std::optional<std::vector<attention_plan>> show_craft_planning_modal(
+        const recipe &rec, const Character &crafter, int batch,
+        const std::vector<attention_plan> &existing );
+
 #endif // CATA_SRC_CRAFTING_H

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -35,17 +35,19 @@ void remove_ammo( std::list<item> &dis_items, Character &p );
 
 void drop_or_handle( const item &newit, Character &p );
 
-// Asks the avatar what to do at each attention step.  Returns nullopt if the
-// avatar cancelled.  `existing` pre-fills choices on resume.
+// Asks the avatar what to do at each remaining unattended step (skipping
+// any step before `from_step`).  Returns nullopt if the avatar cancelled.
+// `existing` pre-fills choices on resume.
 std::optional<std::vector<attention_plan>> show_craft_planning_modal(
-        const recipe &rec, const Character &crafter, int batch,
+        const recipe &rec, const Character &crafter, int batch, int from_step,
         const std::vector<attention_plan> &existing );
 
 // Interrupts the avatar's current activity with a craft_step_complete
-// distraction.  Suppresses if the avatar is already engaged on this same
-// craft.  Falls back to a log message if the avatar is idle and not
-// auto-traveling.
-void fire_step_complete_distraction( const std::string &msg,
+// distraction when the avatar can read time; falls back to a vague flavor
+// message otherwise.  Suppresses entirely if the avatar is already engaged
+// on this same craft.
+void fire_step_complete_distraction( const std::string &interrupt_msg,
+                                     const std::string &no_watch_msg,
                                      const item_location &loc );
 
 // Wakeup hooks for in-progress craft items.  Called by item_wakeup
@@ -53,6 +55,25 @@ void fire_step_complete_distraction( const std::string &msg,
 std::vector<desired_wakeup> craft_enumerate_scheduled_wakeups(
     const item &craft, const item_location &loc );
 void craft_actualize_scheduled( item &craft, item_wakeup_kind kind,
+                                time_point now, const item_location &loc );
+
+// Inline ready-transition for past-due passive steps: when the wakeup did not
+// dispatch (off-bubble drop, save reload, same-turn race), this advances the
+// step or finalizes the craft so callers do not see stale current_step.
+// No-op when not in a passive step or when ready_at is still in the future.
+void craft_resolve_overdue_passive( item &craft, time_point now, item_location &loc );
+
+// Re-arms or clears alarm_at on an already-entered passive step when the
+// player has just edited that step's plan via the resume modal.  Without
+// this, switching to or away from set_timer mid-step has no effect.
+void craft_apply_resume_replan( item_location &loc );
+
+// Stamps passive-step runtime state (passive_started_at, ready_at, alarm_at,
+// fail_at, counter bounds) on a craft sitting at the start of an unattended
+// step, then rebuilds wakeups.  Called from the actor's first-entry path and
+// from craft_resolve_overdue_passive when chaining through consecutive
+// unattended steps.
+void craft_stamp_passive_entry( item &craft, const Character &crafter,
                                 time_point now, const item_location &loc );
 
 #endif // CATA_SRC_CRAFTING_H

--- a/src/crafting_enums.h
+++ b/src/crafting_enums.h
@@ -1,0 +1,27 @@
+#pragma once
+#ifndef CATA_SRC_CRAFTING_ENUMS_H
+#define CATA_SRC_CRAFTING_ENUMS_H
+
+#include <optional>
+
+#include "calendar.h"
+
+enum class step_attention : int {
+    none = 0,
+    unattended,
+    supervised,
+};
+
+enum class step_choice : int {
+    do_wait = 0,
+    do_something,
+    set_timer,
+};
+
+// Per-step choice from the planning modal.
+struct attention_plan {
+    step_choice choice = step_choice::do_wait;
+    std::optional<time_duration> alarm_offset;
+};
+
+#endif // CATA_SRC_CRAFTING_ENUMS_H

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -28,6 +28,7 @@
 #include "character_id.h"
 #include "color.h"
 #include "crafting.h"
+#include "crafting_enums.h"
 #include "crafting_gui_helpers.h"
 #include "display.h"
 #include "flag.h"
@@ -1364,6 +1365,11 @@ void crafting_ui_impl::draw_recipe_info_panel()
                         ImGui::SameLine( 0, ImGui::CalcTextSize( "  " ).x );
                         ImGui::TextColored( cataimgui::imvec4_from_color( act_col ), "%s",
                                             activity.c_str() );
+                        if( step.attention == step_attention::unattended ) {
+                            ImGui::SameLine( 0, ImGui::CalcTextSize( "  " ).x );
+                            ImGui::TextColored( cataimgui::imvec4_from_color( c_yellow ),
+                                                "%s", _( "[unattended]" ) );
+                        }
 
                         ImGui::Indent( step_indent );
 

--- a/src/distraction_manager.cpp
+++ b/src/distraction_manager.cpp
@@ -42,6 +42,7 @@ static const std::vector<configurable_distraction> &get_configurable_distraction
         {&uistate.distraction_mutation,        translate_marker( "Mutation" ),                     translate_marker( "This distraction will interrupt your activity when you gain or lose a mutation." )},
         {&uistate.distraction_oxygen,          translate_marker( "Asphyxiation" ),                 translate_marker( "This distraction will interrupt your activity when you can't breathe." )},
         {&uistate.distraction_withdrawal,      translate_marker( "Withdrawal" ),                  translate_marker( "This distraction will interrupt your activity when you have withdrawals." )},
+        {&uistate.distraction_craft_step_complete, translate_marker( "Craft step complete" ),      translate_marker( "This distraction will interrupt your activity when an unattended crafting step completes." )},
         {&uistate.distraction_all,             translate_marker( "Toggle all" ),                   translate_marker( "Toggle all distractions" ), true }
     };
     return configurable_distractions;
@@ -157,6 +158,7 @@ void distraction_manager_gui::show()
                 uistate.distraction_mutation = toggle_state;
                 uistate.distraction_oxygen = toggle_state;
                 uistate.distraction_withdrawal = toggle_state;
+                uistate.distraction_craft_step_complete = toggle_state;
             }
         }
     }

--- a/src/enums.h
+++ b/src/enums.h
@@ -353,6 +353,7 @@ enum class distraction_type : int {
     mutation,
     oxygen,
     withdrawal,
+    craft_step_complete,
     last,
 };
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -7434,17 +7434,22 @@ void iexamine::workbench_internal( Character &you, const tripoint_bub_ms &examp,
             if( selected_craft->typeId() == itype_disassembly ) {
                 you.disassemble( crafts[amenu2.ret], true );
             } else {
+                craft_resolve_overdue_passive( *selected_craft, calendar::turn, crafts[amenu2.ret] );
+                if( !crafts[amenu2.ret] || !crafts[amenu2.ret].get_item() ) {
+                    break;
+                }
+                selected_craft = crafts[amenu2.ret].get_item();
                 const recipe &rec = selected_craft->get_making();
-                if( rec.has_attention_steps() && you.is_avatar() ) {
-                    std::optional<std::vector<attention_plan>> chosen =
-                            show_craft_planning_modal( rec, you,
-                                                       selected_craft->get_making_batch_size(),
-                                                       selected_craft->get_step_plans() );
+                std::optional<std::vector<attention_plan>> chosen;
+                if( rec.has_remaining_attention_steps( selected_craft->get_current_step() )
+                    && you.is_avatar() ) {
+                    chosen = show_craft_planning_modal( rec, you,
+                                                        selected_craft->get_making_batch_size(),
+                                                        selected_craft->get_current_step(),
+                                                        selected_craft->get_step_plans() );
                     if( !chosen ) {
                         break;
                     }
-                    selected_craft->set_step_plans( std::move( *chosen ) );
-                    selected_craft->set_crafter_id( you.getID() );
                 }
                 if( !you.can_continue_craft( *selected_craft ) ) {
                     break;
@@ -7455,6 +7460,11 @@ void iexamine::workbench_internal( Character &you, const tripoint_bub_ms &examp,
                         _( "<npcname> doesn't know the recipe for the %s and can't continue crafting." ),
                         rec.result_name() );
                     break;
+                }
+                if( chosen ) {
+                    selected_craft->set_step_plans( std::move( *chosen ) );
+                    selected_craft->set_crafter_id( you.getID() );
+                    craft_apply_resume_replan( crafts[amenu2.ret] );
                 }
                 you.add_msg_player_or_npc(
                     pgettext( "in progress craft", "You start working on the %s." ),

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -28,6 +28,8 @@
 #include "construction_group.h"
 #include "coordinates.h"
 #include "craft_command.h"
+#include "crafting.h"
+#include "crafting_enums.h"
 #include "creature.h"
 #include "creature_tracker.h"
 #include "cursesdef.h"
@@ -7432,10 +7434,21 @@ void iexamine::workbench_internal( Character &you, const tripoint_bub_ms &examp,
             if( selected_craft->typeId() == itype_disassembly ) {
                 you.disassemble( crafts[amenu2.ret], true );
             } else {
+                const recipe &rec = selected_craft->get_making();
+                if( rec.has_attention_steps() && you.is_avatar() ) {
+                    std::optional<std::vector<attention_plan>> chosen =
+                            show_craft_planning_modal( rec, you,
+                                                       selected_craft->get_making_batch_size(),
+                                                       selected_craft->get_step_plans() );
+                    if( !chosen ) {
+                        break;
+                    }
+                    selected_craft->set_step_plans( std::move( *chosen ) );
+                    selected_craft->set_crafter_id( you.getID() );
+                }
                 if( !you.can_continue_craft( *selected_craft ) ) {
                     break;
                 }
-                const recipe &rec = selected_craft->get_making();
                 if( !you.has_recipe( &rec ) ) {
                     you.add_msg_player_or_npc(
                         _( "You don't know the recipe for the %s and can't continue crafting." ),

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -421,6 +421,7 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "distraction_mutation", distraction_mutation );
     json.member( "distraction_oxygen", distraction_oxygen );
     json.member( "distraction_withdrawal", distraction_withdrawal );
+    json.member( "distraction_craft_step_complete", distraction_craft_step_complete );
     json.member( "numpad_navigation", numpad_navigation );
 
     json.member( "overmap_sidebar_uistate" );
@@ -513,6 +514,7 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "distraction_mutation", distraction_mutation );
     jo.read( "distraction_oxygen", distraction_oxygen );
     jo.read( "distraction_withdrawal", distraction_withdrawal );
+    jo.read( "distraction_craft_step_complete", distraction_craft_step_complete );
     jo.read( "numpad_navigation", numpad_navigation );
     jo.read( "vmenu_tab", vmenu_tab );
     jo.read( "vmenu_item_sort", vmenu_item_sort );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5275,6 +5275,30 @@ void item::set_crafter_id( character_id id )
     craft_data_->crafter_id = id;
 }
 
+int item::get_passive_start_counter() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->passive_start_counter;
+}
+
+void item::set_passive_start_counter( int c )
+{
+    cata_assert( craft_data_ );
+    craft_data_->passive_start_counter = c;
+}
+
+int item::get_passive_end_counter() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->passive_end_counter;
+}
+
+void item::set_passive_end_counter( int c )
+{
+    cata_assert( craft_data_ );
+    craft_data_->passive_end_counter = c;
+}
+
 const cata::value_ptr<islot_comestible> &item::get_comestible() const
 {
     if( is_craft() && !craft_data_->disassembly ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5155,6 +5155,126 @@ void item::mod_step_progress( double delta )
     craft_data_->step_progress += delta;
 }
 
+const std::vector<attention_plan> &item::get_step_plans() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->step_plans;
+}
+
+void item::set_step_plans( std::vector<attention_plan> plans )
+{
+    cata_assert( craft_data_ );
+    craft_data_->step_plans = std::move( plans );
+}
+
+time_point item::get_passive_started_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->passive_started_at;
+}
+
+void item::set_passive_started_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->passive_started_at = t;
+}
+
+time_point item::get_ready_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->ready_at;
+}
+
+void item::set_ready_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->ready_at = t;
+}
+
+time_point item::get_alarm_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->alarm_at;
+}
+
+void item::set_alarm_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->alarm_at = t;
+}
+
+time_point item::get_fail_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->fail_at;
+}
+
+void item::set_fail_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->fail_at = t;
+}
+
+time_point item::get_pause_started_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->pause_started_at;
+}
+
+void item::set_pause_started_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->pause_started_at = t;
+}
+
+time_point item::get_saved_ready_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->saved_ready_at;
+}
+
+void item::set_saved_ready_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->saved_ready_at = t;
+}
+
+time_point item::get_saved_alarm_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->saved_alarm_at;
+}
+
+void item::set_saved_alarm_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->saved_alarm_at = t;
+}
+
+time_point item::get_saved_fail_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->saved_fail_at;
+}
+
+void item::set_saved_fail_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->saved_fail_at = t;
+}
+
+character_id item::get_crafter_id() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->crafter_id;
+}
+
+void item::set_crafter_id( character_id id )
+{
+    cata_assert( craft_data_ );
+    craft_data_->crafter_id = id;
+}
+
 const cata::value_ptr<islot_comestible> &item::get_comestible() const
 {
     if( is_craft() && !craft_data_->disassembly ) {

--- a/src/item.h
+++ b/src/item.h
@@ -3268,6 +3268,11 @@ class item : public visitable
         character_id get_crafter_id() const;
         void set_crafter_id( character_id id );
 
+        int get_passive_start_counter() const;
+        void set_passive_start_counter( int c );
+        int get_passive_end_counter() const;
+        void set_passive_end_counter( int c );
+
         std::vector<enchant_cache> get_proc_enchantments() const;
         std::vector<enchantment> get_defined_enchantments() const;
         // calculates the enchantment value as if this item were wielded.
@@ -3560,6 +3565,11 @@ class item : public visitable
                 time_point saved_ready_at = calendar::before_time_starts;
                 time_point saved_alarm_at = calendar::before_time_starts;
                 time_point saved_fail_at  = calendar::before_time_starts;
+
+                // Counter bounds snapshotted at passive-step entry; item_tname
+                // projects linearly between them without mutation.
+                int passive_start_counter = 0;
+                int passive_end_counter = 0;
 
                 // Original crafter (for env-check fallback when craft is on
                 // map/vehicle and the crafter is no longer on top of it).

--- a/src/item.h
+++ b/src/item.h
@@ -19,8 +19,10 @@
 #include "calendar.h"
 #include "cata_lazy.h"
 #include "cata_utility.h"
+#include "character_id.h"
 #include "coordinates.h"
 #include "craft_command.h"
+#include "crafting_enums.h"
 #include "enums.h"
 #include "flat_set.h"
 #include "global_vars.h"
@@ -3241,6 +3243,31 @@ class item : public visitable
         void set_step_progress( double progress );
         void mod_step_progress( double delta );
 
+        // Per-step plan from the craft planning modal.
+        const std::vector<attention_plan> &get_step_plans() const;
+        void set_step_plans( std::vector<attention_plan> plans );
+
+        // Calendar tracking for the active passive step.
+        time_point get_passive_started_at() const;
+        void set_passive_started_at( time_point t );
+        time_point get_ready_at() const;
+        void set_ready_at( time_point t );
+        time_point get_alarm_at() const;
+        void set_alarm_at( time_point t );
+        time_point get_fail_at() const;
+        void set_fail_at( time_point t );
+        time_point get_pause_started_at() const;
+        void set_pause_started_at( time_point t );
+        time_point get_saved_ready_at() const;
+        void set_saved_ready_at( time_point t );
+        time_point get_saved_alarm_at() const;
+        void set_saved_alarm_at( time_point t );
+        time_point get_saved_fail_at() const;
+        void set_saved_fail_at( time_point t );
+
+        character_id get_crafter_id() const;
+        void set_crafter_id( character_id id );
+
         std::vector<enchant_cache> get_proc_enchantments() const;
         std::vector<enchantment> get_defined_enchantments() const;
         // calculates the enchantment value as if this item were wielded.
@@ -3515,6 +3542,28 @@ class item : public visitable
                 // Authoritative: advanced by tracking consumed work against step budgets.
                 int current_step = 0;
                 double step_progress = 0.0; // base-speed moves consumed within current step
+
+                // Per-step plan from the planning modal.  Aligned with recipe steps_.
+                std::vector<attention_plan> step_plans;
+
+                // Calendar tracking for the active passive step.
+                // before_time_starts when no passive step is in flight.
+                time_point passive_started_at = calendar::before_time_starts;
+                time_point ready_at  = calendar::before_time_starts;
+                time_point alarm_at  = calendar::before_time_starts;
+                time_point fail_at   = calendar::before_time_starts;
+                // While paused, ready_at is the polling cursor; saved_* park
+                // the originals for restoration on unpause (slid by paused
+                // duration).  Without saving ready_at too, multiple pause
+                // polls would mutate it and lose the original deadline.
+                time_point pause_started_at = calendar::before_time_starts;
+                time_point saved_ready_at = calendar::before_time_starts;
+                time_point saved_alarm_at = calendar::before_time_starts;
+                time_point saved_fail_at  = calendar::before_time_starts;
+
+                // Original crafter (for env-check fallback when craft is on
+                // map/vehicle and the crafter is no longer on top of it).
+                character_id crafter_id;
 
                 // if this is an in progress disassembly as opposed to craft
                 bool disassembly = false;

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -225,7 +225,30 @@ std::string craft( item const &it, unsigned int /* quantity */,
         if( it.charges > 1 ) {
             maintext += string_format( " (%d)", it.charges );
         }
-        const int percent_progress = it.item_counter / 100000;
+        int effective_counter = it.item_counter;
+        const time_point pstart = it.get_passive_started_at();
+        const time_point saved_ready = it.get_saved_ready_at();
+        const time_point ready = saved_ready != calendar::before_time_starts
+                                 ? saved_ready : it.get_ready_at();
+        const int start_counter = it.get_passive_start_counter();
+        const int end_counter = it.get_passive_end_counter();
+        if( pstart != calendar::before_time_starts && ready > pstart && end_counter > start_counter ) {
+            const time_duration step_dur = ready - pstart;
+            time_duration elapsed = calendar::turn - pstart;
+            if( elapsed < 0_seconds ) {
+                elapsed = 0_seconds;
+            }
+            if( elapsed > step_dur ) {
+                elapsed = step_dur;
+            }
+            const int64_t step_dur_moves = std::max( static_cast<int64_t>( 1 ),
+                                           to_moves<int64_t>( step_dur ) );
+            const double fraction = static_cast<double>( to_moves<int64_t>( elapsed ) ) / step_dur_moves;
+            const int projected = static_cast<int>( std::round( start_counter +
+                                                    fraction * ( end_counter - start_counter ) ) );
+            effective_counter = std::max( effective_counter, projected );
+        }
+        const int percent_progress = effective_counter / 100000;
         return string_format( "%s (%d%%)", maintext, percent_progress );
     }
     return {};

--- a/src/item_wakeup.cpp
+++ b/src/item_wakeup.cpp
@@ -9,6 +9,7 @@
 #include "cata_assert.h"
 #include "character.h"
 #include "character_id.h"
+#include "crafting.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
 #include "item.h"
@@ -201,6 +202,9 @@ void clear_test_enumerate_handlers()
 std::vector<desired_wakeup> enumerate_scheduled_dispatch( const item &it,
         const item_location &loc )
 {
+    if( it.is_craft() ) {
+        return craft_enumerate_scheduled_wakeups( it, loc );
+    }
     const std::map<itype_id, item_wakeup_test_enumerator> &reg = test_enumerator_registry();
     const auto entry = reg.find( it.typeId() );
     if( entry != reg.end() ) {
@@ -213,6 +217,10 @@ std::vector<desired_wakeup> enumerate_scheduled_dispatch( const item &it,
 static void dispatch_actualize( item &it, item_wakeup_kind kind, time_point now,
                                 const item_location &loc )
 {
+    if( it.is_craft() ) {
+        craft_actualize_scheduled( it, kind, now, loc );
+        return;
+    }
     const std::map<itype_id, item_wakeup_test_handler> &reg = test_handler_registry();
     const auto it_handler = reg.find( it.typeId() );
     if( it_handler != reg.end() ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -39,6 +39,8 @@
 #include "color.h"
 #include "construction.h"
 #include "coordinates.h"
+#include "crafting.h"
+#include "crafting_enums.h"
 #include "creature.h"
 #include "creature_tracker.h"
 #include "cuboid_rectangle.h"
@@ -8829,10 +8831,20 @@ std::optional<int> iuse::craft( Character *p, item *it, const tripoint_bub_ms & 
         return std::nullopt;
     }
 
+    const recipe &rec = it->get_making();
+    if( rec.has_attention_steps() && p->is_avatar() ) {
+        std::optional<std::vector<attention_plan>> chosen =
+                show_craft_planning_modal( rec, *p, it->get_making_batch_size(),
+                                           it->get_step_plans() );
+        if( !chosen ) {
+            return std::nullopt;
+        }
+        it->set_step_plans( std::move( *chosen ) );
+        it->set_crafter_id( p->getID() );
+    }
     if( !p->can_continue_craft( *it ) ) {
         return std::nullopt;
     }
-    const recipe &rec = it->get_making();
     if( !p->has_recipe( &rec ) ) {
         p->add_msg_player_or_npc(
             _( "You don't know the recipe for the %s and can't continue crafting." ),

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8831,16 +8831,21 @@ std::optional<int> iuse::craft( Character *p, item *it, const tripoint_bub_ms & 
         return std::nullopt;
     }
 
+    item_location craft_loc( *p, it );
+    craft_resolve_overdue_passive( *it, calendar::turn, craft_loc );
+    if( !craft_loc || !craft_loc.get_item() ) {
+        return std::nullopt;
+    }
+    it = craft_loc.get_item();
     const recipe &rec = it->get_making();
-    if( rec.has_attention_steps() && p->is_avatar() ) {
-        std::optional<std::vector<attention_plan>> chosen =
-                show_craft_planning_modal( rec, *p, it->get_making_batch_size(),
-                                           it->get_step_plans() );
+    std::optional<std::vector<attention_plan>> chosen;
+    if( rec.has_remaining_attention_steps( it->get_current_step() ) && p->is_avatar() ) {
+        chosen = show_craft_planning_modal( rec, *p, it->get_making_batch_size(),
+                                            it->get_current_step(),
+                                            it->get_step_plans() );
         if( !chosen ) {
             return std::nullopt;
         }
-        it->set_step_plans( std::move( *chosen ) );
-        it->set_crafter_id( p->getID() );
     }
     if( !p->can_continue_craft( *it ) ) {
         return std::nullopt;
@@ -8852,10 +8857,14 @@ std::optional<int> iuse::craft( Character *p, item *it, const tripoint_bub_ms & 
             rec.result_name() );
         return 0;
     }
+    if( chosen ) {
+        it->set_step_plans( std::move( *chosen ) );
+        it->set_crafter_id( p->getID() );
+        craft_apply_resume_replan( craft_loc );
+    }
     p->add_msg_player_or_npc(
         pgettext( "in progress craft", "You start working on the %s." ),
         pgettext( "in progress craft", "<npcname> starts working on the %s." ), craft_name );
-    item_location craft_loc = item_location( *p, it );
     p->assign_activity( craft_activity_actor( craft_loc, false ) );
 
     return 0;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8691,6 +8691,19 @@ void map::reconcile_item_wakeups()
             }
         }
     }
+
+    auto walk_character = [&wakeups]( Character & c ) {
+        // all_items_loc() is already recursive; rebuild per location directly.
+        for( item_location &loc : c.all_items_loc() ) {
+            if( loc && loc.get_item() != nullptr ) {
+                wakeups.rebuild_for_item( loc );
+            }
+        }
+    };
+    walk_character( get_avatar() );
+    for( npc &n : g->all_npcs() ) {
+        walk_character( n );
+    }
 }
 
 void map::shift_traps( const point_rel_sm &shift )

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1927,6 +1927,19 @@ bool recipe::has_attention_steps() const
     return false;
 }
 
+bool recipe::has_remaining_attention_steps( int from_step ) const
+{
+    if( from_step < 0 ) {
+        from_step = 0;
+    }
+    for( int i = from_step; i < static_cast<int>( steps_.size() ); ++i ) {
+        if( steps_[i].attention != step_attention::none ) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool recipe::is_practice() const
 {
     return practice_data.has_value();

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1495,11 +1495,15 @@ float recipe::proficiency_time_maluses_for_step(
 }
 
 double recipe::step_budget_moves( const Character &guy, size_t step_idx, int batch,
-                                  const crafting_cost_context &ctx ) const
+                                  const crafting_cost_context &ctx,
+                                  recipe_time_flag flags ) const
 {
     cata_assert( step_idx < steps_.size() );
     const recipe_step &s = steps_[step_idx];
-    double t = s.time * proficiency_time_maluses_for_step( guy, s, ctx.books );
+    double t = s.time;
+    if( ( flags & recipe_time_flag::ignore_proficiencies ) != recipe_time_flag::ignore_proficiencies ) {
+        t *= proficiency_time_maluses_for_step( guy, s, ctx.books );
+    }
     if( step_idx < ctx.tool_speeds.size() ) {
         t *= ctx.tool_speeds[step_idx];
     }

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -658,6 +658,37 @@ void recipe_step::load( const JsonObject &jo, const std::string &recipe_name, in
                                       + std::to_string( step_index ) );
     requirement_data::load_requirement( jo, step_req_id, false, false );
     reqs_internal.emplace_back( step_req_id, 1 );
+
+    if( jo.has_member( "attention" ) ) {
+        const std::string s = jo.get_string( "attention" );
+        if( s == "none" ) {
+            attention = step_attention::none;
+        } else if( s == "unattended" ) {
+            attention = step_attention::unattended;
+        } else if( s == "supervised" ) {
+            jo.throw_error( "supervised attention not yet supported" );
+        } else {
+            jo.throw_error( "invalid value for \"attention\": " + s );
+        }
+    }
+
+    if( jo.has_member( "max_time" ) ) {
+        time_duration d;
+        mandatory( jo, false, "max_time", d );
+        if( d <= time_duration::from_moves( time ) ) {
+            jo.throw_error( "max_time must exceed step time" );
+        }
+        max_time = d;
+    }
+    if( jo.has_member( "grace_period" ) ) {
+        if( !max_time.has_value() ) {
+            jo.throw_error( "grace_period requires max_time" );
+        }
+        time_duration d;
+        mandatory( jo, false, "grace_period", d );
+        grace_period = d;
+    }
+    optional( jo, false, "unattend_message", unattend_message );
 }
 
 static cata::value_ptr<parameterized_build_reqs> calculate_all_blueprint_reqs(
@@ -820,6 +851,20 @@ void recipe::finalize()
             step.requirements = std::accumulate(
                                     step.reqs_internal.begin(), step.reqs_internal.end(),
                                     step.requirements );
+            // TODO: charged-tool consumption is not modeled on unattended steps
+            // (the active 5%-loop debit path is bypassed).  Reject after
+            // requirements are fully resolved so step-level "using" injections
+            // are also caught.  Lift once metered charge debit is implemented.
+            if( step.attention == step_attention::unattended ) {
+                for( const std::vector<tool_comp> &tool_group : step.requirements.get_tools() ) {
+                    for( const tool_comp &t : tool_group ) {
+                        if( t.by_charges() ) {
+                            debugmsg( "recipe %s step '%s' is unattended and cannot require charged tools yet",
+                                      ident().str(), step.name.translated() );
+                        }
+                    }
+                }
+            }
             // Merge step requirements into recipe-level for whole-recipe gating
             requirements_ = requirements_ + step.requirements;
             step.reqs_external.clear();
@@ -1866,6 +1911,16 @@ void recipe::apply_positive_morale_mods( Character &guy ) const
 bool recipe::npc_can_craft( std::string & ) const
 {
     return true;
+}
+
+bool recipe::has_attention_steps() const
+{
+    for( const recipe_step &s : steps_ ) {
+        if( s.attention != step_attention::none ) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool recipe::is_practice() const

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -16,6 +16,7 @@
 
 #include "build_reqs.h"
 #include "calendar.h"
+#include "crafting_enums.h"
 #include "proficiency.h"
 #include "requirements.h"
 #include "translation.h"
@@ -125,6 +126,13 @@ struct recipe_step {
     std::vector<std::pair<requirement_id, int>> reqs_external;
     // Populated during finalize from reqs_internal + reqs_external
     requirement_data requirements;
+
+    step_attention attention = step_attention::none;
+    // nullopt = step waits indefinitely.
+    std::optional<time_duration> max_time;
+    // Buffer past max_time before destruction.  Requires max_time.
+    std::optional<time_duration> grace_period;
+    translation unattend_message;
 
     void load( const JsonObject &jo, const std::string &recipe_name, int step_index );
 };
@@ -316,6 +324,7 @@ class recipe
         const std::vector<recipe_step> &steps() const {
             return steps_;
         }
+        bool has_attention_steps() const;
         // Returns aggregate proficiencies for step recipes, or the legacy
         // proficiencies field for stepless recipes.  This is a conservative
         // whole-recipe approximation used for display, gating, approximate

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -339,8 +339,11 @@ class recipe
             const book_proficiency_bonuses &books );
         // Per-step time budget in base moves (with proficiency malus and batch savings).
         // Same per-step formula that batch_time() uses internally.
+        // ignore_proficiencies skips the proficiency malus (passive steps run on
+        // wall-clock independent of crafter skill).
         double step_budget_moves( const Character &guy, size_t step_idx, int batch,
-                                  const crafting_cost_context &ctx ) const;
+                                  const crafting_cost_context &ctx,
+                                  recipe_time_flag flags = recipe_time_flag::none ) const;
 
         // This is used by the basecamp bulletin board.
         std::string required_all_skills_string( const std::map<skill_id, int> & ) const;

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -325,6 +325,7 @@ class recipe
             return steps_;
         }
         bool has_attention_steps() const;
+        bool has_remaining_attention_steps( int from_step ) const;
         // Returns aggregate proficiencies for step recipes, or the legacy
         // proficiencies field for stepless recipes.  This is a conservative
         // whole-recipe approximation used for display, gating, approximate

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -55,6 +55,7 @@
 #include "construction.h"
 #include "coordinates.h"
 #include "craft_command.h"
+#include "crafting_enums.h"
 #include "creature.h"
 #include "creature_tracker.h"
 #include "damage.h"
@@ -2876,6 +2877,12 @@ void item::craft_data::serialize( JsonOut &jsout ) const
     if( crafter_id.is_valid() ) {
         jsout.member( "crafter_id", crafter_id );
     }
+    if( passive_start_counter != 0 ) {
+        jsout.member( "passive_start_counter", passive_start_counter );
+    }
+    if( passive_end_counter != 0 ) {
+        jsout.member( "passive_end_counter", passive_end_counter );
+    }
     jsout.end_object();
 }
 
@@ -2951,6 +2958,8 @@ void item::craft_data::deserialize( const JsonObject &obj )
     if( obj.has_member( "crafter_id" ) ) {
         obj.read( "crafter_id", crafter_id );
     }
+    passive_start_counter = obj.get_int( "passive_start_counter", 0 );
+    passive_end_counter = obj.get_int( "passive_end_counter", 0 );
     // Recipe-edit migration: drop stale passive runtime on shape mismatch.
     bool stale = false;
     if( making && !disassembly ) {
@@ -2959,11 +2968,12 @@ void item::craft_data::deserialize( const JsonObject &obj )
             stale = true;
         }
         if( !stale && passive_started_at != calendar::before_time_starts ) {
-            if( !making->has_steps() ) {
-                stale = true;
-            } else if( current_step >= 0
-                       && current_step < static_cast<int>( making->steps().size() )
-                       && making->steps()[current_step].attention != step_attention::unattended ) {
+            const bool no_steps = !making->has_steps();
+            const bool current_step_attended = making->has_steps()
+                                               && current_step >= 0
+                                               && current_step < static_cast<int>( making->steps().size() )
+                                               && making->steps()[current_step].attention != step_attention::unattended;
+            if( no_steps || current_step_attended ) {
                 stale = true;
             }
         }
@@ -2978,6 +2988,8 @@ void item::craft_data::deserialize( const JsonObject &obj )
         saved_ready_at = calendar::before_time_starts;
         saved_alarm_at = calendar::before_time_starts;
         saved_fail_at = calendar::before_time_starts;
+        passive_start_counter = 0;
+        passive_end_counter = 0;
     }
 }
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2800,6 +2800,30 @@ void time_duration::deserialize( const JsonValue &jsin )
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ///// item.h
 
+static const char *step_choice_to_string( step_choice c )
+{
+    switch( c ) {
+        case step_choice::do_wait:
+            return "do_wait";
+        case step_choice::do_something:
+            return "do_something";
+        case step_choice::set_timer:
+            return "set_timer";
+    }
+    return "do_wait";
+}
+
+static step_choice step_choice_from_string( const std::string &s )
+{
+    if( s == "do_something" ) {
+        return step_choice::do_something;
+    }
+    if( s == "set_timer" ) {
+        return step_choice::set_timer;
+    }
+    return step_choice::do_wait;
+}
+
 void item::craft_data::serialize( JsonOut &jsout ) const
 {
     jsout.start_object();
@@ -2812,6 +2836,46 @@ void item::craft_data::serialize( JsonOut &jsout ) const
     jsout.member( "cached_tool_selections", cached_tool_selections );
     jsout.member( "current_step", current_step );
     jsout.member( "step_progress", step_progress );
+    if( !step_plans.empty() ) {
+        jsout.member( "step_plans" );
+        jsout.start_array();
+        for( const attention_plan &p : step_plans ) {
+            jsout.start_object();
+            jsout.member( "choice", step_choice_to_string( p.choice ) );
+            if( p.alarm_offset.has_value() ) {
+                jsout.member( "alarm_offset", *p.alarm_offset );
+            }
+            jsout.end_object();
+        }
+        jsout.end_array();
+    }
+    if( passive_started_at != calendar::before_time_starts ) {
+        jsout.member( "passive_started_at", passive_started_at );
+    }
+    if( ready_at != calendar::before_time_starts ) {
+        jsout.member( "ready_at", ready_at );
+    }
+    if( alarm_at != calendar::before_time_starts ) {
+        jsout.member( "alarm_at", alarm_at );
+    }
+    if( fail_at != calendar::before_time_starts ) {
+        jsout.member( "fail_at", fail_at );
+    }
+    if( pause_started_at != calendar::before_time_starts ) {
+        jsout.member( "pause_started_at", pause_started_at );
+    }
+    if( saved_ready_at != calendar::before_time_starts ) {
+        jsout.member( "saved_ready_at", saved_ready_at );
+    }
+    if( saved_alarm_at != calendar::before_time_starts ) {
+        jsout.member( "saved_alarm_at", saved_alarm_at );
+    }
+    if( saved_fail_at != calendar::before_time_starts ) {
+        jsout.member( "saved_fail_at", saved_fail_at );
+    }
+    if( crafter_id.is_valid() ) {
+        jsout.member( "crafter_id", crafter_id );
+    }
     jsout.end_object();
 }
 
@@ -2845,6 +2909,75 @@ void item::craft_data::deserialize( const JsonObject &obj )
     } else {
         current_step = 0;
         step_progress = 0.0;
+    }
+    step_plans.clear();
+    if( obj.has_array( "step_plans" ) ) {
+        for( JsonObject row : obj.get_array( "step_plans" ) ) {
+            row.allow_omitted_members();
+            attention_plan p;
+            p.choice = step_choice_from_string( row.get_string( "choice", "do_wait" ) );
+            if( row.has_member( "alarm_offset" ) ) {
+                time_duration d;
+                row.read( "alarm_offset", d );
+                p.alarm_offset = d;
+            }
+            step_plans.push_back( p );
+        }
+    }
+    if( obj.has_member( "passive_started_at" ) ) {
+        obj.read( "passive_started_at", passive_started_at );
+    }
+    if( obj.has_member( "ready_at" ) ) {
+        obj.read( "ready_at", ready_at );
+    }
+    if( obj.has_member( "alarm_at" ) ) {
+        obj.read( "alarm_at", alarm_at );
+    }
+    if( obj.has_member( "fail_at" ) ) {
+        obj.read( "fail_at", fail_at );
+    }
+    if( obj.has_member( "pause_started_at" ) ) {
+        obj.read( "pause_started_at", pause_started_at );
+    }
+    if( obj.has_member( "saved_ready_at" ) ) {
+        obj.read( "saved_ready_at", saved_ready_at );
+    }
+    if( obj.has_member( "saved_alarm_at" ) ) {
+        obj.read( "saved_alarm_at", saved_alarm_at );
+    }
+    if( obj.has_member( "saved_fail_at" ) ) {
+        obj.read( "saved_fail_at", saved_fail_at );
+    }
+    if( obj.has_member( "crafter_id" ) ) {
+        obj.read( "crafter_id", crafter_id );
+    }
+    // Recipe-edit migration: drop stale passive runtime on shape mismatch.
+    bool stale = false;
+    if( making && !disassembly ) {
+        if( !step_plans.empty() && making->has_steps() &&
+            step_plans.size() != making->steps().size() ) {
+            stale = true;
+        }
+        if( !stale && passive_started_at != calendar::before_time_starts ) {
+            if( !making->has_steps() ) {
+                stale = true;
+            } else if( current_step >= 0
+                       && current_step < static_cast<int>( making->steps().size() )
+                       && making->steps()[current_step].attention != step_attention::unattended ) {
+                stale = true;
+            }
+        }
+    }
+    if( stale ) {
+        step_plans.clear();
+        passive_started_at = calendar::before_time_starts;
+        ready_at = calendar::before_time_starts;
+        alarm_at = calendar::before_time_starts;
+        fail_at = calendar::before_time_starts;
+        pause_started_at = calendar::before_time_starts;
+        saved_ready_at = calendar::before_time_starts;
+        saved_alarm_at = calendar::before_time_starts;
+        saved_fail_at = calendar::before_time_starts;
     }
 }
 

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -230,6 +230,7 @@ class uistatedata
         bool distraction_mutation = true;
         bool distraction_oxygen = true;
         bool distraction_withdrawal = true;
+        bool distraction_craft_step_complete = true;
         bool distraction_all = true; // NOLINT(cata-serialize)
         bool numpad_navigation = false;
 

--- a/tests/craft_attention_test.cpp
+++ b/tests/craft_attention_test.cpp
@@ -1,0 +1,490 @@
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "avatar.h"
+#include "calendar.h"
+#include "cata_catch.h"
+#include "character_id.h"
+#include "coordinates.h"
+#include "crafting.h"
+#include "crafting_enums.h"
+#include "flexbuffer_json.h"
+#include "item.h"
+#include "item_components.h"
+#include "item_location.h"
+#include "json.h"
+#include "json_loader.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "map_selector.h"
+#include "point.h"
+#include "recipe.h"
+#include "requirements.h"
+#include "type_id.h"
+
+static const itype_id itype_2x4( "2x4" );
+
+static const recipe_id recipe_cudgel_test_consecutive_unattended(
+    "cudgel_test_consecutive_unattended" );
+static const recipe_id recipe_cudgel_test_first_step_unattended(
+    "cudgel_test_first_step_unattended" );
+static const recipe_id recipe_cudgel_test_only_unattended(
+    "cudgel_test_only_unattended" );
+static const recipe_id recipe_cudgel_test_steps_basic(
+    "cudgel_test_steps_basic" );
+static const recipe_id recipe_cudgel_test_timeout_recipe(
+    "cudgel_test_timeout_recipe" );
+static const recipe_id recipe_cudgel_test_unattended_simple(
+    "cudgel_test_unattended_simple" );
+static const recipe_id recipe_cudgel_test_unattended_with_qual(
+    "cudgel_test_unattended_with_qual" );
+
+TEST_CASE( "attention_recipe_loads_attention_field", "[craft][attention][schema]" )
+{
+    const recipe &r = recipe_cudgel_test_unattended_simple.obj();
+    REQUIRE( r.has_steps() );
+    const std::vector<recipe_step> &steps = r.steps();
+    REQUIRE( steps.size() == 2 );
+    CHECK( steps[0].attention == step_attention::none );
+    CHECK( steps[1].attention == step_attention::unattended );
+}
+
+TEST_CASE( "attention_recipe_loads_max_time_and_grace_period",
+           "[craft][attention][schema]" )
+{
+    const recipe &r = recipe_cudgel_test_timeout_recipe.obj();
+    const recipe_step &cure = r.steps().back();
+    REQUIRE( cure.attention == step_attention::unattended );
+    REQUIRE( cure.max_time.has_value() );
+    CHECK( *cure.max_time == 20_minutes );
+    REQUIRE( cure.grace_period.has_value() );
+    CHECK( *cure.grace_period == 5_minutes );
+}
+
+TEST_CASE( "has_attention_steps_detects_unattended_step",
+           "[craft][attention][schema]" )
+{
+    CHECK( recipe_cudgel_test_unattended_simple.obj().has_attention_steps() );
+    CHECK( recipe_cudgel_test_first_step_unattended.obj().has_attention_steps() );
+    CHECK( recipe_cudgel_test_only_unattended.obj().has_attention_steps() );
+    CHECK_FALSE( recipe_cudgel_test_steps_basic.obj().has_attention_steps() );
+}
+
+TEST_CASE( "has_remaining_attention_steps_excludes_completed_steps",
+           "[craft][attention][schema]" )
+{
+    const recipe &r = recipe_cudgel_test_unattended_simple.obj();
+    REQUIRE( r.steps().size() == 2 );
+    CHECK( r.has_remaining_attention_steps( 0 ) );
+    CHECK( r.has_remaining_attention_steps( 1 ) );
+    CHECK_FALSE( r.has_remaining_attention_steps( 2 ) );
+}
+
+TEST_CASE( "has_remaining_attention_steps_negative_clamps_to_zero",
+           "[craft][attention][schema]" )
+{
+    const recipe &r = recipe_cudgel_test_first_step_unattended.obj();
+    CHECK( r.has_remaining_attention_steps( -5 ) );
+}
+
+TEST_CASE( "has_remaining_attention_steps_consecutive_unattended",
+           "[craft][attention][schema]" )
+{
+    const recipe &r = recipe_cudgel_test_consecutive_unattended.obj();
+    REQUIRE( r.steps().size() == 4 );
+    CHECK( r.has_remaining_attention_steps( 0 ) );
+    CHECK( r.has_remaining_attention_steps( 1 ) );
+    CHECK( r.has_remaining_attention_steps( 2 ) );
+    CHECK_FALSE( r.has_remaining_attention_steps( 3 ) );
+}
+
+TEST_CASE( "attention_recipe_with_quality_loads_quality_requirement",
+           "[craft][attention][schema]" )
+{
+    const recipe &r = recipe_cudgel_test_unattended_with_qual.obj();
+    const recipe_step &bake = r.steps().back();
+    REQUIRE( bake.attention == step_attention::unattended );
+    bool has_oven = false;
+    for( const std::vector<quality_requirement> &group : bake.requirements.get_qualities() ) {
+        for( const quality_requirement &q : group ) {
+            if( q.type.str() == "OVEN" && q.level >= 1 ) {
+                has_oven = true;
+            }
+        }
+    }
+    CHECK( has_oven );
+}
+
+TEST_CASE( "craft_data_persists_passive_counter_bounds",
+           "[craft][attention][persist]" )
+{
+    item craft( recipe_cudgel_test_unattended_simple.obj().result(), calendar::turn );
+    item ingredient( itype_2x4, calendar::turn );
+    item built( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+
+    REQUIRE( built.is_craft() );
+    built.set_passive_started_at( calendar::turn );
+    built.set_ready_at( calendar::turn + 10_minutes );
+    built.set_passive_start_counter( 3000000 );
+    built.set_passive_end_counter( 7000000 );
+
+    std::ostringstream ss;
+    JsonOut jsout( ss );
+    built.serialize( jsout );
+
+    item restored;
+    restored.deserialize( json_loader::from_string( ss.str() ).get_object() );
+
+    REQUIRE( restored.is_craft() );
+    CHECK( restored.get_passive_started_at() == calendar::turn );
+    CHECK( restored.get_ready_at() == calendar::turn + 10_minutes );
+    CHECK( restored.get_passive_start_counter() == 3000000 );
+    CHECK( restored.get_passive_end_counter() == 7000000 );
+}
+
+TEST_CASE( "craft_data_default_passive_counters_are_zero",
+           "[craft][attention][persist]" )
+{
+    item ingredient( itype_2x4, calendar::turn );
+    item built( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    REQUIRE( built.is_craft() );
+    CHECK( built.get_passive_start_counter() == 0 );
+    CHECK( built.get_passive_end_counter() == 0 );
+}
+
+TEST_CASE( "craft_data_serialize_omits_zero_passive_counters",
+           "[craft][attention][persist]" )
+{
+    item ingredient( itype_2x4, calendar::turn );
+    item built( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    REQUIRE( built.is_craft() );
+
+    std::ostringstream ss;
+    JsonOut jsout( ss );
+    built.serialize( jsout );
+    const std::string out = ss.str();
+    CHECK( out.find( "passive_start_counter" ) == std::string::npos );
+    CHECK( out.find( "passive_end_counter" ) == std::string::npos );
+}
+
+TEST_CASE( "craft_tname_projects_progress_during_passive_step",
+           "[craft][attention][display]" )
+{
+    item ingredient( itype_2x4, calendar::turn );
+    item built( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    REQUIRE( built.is_craft() );
+
+    const time_point t0 = calendar::turn;
+    built.item_counter = 1000000; // 10%
+    built.set_passive_started_at( t0 - 5_minutes );
+    built.set_ready_at( t0 + 5_minutes );
+    built.set_passive_start_counter( 1000000 );
+    built.set_passive_end_counter( 9000000 );
+
+    const std::string name = built.tname();
+    // halfway between 10% and 90% = 50%
+    CHECK( name.find( "50%" ) != std::string::npos );
+}
+
+TEST_CASE( "craft_tname_clamps_projection_at_step_boundaries",
+           "[craft][attention][display]" )
+{
+    item ingredient( itype_2x4, calendar::turn );
+    item built( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    REQUIRE( built.is_craft() );
+
+    const time_point t0 = calendar::turn;
+    built.item_counter = 0;
+    built.set_passive_start_counter( 1000000 );
+    built.set_passive_end_counter( 9000000 );
+
+    SECTION( "before passive_started_at" ) {
+        built.set_passive_started_at( t0 + 5_minutes );
+        built.set_ready_at( t0 + 15_minutes );
+        const std::string name = built.tname();
+        CHECK( name.find( "10%" ) != std::string::npos );
+    }
+    SECTION( "after ready_at" ) {
+        built.set_passive_started_at( t0 - 20_minutes );
+        built.set_ready_at( t0 - 10_minutes );
+        const std::string name = built.tname();
+        CHECK( name.find( "90%" ) != std::string::npos );
+    }
+}
+
+TEST_CASE( "craft_tname_falls_back_to_item_counter_outside_passive",
+           "[craft][attention][display]" )
+{
+    item ingredient( itype_2x4, calendar::turn );
+    item built( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    REQUIRE( built.is_craft() );
+    built.item_counter = 4200000; // 42%
+
+    const std::string name = built.tname();
+    CHECK( name.find( "42%" ) != std::string::npos );
+}
+
+TEST_CASE( "craft_tname_never_decreases_below_item_counter",
+           "[craft][attention][display]" )
+{
+    item ingredient( itype_2x4, calendar::turn );
+    item built( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    REQUIRE( built.is_craft() );
+
+    const time_point t0 = calendar::turn;
+    built.item_counter = 8500000; // 85%
+    built.set_passive_started_at( t0 );
+    built.set_ready_at( t0 + 10_minutes );
+    built.set_passive_start_counter( 1000000 );
+    built.set_passive_end_counter( 9000000 );
+
+    const std::string name = built.tname();
+    CHECK( name.find( "85%" ) != std::string::npos );
+}
+
+TEST_CASE( "craft_tname_uses_saved_ready_at_during_pause",
+           "[craft][attention][display]" )
+{
+    item ingredient( itype_2x4, calendar::turn );
+    item built( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    REQUIRE( built.is_craft() );
+
+    const time_point t0 = calendar::turn;
+    built.item_counter = 1000000;
+    built.set_passive_started_at( t0 - 5_minutes );
+    built.set_passive_start_counter( 1000000 );
+    built.set_passive_end_counter( 9000000 );
+
+    // While paused, ready_at is repurposed as polling cursor; saved_ready_at
+    // holds the original deadline.  Display must use the saved value.
+    built.set_ready_at( t0 + 1_minutes );
+    built.set_saved_ready_at( t0 + 5_minutes );
+
+    const std::string name = built.tname();
+    CHECK( name.find( "50%" ) != std::string::npos );
+}
+
+TEST_CASE( "craft_data_persists_attention_runtime_fields",
+           "[craft][attention][persist]" )
+{
+    item ingredient( itype_2x4, calendar::turn );
+    item built( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    REQUIRE( built.is_craft() );
+
+    std::vector<attention_plan> plans( 2 );
+    plans[1].choice = step_choice::set_timer;
+    plans[1].alarm_offset = 7_minutes;
+    built.set_step_plans( plans );
+
+    built.set_passive_started_at( calendar::turn );
+    built.set_ready_at( calendar::turn + 10_minutes );
+    built.set_alarm_at( calendar::turn + 7_minutes );
+    built.set_fail_at( calendar::turn + 25_minutes );
+    built.set_pause_started_at( calendar::turn + 2_minutes );
+    built.set_saved_ready_at( calendar::turn + 11_minutes );
+    built.set_saved_alarm_at( calendar::turn + 8_minutes );
+    built.set_saved_fail_at( calendar::turn + 26_minutes );
+    built.set_crafter_id( character_id( 42 ) );
+
+    std::ostringstream ss;
+    JsonOut jsout( ss );
+    built.serialize( jsout );
+
+    item restored;
+    restored.deserialize( json_loader::from_string( ss.str() ).get_object() );
+
+    REQUIRE( restored.is_craft() );
+    REQUIRE( restored.get_step_plans().size() == 2 );
+    CHECK( restored.get_step_plans()[1].choice == step_choice::set_timer );
+    REQUIRE( restored.get_step_plans()[1].alarm_offset.has_value() );
+    CHECK( *restored.get_step_plans()[1].alarm_offset == 7_minutes );
+    CHECK( restored.get_alarm_at() == calendar::turn + 7_minutes );
+    CHECK( restored.get_fail_at() == calendar::turn + 25_minutes );
+    CHECK( restored.get_pause_started_at() == calendar::turn + 2_minutes );
+    CHECK( restored.get_saved_ready_at() == calendar::turn + 11_minutes );
+    CHECK( restored.get_saved_alarm_at() == calendar::turn + 8_minutes );
+    CHECK( restored.get_saved_fail_at() == calendar::turn + 26_minutes );
+    CHECK( restored.get_crafter_id() == character_id( 42 ) );
+}
+
+TEST_CASE( "craft_data_default_step_plan_serializes_minimally",
+           "[craft][attention][persist]" )
+{
+    item ingredient( itype_2x4, calendar::turn );
+    item built( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    REQUIRE( built.is_craft() );
+
+    std::vector<attention_plan> plans( 2 );  // all defaults: do_wait, no alarm_offset
+    built.set_step_plans( plans );
+
+    std::ostringstream ss;
+    JsonOut jsout( ss );
+    built.serialize( jsout );
+
+    item restored;
+    restored.deserialize( json_loader::from_string( ss.str() ).get_object() );
+
+    REQUIRE( restored.is_craft() );
+    REQUIRE( restored.get_step_plans().size() == 2 );
+    CHECK( restored.get_step_plans()[0].choice == step_choice::do_wait );
+    CHECK_FALSE( restored.get_step_plans()[0].alarm_offset.has_value() );
+}
+
+TEST_CASE( "craft_data_resets_stale_passive_state_on_step_plan_size_mismatch",
+           "[craft][attention][persist][migration]" )
+{
+    item ingredient( itype_2x4, calendar::turn );
+    item_components comps;
+    comps.add( ingredient );
+    item built( &recipe_cudgel_test_unattended_simple.obj(), 1, comps,
+                std::vector<item_comp> {} );
+    REQUIRE( built.is_craft() );
+
+    // Simulate a save written under a different recipe (3 steps) before the
+    // recipe was edited down to 2 steps.
+    std::vector<attention_plan> stale( 3 );
+    stale[1].choice = step_choice::set_timer;
+    stale[1].alarm_offset = 5_minutes;
+    built.set_step_plans( stale );
+    built.set_passive_started_at( calendar::turn );
+    built.set_ready_at( calendar::turn + 10_minutes );
+    built.set_alarm_at( calendar::turn + 5_minutes );
+    built.set_fail_at( calendar::turn + 25_minutes );
+    built.set_passive_start_counter( 1000000 );
+    built.set_passive_end_counter( 5000000 );
+
+    std::ostringstream ss;
+    JsonOut jsout( ss );
+    built.serialize( jsout );
+
+    item restored;
+    restored.deserialize( json_loader::from_string( ss.str() ).get_object() );
+
+    REQUIRE( restored.is_craft() );
+    CHECK( restored.get_step_plans().empty() );
+    CHECK( restored.get_passive_started_at() == calendar::before_time_starts );
+    CHECK( restored.get_ready_at() == calendar::before_time_starts );
+    CHECK( restored.get_alarm_at() == calendar::before_time_starts );
+    CHECK( restored.get_fail_at() == calendar::before_time_starts );
+    CHECK( restored.get_passive_start_counter() == 0 );
+    CHECK( restored.get_passive_end_counter() == 0 );
+}
+
+TEST_CASE( "craft_apply_resume_replan_targets_correct_alarm_slot",
+           "[craft][attention][resume][alarm]" )
+{
+    clear_map();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+    on_map.set_current_step( 1 );
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+
+    SECTION( "live passive step: arms alarm_at" ) {
+        on_map.set_passive_started_at( calendar::turn );
+        on_map.set_ready_at( calendar::turn + 10_minutes );
+        std::vector<attention_plan> plans( 2 );
+        plans[1].choice = step_choice::set_timer;
+        plans[1].alarm_offset = 8_minutes;
+        on_map.set_step_plans( plans );
+
+        craft_apply_resume_replan( loc );
+
+        CHECK( on_map.get_alarm_at() == calendar::turn + 8_minutes );
+        CHECK( on_map.get_saved_alarm_at() == calendar::before_time_starts );
+    }
+
+    SECTION( "env-paused passive step: arms saved_alarm_at" ) {
+        on_map.set_passive_started_at( calendar::turn );
+        on_map.set_ready_at( calendar::turn + 1_minutes );
+        on_map.set_saved_ready_at( calendar::turn + 10_minutes );
+        std::vector<attention_plan> plans( 2 );
+        plans[1].choice = step_choice::set_timer;
+        plans[1].alarm_offset = 8_minutes;
+        on_map.set_step_plans( plans );
+
+        craft_apply_resume_replan( loc );
+
+        CHECK( on_map.get_alarm_at() == calendar::before_time_starts );
+        CHECK( on_map.get_saved_alarm_at() == calendar::turn + 8_minutes );
+    }
+
+    SECTION( "removing timer clears both alarm slots" ) {
+        on_map.set_passive_started_at( calendar::turn );
+        on_map.set_ready_at( calendar::turn + 10_minutes );
+        on_map.set_alarm_at( calendar::turn + 8_minutes );
+        on_map.set_saved_alarm_at( calendar::turn + 8_minutes );
+        std::vector<attention_plan> plans( 2 );
+        plans[1].choice = step_choice::do_wait;
+        on_map.set_step_plans( plans );
+
+        craft_apply_resume_replan( loc );
+
+        CHECK( on_map.get_alarm_at() == calendar::before_time_starts );
+        CHECK( on_map.get_saved_alarm_at() == calendar::before_time_starts );
+    }
+
+    SECTION( "before passive entry: no-op" ) {
+        // passive_started_at left at before_time_starts.
+        std::vector<attention_plan> plans( 2 );
+        plans[1].choice = step_choice::set_timer;
+        plans[1].alarm_offset = 8_minutes;
+        on_map.set_step_plans( plans );
+
+        craft_apply_resume_replan( loc );
+
+        CHECK( on_map.get_alarm_at() == calendar::before_time_starts );
+        CHECK( on_map.get_saved_alarm_at() == calendar::before_time_starts );
+    }
+}
+
+TEST_CASE( "craft_resolve_overdue_passive_chains_preserve_wall_time",
+           "[craft][attention][resume][overdue]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_consecutive_unattended.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+
+    // Position at the first unattended step (Cure A, idx 1) with passive
+    // state stamped manually.  Step 2 (Cure B) is also unattended; step 3
+    // (Finish) is active.
+    on_map.set_current_step( 1 );
+    on_map.set_passive_started_at( calendar::turn );
+    on_map.set_ready_at( calendar::turn + 10_minutes );
+    on_map.set_crafter_id( u.getID() );
+    std::vector<attention_plan> plans( 4 );
+    on_map.set_step_plans( plans );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+
+    SECTION( "now past both passive deadlines: chain advances to active step" ) {
+        // step 1 ends at turn+10m, step 2 chained at turn+10m ends at turn+20m.
+        // Now at turn+25m: both overdue, both should drain.
+        craft_resolve_overdue_passive( on_map, calendar::turn + 25_minutes, loc );
+
+        CHECK( on_map.get_current_step() == 3 );
+        CHECK( on_map.get_passive_started_at() == calendar::before_time_starts );
+    }
+
+    SECTION( "now past first deadline only: chain stops at second step alive" ) {
+        // step 1 ends at turn+10m, step 2 chained at turn+10m ends at turn+20m.
+        // Now at turn+15m: step 2 is mid-flight, not overdue.
+        craft_resolve_overdue_passive( on_map, calendar::turn + 15_minutes, loc );
+
+        CHECK( on_map.get_current_step() == 2 );
+        CHECK( on_map.get_passive_started_at() == calendar::turn + 10_minutes );
+        CHECK( on_map.get_ready_at() == calendar::turn + 20_minutes );
+    }
+}


### PR DESCRIPTION
#### Summary
Features "Recipes can mark steps as unattended; player can wait, walk away, or set a timer"

#### Purpose of change

Recipe-step infrastructure exists, but every step demands full attention. No way to model "let dough rise for 10 minutes" as something you can leave alone, and that's a lot of cooking, fermenting, drying.

Builds on #86904 for off-bubble-aware timing.

#### Describe the solution

Steps can be marked `"attention": "unattended"`. Starting/resuming such a recipe shows a modal per unattended step: wait, do something else, or set a timer (timer only when you have a watch or smartphone).

Wait roots you under a new ACT_CRAFT_WAIT activity. Do-something-else cleanly ends the activity. Timer sets a timer with your clock.

Item name shows live progress while you wander by projecting between counter bounds snapshotted at step entry. When the step finishes, you get a craft-step-complete distraction with item + step name; without a timepiece it's a flavor "you suddenly remember..." log line instead, since you can't actually count time. Suppressed when you're already on that same craft. Timer's alarm uses regular alarm sound + noise distraction.

Terminal unattended step auto-finalizes at ready time so morale, EOCs, heat, and birthday all use proper in-game time, not walk-back time.

Env requirements enforced over the wait: failure pauses + slides the deadline forward, restored env unpauses. Binary destroy at max_time + grace_period. Original crafter remembered so env checks pick up pseudo-tools / bionics / trait qualities when they're standing next to the workbench. Past-due wakeups (off-bubble, save reload, same-turn race) resolved inline so you can't land in a stale loop where the modal re-prompts a finished step.

Bread's "let dough rise" marked as the proof case. NPCs implicit do_wait on attention recipes.

#### Describe alternatives you've considered

For "live progress while wandering": lazy tname with crafter lookup (expensive + stateful), periodic display-only wakeups (churn for visuals), or item processing hook (wrong layer, off-bubble-blind). Snapshotted counter bounds + linear projection beats all three.

Auto-finalize on terminal unattended instead of "ready to collect on walk-back" because deferring complete_craft mis-times morale, EOCs, heat, rot start.

Reservations and supervised attention are out of scope, schema room reserved.

#### Testing

Mixed some dough. Played on my smartphone. Proceeded straight to baking. Bread tasty.

#### Additional context

Known open work for unattended crafting:

- Supervised attention (proximity-required, pause / higher failure chance) reserved in schema but rejected at load.
- No reservation system for tile/tool conflicts between concurrent crafts.
- Food rot acceleration during grace period not modeled; failure is binary destroy.
- Recipe-step drift on save/load relies on existing clamp behavior, no migration tool or debugmsg.
- NPCs always implicit do_wait; no explicit choice path.
- Timer offers two presets ("when step finishes" / "5 minutes before"); arbitrary offsets deferred.

Depends on #86904.