### PR TITLE
Aftershock: Railguns use multimag infrastructure

### DIFF
--- a/data/mods/aftershock_exoplanet/items/gun/30x200mm_rail.json
+++ b/data/mods/aftershock_exoplanet/items/gun/30x200mm_rail.json
@@ -25,9 +25,19 @@
     "durability": 6,
     "ammo": [ "30x200mm" ],
     "clip_size": 1,
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "30x200mm": 1 } } ],
+    "pocket_data": [
+      { "id": "ammo", "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "30x200mm": 1 } },
+      {
+        "id": "power",
+        "pocket_type": "MAGAZINE_WELL",
+        "max_contains_volume": "20 L",
+        "max_contains_weight": "20 kg",
+        "magazine_well": "75 ml",
+        "item_restriction": [ "afs_cartridge" ]
+      }
+    ],
+    "firing_requirements": { "DEFAULT": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 500 } ] },
     "modes": [ [ "DEFAULT", "RDY", 1 ] ],
-    "energy_drain": "1000 kJ",
     "reload": 400,
     "valid_mod_locations": [ [ "grip", 1 ], [ "sling", 1 ], [ "sights", 1 ], [ "rail mount", 1 ], [ "underbarrel", 1 ] ],
     "built_in_mods": [ "bipod", "afs_smart_scope" ],

--- a/data/mods/aftershock_exoplanet/items/gun/7.50mm.json
+++ b/data/mods/aftershock_exoplanet/items/gun/7.50mm.json
@@ -15,7 +15,7 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "afs_7.50mm" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": -4 },
+    "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "dispersion": 175,
     "durability": 9,
     "min_strength": 16,
@@ -37,12 +37,22 @@
     ],
     "pocket_data": [
       {
+        "id": "ammo",
         "pocket_type": "MAGAZINE",
         "holster": true,
         "ammo_restriction": { "afs_7.50mm": 9 },
         "allowed_speedloaders": [ "afs_marsect72_speedloader9" ]
+      },
+      {
+        "id": "power",
+        "pocket_type": "MAGAZINE_WELL",
+        "max_contains_volume": "20 L",
+        "max_contains_weight": "20 kg",
+        "magazine_well": "75 ml",
+        "item_restriction": [ "afs_compact_cartridge" ]
       }
     ],
+    "firing_requirements": { "DEFAULT": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 5 } ] },
     "built_in_mods": [ "afs_marsec_t72_shotgun" ]
   },
   {

--- a/data/mods/aftershock_exoplanet/items/gun/mining_rod.json
+++ b/data/mods/aftershock_exoplanet/items/gun/mining_rod.json
@@ -18,11 +18,20 @@
     "range": 60,
     "dispersion": 45,
     "durability": 8,
-    "energy_drain": "50 kJ",
     "reload": 2000,
     "clip_size": 1,
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "metal_rail": 1 } } ],
-    "flags": [ "USE_UPS" ],
+    "pocket_data": [
+      { "id": "ammo", "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "metal_rail": 1 } },
+      {
+        "id": "power",
+        "pocket_type": "MAGAZINE_WELL",
+        "max_contains_volume": "20 L",
+        "max_contains_weight": "20 kg",
+        "magazine_well": "75 ml",
+        "item_restriction": [ "afs_cartridge" ]
+      }
+    ],
+    "firing_requirements": { "DEFAULT": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 100 } ] },
     "melee_damage": { "bash": 12 }
   }
 ]

--- a/data/mods/aftershock_exoplanet/items/gun/needle.json
+++ b/data/mods/aftershock_exoplanet/items/gun/needle.json
@@ -37,7 +37,22 @@
       [ "underbarrel", 1 ]
     ],
     "flags": [ "WATERPROOF_GUN", "NEVER_JAMS" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "3x35_150_mag", "3x35_75_mag" ] } ]
+    "pocket_data": [
+      { "id": "ammo", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "3x35_150_mag", "3x35_75_mag" ], "rigid": true },
+      {
+        "id": "power",
+        "pocket_type": "MAGAZINE_WELL",
+        "max_contains_volume": "20 L",
+        "max_contains_weight": "20 kg",
+        "magazine_well": "75 ml",
+        "item_restriction": [ "afs_cartridge" ]
+      }
+    ],
+    "firing_requirements": {
+      "DEFAULT": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 10 } ],
+      "BURST": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 10 } ],
+      "AUTO": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 10 } ]
+    }
   },
   {
     "id": "3x35_pistol",
@@ -61,7 +76,7 @@
     "skill": "pistol",
     "dispersion": 280,
     "durability": 9,
-    "modes": [ [ "BURST", "2 rd.", 3 ], [ "AUTO", "auto", 5 ] ],
+    "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "BURST", "3 rd.", 3 ], [ "AUTO", "auto", 5 ] ],
     "valid_mod_locations": [
       [ "accessories", 3 ],
       [ "grip", 1 ],
@@ -73,7 +88,22 @@
       [ "underbarrel", 1 ]
     ],
     "flags": [ "WATERPROOF_GUN", "NEVER_JAMS" ],
-    "weapon_category": [ "AUTOMATIC_PISTOLS" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "3x35_75_mag", "3x35_150_mag" ] } ]
+    "pocket_data": [
+      { "id": "ammo", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "3x35_150_mag", "3x35_75_mag" ], "rigid": true },
+      {
+        "id": "power",
+        "pocket_type": "MAGAZINE_WELL",
+        "max_contains_volume": "20 L",
+        "max_contains_weight": "20 kg",
+        "magazine_well": "75 ml",
+        "item_restriction": [ "afs_cartridge" ]
+      }
+    ],
+    "firing_requirements": {
+      "DEFAULT": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 5 } ],
+      "BURST": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 10 } ],
+      "AUTO": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 10 } ]
+    },
+    "weapon_category": [ "AUTOMATIC_PISTOLS" ]
   }
 ]

--- a/data/mods/aftershock_exoplanet/items/gun/projectile.json
+++ b/data/mods/aftershock_exoplanet/items/gun/projectile.json
@@ -44,12 +44,21 @@
     "durability": 6,
     "ammo": [ "metal_rail" ],
     "clip_size": 1,
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "metal_rail": 1 } } ],
-    "energy_drain": "40 kJ",
+    "pocket_data": [
+      { "id": "ammo", "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "metal_rail": 1 } },
+      {
+        "id": "power",
+        "pocket_type": "MAGAZINE_WELL",
+        "max_contains_volume": "20 L",
+        "max_contains_weight": "20 kg",
+        "magazine_well": "75 ml",
+        "item_restriction": [ "afs_cartridge" ]
+      }
+    ],
+    "firing_requirements": { "DEFAULT": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 100 } ] },
     "reload": 1200,
     "valid_mod_locations": [ [ "grip", 1 ], [ "sling", 1 ], [ "stock", 1 ], [ "sights", 1 ], [ "rail mount", 1 ], [ "underbarrel mount", 1 ] ],
     "ammo_effects": [ "TRAIL" ],
-    "flags": [ "USE_UPS" ],
     "melee_damage": { "bash": 10 }
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Railguns use power cartridges instead of requiring an UPS"

#### Purpose of change
Take advantage of the new multimag infrastructure for railguns, replacing UPS. 

#### Describe the solution
All railguns now also take power cartridges for powering up.

#### Testing
All guns test fired, seems to work.