### PR TITLE
Gastropod Foot coverage

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -109,6 +109,10 @@
     "type": "json_flag"
   },
   {
+    "id": "ALLOWS_GASTROPOD_FOOT",
+    "type": "json_flag"
+  },
+  {
     "id": "ALLOWS_TALONS",
     "type": "json_flag"
   },

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -1748,7 +1748,7 @@
         "covers": [ "leg_l", "leg_r", "gastropod_foot" ],
         "coverage": 65,
         "encumbrance": 4,
-        "specifically_covers": [ "leg_draped_l", "leg_draped_r", "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r", "leg_gastropod_draped" ],
         "layers": [ "BELTED" ]
       }
     ]
@@ -1804,15 +1804,7 @@
         "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
         "coverage": 65,
         "encumbrance": 8,
-        "specifically_covers": [
-          "leg_draped_l",
-          "leg_draped_r",
-          "leg_hip_gastropod_l",
-          "leg_hip_gastropod_r",
-          "leg_upper_gastropod",
-          "tail_default_base",
-          "tail_default_center"
-        ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r", "leg_gastropod_draped", "tail_default_base", "tail_default_center" ],
         "layers": [ "BELTED" ]
       }
     ],
@@ -1843,15 +1835,7 @@
         "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
         "coverage": 65,
         "encumbrance": 2,
-        "specifically_covers": [
-          "leg_draped_l",
-          "leg_draped_r",
-          "leg_hip_gastropod_l",
-          "leg_hip_gastropod_r",
-          "leg_upper_gastropod",
-          "tail_default_base",
-          "tail_default_center"
-        ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r", "leg_gastropod_draped", "tail_default_base", "tail_default_center" ],
         "layers": [ "BELTED" ]
       }
     ],
@@ -1900,15 +1884,7 @@
         "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
         "coverage": 65,
         "encumbrance": 2,
-        "specifically_covers": [
-          "leg_draped_l",
-          "leg_draped_r",
-          "leg_hip_gastropod_l",
-          "leg_hip_gastropod_r",
-          "leg_upper_gastropod",
-          "tail_default_base",
-          "tail_default_center"
-        ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r", "leg_gastropod_draped", "tail_default_base", "tail_default_center" ],
         "layers": [ "BELTED" ]
       }
     ]
@@ -1937,15 +1913,7 @@
         "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
         "coverage": 65,
         "encumbrance": 6,
-        "specifically_covers": [
-          "leg_draped_l",
-          "leg_draped_r",
-          "leg_hip_gastropod_l",
-          "leg_hip_gastropod_r",
-          "leg_upper_gastropod",
-          "tail_default_base",
-          "tail_default_center"
-        ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r", "leg_gastropod_draped", "tail_default_base", "tail_default_center" ],
         "layers": [ "BELTED" ]
       }
     ]
@@ -1974,15 +1942,7 @@
         "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
         "coverage": 65,
         "encumbrance": 6,
-        "specifically_covers": [
-          "leg_draped_l",
-          "leg_draped_r",
-          "leg_hip_gastropod_l",
-          "leg_hip_gastropod_r",
-          "leg_upper_gastropod",
-          "tail_default_base",
-          "tail_default_center"
-        ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r", "leg_gastropod_draped", "tail_default_base", "tail_default_center" ],
         "layers": [ "BELTED" ]
       }
     ]
@@ -2011,15 +1971,7 @@
         "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
         "coverage": 65,
         "encumbrance": 5,
-        "specifically_covers": [
-          "leg_draped_l",
-          "leg_draped_r",
-          "leg_hip_gastropod_l",
-          "leg_hip_gastropod_r",
-          "leg_upper_gastropod",
-          "tail_default_base",
-          "tail_default_center"
-        ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r", "leg_gastropod_draped", "tail_default_base", "tail_default_center" ],
         "layers": [ "BELTED" ]
       }
     ]
@@ -2048,15 +2000,7 @@
         "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
         "coverage": 65,
         "encumbrance": 3,
-        "specifically_covers": [
-          "leg_draped_l",
-          "leg_draped_r",
-          "leg_hip_gastropod_l",
-          "leg_hip_gastropod_r",
-          "leg_upper_gastropod",
-          "tail_default_base",
-          "tail_default_center"
-        ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r", "leg_gastropod_draped", "tail_default_base", "tail_default_center" ],
         "layers": [ "BELTED" ]
       }
     ]

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -16,13 +16,13 @@
     "warmth": 20,
     "material_thickness": 0.3,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS" ],
+    "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_GASTROPOD_FOOT" ],
     "use_action": [ "POST_UP" ],
     "armor": [
       {
         "encumbrance": 50,
         "coverage": 60,
-        "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+        "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "tail", "gastropod_foot" ]
       }
     ]
   },
@@ -45,7 +45,32 @@
       {
         "encumbrance": 0,
         "coverage": 100,
-        "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
+        "covers": [
+          "leg_l",
+          "leg_r",
+          "torso",
+          "arm_l",
+          "arm_r",
+          "hand_l",
+          "hand_r",
+          "head",
+          "foot_l",
+          "foot_r",
+          "mouth",
+          "eyes",
+          "tail",
+          "gastropod_foot",
+          "beak",
+          "muzzle",
+          "hoof_r",
+          "hoof_l",
+          "avian_talon_l",
+          "avian_talon_r",
+          "animal_paw_l",
+          "animal_paw_r",
+          "animal_paw_rabbit_l",
+          "animal_paw_rabbit_r"
+        ]
       }
     ]
   },
@@ -1720,10 +1745,10 @@
     "armor": [
       { "encumbrance": 4, "coverage": 65, "covers": [ "torso" ] },
       {
-        "covers": [ "leg_l", "leg_r" ],
+        "covers": [ "leg_l", "leg_r", "gastropod_foot" ],
         "coverage": 65,
         "encumbrance": 4,
-        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r", "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ],
         "layers": [ "BELTED" ]
       }
     ]
@@ -1745,10 +1770,10 @@
     "armor": [
       { "encumbrance": 4, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
-        "covers": [ "leg_l", "leg_r" ],
+        "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
         "coverage": 65,
         "encumbrance": 4,
-        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r", "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ],
         "layers": [ "BELTED" ]
       }
     ],
@@ -1772,14 +1797,22 @@
     "looks_like": "coat_rain",
     "symbol": "[",
     "color": "light_blue",
-    "flags": [ "OVERSIZE", "HOOD", "BELTED", "STURDY" ],
+    "flags": [ "OVERSIZE", "HOOD", "BELTED", "STURDY", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "encumbrance": 8, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
-        "covers": [ "leg_l", "leg_r" ],
+        "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
         "coverage": 65,
         "encumbrance": 8,
-        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "specifically_covers": [
+          "leg_draped_l",
+          "leg_draped_r",
+          "leg_hip_gastropod_l",
+          "leg_hip_gastropod_r",
+          "leg_upper_gastropod",
+          "tail_default_base",
+          "tail_default_center"
+        ],
         "layers": [ "BELTED" ]
       }
     ],
@@ -1803,14 +1836,22 @@
     "warmth": 10,
     "material_thickness": 0.2,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "HOOD", "BELTED" ],
+    "flags": [ "OVERSIZE", "HOOD", "BELTED", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "encumbrance": 2, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
-        "covers": [ "leg_l", "leg_r" ],
+        "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
         "coverage": 65,
         "encumbrance": 2,
-        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "specifically_covers": [
+          "leg_draped_l",
+          "leg_draped_r",
+          "leg_hip_gastropod_l",
+          "leg_hip_gastropod_r",
+          "leg_upper_gastropod",
+          "tail_default_base",
+          "tail_default_center"
+        ],
         "layers": [ "BELTED" ]
       }
     ],
