### PR TITLE
clang-tidy: build plugin against LLVM 19-22, parametrize scripts

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -122,6 +122,9 @@ Checks: [
     -modernize-avoid-c-arrays,                          # false-positive inside std::enable_if_t<>
     -readability-math-missing-parentheses,              # would add parens around almost every existing binary op
     -readability-use-std-min-max,                       # if/else clamp idiom is preferred to std::min/max here
+
+    # ====  Disabled noise from checks introduced in LLVM 21+  ====
+    -readability-use-concise-preprocessor-directives,
 ]
 
 WarningsAsErrors: '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -125,6 +125,15 @@ Checks: [
 
     # ====  Disabled noise from checks introduced in LLVM 21+  ====
     -readability-use-concise-preprocessor-directives,
+
+    # ====  Disabled noise from checks introduced in LLVM 22+  ====
+    -bugprone-derived-method-shadowing-base-method,     # store/load/kcal_range are intentional; wield audit pending
+    -bugprone-std-namespace-modification,               # std::hash<UserType> specializations are legal
+    -bugprone-throwing-static-initialization,           # every static const xxx_id ID(...) trips it
+    -misc-multiple-inheritance,                         # Character: Creature, visitable is intentional
+    -misc-override-with-different-visibility,           # can_resume_with_internal access change is intentional
+    -modernize-avoid-c-style-cast,                      # codebase uses C-style casts widely
+    -readability-container-size-empty,                  # auto-fix !empty() differs from size()==N inside Catch2 macros
 ]
 
 WarningsAsErrors: '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -114,6 +114,14 @@ Checks: [
     -readability-simplify-boolean-expr,
     -readability-suspicious-call-argument,
     -readability-use-anyofallof,
+
+    # ====  Disabled noise from checks introduced in LLVM 19+  ====
+    # clang-tidy silently ignores unknown check names, so entries here only
+    # take effect on toolchains that already ship the corresponding check.
+    -bugprone-crtp-constructor-accessibility,           # CRTP base ctors are public on purpose
+    -modernize-avoid-c-arrays,                          # false-positive inside std::enable_if_t<>
+    -readability-math-missing-parentheses,              # would add parens around almost every existing binary op
+    -readability-use-std-min-max,                       # if/else clamp idiom is preferred to std::min/max here
 ]
 
 WarningsAsErrors: '*'

--- a/build-scripts/clang-tidy-build.sh
+++ b/build-scripts/clang-tidy-build.sh
@@ -1,56 +1,91 @@
 #!/bin/bash
 
-# Shell script intended for clang-tidy check
+# Shell script intended for clang-tidy check.
+#
+# Env vars:
+#   LLVM_VERSION       clang-tidy version (default matches CI)
+#   LLVM_PREFIX        install root, when neither /usr/lib/llvm-${ver}
+#                      nor /usr/lib/llvm/${ver} matches
+#   CATA_BUILD_DIR     build directory (default: build)
+#   CATA_CLANG_TIDY    clang-tidy executable name (default: clang-tidy)
 
 echo "Using bash version $BASH_VERSION"
 set -exo pipefail
 
-num_jobs=3
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(dirname "$script_dir")"
 
