### PR TITLE
migrating old case hardening and quenching prof

### DIFF
--- a/data/json/obsoletion_and_migration_0.J/proficiencies.json
+++ b/data/json/obsoletion_and_migration_0.J/proficiencies.json
@@ -6,5 +6,15 @@
   {
     "type": "proficiency_migration",
     "from": "prof_wp_slime_advanced"
+  },
+  {
+    "type": "proficiency_migration",
+    "from": "prof_case_hardening",
+    "to": "prof_hardening"
+  },
+  {
+    "type": "proficiency_migration",
+    "from": "prof_quenching",
+    "to": "prof_tempering"
   }
 ]


### PR DESCRIPTION
#### Summary
Bugfixes "Migrate old proficiencies so they dont throw errors on legacy saves"

#### Purpose of change

Forgot to migrate them in #86735. Doing so now

#### Describe the solution

Add them to proficiency migrations 0.J

#### Describe alternatives you've considered

N/A

#### Testing

Works

#### Additional context

N/A