@@ -1852,14 +1893,22 @@
     "color": "dark_gray",
     "warmth": 8,
     "material_thickness": 0.1,
-    "flags": [ "OVERSIZE", "BELTED" ],
+    "flags": [ "OVERSIZE", "BELTED", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "encumbrance": 2, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
-        "covers": [ "leg_l", "leg_r" ],
+        "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
         "coverage": 65,
         "encumbrance": 2,
-        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "specifically_covers": [
+          "leg_draped_l",
+          "leg_draped_r",
+          "leg_hip_gastropod_l",
+          "leg_hip_gastropod_r",
+          "leg_upper_gastropod",
+          "tail_default_base",
+          "tail_default_center"
+        ],
         "layers": [ "BELTED" ]
       }
     ]
@@ -1881,14 +1930,22 @@
     "warmth": 60,
     "material_thickness": 0.6,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "BELTED", "RAINPROOF" ],
+    "flags": [ "OVERSIZE", "HOOD", "BELTED", "RAINPROOF", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "encumbrance": 6, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
-        "covers": [ "leg_l", "leg_r" ],
+        "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
         "coverage": 65,
         "encumbrance": 6,
-        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "specifically_covers": [
+          "leg_draped_l",
+          "leg_draped_r",
+          "leg_hip_gastropod_l",
+          "leg_hip_gastropod_r",
+          "leg_upper_gastropod",
+          "tail_default_base",
+          "tail_default_center"
+        ],
         "layers": [ "BELTED" ]
       }
     ]
@@ -1910,14 +1967,22 @@
     "warmth": 40,
     "material_thickness": 1.5,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "BELTED", "RAINPROOF" ],
+    "flags": [ "OVERSIZE", "HOOD", "BELTED", "RAINPROOF", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "encumbrance": 6, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
-        "covers": [ "leg_l", "leg_r" ],
+        "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
         "coverage": 65,
         "encumbrance": 6,
-        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "specifically_covers": [
+          "leg_draped_l",
+          "leg_draped_r",
+          "leg_hip_gastropod_l",
+          "leg_hip_gastropod_r",
+          "leg_upper_gastropod",
+          "tail_default_base",
+          "tail_default_center"
+        ],
         "layers": [ "BELTED" ]
       }
     ]
@@ -1939,14 +2004,22 @@
     "warmth": 50,
     "material_thickness": 0.5,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "BELTED" ],
+    "flags": [ "OVERSIZE", "HOOD", "BELTED", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "encumbrance": 5, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
-        "covers": [ "leg_l", "leg_r" ],
+        "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
         "coverage": 65,
         "encumbrance": 5,
-        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "specifically_covers": [
+          "leg_draped_l",
+          "leg_draped_r",
+          "leg_hip_gastropod_l",
+          "leg_hip_gastropod_r",
+          "leg_upper_gastropod",
+          "tail_default_base",
+          "tail_default_center"
+        ],
         "layers": [ "BELTED" ]
       }
     ]
@@ -1968,14 +2041,22 @@
     "warmth": 5,
     "material_thickness": 0.3,
     "environmental_protection": 5,
-    "flags": [ "OVERSIZE", "BELTED" ],
+    "flags": [ "OVERSIZE", "BELTED", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "encumbrance": 3, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "head", "hand_l", "hand_r" ] },
       {
-        "covers": [ "leg_l", "leg_r" ],
+        "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
         "coverage": 65,
         "encumbrance": 3,
-        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "specifically_covers": [
+          "leg_draped_l",
+          "leg_draped_r",
+          "leg_hip_gastropod_l",
+          "leg_hip_gastropod_r",
+          "leg_upper_gastropod",
+          "tail_default_base",
+          "tail_default_center"
+        ],
         "layers": [ "BELTED" ]
       }
     ]
@@ -2144,7 +2225,7 @@
     "material": [ "nylon" ],
     "weight": "450 g",
     "volume": "2300 ml",
-    "flags": [ "RAINPROOF", "HOOD", "OVERSIZE", "OUTER" ],
+    "flags": [ "RAINPROOF", "HOOD", "OVERSIZE", "OUTER", "ALLOWS_GASTROPOD_FOOT" ],
     "environmental_protection": 2,
     "material_thickness": 0.2,
     "pocket_data": [
@@ -2170,8 +2251,18 @@
       { "covers": [ "arm_l", "arm_r" ], "specifically_covers": [ "arm_lower_l", "arm_lower_r" ], "coverage": 90 },
       {
         "coverage": 100,
-        "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_upper_r", "leg_upper_l" ]
+        "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
+        "specifically_covers": [
+          "leg_hip_l",
+          "leg_hip_r",
+          "leg_upper_r",
+          "leg_upper_l",
+          "leg_hip_gastropod_l",
+          "leg_hip_gastropod_r",
+          "leg_upper_gastropod",
+          "tail_default_base",
+          "tail_default_center"
+        ]
       }
     ]
   },
@@ -2190,7 +2281,7 @@
     "material": [ "nylon" ],
     "weight": "1100 g",
     "volume": "3800 ml",
-    "flags": [ "RAINPROOF", "HOOD", "OVERSIZE", "OUTER", "STURDY" ],
+    "flags": [ "RAINPROOF", "HOOD", "OVERSIZE", "OUTER", "STURDY", "ALLOWS_GASTROPOD_FOOT" ],
     "environmental_protection": 4,
     "warmth": 5,
     "material_thickness": 0.4,
@@ -2217,8 +2308,18 @@
       { "covers": [ "arm_l", "arm_r" ], "specifically_covers": [ "arm_lower_l", "arm_lower_r" ], "coverage": 90 },
       {
         "coverage": 100,
-        "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_upper_r", "leg_upper_l" ]
+        "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
+        "specifically_covers": [
+          "leg_hip_l",
+          "leg_hip_r",
+          "leg_upper_r",
+          "leg_upper_l",
+          "leg_hip_gastropod_l",
+          "leg_hip_gastropod_r",
+          "leg_upper_gastropod",
+          "tail_default_base",
+          "tail_default_center"
+        ]
       }
     ]
   },
@@ -2237,7 +2338,7 @@
     "weight": "900 g",
     "volume": "4000 ml",
     "warmth": 50,
-    "flags": [ "OVERSIZE", "OUTER", "SOFT" ],
+    "flags": [ "OVERSIZE", "OUTER", "SOFT", "ALLOWS_GASTROPOD_FOOT" ],
     "environmental_protection": 4,
     "material_thickness": 0.4,
     "armor": [
@@ -2251,8 +2352,18 @@
       { "covers": [ "arm_l", "arm_r" ], "specifically_covers": [ "arm_lower_l", "arm_lower_r" ], "coverage": 90 },
       {
         "coverage": 100,
-        "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_upper_r", "leg_upper_l" ]
+        "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
+        "specifically_covers": [
+          "leg_hip_l",
+          "leg_hip_r",
+          "leg_upper_r",
+          "leg_upper_l",
+          "leg_hip_gastropod_l",
+          "leg_hip_gastropod_r",
+          "leg_upper_gastropod",
+          "tail_default_base",
+          "tail_default_center"
+        ]
       }
     ]
   },