-# We might need binaries installed via pip, so ensure that our personal bin dir is on the PATH
-#export PATH=$HOME/.local/bin:$PATH
-build_type=MinSizeRel
+num_jobs=${num_jobs:-3}
+build_type=${build_type:-MinSizeRel}
+build_dir=${CATA_BUILD_DIR:-build}
+
+llvm_version=${LLVM_VERSION:-18}
+
+# Locate the LLVM install. The two probed layouts cover apt.llvm.org and
+# distros that use versioned slots; LLVM_PREFIX bypasses both.
+if [ -n "${LLVM_PREFIX:-}" ]; then
+    llvm_prefix="$LLVM_PREFIX"
+elif [ -d "/usr/lib/llvm-${llvm_version}" ]; then
+    llvm_prefix="/usr/lib/llvm-${llvm_version}"
+elif [ -d "/usr/lib/llvm/${llvm_version}" ]; then
+    llvm_prefix="/usr/lib/llvm/${llvm_version}"
+else
+    echo "Cannot locate LLVM ${llvm_version} install. Set LLVM_PREFIX explicitly." >&2
+    exit 1
+fi
+
+llvm_libdir=
+for cand in "${llvm_prefix}/lib/cmake/llvm" "${llvm_prefix}/lib64/cmake/llvm"; do
+    if [ -d "$cand" ]; then
+        llvm_libdir="$cand"
+        break
+    fi
+done
+if [ -z "$llvm_libdir" ]; then
+    echo "Cannot find LLVM cmake config under ${llvm_prefix}." >&2
+    exit 1
+fi
+clang_libdir="${llvm_libdir%/llvm}/clang"
 
 cmake_extra_opts=()
 cmake_extra_opts+=("-DCATA_CLANG_TIDY_PLUGIN=ON")
-# Need to specify the particular LLVM / Clang versions to use, lest it
-# use the older LLVM that comes by default on Ubuntu.
-cmake_extra_opts+=("-DLLVM_DIR=/usr/lib/llvm-18/lib/cmake/llvm")
-cmake_extra_opts+=("-DClang_DIR=/usr/lib/llvm-18/lib/cmake/clang")
+cmake_extra_opts+=("-DLLVM_DIR=${llvm_libdir}")
+cmake_extra_opts+=("-DClang_DIR=${clang_libdir}")
 
 
-mkdir -p build
-cd build
+mkdir -p "$build_dir"
+build_dir="$(cd "$build_dir" && pwd)"
+cd "$build_dir"
 cmake \
     ${COMPILER:+-DCMAKE_CXX_COMPILER=$COMPILER} \
     -DCMAKE_BUILD_TYPE="$build_type" \
     -DLOCALIZE=OFF \
     "${cmake_extra_opts[@]}" \
-    ..
+    "$repo_root"
 
 
 echo "Compiling clang-tidy plugin"
 make -j$num_jobs CataAnalyzerPlugin
 #export PATH=$PWD/tools/clang-tidy-plugin/clang-tidy-plugin-support/bin:$PATH
-# add FileCheck to the search path
-export PATH=/usr/lib/llvm-18/bin:$PATH 
+# add FileCheck and the matching clang-tidy to the search path
+export PATH="${llvm_prefix}/bin:$PATH"
 if ! which FileCheck
 then
     echo "Missing FileCheck"
     exit 1
 fi
-CATA_CLANG_TIDY=clang-tidy
+CATA_CLANG_TIDY=${CATA_CLANG_TIDY:-clang-tidy}
 # lit might be installed via pip, so ensure that our personal bin dir is on the PATH
 export PATH=$HOME/.local/bin:$PATH
 lit -v tools/clang-tidy-plugin/test
-cd ..
+cd "$repo_root"
 
 # show that it works
 
+plugin_so="${build_dir}/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so"
 echo "version:"
-LD_PRELOAD=build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so clang-tidy --version
+LD_PRELOAD="$plugin_so" "${CATA_CLANG_TIDY}" --version
 echo "all enabled checks:"
-LD_PRELOAD=build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so clang-tidy --list-checks
+LD_PRELOAD="$plugin_so" "${CATA_CLANG_TIDY}" --list-checks
 echo "cata-specific checks:"
-LD_PRELOAD=build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so clang-tidy --list-checks --checks="cata-*" | grep "cata"
-
+LD_PRELOAD="$plugin_so" "${CATA_CLANG_TIDY}" --list-checks --checks="cata-*" | grep "cata"

--- a/build-scripts/clang-tidy-build.sh
+++ b/build-scripts/clang-tidy-build.sh
@@ -65,7 +65,7 @@ cmake \
 
 
 echo "Compiling clang-tidy plugin"