@@ -2274,8 +2385,20 @@
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 80, "encumbrance": 12 },
       { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100 },
       {
-        "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_r", "leg_knee_l", "leg_hip_r", "leg_hip_l" ],
+        "covers": [ "leg_l", "leg_r", "gastropod_foot", "tail" ],
+        "specifically_covers": [
+          "leg_upper_l",
+          "leg_upper_r",
+          "leg_knee_r",
+          "leg_knee_l",
+          "leg_hip_r",
+          "leg_hip_l",
+          "leg_hip_gastropod_l",
+          "leg_hip_gastropod_r",
+          "leg_upper_gastropod",
+          "tail_default_base",
+          "tail_default_center"
+        ],
         "coverage": 100
       },
       { "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ], "coverage": 10 },

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -62,7 +62,7 @@
     "color": "dark_gray",
     "warmth": 20,
     "material_thickness": 1,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper", "torso_lower" ], "coverage": 100, "encumbrance": 10 },
       {
@@ -147,7 +147,7 @@
     "warmth": 80,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "ALLOWS_GASTROPOD_FOOT" ],
     "variant_type": "generic",
     "variants": [
       {
@@ -676,7 +676,7 @@
     "warmth": 15,
     "material_thickness": 1.5,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "duster_fur",

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -72,6 +72,20 @@
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": 10,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 67,
+        "encumbrance": 10,
+        "specifically_covers": [ "leg_upper_gastropod" ],
+        "layers": [ "BELTED" ]
+      },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": 10 },
       {
         "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ],
@@ -586,6 +600,20 @@
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 60,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_upper_gastropod" ],
+        "layers": [ "BELTED" ]
+      },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 7, 7 ] },
       {
         "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ],
@@ -665,6 +693,20 @@
         "coverage": 86,
         "encumbrance": [ 4, 5 ],
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 60,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_upper_gastropod" ],
         "layers": [ "BELTED" ]
       },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 13, 13 ] },
@@ -814,6 +856,20 @@
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 60,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_upper_gastropod" ],
+        "layers": [ "BELTED" ]
+      },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 15, 15 ] },
       {
         "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ],
@@ -912,6 +968,20 @@
         "coverage": 79,
         "encumbrance": [ 11, 13 ],
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": [ 11, 13 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 55,
+        "encumbrance": [ 11, 13 ],
+        "specifically_covers": [ "leg_upper_gastropod" ],
         "layers": [ "BELTED" ]
       },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 11, 11 ] },
@@ -2042,6 +2112,12 @@
         "coverage": 100,
         "encumbrance": 2
       },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ],
+        "encumbrance": 2
+      },
       { "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ], "coverage": 50 },
       {
         "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ],
@@ -2098,6 +2174,12 @@
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 95 },
       { "covers": [ "leg_l", "leg_r" ], "coverage": 100, "encumbrance": [ 2, 2 ] },
       {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ],
+        "encumbrance": [ 2, 2 ]
+      },
+      {
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r", "arm_upper_r", "arm_upper_l", "arm_elbow_r", "arm_elbow_l" ],
         "coverage": 100,
@@ -2142,6 +2224,12 @@
       { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100, "encumbrance": [ 1, 3 ] },
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 95 },
       { "covers": [ "leg_l", "leg_r" ], "coverage": 100, "encumbrance": [ 1, 1 ] },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": [ 1, 1 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ]
+      },
       {
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r", "arm_upper_r", "arm_upper_l", "arm_elbow_r", "arm_elbow_l" ],
@@ -2222,9 +2310,15 @@
         "encumbrance": 10,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ]
       },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ],
+        "encumbrance": 10
+      },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": 10 },
       { "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ], "coverage": 60, "encumbrance": 8 },
-      { "covers": [ "tail_thick", "tail_club" ], "coverage": 45, "encumbrance": 8, "layers": [ "BELTED" ] }
+      { "covers": [ "tail_thick", "tail_club" ], "coverage": 45, "encumbrance": 8 }
     ]
   },
   {
@@ -2385,6 +2479,13 @@
         "layers": [ "BELTED" ]
       },
       {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 80,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ],
+        "encumbrance": [ 8, 10 ],
+        "layers": [ "BELTED" ]
+      },
+      {
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r", "arm_upper_r", "arm_upper_l", "arm_elbow_r", "arm_elbow_l" ],
         "coverage": 100,
@@ -2477,6 +2578,12 @@
         "layers": [ "BELTED" ]
       },
       {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 80,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ],
+        "encumbrance": 10
+      },
+      {
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r", "arm_upper_r", "arm_upper_l", "arm_elbow_r", "arm_elbow_l" ],
         "coverage": 100,
@@ -2518,6 +2625,13 @@
         "coverage": 86,
         "encumbrance": 2,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 80,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ],
+        "encumbrance": 2,
         "layers": [ "BELTED" ]
       },
       {
@@ -2563,6 +2677,13 @@
         "coverage": 92,
         "encumbrance": 2,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 80,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ],
+        "encumbrance": 2,
         "layers": [ "BELTED" ]
       },
       {
@@ -2618,6 +2739,13 @@
         "layers": [ "BELTED" ]
       },
       {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 80,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ],
+        "encumbrance": 2,
+        "layers": [ "BELTED" ]
+      },
+      {
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r", "arm_upper_r", "arm_upper_l", "arm_elbow_r", "arm_elbow_l" ],
         "coverage": 100,
@@ -2654,6 +2782,13 @@
         "coverage": 100,
         "encumbrance": [ 6, 6 ],
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 95,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ],
+        "encumbrance": [ 6, 6 ],
         "layers": [ "BELTED" ]
       },
       {
@@ -2723,6 +2858,18 @@
         "encumbrance": 2
       },
       { "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ], "coverage": 90 },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ],
+        "encumbrance": 2
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 30,
+        "specifically_covers": [ "leg_lower_gastropod" ],
+        "encumbrance": 2
+      },
       {
         "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ],
         "coverage": 75,

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -1176,6 +1176,12 @@
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
         "coverage": 100,
         "encumbrance": [ 7, 7 ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": [ 7, 7 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
       }
     ],
     "pocket_data": [
@@ -1711,6 +1717,12 @@
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
         "coverage": 80,
         "encumbrance": [ 0, 0 ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 80,
+        "encumbrance": 0,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
       }
     ],
     "pocket_data": [
@@ -3860,7 +3872,24 @@
         "coverage": 100,
         "encumbrance": 3
       },
-      { "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ], "coverage": 80 }
+      { "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ], "coverage": 80 },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": 5,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
+      },
+      { "covers": [ "gastropod_foot" ], "coverage": 50, "specifically_covers": [ "leg_upper_gastropod" ] },
+      {
+        "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ],
+        "material": [ { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 } ],
+        "coverage": 50
+      },
+      {
+        "covers": [ "tail_thick", "tail_club" ],
+        "material": [ { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 } ],
+        "coverage": 40
+      }
     ]
   },
   {
@@ -3889,7 +3918,24 @@
         "coverage": 95,
         "encumbrance": 5
       },
-      { "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ], "coverage": 65 }
+      { "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ], "coverage": 65 },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": 5,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
+      },
+      { "covers": [ "gastropod_foot" ], "coverage": 65, "specifically_covers": [ "leg_upper_gastropod" ] },
+      {
+        "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ],
+        "material": [ { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 } ],
+        "coverage": 50
+      },
+      {
+        "covers": [ "tail_thick", "tail_club" ],
+        "material": [ { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 } ],
+        "coverage": 40
+      }
     ]
   },
   {
@@ -3930,6 +3976,28 @@
         "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r", "leg_lower_l", "leg_lower_r", "leg_hip_l", "leg_hip_r" ],
         "material": [ { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 } ],
         "coverage": 100
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "material": [ { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 } ],
+        "coverage": 100,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 60,
+        "material": [ { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 } ],
+        "specifically_covers": [ "leg_upper_gastropod" ]
+      },
+      {
+        "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ],
+        "material": [ { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 } ],
+        "coverage": 50
+      },
+      {
+        "covers": [ "tail_thick", "tail_club" ],
+        "material": [ { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 } ],
+        "coverage": 40
       }
     ],
     "pocket_data": [

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -118,6 +118,12 @@
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
         "coverage": 90,
         "encumbrance": [ 4, 5 ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 90,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
       }
     ],
     "pocket_data": [
@@ -3068,6 +3074,20 @@
         "layers": [ "BELTED" ]
       },
       {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 60,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_upper_gastropod" ],
+        "layers": [ "BELTED" ]
+      },
+      {
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r" ],
         "coverage": 40,
@@ -3152,6 +3172,20 @@
         "coverage": 85,
         "encumbrance": [ 4, 5 ],
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 60,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_upper_gastropod" ],
         "layers": [ "BELTED" ]
       },
       {
@@ -3250,6 +3284,20 @@
         "coverage": 85,
         "encumbrance": [ 4, 5 ],
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 60,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_upper_gastropod" ],
         "layers": [ "BELTED" ]
       },
       {
@@ -3357,6 +3405,18 @@
         "encumbrance": [ 4, 5 ]
       },
       {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 60,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_upper_gastropod" ]
+      },
+      {
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
         "coverage": 80,
@@ -3412,6 +3472,18 @@
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
         "coverage": 80,
         "encumbrance": [ 0, 0 ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 60,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_upper_gastropod" ]
       },
       { "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ], "coverage": 85, "encumbrance": [ 5, 5 ] },
       { "covers": [ "tail_thick", "tail_club" ], "coverage": 65, "encumbrance": [ 5, 5 ] }
@@ -3475,6 +3547,18 @@
         "coverage": 80,
         "encumbrance": [ 0, 0 ]
       },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 60,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_upper_gastropod" ]
+      },
       { "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ], "coverage": 85, "encumbrance": [ 5, 5 ] },
       { "covers": [ "tail_thick", "tail_club" ], "coverage": 65, "encumbrance": [ 5, 5 ] }
     ]
@@ -3510,6 +3594,12 @@
         "coverage": 100,
         "encumbrance": 3
       },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": 3,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
+      },
       { "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ], "coverage": 80 }
     ]
   },
@@ -3535,6 +3625,18 @@
         "encumbrance": 7,
         "coverage": 100,
         "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": 7,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 95,
+        "encumbrance": 7,
+        "specifically_covers": [ "leg_upper_gastropod" ]
       },
       { "encumbrance": 7, "coverage": 85, "covers": [ "tail_thick", "tail_club" ] }
     ]
@@ -3569,11 +3671,18 @@
         "encumbrance": [ 0, 0 ]
       },
       {
-        "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ],
-        "coverage": 75,
-        "encumbrance": [ 5, 5 ],
-        "layers": [ "BELTED" ]
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
       },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 60,
+        "encumbrance": [ 0, 0 ],
+        "specifically_covers": [ "leg_upper_gastropod" ]
+      },
+      { "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ], "coverage": 75, "encumbrance": [ 5, 5 ] },
       { "covers": [ "tail_thick", "tail_club" ], "coverage": 50, "encumbrance": [ 5, 5 ], "layers": [ "BELTED" ] }
     ],
     "pocket_data": [
@@ -3617,6 +3726,18 @@
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
         "coverage": 80,
         "encumbrance": [ 0, 0 ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 60,
+        "encumbrance": [ 0, 0 ],
+        "specifically_covers": [ "leg_upper_gastropod" ]
       },
       {
         "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ],
@@ -3678,6 +3799,18 @@
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
         "coverage": 80,
         "encumbrance": [ 0, 0 ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 60,
+        "encumbrance": [ 0, 0 ],
+        "specifically_covers": [ "leg_upper_gastropod" ]
       },
       {
         "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ],
@@ -3971,6 +4104,18 @@
         "coverage": 80,
         "encumbrance": [ 0, 0 ]
       },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": [ 4, 5 ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 60,
+        "encumbrance": [ 0, 0 ],
+        "specifically_covers": [ "leg_upper_gastropod" ]
+      },
       { "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ], "coverage": 75, "encumbrance": [ 5, 5 ] },
       { "covers": [ "tail_thick", "tail_club" ], "coverage": 50, "encumbrance": [ 5, 5 ] }
     ],
@@ -4003,6 +4148,20 @@
         "coverage": 95,
         "encumbrance": 12,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": 12,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 95,
+        "encumbrance": 12,
+        "specifically_covers": [ "leg_upper_gastropod" ],
         "layers": [ "BELTED" ]
       },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": 12 },
@@ -4039,6 +4198,20 @@
         "coverage": 95,
         "encumbrance": 10,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": 10,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 85,
+        "encumbrance": 10,
+        "specifically_covers": [ "leg_upper_gastropod" ],
         "layers": [ "BELTED" ]
       },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": 10 },

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -771,7 +771,7 @@
     "warmth": 50,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "xl_duster_fur",
@@ -818,7 +818,7 @@
     "name": { "str": "faux fur duster" },
     "description": "A thick faux fur duster, falling below your knees.  Has many pockets for storing things.",
     "material": [ "faux_fur", "cotton" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "ALLOWS_GASTROPOD_FOOT" ],
     "warmth": 40
   },
   {
@@ -932,7 +932,7 @@
     "warmth": 30,
     "material_thickness": 1.5,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "xl_duster_leather",
@@ -1032,7 +1032,7 @@
     "warmth": 50,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "COLLAR", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "COLLAR", "OUTER", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "hakama_gi",
@@ -1233,7 +1233,7 @@
     ],
     "warmth": 20,
     "material_thickness": 0.4,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "ALLOWS_GASTROPOD_FOOT" ],
     "variant_type": "generic",
     "variants": [
       {
@@ -1736,7 +1736,7 @@
     ],
     "warmth": 10,
     "material_thickness": 0.2,
-    "flags": [ "OUTER", "VARSIZE", "POCKETS" ]
+    "flags": [ "OUTER", "VARSIZE", "POCKETS", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "jacket_leather",
@@ -2120,7 +2120,7 @@
     "color": "brown",
     "warmth": 20,
     "material_thickness": 0.5,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 70, "encumbrance": 2 },
       { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100 },
@@ -2222,7 +2222,7 @@
     ],
     "warmth": 20,
     "material_thickness": 0.2,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "yukata",
@@ -2273,7 +2273,7 @@
     ],
     "warmth": 5,
     "material_thickness": 0.15,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "haori",
@@ -2319,7 +2319,7 @@
     "color": "white",
     "warmth": 17,
     "material_thickness": 0.3,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper", "torso_lower" ], "coverage": 100, "encumbrance": 10 },
       {
@@ -2571,7 +2571,7 @@
     ],
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "OUTER" ]
+    "flags": [ "VARSIZE", "OUTER", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "ghost_robe",
@@ -2620,7 +2620,7 @@
     ],
     "warmth": 8,
     "material_thickness": 0.1,
-    "flags": [ "UNRESTRICTED", "OUTER", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "UNRESTRICTED", "OUTER", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "ghost_robe_sheet",
@@ -2672,7 +2672,7 @@
     ],
     "warmth": 5,
     "material_thickness": 0.1,
-    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "grim_reaper_robe",
@@ -2729,7 +2729,7 @@
     },
     "warmth": 10,
     "material_thickness": 0.1,