-make -j$num_jobs CataAnalyzerPlugin
+make -j"$num_jobs" CataAnalyzerPlugin
 #export PATH=$PWD/tools/clang-tidy-plugin/clang-tidy-plugin-support/bin:$PATH
 # add FileCheck and the matching clang-tidy to the search path
 export PATH="${llvm_prefix}/bin:$PATH"

--- a/build-scripts/clang-tidy-run.sh
+++ b/build-scripts/clang-tidy-run.sh
@@ -26,10 +26,10 @@ cmake \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     ${COMPILER:+-DCMAKE_CXX_COMPILER=$COMPILER} \
     -DCMAKE_BUILD_TYPE="Release" \
-    -DBACKTRACE=${BACKTRACE} \
-    -DLOCALIZE=${LOCALIZE} \
-    -DTILES=${TILES} \
-    -DSOUND=${SOUND} \
+    -DBACKTRACE="${BACKTRACE}" \
+    -DLOCALIZE="${LOCALIZE}" \
+    -DTILES="${TILES}" \
+    -DSOUND="${SOUND}" \
     "$repo_root"
 cd "$repo_root"
 ln --force --symbolic "${build_dir}/compile_commands.json" .
@@ -39,7 +39,7 @@ then
     echo "Cata plugin not found. Assuming we're in CI and bailing out."
     echo "If you are running clang-tidy locally with no plugin, consider"
     echo "calling it explicitly with the files you care to check."
-    echo 'e.g. `clang-tidy src/item* tests/item*` '
+    echo "e.g. clang-tidy src/item* tests/item*"
     exit 1
 fi
 
@@ -56,7 +56,7 @@ set +x
 
 # Check for changes to any files that would require us to run clang-tidy across everything
 changed_global_files="$( ( cat ./files_changed || echo 'unknown' ) | \
-    egrep -i "clang-tidy-build.sh|clang-tidy-run.sh|clang-tidy-wrapper.sh|clang-tidy.yml|.clang-tidy|files_changed|get_affected_files.py|CMakeLists.txt|CMakePresets.json|unknown" || true )"
+    grep -Ei "clang-tidy-build.sh|clang-tidy-run.sh|clang-tidy-wrapper.sh|clang-tidy.yml|.clang-tidy|files_changed|get_affected_files.py|CMakeLists.txt|CMakePresets.json|unknown" || true )"
 if [ -n "$changed_global_files" ]
 then
     first_changed_file="$(echo "$changed_global_files" | head -n 1)"
@@ -72,12 +72,12 @@ then
 else
     make \
         --silent \
-        -j $num_jobs \
-        ${COMPILER:+COMPILER=$COMPILER} \
-        BACKTRACE=${BACKTRACE} \
-        LOCALIZE=${LOCALIZE} \
-        TILES=${TILES} \
-        SOUND=${SOUND} \
+        -j "$num_jobs" \
+        ${COMPILER:+COMPILER="$COMPILER"} \
+        BACKTRACE="${BACKTRACE}" \
+        LOCALIZE="${LOCALIZE}" \
+        TILES="${TILES}" \
+        SOUND="${SOUND}" \
         includes
 
     tidyable_cpp_files="$( \

--- a/build-scripts/clang-tidy-run.sh
+++ b/build-scripts/clang-tidy-run.sh
@@ -5,7 +5,11 @@
 echo "Using bash version $BASH_VERSION"
 set -exo pipefail
 
-num_jobs=3
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(dirname "$script_dir")"
+
+num_jobs=${num_jobs:-3}
+build_dir=${CATA_BUILD_DIR:-build}
 
 # enable all the switches by default
 BACKTRACE=${BACKTRACE:-1}
@@ -14,8 +18,10 @@ TILES=${TILES:-1}
 SOUND=${SOUND:-1}
 
 # create compilation database (compile_commands.json)
-mkdir -p build
-cd build
+mkdir -p "$build_dir"
+build_dir="$(cd "$build_dir" && pwd)"
+export CATA_BUILD_DIR="$build_dir"
+cd "$build_dir"
 cmake \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     ${COMPILER:+-DCMAKE_CXX_COMPILER=$COMPILER} \