-    "flags": [ "UNRESTRICTED", "OUTER", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "UNRESTRICTED", "OUTER", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "grim_reaper_robe_faceless",
@@ -2849,7 +2849,7 @@
     ],
     "warmth": 15,
     "material_thickness": 1.5,
-    "flags": [ "VARSIZE", "OUTER", "HOOD" ]
+    "flags": [ "VARSIZE", "OUTER", "HOOD", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "samghati",
@@ -2867,7 +2867,7 @@
     "color": "brown",
     "warmth": 12,
     "material_thickness": 0.5,
-    "flags": [ "VARSIZE", "OUTER" ],
+    "flags": [ "VARSIZE", "OUTER", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100, "encumbrance": 2 },
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 80 },
@@ -3162,7 +3162,7 @@
     "warmth": 15,
     "material_thickness": 1.5,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "sleeveless_duster_fur",
@@ -3263,7 +3263,7 @@
     "warmth": 50,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "sleeveless_duster_faux_fur",
@@ -3375,7 +3375,7 @@
     "warmth": 30,
     "material_thickness": 1.5,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "sleeveless_trenchcoat",
@@ -3403,7 +3403,7 @@
     "warmth": 15,
     "material_thickness": 1.5,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ],
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 7, 15 ] },
       {
@@ -3466,7 +3466,7 @@
     "warmth": 50,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 9, 19 ] },
       {
@@ -3540,7 +3540,7 @@
     "warmth": 30,
     "material_thickness": 1.5,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 11, 17 ] },
       {
@@ -3593,7 +3593,7 @@
     "color": "dark_gray",
     "warmth": 2,
     "material_thickness": 1,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100, "encumbrance": 3 },
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 95 },
@@ -3633,7 +3633,7 @@
     "color": "white",
     "warmth": 20,
     "material_thickness": 0.2,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       {
         "encumbrance": 7,
@@ -3710,7 +3710,7 @@
     "warmth": 15,
     "material_thickness": 1.5,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "trenchcoat_fur",
@@ -3772,7 +3772,7 @@
     "warmth": 50,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "trenchcoat_faux_fur",
@@ -3845,7 +3845,7 @@
     "warmth": 30,
     "material_thickness": 1.5,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "tunic",
@@ -3863,7 +3863,7 @@
     "color": "dark_gray",
     "warmth": 2,
     "material_thickness": 0.3,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100, "encumbrance": 3 },
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 95 },
@@ -3910,7 +3910,7 @@
     "color": "light_red",
     "warmth": 15,
     "material_thickness": 0.3,
-    "flags": [ "OVERSIZE" ],
+    "flags": [ "OVERSIZE", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 95, "encumbrance": 5 },
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 85 },
@@ -4027,7 +4027,7 @@
     ],
     "warmth": 30,
     "material_thickness": 0.5,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "waistcoat",
@@ -4192,7 +4192,7 @@
     "warmth": 30,
     "material_thickness": 1.5,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "OUTER" ]
+    "flags": [ "VARSIZE", "OUTER", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "plaguedoctor_robe",
@@ -4210,7 +4210,7 @@
     "color": "dark_gray",
     "warmth": 24,
     "material_thickness": 1,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper", "torso_lower" ], "coverage": 100, "encumbrance": 12 },
       {
@@ -4260,7 +4260,7 @@
     "color": "dark_gray",
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper", "torso_lower" ], "coverage": 100, "encumbrance": 10 },
       {

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -2326,13 +2326,15 @@
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 75,
         "encumbrance": 10,
-        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ]
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
       },
       {
         "covers": [ "gastropod_foot" ],
         "coverage": 100,
         "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ],
-        "encumbrance": 10
+        "encumbrance": 10,
+        "layers": [ "BELTED" ]
       },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": 10 },
       { "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ], "coverage": 60, "encumbrance": 8 },

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -76,7 +76,7 @@
         "covers": [ "gastropod_foot" ],
         "coverage": 100,
         "encumbrance": 10,
-        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
         "layers": [ "BELTED" ]
       },
       {

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -1943,6 +1943,12 @@
     "armor": [
       { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] },
       { "coverage": 60, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
+      },
+      { "covers": [ "gastropod_foot" ], "coverage": 50, "specifically_covers": [ "leg_upper_gastropod" ] },
       { "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ], "coverage": 50 },
       { "covers": [ "tail_thick", "tail_club" ], "coverage": 40 }
     ],
@@ -1971,6 +1977,12 @@
     "armor": [
       { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] },
       { "coverage": 75, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
+      },
+      { "covers": [ "gastropod_foot" ], "coverage": 60, "specifically_covers": [ "leg_upper_gastropod" ] },
       { "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ], "coverage": 55 },
       { "covers": [ "tail_thick", "tail_club" ], "coverage": 45 }
     ],
@@ -2077,6 +2089,12 @@
     "material_thickness": 0.2,
     "flags": [ "VARSIZE" ],
     "armor": [
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ]
+      },
+      { "covers": [ "gastropod_foot" ], "coverage": 30, "specifically_covers": [ "leg_lower_gastropod" ] },
       { "coverage": 100, "covers": [ "leg_l", "leg_r", "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ] },
       { "covers": [ "tail_thick", "tail_club" ], "coverage": 90 }
     ]
@@ -2100,7 +2118,15 @@
     "flags": [ "VARSIZE", "OVERSIZE", "WATER_FRIENDLY" ],
     "armor": [
       { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] },
-      { "coverage": 38, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+      { "coverage": 38, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
+      },
+      { "covers": [ "gastropod_foot" ], "coverage": 35, "specifically_covers": [ "leg_upper_gastropod" ] },
+      { "coverage": 40, "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ] },
+      { "covers": [ "tail_thick", "tail_club" ], "coverage": 15 }
     ]
   },
   {
@@ -2127,7 +2153,15 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       },
-      { "coverage": 38, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+      { "coverage": 38, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
+      },
+      { "covers": [ "gastropod_foot" ], "coverage": 25, "specifically_covers": [ "leg_upper_gastropod" ] },
+      { "coverage": 15, "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ] },
+      { "covers": [ "tail_thick", "tail_club" ], "coverage": 10 }
     ]
   },
   {

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -1953,7 +1953,7 @@
       { "covers": [ "tail_thick", "tail_club" ], "coverage": 40 }
     ],
     "material_thickness": 0.65,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE", "ALLOWS_GASTROPOD_FOOT" ]
   },
   {
     "id": "skirt",
@@ -1973,7 +1973,7 @@
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "1 kg", "moves": 80 } ],
     "warmth": 5,
     "material_thickness": 0.1,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] },
       { "coverage": 75, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] },
@@ -2087,7 +2087,7 @@
     "faults": [ { "fault_group": "fabric_cotton" } ],
     "warmth": 10,
     "material_thickness": 0.2,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       {
         "covers": [ "gastropod_foot" ],
@@ -2115,7 +2115,7 @@
     "color": "yellow",
     "warmth": 1,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "OVERSIZE", "WATER_FRIENDLY" ],
+    "flags": [ "VARSIZE", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] },
       { "coverage": 38, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] },
@@ -2145,7 +2145,7 @@
     "color": "brown",
     "warmth": 10,
     "material_thickness": 0.6,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       {
         "encumbrance": 10,

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -1407,6 +1407,13 @@
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
         "coverage": 50,
         "encumbrance": 0
+      },
+      {
+        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.2 } ],
+        "covers": [ "gastropod_foot" ],
+        "coverage": 50,
+        "encumbrance": 0,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
       }
     ]
   },

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -185,6 +185,24 @@
         "cover_vitals": 70,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_hip_l", "leg_upper_r", "leg_hip_r" ]
+      },
+      {
+        "material": [ { "type": "lc_steel", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "encumbrance": 22,
+        "coverage": 90,
+        "cover_ranged": 95,
+        "cover_vitals": 70,
+        "covers": [ "gastropod_foot" ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
+      },
+      {
+        "material": [ { "type": "lc_steel", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "encumbrance": 22,
+        "coverage": 50,
+        "cover_ranged": 55,
+        "cover_vitals": 40,
+        "covers": [ "gastropod_foot" ],
+        "specifically_covers": [ "leg_upper_gastropod" ]
       }
     ]
   },
@@ -346,7 +364,7 @@
     "longest_side": "60 cm",
     "warmth": 15,
     "material_thickness": 4,
-    "flags": [ "OUTER", "NO_REPAIR" ],
+    "flags": [ "OUTER", "NO_REPAIR", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       {
         "material": [
@@ -382,6 +400,18 @@
         "cover_vitals": 70,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
+      },
+      {
+        "material": [
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "carpet_pilling", "covered_by_mat": 100, "thickness": 3.0 }
+        ],
+        "encumbrance": 5,
+        "coverage": 85,
+        "cover_ranged": 95,
+        "cover_vitals": 70,
+        "covers": [ "gastropod_foot" ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
       }
     ]
   },
@@ -484,7 +514,7 @@
     "color": "brown",
     "warmth": 18,
     "material_thickness": 5,
-    "flags": [ "VARSIZE", "OUTER", "STURDY" ],
+    "flags": [ "VARSIZE", "OUTER", "STURDY", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "encumbrance": 17, "coverage": 93, "cover_melee": 95, "cover_ranged": 90, "cover_vitals": 100, "covers": [ "torso" ] },
       {
@@ -503,6 +533,15 @@
         "cover_vitals": 100,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
+      },
+      {
+        "encumbrance": 4,
+        "coverage": 93,
+        "cover_melee": 95,
+        "cover_ranged": 90,
+        "cover_vitals": 100,
+        "covers": [ "gastropod_foot" ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
       }
     ],
     "melee_damage": { "bash": 6 }
@@ -1007,7 +1046,7 @@
     "warmth": 20,
     "longest_side": "60 cm",
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "OUTER", "STURDY" ],
+    "flags": [ "VARSIZE", "OUTER", "STURDY", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "encumbrance": 20, "coverage": 95, "covers": [ "torso" ] },
       {
@@ -1019,8 +1058,8 @@
       {
         "encumbrance": 4,
         "coverage": 95,
-        "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
+        "covers": [ "leg_l", "leg_r", "gastropod_foot" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
       }
     ]
   },
@@ -1739,7 +1778,7 @@
     "warmth": 20,
     "longest_side": "60 cm",
     "material_thickness": 2,
-    "flags": [ "OUTER", "STURDY", "CONDUCTIVE" ],
+    "flags": [ "OUTER", "STURDY", "CONDUCTIVE", "ALLOWS_GASTROPOD_FOOT" ],
     "max_worn": 1,
     "armor": [
       {
@@ -1758,8 +1797,8 @@
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
-        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r" ],
-        "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l", "leg_hip_l", "leg_hip_r" ],
+        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "gastropod_foot" ],
+        "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l", "leg_hip_l", "leg_hip_r", "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
         "coverage": 100,
         "encumbrance": 10
       }
@@ -1866,7 +1905,7 @@
     "warmth": 20,
     "longest_side": "60 cm",
     "material_thickness": 4,
-    "flags": [ "OUTER", "STURDY", "CONDUCTIVE" ],
+    "flags": [ "OUTER", "STURDY", "CONDUCTIVE", "ALLOWS_GASTROPOD_FOOT" ],
     "max_worn": 1,
     "armor": [
       {
@@ -1885,8 +1924,8 @@
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
-        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r" ],
-        "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l", "leg_hip_l", "leg_hip_r" ],
+        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "gastropod_foot" ],
+        "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l", "leg_hip_l", "leg_hip_r", "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
         "coverage": 100,
         "encumbrance": 10
       }
@@ -2012,8 +2051,8 @@
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
-        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r" ],
-        "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l", "leg_hip_l", "leg_hip_r" ],
+        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "gastropod_foot" ],
+        "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l", "leg_hip_l", "leg_hip_r", "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
         "coverage": 100,
         "encumbrance": 10
       }
@@ -2195,7 +2234,7 @@
     "color": "dark_gray",
     "warmth": 20,
     "longest_side": "60 cm",
-    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "PADDED" ],
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "PADDED", "ALLOWS_GASTROPOD_FOOT" ],
     "use_action": [ { "type": "attach_molle", "size": 6 }, { "type": "detach_molle" } ],
     "armor": [
       {
@@ -2225,6 +2264,13 @@
         "coverage": 30,
         "material": [ { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 7 } ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
+      },
+      {
+        "volume_encumber_modifier": 0,
+        "coverage": 30,
+        "material": [ { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 7 } ],
+        "covers": [ "gastropod_foot" ],
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
       }
     ]
   },

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -677,7 +677,7 @@
     "looks_like": "vest_leather",
     "color": "light_red",
     "warmth": 0,
-    "flags": [ "VARSIZE", "STURDY", "OUTER" ],
+    "flags": [ "VARSIZE", "STURDY", "OUTER", "ALLOWS_GASTROPOD_FOOT" ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -704,6 +704,13 @@
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
         "coverage": 50,
         "encumbrance": 0
+      },
+      {
+        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.2 } ],
+        "covers": [ "gastropod_foot" ],
+        "coverage": 50,
+        "encumbrance": 0,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r" ]
       },
       {
         "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.2 } ],

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -677,7 +677,7 @@
     "faults": [ { "fault_group": "fabric_cotton" } ],
     "warmth": 5,
     "material_thickness": 0.2,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "ALLOWS_GASTROPOD_FOOT" ],
     "armor": [
       { "encumbrance": 7, "coverage": 85, "covers": [ "torso" ] },
       { "encumbrance": 4, "coverage": 55, "covers": [ "leg_l", "leg_r" ] },

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -681,6 +681,18 @@
     "armor": [
       { "encumbrance": 7, "coverage": 85, "covers": [ "torso" ] },
       { "encumbrance": 4, "coverage": 55, "covers": [ "leg_l", "leg_r" ] },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": 7,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "encumbrance": 4,
+        "coverage": 40,
+        "specifically_covers": [ "leg_lower_gastropod" ]
+      },
       { "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ], "coverage": 35, "encumbrance": 4 },
       { "covers": [ "tail_thick", "tail_club" ], "coverage": 20, "encumbrance": 4 }
     ],
@@ -711,6 +723,18 @@
     "description": "A long cotton dress.",
     "armor": [
       { "encumbrance": 7, "coverage": 85, "covers": [ "torso", "leg_l", "leg_r" ] },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": 7,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 40,
+        "encumbrance": 4,
+        "specifically_covers": [ "leg_lower_gastropod" ]
+      },
       { "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ], "coverage": 75, "encumbrance": 6 },
       { "covers": [ "tail_thick", "tail_club" ], "coverage": 65, "encumbrance": 8 }
     ],
@@ -782,6 +806,18 @@
       { "encumbrance": 7, "coverage": 85, "covers": [ "torso" ] },
       { "encumbrance": 1, "coverage": 85, "covers": [ "arm_l", "arm_r" ] },
       { "encumbrance": 4, "coverage": 55, "covers": [ "leg_l", "leg_r" ] },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": 7,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 40,
+        "encumbrance": 4,
+        "specifically_covers": [ "leg_lower_gastropod" ]
+      },
       { "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ], "coverage": 35, "encumbrance": 4 },
       { "covers": [ "tail_thick", "tail_club" ], "coverage": 20, "encumbrance": 4 }
     ],