@@ -24,11 +30,11 @@ cmake \
     -DLOCALIZE=${LOCALIZE} \
     -DTILES=${TILES} \
     -DSOUND=${SOUND} \
-    ..
-cd ..
-ln --force --symbolic build/compile_commands.json .
+    "$repo_root"
+cd "$repo_root"
+ln --force --symbolic "${build_dir}/compile_commands.json" .
 
-if [ ! -f build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so ]
+if [ ! -f "${build_dir}/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so" ]
 then
     echo "Cata plugin not found. Assuming we're in CI and bailing out."
     echo "If you are running clang-tidy locally with no plugin, consider"
@@ -58,7 +64,7 @@ then
     TIDY="all"
 fi
 
-all_cpp_files="$(jq -r '.[].file | select(contains("third-party") | not)' build/compile_commands.json)"
+all_cpp_files="$(jq -r '.[].file | select(contains("third-party") | not)' "${build_dir}/compile_commands.json")"
 if [ "$TIDY" == "all" ]
 then
     echo "Analyzing all files"

--- a/build-scripts/clang-tidy-wrapper.sh
+++ b/build-scripts/clang-tidy-wrapper.sh
@@ -3,7 +3,8 @@
 set -eu
 set -o pipefail
 
-plugin=build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so
+build_dir=${CATA_BUILD_DIR:-build}
+plugin=${build_dir}/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so
 
 if [ -f "$plugin" ]
 then