@@ -837,6 +873,18 @@
       { "encumbrance": 7, "coverage": 85, "covers": [ "torso" ] },
       { "encumbrance": 1, "coverage": 85, "covers": [ "arm_l", "arm_r" ] },
       { "encumbrance": 7, "coverage": 85, "covers": [ "leg_l", "leg_r" ] },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 100,
+        "encumbrance": 7,
+        "specifically_covers": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ]
+      },
+      {
+        "covers": [ "gastropod_foot" ],
+        "coverage": 40,
+        "encumbrance": 4,
+        "specifically_covers": [ "leg_lower_gastropod" ]
+      },
       { "covers": [ "tail_long", "tail_fluffy", "tail_bovine", "tail_rat" ], "coverage": 75, "encumbrance": 6 },
       { "covers": [ "tail_thick", "tail_club" ], "coverage": 65, "encumbrance": 8 }
     ],

--- a/data/json/mutations/limbs_body_parts.json
+++ b/data/json/mutations/limbs_body_parts.json
@@ -1074,7 +1074,7 @@
     "drench_capacity": 700,
     "bionic_slots": 58,
     "flags": [ "LIMB_LOWER" ],
-    "sub_parts": [ "leg_hip_l", "leg_upper_l", "leg_lower_l", "leg_hip_r", "leg_upper_r", "leg_lower_r" ],
+    "sub_parts": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod", "leg_lower_gastropod" ],
     "encumbrance_per_weight": [
       { "weight": "1 mg", "encumbrance": 1 },
       { "weight": "300 g", "encumbrance": 4 },

--- a/data/json/mutations/limbs_body_parts.json
+++ b/data/json/mutations/limbs_body_parts.json
@@ -1462,7 +1462,7 @@
     "hp_bar_ui_text": "TST TAIL",
     "base_hp": 20,
     "limb_scores": [ [ "balance", 0.0 ] ],
-    "sub_parts": [ "sub_limb_debug_tail" ]
+    "sub_parts": [ "tail_default_base", "tail_default_center", "tail_default_tip" ]
   },
   {
     "id": "tail_long",

--- a/data/json/mutations/limbs_sublimbs.json
+++ b/data/json/mutations/limbs_sublimbs.json
@@ -1545,8 +1545,7 @@
     "side": "left",
     "opposite": "leg_hip_gastropod_r",
     "name_multiple": "hips",
-    "name": "left hip",
-    "similar_bodypart": "leg_hip_l"
+    "name": "left hip"
   },
   {
     "id": "leg_hip_gastropod_r",
@@ -1556,8 +1555,7 @@
     "side": "right",
     "opposite": "leg_hip_gastropod_l",
     "name_multiple": "hips",
-    "name": "left hip",
-    "similar_bodypart": "leg_hip_r"
+    "name": "left hip"
   },
   {
     "id": "leg_upper_gastropod",

--- a/data/json/mutations/limbs_sublimbs.json
+++ b/data/json/mutations/limbs_sublimbs.json
@@ -2038,6 +2038,36 @@
     "name": "right heel"
   },
   {
+    "id": "tail_default_base",
+    "type": "sub_body_part",
+    "name": "default tail base",
+    "name_multiple": "default bases",
+    "max_coverage": 10,
+    "parent": "tail",
+    "side": "both",
+    "opposite": "tail_default_tip"
+  },
+  {
+    "id": "tail_default_center",
+    "type": "sub_body_part",
+    "name": "default tail center",
+    "name_multiple": "default tail centers",
+    "max_coverage": 60,
+    "parent": "tail",
+    "side": "both",
+    "opposite": "tail_default_center"
+  },
+  {
+    "id": "tail_default_tip",
+    "type": "sub_body_part",
+    "name": "default tail tip",
+    "name_multiple": "default tail tips",
+    "max_coverage": 30,
+    "parent": "tail",
+    "side": "both",
+    "opposite": "tail_default_base"
+  },
+  {
     "id": "tail_long_base",
     "type": "sub_body_part",
     "name": "long tail base",
@@ -2045,7 +2075,8 @@
     "max_coverage": 10,
     "parent": "tail_long",
     "side": "both",
-    "opposite": "tail_long_tip"
+    "opposite": "tail_long_tip",
+    "similar_bodypart": "tail_default_base"
   },
   {
     "id": "tail_long_center",
@@ -2055,7 +2086,8 @@
     "max_coverage": 60,
     "parent": "tail_long",
     "side": "both",
-    "opposite": "tail_long_center"
+    "opposite": "tail_long_center",
+    "similar_bodypart": "tail_default_center"
   },
   {
     "id": "tail_long_tip",
@@ -2065,7 +2097,8 @@
     "max_coverage": 30,
     "parent": "tail_long",
     "side": "both",
-    "opposite": "tail_long_base"
+    "opposite": "tail_long_base",
+    "similar_bodypart": "tail_default_tip"
   },
   {
     "id": "tail_fluffy_base",
@@ -2075,7 +2108,8 @@
     "max_coverage": 10,
     "parent": "tail_fluffy",
     "side": "both",
-    "opposite": "tail_fluffy_tip"
+    "opposite": "tail_fluffy_tip",
+    "similar_bodypart": "tail_default_base"
   },
   {
     "id": "tail_fluffy_center",
@@ -2085,7 +2119,8 @@
     "max_coverage": 60,
     "parent": "tail_fluffy",
     "side": "both",
-    "opposite": "tail_fluffy_center"
+    "opposite": "tail_fluffy_center",
+    "similar_bodypart": "tail_default_center"
   },
   {
     "id": "tail_fluffy_tip",
@@ -2095,7 +2130,8 @@
     "max_coverage": 30,
     "parent": "tail_fluffy",
     "side": "both",
-    "opposite": "tail_fluffy_base"
+    "opposite": "tail_fluffy_base",
+    "similar_bodypart": "tail_default_tip"
   },
   {
     "id": "tail_thick_base",
@@ -2105,7 +2141,8 @@
     "max_coverage": 10,
     "parent": "tail_thick",
     "side": "both",
-    "opposite": "tail_thick_tip"
+    "opposite": "tail_thick_tip",
+    "similar_bodypart": "tail_default_base"
   },
   {
     "id": "tail_thick_center",
@@ -2115,7 +2152,8 @@
     "max_coverage": 60,
     "parent": "tail_thick",
     "side": "both",
-    "opposite": "tail_thick_center"
+    "opposite": "tail_thick_center",
+    "similar_bodypart": "tail_default_center"
   },
   {
     "id": "tail_thick_tip",
@@ -2125,7 +2163,8 @@
     "max_coverage": 30,
     "parent": "tail_thick",
     "side": "both",
-    "opposite": "tail_thick_base"
+    "opposite": "tail_thick_base",
+    "similar_bodypart": "tail_default_tip"
   },
   {
     "id": "tail_scorpion_base",
@@ -2165,7 +2204,8 @@
     "max_coverage": 10,
     "parent": "tail_club",
     "side": 0,
-    "opposite": "tail_club_club"
+    "opposite": "tail_club_club",
+    "similar_bodypart": "tail_default_base"
   },
   {
     "id": "tail_club_center",
@@ -2175,7 +2215,8 @@
     "max_coverage": 60,
     "parent": "tail_club",
     "side": 0,
-    "opposite": "tail_club_center"
+    "opposite": "tail_club_center",
+    "similar_bodypart": "tail_default_center"
   },
   {
     "id": "tail_club_club",
@@ -2185,7 +2226,8 @@
     "max_coverage": 30,
     "parent": "tail_club",
     "side": 0,
-    "opposite": "tail_club_base"
+    "opposite": "tail_club_base",
+    "similar_bodypart": "tail_default_tip"
   },
   {
     "id": "tail_bovine_base",
@@ -2195,7 +2237,8 @@
     "max_coverage": 10,
     "parent": "tail_bovine",
     "side": 0,
-    "opposite": "tail_bovine_tip"
+    "opposite": "tail_bovine_tip",
+    "similar_bodypart": "tail_default_base"
   },
   {
     "id": "tail_bovine_center",
@@ -2205,7 +2248,8 @@
     "max_coverage": 60,
     "parent": "tail_bovine",
     "side": 0,
-    "opposite": "tail_bovine_center"
+    "opposite": "tail_bovine_center",
+    "similar_bodypart": "tail_default_center"
   },
   {
     "id": "tail_bovine_tip",
@@ -2215,7 +2259,8 @@
     "max_coverage": 30,
     "parent": "tail_bovine",
     "side": 0,
-    "opposite": "tail_bovine_base"
+    "opposite": "tail_bovine_base",
+    "similar_bodypart": "tail_default_tip"
   },
   {
     "id": "tail_raptor_base",
@@ -2287,7 +2332,8 @@
     "max_coverage": 10,
     "parent": "tail_rat",
     "side": "both",
-    "opposite": "tail_rat_tip"
+    "opposite": "tail_rat_tip",
+    "similar_bodypart": "tail_default_base"
   },
   {
     "id": "tail_rat_center",
@@ -2297,7 +2343,8 @@
     "max_coverage": 60,
     "parent": "tail_rat",
     "side": "both",
-    "opposite": "tail_rat_center"
+    "opposite": "tail_rat_center",
+    "similar_bodypart": "tail_default_center"
   },
   {
     "id": "tail_rat_tip",
@@ -2307,6 +2354,7 @@
     "max_coverage": 30,
     "parent": "tail_rat",
     "side": "both",
-    "opposite": "tail_rat_base"
+    "opposite": "tail_rat_base",
+    "similar_bodypart": "tail_default_tip"
   }
 ]