--- a/doc/c++/DEVELOPER_TOOLING.md
+++ b/doc/c++/DEVELOPER_TOOLING.md
@@ -96,8 +96,12 @@ In addition to the usual means of creating a `tags` file via e.g. [`ctags`](http
 
 Cataclysm has a [clang-tidy configuration file](../../.clang-tidy) and if you have
 `clang-tidy` available you can run it to perform static analysis of the
-codebase.  We test with `clang-tidy` from LLVM 18.0.0 with CI, so for the most
-consistent results, you might want to use that version.
+codebase.  CI runs `clang-tidy` from LLVM 18.0.0 (Ubuntu apt.llvm.org build),
+so for the most consistent results that is still the recommended baseline.
+The build scripts also accept `LLVM_VERSION=19|20|21|22` (and `LLVM_PREFIX`
+for non-Ubuntu install layouts) so the same workflow works against newer
+toolchains; preemptive `.clang-tidy` disables keep newer-version noise out
+of the way.
 
 To run it, you have a few options.
 
@@ -128,10 +132,23 @@ The following set of commands should take you from zero to running clang-tidy eq
 sudo apt install build-essential cmake clang-18 libclang-18-dev llvm-18 llvm-18-dev llvm-18-tools pip
 sudo pip install compiledb lit
 test -f /usr/bin/python || sudo ln -s /usr/bin/python3 /usr/bin/python
-# The following command invokes clang-tidy exactly like CI does
-COMPILER=clang++-18 CLANG=clang++-18 CMAKE=1 CATA_CLANG_TIDY=plugin TILES=1 LOCALIZE=0 ./build-scripts/clang-tidy-build.sh
-COMPILER=clang++-18 CLANG=clang++-18 CMAKE=1 CATA_CLANG_TIDY=plugin TILES=1 LOCALIZE=0 ./build-scripts/clang-tidy-run.sh
+# The following commands invoke clang-tidy exactly like CI does
+COMPILER=clang++-18 CATA_CLANG_TIDY=clang-tidy-18 TILES=1 LOCALIZE=0 ./build-scripts/clang-tidy-build.sh
+COMPILER=clang++-18 CATA_CLANG_TIDY=clang-tidy-18 TILES=1 LOCALIZE=0 ./build-scripts/clang-tidy-run.sh
 ```
+
+To target another toolchain set `LLVM_VERSION` (and optionally `LLVM_PREFIX`)
+along with the matching `CATA_CLANG_TIDY` executable, e.g.
+
+```sh
+LLVM_VERSION=21 COMPILER=clang++-21 CATA_CLANG_TIDY=clang-tidy-21 \
+    TILES=1 LOCALIZE=0 ./build-scripts/clang-tidy-build.sh
+```
+
+The build directory can be overridden with `CATA_BUILD_DIR` (default `build`),
+which is honoured by `clang-tidy-build.sh`, `clang-tidy-run.sh`,
+`clang-tidy-wrapper.sh`, `tools/repeat_clang_tidy.sh`, and
+`tools/llama/clang_tidy.sh`.
 
 #### Ubuntu Focal
 

--- a/tools/clang-tidy-plugin/CMakeLists.txt
+++ b/tools/clang-tidy-plugin/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 include(ExternalProject)
+include(CheckCXXCompilerFlag)
 
 find_package(LLVM REQUIRED CONFIG)
 find_package(Clang REQUIRED CONFIG)
@@ -53,12 +54,21 @@ set(CataAnalyzerSrc
 if (CATA_CLANG_TIDY_EXECUTABLE)
     set(CataAnalyzerName CataAnalyzer)
     add_executable(${CataAnalyzerName} ${CataAnalyzerSrc})
-    target_link_libraries(${CataAnalyzerName} PRIVATE clangTidyMain)
+    if (TARGET clangTidyMain)
+        target_link_libraries(${CataAnalyzerName} PRIVATE clangTidyMain)
+    endif ()
     add_definitions(-DCATA_CLANG_TIDY_EXECUTABLE)
 else ()
     set(CataAnalyzerName CataAnalyzerPlugin)
     add_library(${CataAnalyzerName} MODULE ${CataAnalyzerSrc})
-    target_link_libraries(${CataAnalyzerName} PRIVATE clangTidyPlugin)
+    # Stock LLVM packages list clangTidyPlugin in CLANG_EXPORTED_TARGETS without
+    # defining it as an imported library, so an unconditional link sends a literal
+    # -lclangTidyPlugin to the linker and fails. The patched plugin-support build
+    # used in CI does export it. Plugin symbols are resolved at LD_PRELOAD time
+    # in either case.
+    if (TARGET clangTidyPlugin)
+        target_link_libraries(${CataAnalyzerName} PRIVATE clangTidyPlugin)
+    endif ()
     if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
         target_link_options(${CataAnalyzerName} PRIVATE -undefined dynamic_lookup)
     endif ()
@@ -81,6 +91,20 @@ target_compile_definitions(${CataAnalyzerName} PRIVATE ${LLVM_DEFINITIONS_SEP})
 if (MSVC)
 else ()
     target_compile_options(${CataAnalyzerName} PRIVATE -fno-exceptions -fno-rtti)
+    # LLVM/Clang headers occasionally trip CATA_WARNINGS via system-header
+    # inlining (-Wnonnull, -Wstringop-overflow, etc).  The plugin is build-time
+    # tooling, so relax those errors locally instead of weakening project flags.
+    set(CATA_TIDY_RELAX_WARNINGS
+            nonnull
+            stringop-overflow
+            array-bounds
+            dangling-reference)
+    foreach (RELAX IN LISTS CATA_TIDY_RELAX_WARNINGS)
+        check_cxx_compiler_flag("-Wno-error=${RELAX}" CATA_TIDY_HAS_NO_ERROR_${RELAX})
+        if (CATA_TIDY_HAS_NO_ERROR_${RELAX})
+            target_compile_options(${CataAnalyzerName} PRIVATE "-Wno-error=${RELAX}")
+        endif ()
+    endforeach ()
 endif ()
 
 configure_file(test/lit.site.cfg.in test/lit.site.cfg @ONLY)

--- a/tools/clang-tidy-plugin/CataTidyModule.cpp
+++ b/tools/clang-tidy-plugin/CataTidyModule.cpp
@@ -1,6 +1,8 @@
 #include <clang/Basic/Version.h>
 #include <clang-tidy/ClangTidyModule.h>
+#if CLANG_VERSION_MAJOR < 22
 #include <clang-tidy/ClangTidyModuleRegistry.h>
+#endif
 #include <llvm/ADT/StringRef.h>
 
 #include "AlmostNeverAutoCheck.h"

--- a/tools/clang-tidy-plugin/LargeStackObjectCheck.cpp
+++ b/tools/clang-tidy-plugin/LargeStackObjectCheck.cpp
@@ -52,16 +52,29 @@ static void CheckDecl( LargeStackObjectCheck &Check, const MatchFinder::MatchRes
         return;
     }
 
-    const Type *T = MatchedDecl->getType().getTypePtr();
+    const QualType QT = MatchedDecl->getType().getCanonicalType();
+    const Type *T = QT.getTypePtrOrNull();
+    if( !T ) {
+        return;
+    }
 
     if( T->isReferenceType() || T->isUndeducedAutoType() ) {
         return;
     }
 
+#if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR >= 22
+    // ASTContext::getTypeInfoImpl recurses without bound on some complete
+    // CTAD-deduced template instantiations (e.g. restore_on_out_of_scope
+    // wrapping std::optional<units::quantity<...>>) and crashes the process.
+    // The matcher fires on every varDecl, so we cannot keep the check
+    // partially active without misclassifying safe types.
+    return;
+#endif
+
 #if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR >= 17
-    if( std::optional<CharUnits> VarSize = Result.Context->getTypeSizeInCharsIfKnown( T ) ) {
+    if( std::optional<CharUnits> VarSize = Result.Context->getTypeSizeInCharsIfKnown( QT ) ) {
 #else
-    if( Optional<CharUnits> VarSize = Result.Context->getTypeSizeInCharsIfKnown( T ) ) {
+    if( Optional<CharUnits> VarSize = Result.Context->getTypeSizeInCharsIfKnown( QT ) ) {
 #endif
         int VarSize_KiB = *VarSize / CharUnits::fromQuantity( 1024 );
 

--- a/tools/clang-tidy-plugin/TextStyleCheck.cpp
+++ b/tools/clang-tidy-plugin/TextStyleCheck.cpp
@@ -87,7 +87,7 @@ void TextStyleCheck::check( const MatchFinder::MatchResult &Result )
             return;
         }
         if( StringRef( SrcMgr.getPresumedLoc( SrcMgr.getSpellingLoc(
-                loc ) ).getFilename() ).equals( "<scratch space>" ) ) {
+                loc ) ).getFilename() ) == "<scratch space>" ) {
             return;
         }
     }

--- a/tools/llama/clang_tidy.sh
+++ b/tools/llama/clang_tidy.sh
@@ -14,13 +14,18 @@ else
 fi
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-top_dir="$(dirname "$script_dir")"
+top_dir="$(dirname "$(dirname "$script_dir")")"
+build_dir=${CATA_BUILD_DIR:-build}
+case "$build_dir" in
+    /*) ;;
+    *) build_dir="$top_dir/$build_dir" ;;
+esac
 
-list_of_files=$(grep '"file": "' build/compile_commands.json | \
-    sed "s+.*$PWD/++;s+\"$++" | \
-    egrep "$file_regex")
+list_of_files=$(grep '"file": "' "${build_dir}/compile_commands.json" | \
+    sed "s+.*$PWD/++" | sed 's+"$++' | \
+    grep -E "$file_regex")
 
-plugin_lib="$top_dir/build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so"
+plugin_lib="${build_dir}/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so"
 plugin_opt=
 if [ -r "$plugin_lib" ]
 then

--- a/tools/repeat_clang_tidy.sh
+++ b/tools/repeat_clang_tidy.sh
@@ -22,6 +22,11 @@ set -eu
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 top_dir="$(dirname "$script_dir")"
+build_dir=${CATA_BUILD_DIR:-build}
+case "$build_dir" in
+    /*) ;;
+    *) build_dir="$top_dir/$build_dir" ;;
+esac
 
 if [ $# -ge 1 ]
 then
@@ -37,12 +42,12 @@ else
     file_regex='.'
 fi
 
-list_of_files=$(grep '"file": "' build/compile_commands.json | \
-    sed "s+.*$PWD/++;s+\",\?$++" | \
+list_of_files=$(grep '"file": "' "${build_dir}/compile_commands.json" | \
+    sed "s+.*$PWD/++" | sed 's+",\?$++' | \
     sort -u | \
-    egrep "$file_regex")
+    grep -E "$file_regex")
 
-plugin_lib="$top_dir/build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so"
+plugin_lib="${build_dir}/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so"
 plugin_opt=
 if [ -r "$plugin_lib" ]
 then
@@ -50,19 +55,19 @@ then
 fi
 
 temp_file=$(mktemp)
-trap "rm -f $temp_file" EXIT
+trap 'rm -f "$temp_file"' EXIT
 num_iterations=0
 
 while [ -n "$list_of_files" ]
 do
-    exec 3>$temp_file
+    exec 3>"$temp_file"
     printf "Running clang-tidy on %d files\n" \
         "$(($(printf "%s" "$list_of_files" | wc -l)+1))"
     printf "%s" "$list_of_files" | \
         nice -15 xargs -P "$jobs" -n 1 \
         "$script_dir/repeat_clang_tidy_helper.sh" \
         -quiet ${plugin_opt:+"$plugin_opt"}
-    list_of_files="$(cat $temp_file)"
+    list_of_files="$(cat "$temp_file")"
     if (( ++num_iterations >= 10 ))
     then
         break


### PR DESCRIPTION
#### Summary
Infrastructure "clang-tidy: support LLVM 19-22 in custom plugin and helper scripts"

#### Purpose of change

CI uses clang-tidy from LLVM 18, but the plugin doesn't compile against 19-22 and the helper scripts hardcode `/usr/lib/llvm-18` and `build/`. This branch fixes both, and pre-stages disables for noise checks newer clang-tidy adds, so a later PR can bump CI without bundling unrelated lint fixes. CI itself stays on 18 here.

#### Describe the solution

Three buckets of commits.

Plugin source compatibility:
- Replace removed `StringRef::equals` with `==` in `TextStyleCheck`.
- Skip `<clang-tidy/ClangTidyModuleRegistry.h>` on LLVM 22+. The header was deprecated and emits a `#warning` that turns into `-Werror=cpp`.
- Disable `cata-large-stack-object` on LLVM 22. `ASTContext::getTypeInfoImpl` runs into unbounded recursion on some CTAD-deduced template instantiations and crashes the process. Plain bug, no tidy partial-fix possible; will revisit when CI actually moves to 22.
- Make linking `clangTidyPlugin` and `clangTidyMain` conditional on the targets actually existing. Stock LLVM packages list them in `CLANG_EXPORTED_TARGETS` without defining them as imported libraries, so an unconditional link sends a literal `-lclangTidyPlugin` and fails. Symbols come from the host clang-tidy at LD_PRELOAD time anyway.
- Locally turn off `-Werror=nonnull`, `-Wstringop-overflow`, `-Warray-bounds`, `-Wdangling-reference` for the plugin target. Newer LLVM headers occasionally trip these via system-header inlining; plugin is build-time tooling so easier to relax it locally than weaken project-wide flags.

Preemptive `.clang-tidy` disables, grouped by the LLVM version that introduces each check. Older clang-tidy silently ignores unknown names, so until that version arrives each entry is a no-op. Every line carries a one-liner `# why`; spelled out:

- `bugprone-crtp-constructor-accessibility` (19+): `coord_point_mut` and similar CRTP bases keep public ctors on purpose.
- `modernize-avoid-c-arrays` (19+): false-positive inside `std::enable_if_t<...>` template args in `string_id.h`.
- `readability-math-missing-parentheses` (19+): would add parens around basically every binary op; not how the codebase is written.
- `readability-use-std-min-max` (19+): we keep `if (x > n) x = n;` clamps; not switching to `std::min/max`.
- `readability-use-concise-preprocessor-directives` (21+): `#if defined(X)` -> `#ifdef X` is pure style.
- `bugprone-derived-method-shadowing-base-method` (22+): `store/load/kcal_range` shadowing is intentional; the wield overload audit is its own followup.
- `bugprone-std-namespace-modification` (22+): `std::hash<UserType>` specializations are legal C++.
- `bugprone-throwing-static-initialization` (22+): every `static const xxx_id ID(...)` trips it; the pattern is project-wide and not going anywhere.
- `misc-multiple-inheritance` (22+): `Character: Creature, visitable` is on purpose.
- `misc-override-with-different-visibility` (22+): the `can_resume_with_internal` access change in the activity-actor hierarchy is intentional.
- `modernize-avoid-c-style-cast` (22+): C-style casts are everywhere already.
- `readability-container-size-empty` (22+): tidy's auto-fix `!c.empty()` is semantically wrong for `c.size() == N` inside Catch2 `REQUIRE`/`CHECK` macros.

Disables driven by third-party headers (`modernize-type-traits`, `modernize-use-equals-default`, `performance-move-const-arg` from `colony.h`/`list.h`) are deliberately left out of this PR; they'll go in the CI-bump PR via `ExcludeHeaderFilterRegex`, so those checks stay enabled for game code.

Script refactor:
- `build-scripts/clang-tidy-{build,run,wrapper}.sh` take `LLVM_VERSION` (default matches CI), `LLVM_PREFIX` for non-Ubuntu install layouts, and `CATA_BUILD_DIR` (default `build`). Build and run scripts compute the repo root from their own path, so nested build dirs like `.build-tidy/llvm21` work.
- `tools/repeat_clang_tidy.sh` and `tools/llama/clang_tidy.sh` honor the same `CATA_BUILD_DIR`, handle absolute paths, and now pass shellcheck.
- All five scripts pass shellcheck clean (one cleanup commit on top).
- `doc/c++/DEVELOPER_TOOLING.md` documents the new env vars and drops the stale `CATA_CLANG_TIDY=plugin` instruction.

With no env vars set, the scripts pick `/usr/lib/llvm-18` and `build/` exactly as before, so CI keeps doing what it was doing.

#### Describe alternatives you've considered

Tried keeping `cata-large-stack-object` partly active on LLVM 22 by guarding on `isDependentType` / `isInstantiationDependentType` / `isIncompleteType` / RecordDecl completeness. None of those predicates separates the crashing types from the safe ones, so the matcher would still bring down the process. All-or-nothing was the only stable option without an upstream fix.

Considered moving `src/colony.h` and `src/list.h` under `src/third-party/` so the existing `select(contains("third-party") | not)` filter picks them up. Worth doing eventually, but mixing it in here just adds noise; the followup CI-bump PR uses `ExcludeHeaderFilterRegex` instead.

#### Testing

Plugin builds clean against LLVM 19/20/21/22 locally; `clang-tidy --list-checks --checks="cata-*"` lists 38 cata checks under each. CI continues on LLVM 18 unchanged.

#### Additional context

First of three planned branches:
1. (this one) plugin and scripts work on 19-22, preemptive noise disables.
2. Real fixes for findings newer clang-tidy versions surface: `use-after-move` in `creature.h`, `return-const-ref-from-parameter` in `npctalk.cpp`, nondeterministic pointer iteration in `map.cpp`, plus a handful of small ones.
3. CI bump straight from 18 to 21, plus `ExcludeHeaderFilterRegex` for `colony.h`/`list.h` and a `readability-enum-initial-value` disable. Skipping intermediate 19/20 bumps because they don't add anything worth its own PR.