--- a/data/json/mutations/limbs_sublimbs.json
+++ b/data/json/mutations/limbs_sublimbs.json
@@ -1538,6 +1538,48 @@
     "max_coverage": 40
   },
   {
+    "id": "leg_hip_gastropod_l",
+    "type": "sub_body_part",
+    "max_coverage": 5,
+    "parent": "gastropod_foot",
+    "side": "left",
+    "opposite": "leg_hip_gastropod_r",
+    "name_multiple": "hips",
+    "name": "left hip",
+    "similar_bodypart": "leg_hip_l"
+  },
+  {
+    "id": "leg_hip_gastropod_r",
+    "type": "sub_body_part",
+    "max_coverage": 5,
+    "parent": "gastropod_foot",
+    "side": "right",
+    "opposite": "leg_hip_gastropod_l",
+    "name_multiple": "hips",
+    "name": "left hip",
+    "similar_bodypart": "leg_hip_r"
+  },
+  {
+    "id": "leg_upper_gastropod",
+    "type": "sub_body_part",
+    "max_coverage": 45,
+    "parent": "gastropod_foot",
+    "side": "both",
+    "opposite": "leg_upper_gastropod",
+    "name_multiple": "upper feet",
+    "name": "upper foot"
+  },
+  {
+    "id": "leg_lower_gastropod",
+    "type": "sub_body_part",
+    "max_coverage": 45,
+    "parent": "gastropod_foot",
+    "side": "both",
+    "opposite": "leg_lower_gastropod",
+    "name_multiple": "lower feet",
+    "name": "lower foot"
+  },
+  {
     "id": "leg_crab_basis_fl",
     "type": "sub_body_part",
     "max_coverage": 5,

--- a/data/json/mutations/limbs_sublimbs.json
+++ b/data/json/mutations/limbs_sublimbs.json
@@ -1558,6 +1558,18 @@
     "name": "left hip"
   },
   {
+    "id": "leg_gastropod_draped",
+    "type": "sub_body_part",
+    "max_coverage": 100,
+    "parent": "gastropod_foot",
+    "side": "both",
+    "secondary": true,
+    "opposite": "leg_gastropod_draped",
+    "name_multiple": "legs (draped)",
+    "name": "leg (draped)",
+    "locations_under": [ "leg_hip_gastropod_l", "leg_hip_gastropod_r", "leg_upper_gastropod" ]
+  },
+  {
     "id": "leg_upper_gastropod",
     "type": "sub_body_part",
     "max_coverage": 45,

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5200,6 +5200,7 @@
     "flags": [ "SLUDGE_IMMUNE", "TOUGH_FEET" ],
     "destroys_gear": true,
     "restricts_gear": [ "leg_l", "leg_r", "foot_l", "foot_r" ],
+    "allowed_items": [ "ALLOWS_GASTROPOD_FOOT" ],
     "enchantments": [
       {
         "values": [ { "value": "MOVECOST_FLATGROUND_MOD", "multiply": 0.25 }, { "value": "FOOTSTEP_NOISE", "multiply": -0.75 } ]

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -176,8 +176,9 @@ Some armor flags, such as `WATCH` and `ALARMCLOCK` are compatible with other ite
 - ```ABLATIVE_SKIRT``` item can be worn with Hub 01 armor without encumbrance penalty; specifically can be put in pocket for armor with this flag restriction.
 - ```ACTIVE_CLOAKING``` While active, drains UPS to provide invisibility.
 - ```ALARMCLOCK``` Has an alarm-clock feature.
+- ```ALLOWS_GASTROPOD_FOOT``` You can wear this item even if you have a gastropod foot instead of human legs.
 - ```ALLOWS_NATURAL_ATTACKS``` Doesn't prevent any natural attacks or similar benefits from mutations, fingertip razors, etc., like most items covering the relevant body part would.
-- ```ALLOWS_TAIL``` You can wear this leg-covering item even if you have a tail.
+- ```ALLOWS_TAIL``` You can wear this leg-covering item even if you have a tail
 - ```ALLOWS_TALONS``` People with talon mutations still can wear this armor, that cover feet.
 - ```AURA``` This item goes in the outer aura layer, intended for metaphysical effects.
 - ```BAROMETER``` This gear is equipped with an accurate barometer (which is used to measure atmospheric pressure).


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Gastropod Foot coverage"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Have you been annoyed that your dress doesn't cover your gastropod foot? Well, be annoyed no more.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Implement gastropod foot sublimbs.

Implement coverage for the foot from all the things that cover tails (mainly, robes, big coats, dresses, etc). Use an `ALLOW_GASTROPOD_FOOT` flag to let gastropod mutants wear dresses and coats and kimono but not pants

Also allow Gastropod Foot for armor that covers the torso and the hips (like a chainmail cuirass)

Do tail and gastropod foot coverage for cloaks (which I missed the first time)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Put on a trenchcoat, it covered the gastropod foot a bit.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

It'd be nice if e.g. the sleeveless duster did not have to redefine the entire armor field just to remove coverage from the arms. 

Does anyone actually mutate gastropod? 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
