### PR TITLE
clang-tidy: fix lint findings under LLVM 21

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6831,7 +6831,7 @@ static void debug_drop_list( const std::vector<drop_or_stash_item_info> &items )
 
     std::string res( "Items ordered to drop:\n" );
     for( const drop_or_stash_item_info &it : items ) {
-        item_location loc = it.loc();
+        const item_location &loc = it.loc();
         if( !loc ) {
             // some items could have been destroyed by e.g. monster attack
             continue;
@@ -8962,6 +8962,8 @@ void outfit_swap_actor::finish( player_activity &act, Character &who )
             //Due to the eoc triggered who.takeoff, the item may become invalid.
             continue;
         }
+        // Copy is intentional: who.takeoff below may invalidate worn_item.
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
         item outfit_component( *worn_item );
         std::size_t old_it_list_size = it_list.size();
         if( who.takeoff( worn_item, &it_list ) && it_list.size() > old_it_list_size ) {

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1527,7 +1527,7 @@ std::unique_ptr<activity_actor> hacksaw_activity_actor::deserialize( JsonValue &
     data.read( "type", actor.type );
     data.read( "veh_pos", actor.veh_pos );
     data.read( "moves_left", actor.moves_left );
-    return actor.clone();
+    return std::make_unique<hacksaw_activity_actor>( actor );
 }
 
 static std::string enumerate_ints_to_string( const std::vector<int> &vec )

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -679,7 +679,7 @@ class hacksaw_activity_actor : public activity_actor
         void serialize( JsonOut &jsout ) const override;
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 
-        int moves_left;
+        int moves_left = 0;
         // debugmsg causes a backtrace when fired during cata_test
         bool testing = false;  // NOLINT(cata-serialize)
     private:
@@ -2431,7 +2431,7 @@ class insert_item_activity_actor : public activity_actor
         item_location holster;
         drop_locations items;
         contents_change_handler handler;
-        bool all_pockets_rigid;
+        bool all_pockets_rigid = false;
         bool reopen_menu;
         // allow put charge items into holster's nested pocket
         bool allow_fill_count_by_charge_item_nested;

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2680,11 +2680,11 @@ requirement_id synthesize_requirements(
 requirement_id remove_met_requirements( requirement_id base_req_id, Character &you )
 {
 
-    requirement_data reqs = base_req_id.obj();
+    const requirement_data &reqs = base_req_id.obj();
     // Remove the requirements already met
     requirement_data::alter_tool_comp_vector tool_reqs_vector = reqs.get_tools();
     requirement_data::alter_quali_req_vector quality_reqs_vector = reqs.get_qualities();
-    requirement_data::alter_item_comp_vector component_reqs_vector = reqs.get_components();
+    const requirement_data::alter_item_comp_vector &component_reqs_vector = reqs.get_components();
     requirement_data::alter_tool_comp_vector reduced_tool_reqs_vector;
     requirement_data::alter_quali_req_vector reduced_quality_reqs_vector;
 

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -2461,7 +2461,7 @@ void advanced_inventory::do_return_entry()
 
 void advanced_inventory::temp_hide()
 {
-    ui.reset();
+    ui = nullptr;
     do_return_entry();
     cancel_aim_processing();
 }

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -124,6 +124,8 @@ basecamp::basecamp() = default;
 
 basecamp_map::basecamp_map( const basecamp_map & ) {}
 
+// rhs is intentionally ignored; assignment resets the cached map.
+// NOLINTNEXTLINE(bugprone-unhandled-self-assignment,cert-oop54-cpp)
 basecamp_map &basecamp_map::operator=( const basecamp_map & )
 {
     map_.reset();

--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -405,6 +405,8 @@ static const bodygraph_id &get_bg_rows( const bodygraph_id &bgid )
     if( !!bgid->mirror ) {
         return get_bg_rows( bgid->mirror.value() );
     }
+    // bodygraph_id is a string_id with stable storage; callers do not pass temporaries.
+    // NOLINTNEXTLINE(bugprone-return-const-ref-from-parameter)
     return bgid;
 }
 

--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -661,7 +661,7 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
         monster_weight = std::round( 0.85 * monster_weight );
     }
     const int entry_count = ( action == butcher_type::DISSECT &&
-                              !mt.dissect.is_empty() ) ? mt.dissect->get_all().size() : mt.harvest->get_all().size();
+                              !mt.dissect.is_empty() ) ? mt.dissect->entries().size() : mt.harvest->entries().size();
     int monster_weight_remaining = monster_weight;
     int practice = 0;
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -917,10 +917,8 @@ void tileset_cache::loader::load_internal( const JsonObject &config,
             // Update maximum tile extent
             ts.max_tile_extent = half_open_rectangle<point> {
                 {
-                    std::min( ts.max_tile_extent.p_min.x,
-                              std::min( sprite_offset.x, sprite_offset_retracted.x ) ),
-                    std::min( ts.max_tile_extent.p_min.y,
-                              std::min( sprite_offset.y, sprite_offset_retracted.y ) ),
+                    std::min( { ts.max_tile_extent.p_min.x, sprite_offset.x, sprite_offset_retracted.x } ),
+                    std::min( { ts.max_tile_extent.p_min.y, sprite_offset.y, sprite_offset_retracted.y } ),
                 }, {
                     std::max( ts.max_tile_extent.p_max.x,
                               sprite_width + std::max( sprite_offset.x, sprite_offset_retracted.x ) ),

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -720,6 +720,8 @@ Integer svto( std::string_view s )
 {
     Integer result = 0;
     const char *end = s.data() + s.size();
+    // from_chars takes a [first, last) pointer pair, not a null-terminated string.
+    // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
     std::from_chars_result r = std::from_chars( s.data(), end, result );
     if( r.ptr != end ) {
         cata_fatal( "could not parse string_view as an integer" );
@@ -909,16 +911,18 @@ std::string io::enum_to_string<aggregate_type>( aggregate_type agg )
 
 std::optional<double> svtod( std::string_view token, bool debugmsg_on_fail )
 {
+    // strtod requires a null-terminated string; copy through std::string.
+    std::string token_owned( token );
     char *pEnd = nullptr;
-    double const val = std::strtod( token.data(), &pEnd );
-    if( pEnd == token.data() + token.size() ) {
+    double const val = std::strtod( token_owned.c_str(), &pEnd );
+    if( pEnd == token_owned.data() + token_owned.size() ) {
         return { val };
     }
     char block = *pEnd;
     if( block == ',' || block == '.' ) {
         // likely localized with a different locale
-        std::string unlocalized( token );
-        unlocalized[pEnd - token.data()] = block == ',' ? '.' : ',';
+        std::string unlocalized = token_owned;
+        unlocalized[pEnd - token_owned.data()] = block == ',' ? '.' : ',';
         return svtod( unlocalized );
     }
     if( debugmsg_on_fail ) {

--- a/src/cata_variant.cpp
+++ b/src/cata_variant.cpp
@@ -10,7 +10,7 @@ static bool is_valid_impl_2( const std::string &s )
 }
 
 template<size_t... I>
-constexpr bool is_valid_impl( const cata_variant &v, std::index_sequence<I...> )
+static constexpr bool is_valid_impl( const cata_variant &v, std::index_sequence<I...> )
 {
     constexpr size_t num_types = static_cast<size_t>( cata_variant_type::num_types );
     constexpr std::array<bool( * )( const std::string & ), num_types> is_valid_helpers = {{

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2490,7 +2490,7 @@ void outfit::write_text_memorial( std::ostream &file, const std::string &indent,
                                   const char *eol ) const
 {
     for( const item &elem : worn ) {
-        item next_item = elem;
+        const item &next_item = elem;
         file << indent << next_item.invlet << " - " << next_item.tname( 1, false );
         if( next_item.charges > 0 ) {
             file << " (" << next_item.charges << ")";

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -220,8 +220,11 @@ bool Character::try_remove_grab( bool attacking )
 
         // No need to recalculate it in-loop, breaking previous grabs doesn't change skills
         float skill_factor = std::min( 0.8f,
-                                       std::max( std::max( static_cast<float>( get_skill_level( skill_melee ) ) / 10, 0.1f ),
-                                               std::max( static_cast<float>( get_skill_level( skill_unarmed ) ) / 8, 0.1f ) ) );
+        std::max( {
+            static_cast<float>( get_skill_level( skill_melee ) ) / 10,
+            0.1f,
+            static_cast<float>( get_skill_level( skill_unarmed ) ) / 8
+        } ) );
         int grab_break_factor = has_grab_break_tec() ? 10 : 0;
         const tripoint_range<tripoint_bub_ms> &surrounding = here.points_in_radius( pos_bub(), 1, 0 );
 

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -38,8 +38,8 @@ static const itype_id itype_small_repairkit( "small_repairkit" );
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
 
 template <typename T, typename Output>
-void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nested,
-                       bool now = true )
+static void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nested,
+                              bool now = true )
 {
     src.visit_items( [&src, &nested, &out, &obj, empty, now]( item * node, item * parent ) {
 

--- a/src/climbing.cpp
+++ b/src/climbing.cpp
@@ -239,7 +239,8 @@ void climbing_aid::climb_cost::deserialize( const JsonObject &jo )
 }
 
 template< typename Lambda >
-void for_each_aid_condition( const climbing_aid::condition_list &conditions, const Lambda &func )
+static void for_each_aid_condition( const climbing_aid::condition_list &conditions,
+                                    const Lambda &func )
 {
     for( const climbing_aid::condition &cond : conditions ) {
         if( int( cond.cat ) < int( climbing_lookup.size() ) ) {

--- a/src/clone_ptr.h
+++ b/src/clone_ptr.h
@@ -18,7 +18,9 @@ class clone_ptr
         clone_ptr( const clone_ptr &other ) : p_( other.p_ ? other.p_->clone() : nullptr ) {}
         clone_ptr( clone_ptr && ) noexcept = default;
         clone_ptr &operator=( const clone_ptr &other ) {
-            p_ = other.p_ ? other.p_->clone() : nullptr;
+            if( this != &other ) {
+                p_ = other.p_ ? other.p_->clone() : nullptr;
+            }
             return *this;
         }
         clone_ptr &operator=( clone_ptr && ) noexcept = default;

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -2123,7 +2123,7 @@ conditional_t::func f_is_rotten()
 
 template<class T>
 static std::function<T( const_dialogue const & )> get_get_str_( const JsonObject &jo,
-        std::function<T( const std::string & )> ret_func )
+        const std::function<T( const std::string & )> &ret_func )
 {
     if( !jo.has_string( "mutator" ) ) {
         return nullptr;
@@ -2172,7 +2172,7 @@ static std::function<T( const_dialogue const & )> get_get_str_( const JsonObject
 
 template<class T>
 static std::function<T( const_dialogue const & )> get_get_translation_( const JsonObject &jo,
-        std::function<T( const translation & )> ret_func )
+        const std::function<T( const translation & )> &ret_func )
 {
     // straight translation - used by diag_value_or_var
     if( jo.get_bool( "i18n", false ) && jo.has_string( "str" ) ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -2891,7 +2891,7 @@ static void sort_body_parts( std::vector<bodypart_id> &bps, const Creature *c )
         pending.pop();
         result.push_back( next );
 
-        const cata::flat_set<bodypart_id> children_set = parts_connected_to.at( next );
+        const cata::flat_set<bodypart_id> &children_set = parts_connected_to.at( next );
         std::vector<bodypart_id> children( children_set.begin(), children_set.end() );
         std::sort( children.begin(), children.end(), compare_children );
         for( const bodypart_id &child : children ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1173,7 +1173,11 @@ struct projectile_attack_results {
     std::string wp_hit;
     bool is_crit = false;
     bool is_headshot = false;
-    const weakpoint *wp;
+    // TODO: select_body_part_projectile_attack only sets wp for monster targets; the
+    // non-monster path leaves it null, so deal_projectile_attack must guard the deref.
+    // Long-term: change deal_damage to take const weakpoint* (or std::optional) so the
+    // missing weakpoint is explicit at the API boundary.
+    const weakpoint *wp = nullptr;
 
     explicit projectile_attack_results( const projectile &proj ) {
         max_damage = proj.impact.total_damage();
@@ -1449,7 +1453,10 @@ void Creature::deal_projectile_attack( map *here, Creature *source, dealt_projec
         }
     }
 
-    dealt_dam = deal_damage( source, hit_selection.bp_hit, impact, wp_attack_copy, *hit_selection.wp );
+    // TODO: see note on projectile_attack_results::wp; this fallback hides the API gap.
+    static const weakpoint default_weakpoint;
+    dealt_dam = deal_damage( source, hit_selection.bp_hit, impact, wp_attack_copy,
+                             hit_selection.wp ? *hit_selection.wp : default_weakpoint );
     // Force damage instance to match the selected body point
     dealt_dam.bp_hit = hit_selection.bp_hit;
     // Retrieve the selected weakpoint from the damage instance.

--- a/src/creature.h
+++ b/src/creature.h
@@ -1107,50 +1107,48 @@ class Creature : public viewer
                                     const translation &/*npc_msg*/ ) const;
         template<typename ...Args>
         void add_msg_player_or_npc( const char *const player_msg, const char *const npc_msg,
-                                    Args &&... args ) const {
-            return add_msg_player_or_npc( string_format( player_msg, std::forward<Args>( args )... ),
-                                          string_format( npc_msg, std::forward<Args>( args )... ) );
+                                    const Args &... args ) const {
+            return add_msg_player_or_npc( string_format( player_msg, args... ),
+                                          string_format( npc_msg, args... ) );
         }
         template<typename ...Args>
         void add_msg_player_or_npc( const std::string &player_msg, const std::string &npc_msg,
-                                    Args &&... args ) const {
-            return add_msg_player_or_npc( string_format( player_msg, std::forward<Args>( args )... ),
-                                          string_format( npc_msg, std::forward<Args>( args )... ) );
+                                    const Args &... args ) const {
+            return add_msg_player_or_npc( string_format( player_msg, args... ),
+                                          string_format( npc_msg, args... ) );
         }
         template<typename ...Args>
         void add_msg_player_or_npc( const translation &player_msg, const translation &npc_msg,
-                                    Args &&... args ) const {
-            return add_msg_player_or_npc( string_format( player_msg.translated(),
-                                          std::forward<Args>( args )... ),
-                                          string_format( npc_msg.translated(), std::forward<Args>( args )... ) );
+                                    const Args &... args ) const {
+            return add_msg_player_or_npc( string_format( player_msg.translated(), args... ),
+                                          string_format( npc_msg.translated(), args... ) );
         }
         template<typename ...Args>
         void add_msg_player_or_npc( const game_message_params &params, const char *const player_msg,
-                                    const char *const npc_msg, Args &&... args ) const {
+                                    const char *const npc_msg, const Args &... args ) const {
             if( params.type == m_debug && !debug_mode ) {
                 return;
             }
-            return add_msg_player_or_npc( params, string_format( player_msg, std::forward<Args>( args )... ),
-                                          string_format( npc_msg, std::forward<Args>( args )... ) );
+            return add_msg_player_or_npc( params, string_format( player_msg, args... ),
+                                          string_format( npc_msg, args... ) );
         }
         template<typename ...Args>
         void add_msg_player_or_npc( const game_message_params &params, const std::string &player_msg,
-                                    const std::string &npc_msg, Args &&... args ) const {
+                                    const std::string &npc_msg, const Args &... args ) const {
             if( params.type == m_debug && !debug_mode ) {
                 return;
             }
-            return add_msg_player_or_npc( params, string_format( player_msg, std::forward<Args>( args )... ),
-                                          string_format( npc_msg, std::forward<Args>( args )... ) );
+            return add_msg_player_or_npc( params, string_format( player_msg, args... ),
+                                          string_format( npc_msg, args... ) );
         }
         template<typename ...Args>
         void add_msg_player_or_npc( const game_message_params &params, const translation &player_msg,
-                                    const translation &npc_msg, Args &&... args ) const {
+                                    const translation &npc_msg, const Args &... args ) const {
             if( params.type == m_debug && !debug_mode ) {
                 return;
             }
-            return add_msg_player_or_npc( params, string_format( player_msg.translated(),
-                                          std::forward<Args>( args )... ),
-                                          string_format( npc_msg.translated(), std::forward<Args>( args )... ) );
+            return add_msg_player_or_npc( params, string_format( player_msg.translated(), args... ),
+                                          string_format( npc_msg.translated(), args... ) );
         }
 
         virtual void add_msg_player_or_say( const std::string &/*player_msg*/,
@@ -1165,50 +1163,48 @@ class Creature : public viewer
                                     const translation &/*npc_speech*/ ) const;
         template<typename ...Args>
         void add_msg_player_or_say( const char *const player_msg, const char *const npc_speech,
-                                    Args &&... args ) const {
-            return add_msg_player_or_say( string_format( player_msg, std::forward<Args>( args )... ),
-                                          string_format( npc_speech, std::forward<Args>( args )... ) );
+                                    const Args &... args ) const {
+            return add_msg_player_or_say( string_format( player_msg, args... ),
+                                          string_format( npc_speech, args... ) );
         }
         template<typename ...Args>
         void add_msg_player_or_say( const std::string &player_msg, const std::string &npc_speech,
-                                    Args &&... args ) const {
-            return add_msg_player_or_say( string_format( player_msg, std::forward<Args>( args )... ),
-                                          string_format( npc_speech, std::forward<Args>( args )... ) );
+                                    const Args &... args ) const {
+            return add_msg_player_or_say( string_format( player_msg, args... ),
+                                          string_format( npc_speech, args... ) );
         }
         template<typename ...Args>
         void add_msg_player_or_say( const translation &player_msg, const translation &npc_speech,
-                                    Args &&... args ) const {
-            return add_msg_player_or_say( string_format( player_msg.translated(),
-                                          std::forward<Args>( args )... ),
-                                          string_format( npc_speech.translated(), std::forward<Args>( args )... ) );
+                                    const Args &... args ) const {
+            return add_msg_player_or_say( string_format( player_msg.translated(), args... ),
+                                          string_format( npc_speech.translated(), args... ) );
         }
         template<typename ...Args>
         void add_msg_player_or_say( const game_message_params &params, const char *const player_msg,
-                                    const char *const npc_speech, Args &&... args ) const {
+                                    const char *const npc_speech, const Args &... args ) const {
             if( params.type == m_debug && !debug_mode ) {
                 return;
             }
-            return add_msg_player_or_say( params, string_format( player_msg, std::forward<Args>( args )... ),
-                                          string_format( npc_speech, std::forward<Args>( args )... ) );
+            return add_msg_player_or_say( params, string_format( player_msg, args... ),
+                                          string_format( npc_speech, args... ) );
         }
         template<typename ...Args>
         void add_msg_player_or_say( const game_message_params &params, const std::string &player_msg,
-                                    const std::string &npc_speech, Args &&... args ) const {
+                                    const std::string &npc_speech, const Args &... args ) const {
             if( params.type == m_debug && !debug_mode ) {
                 return;
             }
-            return add_msg_player_or_say( params, string_format( player_msg, std::forward<Args>( args )... ),
-                                          string_format( npc_speech, std::forward<Args>( args )... ) );
+            return add_msg_player_or_say( params, string_format( player_msg, args... ),
+                                          string_format( npc_speech, args... ) );
         }
         template<typename ...Args>
         void add_msg_player_or_say( const game_message_params &params, const translation &player_msg,
-                                    const translation &npc_speech, Args &&... args ) const {
+                                    const translation &npc_speech, const Args &... args ) const {
             if( params.type == m_debug && !debug_mode ) {
                 return;
             }
-            return add_msg_player_or_say( params, string_format( player_msg.translated(),
-                                          std::forward<Args>( args )... ),
-                                          string_format( npc_speech.translated(), std::forward<Args>( args )... ) );
+            return add_msg_player_or_say( params, string_format( player_msg.translated(), args... ),
+                                          string_format( npc_speech.translated(), args... ) );
         }
 
         virtual std::vector<std::string> extended_description() const = 0;

--- a/src/creature_tracker.cpp
+++ b/src/creature_tracker.cpp
@@ -24,6 +24,8 @@
 #include "submap.h"  // IWYU pragma: keep
 #include "type_id.h"
 
+class Character;
+
 static const efftype_id effect_ridden( "ridden" );
 
 #define dbg(x) DebugLog((x),D_GAME) << __FILE__ << ":" << __LINE__ << ": "
@@ -318,13 +320,14 @@ T *creature_tracker::creature_at( const tripoint_abs_ms &p, bool allow_hallucina
         // otherwise, keep looking for the rider.
         // creature_at<creature> or creature_at() with no template will still default to returning monster first,
         // which is ok for the occasions where that happens.
-        if( !mon_ptr->has_effect( effect_ridden ) || ( std::is_same<T, monster>::value ||
-                std::is_same<T, Creature>::value || std::is_same<T, const monster>::value ||
-                std::is_same<T, const Creature>::value ) ) {
+        if( !mon_ptr->has_effect( effect_ridden ) || ( std::is_same_v<T, monster> ||
+                std::is_same_v<T, Creature> || std::is_same_v<T, const monster> ||
+                std::is_same_v<T, const Creature> ) ) {
             return dynamic_cast<T *>( mon_ptr.get() );
         }
     }
-    if( !std::is_same<T, npc>::value && !std::is_same<T, const npc>::value ) {
+    constexpr bool is_npc = std::is_same_v<T, npc> || std::is_same_v<T, const npc>;
+    if( !is_npc ) {
         avatar &you = get_avatar();
         if( p == you.pos_abs() ) {
             return dynamic_cast<T *>( &you );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2654,7 +2654,7 @@ static void character_edit_menu()
         case D_MISSION_ADD: {
             uilist types;
             types.text = _( "Choose mission type" );
-            const auto all_missions = mission_type::get_all();
+            const auto &all_missions = mission_type::get_all();
             std::vector<const mission_type *> mts;
             for( size_t i = 0; i < all_missions.size(); i++ ) {
                 types.addentry( i, true, -1, all_missions[i].tname() );
@@ -3314,7 +3314,7 @@ static void display_talk_topic()
             }
             talk_topic_menu.query();
             if( talk_topic_menu.ret >= 0 && talk_topic_menu.ret < static_cast<int>( dialogue_ids.size() ) ) {
-                const std::string selected_topic = dialogue_ids[talk_topic_menu.ret];
+                const std::string &selected_topic = dialogue_ids[talk_topic_menu.ret];
                 a.talk_to( get_talker_for( selected_npc ), false, false, false, selected_topic );
             }
         }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3189,7 +3189,8 @@ static void debug_menu_game_state()
             creature_names_sorted.emplace_back( it );
         }
 
-        std::stable_sort( creature_names_sorted.begin(), creature_names_sorted.end(), []( auto a, auto b ) {
+        std::stable_sort( creature_names_sorted.begin(), creature_names_sorted.end(),
+        []( const auto & a, const auto & b ) {
             return a.second > b.second;
         } );
 

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -165,7 +165,7 @@ static std::vector<std::string> fld_string( const std::string &str, int width )
 }
 
 template<class SAVEOBJ>
-void edit_json( SAVEOBJ &it )
+static void edit_json( SAVEOBJ &it )
 {
     int tmret = -1;
     std::string save1 = serialize( it );
@@ -344,7 +344,7 @@ if (!!selected_ter) {
 
 */
 template <typename T_t, typename T_id>
-void brush_set_feature( editmap_brush &brush, T_id &brush_selected, bool &brush_enabled )
+static void brush_set_feature( editmap_brush &brush, T_id &brush_selected, bool &brush_enabled )
 {
     std::optional<T_id> selected_ter = brush.select_feature<T_t>();
     if( selected_ter.has_value() ) {

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -351,7 +351,7 @@ static void do_blast( map *m, const Creature *source, const tripoint_bub_ms &p, 
 
         if( const optional_vpart_position vp = m->veh_at( pt ) ) {
             // TODO: Make this weird unit used by vehicle::damage more sensible
-            vp->vehicle().damage( m[0], vp->part_index(), force,
+            vp->vehicle().damage( *m, vp->part_index(), force,
                                   fire ? damage_heat : damage_bash, false );
         }
 
@@ -504,7 +504,7 @@ static std::vector<tripoint_bub_ms> shrapnel( map *m, const Creature *source,
         }
         if( m->impassable( target ) ) {
             if( optional_vpart_position vp = m->veh_at( target ) ) {
-                vp->vehicle().damage( m[0], vp->part_index(), damage / 10 );
+                vp->vehicle().damage( *m, vp->part_index(), damage / 10 );
             } else {
                 m->bash( target, damage / 100, true );
             }

--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -345,7 +345,7 @@ void fault_fix::finalize()
     for( const fault_id &fid : faults_removed ) {
         const_cast<fault &>( *fid ).fixes.emplace( id );
     }
-    requirements->finalize();
+    requirement_data::finalize();
 }
 
 void fault_fix::check() const

--- a/src/flexbuffer_json-inl.h
+++ b/src/flexbuffer_json-inl.h
@@ -825,6 +825,10 @@ inline std::string JsonObject::get_string( const char *key ) const
 {
     return get_member( key );
 }
+inline std::string JsonObject::get_string( std::string_view key ) const
+{
+    return get_member( key );
+}
 
 template<typename T, typename std::enable_if_t<std::is_convertible_v<T, std::string>>*>
 std::string JsonObject::get_string( const std::string &key, T &&fallback ) const

--- a/src/flexbuffer_json.h
+++ b/src/flexbuffer_json.h
@@ -609,6 +609,7 @@ class JsonObject : JsonWithPath
 
         std::string get_string( const std::string &key ) const;
         std::string get_string( const char *key ) const;
+        std::string get_string( std::string_view key ) const;
 
         template<typename T, typename std::enable_if_t<std::is_convertible_v<T, std::string>>* = nullptr>
         std::string get_string( const std::string &key, T && fallback ) const;

--- a/src/game.h
+++ b/src/game.h
@@ -139,13 +139,13 @@ struct pulp_data {
     // how far the splatter goes
     int mess_radius = 1;
     // how much damage you deal to corpse every second, average of multiple values
-    float nominal_pulp_power;
+    float nominal_pulp_power = 0.0f;
     // The actual power produced, adjusted based on time adjustments.
-    float pulp_power;
+    float pulp_power = 0.0f;
     // how much stamina is consumed after each punch
-    float pulp_effort;
+    float pulp_effort = 0.0f;
     // time to pulp the corpse
-    int time_to_pulp;
+    int time_to_pulp = 0;
     // potential prof we can learn by pulping
     std::optional<proficiency_id> unknown_prof;
     // if monster has PULP_PRYING flag, can you pry armor faster using tool

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -3181,8 +3181,8 @@ class select_ammo_inventory_preset : public inventory_selector_preset
 
         // sort in order of move cost (ascending), then remaining ammo (descending) with empty magazines always last
         bool sort_compare( const inventory_entry &lhs, const inventory_entry &rhs ) const override {
-            item_location left = lhs.any_item();
-            item_location right = rhs.any_item();
+            const item_location &left = lhs.any_item();
+            const item_location &right = rhs.any_item();
 
             if( left->ammo_remaining( ) == 0 || right->ammo_remaining( ) == 0 ) {
                 return ( left->ammo_remaining( ) != 0 ) > ( right->ammo_remaining( ) != 0 );

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -277,6 +277,8 @@ class generic_factory
                 check_plural = check_plural_t::none;
                 const std::string abstract_id =  jo.get_string( abstract_member_name );
                 def.id = string_id<T>( abstract_id );
+                // def is a local stack object; virtual dispatch is fine here.
+                // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
                 def.load( jo, src );
                 abstracts[abstract_id] = def;
             }
@@ -371,6 +373,8 @@ class generic_factory
                     }
                     def.id = string_id<T>( e );
                     mod_tracker::assign_src( def, src );
+                    // def is a local stack object; virtual dispatch is fine here.
+                    // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
                     def.load( jo, src );
                     insert( def );
                 }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1861,7 +1861,7 @@ static void fire()
 static void open_movement_mode_menu()
 {
     avatar &player_character = get_avatar();
-    std::vector<move_mode_id> modes = move_modes_by_speed();
+    const std::vector<move_mode_id> &modes = move_modes_by_speed();
     const int cycle = 1027;
     uilist as_m;
 

--- a/src/hash_utils.h
+++ b/src/hash_utils.h
@@ -25,7 +25,7 @@ namespace tuple_hash_detail
 {
 
 // Recursive template code derived from Matthieu M.
-template < class Tuple, size_t Index = std::tuple_size<Tuple>::value - 1 >
+template < class Tuple, size_t Index = std::tuple_size_v<Tuple> - 1 >
 struct Impl
 {
     static void apply( size_t &seed, const Tuple &tuple ) {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5783,8 +5783,8 @@ static Character &best_installer( Character &you, Character &null_player, int di
 }
 
 template<typename ...Args>
-inline void popup_player_or_npc( Character &you, const char *player_mes, const char *npc_mes,
-                                 Args &&... args )
+static inline void popup_player_or_npc( Character &you, const char *player_mes, const char *npc_mes,
+                                        Args &&... args )
 {
     if( you.is_avatar() ) {
         popup( player_mes, std::forward<Args>( args )... );

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -191,8 +191,8 @@ void handle_harvest( Character &you, const itype_id &itemid, bool force_drop );
 using iexamine_examine_function = void ( * )( Character &, const tripoint_bub_ms & );
 using iexamine_can_examine_function = bool ( * )( const tripoint_bub_ms & );
 struct iexamine_functions {
-    iexamine_can_examine_function can_examine;
-    iexamine_examine_function examine;
+    iexamine_can_examine_function can_examine = nullptr;
+    iexamine_examine_function examine = nullptr;
 };
 
 iexamine_functions iexamine_functions_from_string( const std::string &function_name );

--- a/src/input_context.h
+++ b/src/input_context.h
@@ -118,6 +118,9 @@ class input_context
 
         template<typename Rhs>
         void reassign( Rhs &&other ) {
+            // Distinct member moves from the same source object are intentional;
+            // suppress the conservative use-after-move alert on the per-member chain.
+            // NOLINTBEGIN(bugprone-use-after-move)
             // Don't touch the handle
 #if defined(__ANDROID__)
             registered_manual_keys = std::forward<Rhs>( other ).registered_manual_keys;
@@ -135,6 +138,7 @@ class input_context
             timeout = std::forward<Rhs>( other ).timeout;
             preferred_keyboard_mode = std::forward<Rhs>( other ).preferred_keyboard_mode;
             action_name_overrides = std::forward<Rhs>( other ).action_name_overrides;
+            // NOLINTEND(bugprone-use-after-move)
         }
 
 

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -909,7 +909,7 @@ units::mass inventory::weight() const
 // Helper function to iterate over the intersection of the inventory and a list
 // of items given
 template<typename F>
-void for_each_item_in_both(
+static void for_each_item_in_both(
     const invstack &items, const std::map<const item *, int> &other, const F &f )
 {
     // Shortcut the logic in the common case where other is empty

--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -262,7 +262,7 @@ void item_action_generator::check_consistency() const
 {
     for( const auto &elem : item_actions ) {
         const item_action &action = elem.second;
-        if( !item_controller->has_iuse( action.id ) ) {
+        if( !Item_factory::has_iuse( action.id ) ) {
             debugmsg( "Item action \"%s\" isn't known to the game.  Check item action definitions in JSON.",
                       action.id.c_str() );
         }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1985,7 +1985,7 @@ static std::pair<std::string, use_function> use_function_reader_helper(
         if( !method.get_actor_ptr() ) {
             return std::make_pair( type, use_function() );
         }
-        method.get_actor_ptr()->load( use_obj, std::string( src.data() ) );
+        method.get_actor_ptr()->load( use_obj, std::string( src ) );
         return std::make_pair( type, method );
     } else if( val.test_array() ) {
         JsonArray use_arr = val.get_array();
@@ -2260,7 +2260,7 @@ class snippet_reader : public generic_typed_reader<snippet_reader>
                 // auto-create a category that is unlikely to already be used and put the
                 // snippets in it.
                 std::string snippet_category = "auto:" + def.get_id().str();
-                SNIPPET.add_snippets_from_json( snippet_category, val.get_array(), std::string( src.data() ) );
+                SNIPPET.add_snippets_from_json( snippet_category, val.get_array(), std::string( src ) );
                 return snippet_category;
             } else {
                 return val.get_string();

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -5309,6 +5309,7 @@ void items::finalize_all()
 void items::reset()
 {
     item_controller->get_generic_factory().reset();
+    // NOLINTNEXTLINE(readability-ambiguous-smartptr-reset-call) calls Item_factory::reset, not unique_ptr::reset
     item_controller->reset();
 }
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -325,7 +325,7 @@ static bool is_physical( const itype &type )
 }
 
 template<typename T>
-bool load_min_max( std::pair<T, T> &pa, const JsonObject &obj, const std::string &name )
+static bool load_min_max( std::pair<T, T> &pa, const JsonObject &obj, const std::string &name )
 {
     bool result = false;
     if( obj.has_array( name ) ) {
@@ -4768,7 +4768,7 @@ static Item_group *make_group_or_throw(
 }
 
 template<typename T>
-bool load_str_arr( std::vector<T> &arr, const JsonObject &obj, std::string_view name )
+static bool load_str_arr( std::vector<T> &arr, const JsonObject &obj, std::string_view name )
 {
     if( obj.has_array( name ) ) {
         for( const std::string str : obj.get_array( name ) ) {

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -810,9 +810,11 @@ std::pair<int, int> item::reach_range( const Character &guy ) const
                 continue;
             }
             if( m.second.melee() ) {
-                res = std::max( res, std::max( 1,
-                                               static_cast<int>( guy.calculate_by_enchantment( m.second.qty + reach_attack_add,
-                                                       enchant_vals::mod::MELEE_RANGE_MODIFIER ) ) ) );
+                res = std::max( {
+                    res, 1,
+                    static_cast<int>( guy.calculate_by_enchantment( m.second.qty + reach_attack_add,
+                                      enchant_vals::mod::MELEE_RANGE_MODIFIER ) )
+                } );
             }
         }
     }

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2810,7 +2810,7 @@ const std::optional<std::string> &item_pocket::favorite_settings::get_preset_nam
 }
 
 template<typename T>
-static std::string enumerate( cata::flat_set<T> container )
+static std::string enumerate( const cata::flat_set<T> &container )
 {
     std::vector<std::string> output;
     for( const T &id : container ) {

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2810,7 +2810,7 @@ const std::optional<std::string> &item_pocket::favorite_settings::get_preset_nam
 }
 
 template<typename T>
-std::string enumerate( cata::flat_set<T> container )
+static std::string enumerate( cata::flat_set<T> container )
 {
     std::vector<std::string> output;
     for( const T &id : container ) {

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -39,7 +39,7 @@ static std::pair<std::string, std::string> get_both( std::string_view a );
 template<typename Unit, size_t N>
 static std::function< bool( const item & )> can_contain_filter( std::string_view hint,
         std::string_view filter, Unit max, const std::array<std::pair<std::string_view, Unit>, N> &units,
-        std::function<item( itype *, Unit u )> set_function )
+        const std::function<item( itype *, Unit u )> &set_function )
 {
     // TODO: LAMBDA_NORETURN_CLANG21x1 can be replaced with [[noreturn]] once we switch to C++23 on all compilers
     auto const error = [hint, filter]( char const *, size_t /* offset */ ) LAMBDA_NORETURN_CLANG21x1 {

--- a/src/item_search.h
+++ b/src/item_search.h
@@ -19,7 +19,7 @@ struct map_data_common_t;
  */
 template<typename T>
 std::function<bool( const T & )> filter_from_string( std::string filter,
-        std::function<std::function<bool( const T & )>( const std::string & )> basic_filter )
+        const std::function<std::function<bool( const T & )>( const std::string & )> &basic_filter )
 {
     if( filter.empty() ) {
         // Variable without name prevents unused parameter warning

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8655,9 +8655,11 @@ std::optional<int> iuse::wash_items( Character *p, bool soft_items, bool hard_it
                               crafting_inv.charges_of( itype_water, INT_MAX, is_liquid ),
                               crafting_inv.charges_of( itype_water_clean, INT_MAX, is_liquid )
                           );
-    int available_cleanser = std::max( crafting_inv.charges_of( itype_soap ),
-                                       std::max( crafting_inv.charges_of( itype_detergent ),
-                                               crafting_inv.charges_of( itype_liquid_soap, INT_MAX, is_liquid ) ) );
+    int available_cleanser = std::max( {
+        crafting_inv.charges_of( itype_soap ),
+        crafting_inv.charges_of( itype_detergent ),
+        crafting_inv.charges_of( itype_liquid_soap, INT_MAX, is_liquid )
+    } );
 
     const inventory_filter_preset preset( [soft_items, hard_items]( const item_location & location ) {
         return location->has_flag( flag_FILTHY ) && !location->has_flag( flag_NO_CLEAN ) &&

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5727,7 +5727,7 @@ std::optional<int> sew_advanced_actor::use( Character *p, item &it, map *here,
 
     int index = 0;
     for( const clothing_mod_id &cm : clothing_mods ) {
-        clothing_mod obj = cm.obj();
+        const clothing_mod &obj = cm.obj();
         item temp_item = modded_copy( mod, obj.flag );
         temp_item.update_clothing_mod_val();
 

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -1064,14 +1064,14 @@ template<int xx, int xy, int yx, int yy, typename T, typename Out,
          void( *update_output )( Out &, const T &, quadrant ),
          T( *accumulate )( const T &, const T &, const int & ),
          bool with_color = false>
-void castLight( cata::mdarray<Out, point_bub_ms> &output_cache,
-                const cata::mdarray<T, point_bub_ms> &input_array,
-                const point_bub_ms &offset, int offsetDistance,
-                T numerator = VISIBILITY_FULL,
-                int row = 1, float start = 1.0f, float end = 0.0f,
-                T cumulative_transparency = T( LIGHT_TRANSPARENCY_OPEN_AIR ),
-                light_color_rgb source_color = {},
-                cata::mdarray<light_color_rgb, point_bub_ms> *color_cache = nullptr );
+static void castLight( cata::mdarray<Out, point_bub_ms> &output_cache,
+                       const cata::mdarray<T, point_bub_ms> &input_array,
+                       const point_bub_ms &offset, int offsetDistance,
+                       T numerator = VISIBILITY_FULL,
+                       int row = 1, float start = 1.0f, float end = 0.0f,
+                       T cumulative_transparency = T( LIGHT_TRANSPARENCY_OPEN_AIR ),
+                       light_color_rgb source_color = {},
+                       cata::mdarray<light_color_rgb, point_bub_ms> *color_cache = nullptr );
 
 template<int xx, int xy, int yx, int yy, typename T, typename Out,
          T( *calc )( const T &, const T &, const int & ),

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -203,9 +203,9 @@ bool string_id<enchantment>::is_valid() const
 }
 
 template<typename TKey>
-void load_add_and_multiply_dbl_or_var( const JsonObject &jo, std::string_view array_key,
-                                       const std::string &type_key, std::map<TKey, dbl_or_var> &add_map,
-                                       std::map<TKey, dbl_or_var> &mult_map )
+static void load_add_and_multiply_dbl_or_var( const JsonObject &jo, std::string_view array_key,
+        const std::string &type_key, std::map<TKey, dbl_or_var> &add_map,
+        std::map<TKey, dbl_or_var> &mult_map )
 {
     if( jo.has_array( array_key ) ) {
         for( const JsonObject value_obj : jo.get_array( array_key ) ) {
@@ -239,8 +239,8 @@ double enchant_cache::get_value( const TKey &value, const std::map<TKey, double>
 }
 
 template<typename TKey>
-void load_add_and_multiply( const JsonObject &jo, std::string_view array_key,
-                            const std::string &type_key, std::map<TKey, double> &add_map, std::map<TKey, double> &mult_map )
+static void load_add_and_multiply( const JsonObject &jo, std::string_view array_key,
+                                   const std::string &type_key, std::map<TKey, double> &add_map, std::map<TKey, double> &mult_map )
 {
     if( jo.has_array( array_key ) ) {
         for( const JsonObject value_obj : jo.get_array( array_key ) ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6580,8 +6580,8 @@ bool map::only_liquid_in_liquidcont( const tripoint_bub_ms &p )
 }
 
 template <typename Stack>
-std::list<item> use_amount_stack( Stack stack, const itype_id &type, int &quantity,
-                                  const std::function<bool( const item & )> &filter )
+static std::list<item> use_amount_stack( Stack stack, const itype_id &type, int &quantity,
+        const std::function<bool( const item & )> &filter )
 {
     std::list<item> ret;
     for( auto a = stack.begin(); a != stack.end() && quantity > 0; ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10201,7 +10201,7 @@ int map::determine_wall_corner( const tripoint_bub_ms &p ) const
 
         case 8 | 0 | 1 | 4:
             return LINE_XOXX;
-        case 0 | 0 | 1 | 4:
+        case 0 | 0 | 1 | 4: // NOLINT(misc-redundant-expression)
             return LINE_OOXX;
 
         case 8 | 2 | 0 | 4:
@@ -10210,7 +10210,7 @@ int map::determine_wall_corner( const tripoint_bub_ms &p ) const
             return LINE_OXOX;
         case 8 | 0 | 0 | 4: // NOLINT(misc-redundant-expression)
             return LINE_XOOX;
-        case 0 | 0 | 0 | 4:
+        case 0 | 0 | 0 | 4: // NOLINT(misc-redundant-expression)
             return LINE_OXOX; // LINE_OOOX would be better
 
         case 8 | 2 | 1 | 0:
@@ -10219,7 +10219,7 @@ int map::determine_wall_corner( const tripoint_bub_ms &p ) const
             return LINE_OXXO;
         case 8 | 0 | 1 | 0: // NOLINT(bugprone-branch-clone,misc-redundant-expression)
             return LINE_XOXO;
-        case 0 | 0 | 1 | 0:
+        case 0 | 0 | 1 | 0: // NOLINT(misc-redundant-expression)
             return LINE_XOXO; // LINE_OOXO would be better
         case 8 | 2 | 0 | 0: // NOLINT(misc-redundant-expression)
             return LINE_XXOO;
@@ -10228,7 +10228,7 @@ int map::determine_wall_corner( const tripoint_bub_ms &p ) const
         case 8 | 0 | 0 | 0: // NOLINT(misc-redundant-expression)
             return LINE_XOXO; // LINE_XOOO would be better
 
-        case 0 | 0 | 0 | 0:
+        case 0 | 0 | 0 | 0: // NOLINT(misc-redundant-expression)
             return ter( p ).obj().symbol(); // technically just a column
 
         default:

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -763,7 +763,12 @@ void map::resolve_off_map_grid_generation()
     power_network_manager &pnm = g->power_networks();
     pnm.begin_rebuild();
 
-    for( vehicle *veh : in_bubble ) {
+    std::vector<vehicle *> ordered_in_bubble( in_bubble.begin(), in_bubble.end() );
+    std::sort( ordered_in_bubble.begin(), ordered_in_bubble.end(),
+    []( const vehicle * a, const vehicle * b ) {
+        return a->pos_abs() < b->pos_abs();
+    } );
+    for( vehicle *veh : ordered_in_bubble ) {
         if( resolved.count( veh ) ) {
             continue;
         }
@@ -925,7 +930,12 @@ void map::vehmove()
             veh->get_connected_vehicles( *this, connected_vehs );
         }
     }
-    for( vehicle *connected_veh : connected_vehs ) {
+    std::vector<vehicle *> ordered_connected( connected_vehs.begin(), connected_vehs.end() );
+    std::sort( ordered_connected.begin(), ordered_connected.end(),
+    []( const vehicle * a, const vehicle * b ) {
+        return a->pos_abs() < b->pos_abs();
+    } );
+    for( vehicle *connected_veh : ordered_connected ) {
         vehs.emplace( connected_veh, false ); // add with 'false' if does not exist (off map)
     }
     for( const std::pair<vehicle *const, bool> &veh_pair : vehs ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4688,6 +4688,8 @@ bash_params map::bash( const tripoint_bub_ms &p, const int str,
                        bool silent, bool destroy, bool bash_floor,
                        const vehicle *bashing_vehicle, bool repair_missing_ground )
 {
+    // Temporary map is bound to a const reference for the call duration; bash returns by value.
+    // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape)
     return bash( p, {{{damage_bash, str}}}, silent, destroy, bash_floor, bashing_vehicle,
     repair_missing_ground );
 }

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -117,7 +117,7 @@ using namespace map_field_processing;
 void map::create_burnproducts( const tripoint_bub_ms &p, const item &fuel,
                                const units::mass &burned_mass )
 {
-    const std::map<material_id, int> all_mats = fuel.made_of();
+    const std::map<material_id, int> &all_mats = fuel.made_of();
     if( all_mats.empty() ) {
         return;
     }

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -625,8 +625,9 @@ ter_t null_terrain_t()
 }
 
 template<typename C, typename F>
-void load_season_array( const JsonObject &jo, const std::string &key, const std::string &context,
-                        const bool ignore_absent_key, C &container, F load_func )
+static void load_season_array( const JsonObject &jo, const std::string &key,
+                               const std::string &context,
+                               const bool ignore_absent_key, C &container, F load_func )
 {
     if( jo.has_string( key ) ) {
         container.fill( load_func( jo.get_string( key ) ) );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -4030,8 +4030,9 @@ void jmapgen_objects::load_objects( const JsonObject &jsi, const std::string &me
 }
 
 template<typename PieceType>
-void load_place_mapings( const JsonObject &jobj, mapgen_palette::placing_map::mapped_type &vect,
-                         const std::string &context )
+static void load_place_mapings( const JsonObject &jobj,
+                                mapgen_palette::placing_map::mapped_type &vect,
+                                const std::string &context )
 {
     vect.push_back( make_shared_fast<PieceType>( jobj, context ) );
 }
@@ -4045,8 +4046,9 @@ an overload below.
 The mapgen piece is loaded from the member of the json object named key.
 */
 template<typename PieceType>
-void load_place_mapings( const JsonValue &value, mapgen_palette::placing_map::mapped_type &vect,
-                         const std::string &context )
+static void load_place_mapings( const JsonValue &value,
+                                mapgen_palette::placing_map::mapped_type &vect,
+                                const std::string &context )
 {
     if( value.test_object() ) {
         load_place_mapings<PieceType>( value.get_object(), vect, context );
@@ -4061,7 +4063,7 @@ void load_place_mapings( const JsonValue &value, mapgen_palette::placing_map::ma
 This function allows loading the mapgen pieces from a single string, *or* a json object.
 */
 template<typename PieceType>
-void load_place_mapings_string(
+static void load_place_mapings_string(
     const JsonValue &value, mapgen_palette::placing_map::mapped_type &vect,
     const std::string &context )
 {
@@ -4093,7 +4095,7 @@ instance of jmapgen_alternatively which will chose the mapgen piece to apply to 
 Use this with terrain or traps or other things that can not be applied twice to the same place.
 */
 template<typename PieceType>
-void load_place_mapings_alternatively(
+static void load_place_mapings_alternatively(
     const JsonValue &value, mapgen_palette::placing_map::mapped_type &vect,
     const std::string &context )
 {

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -127,7 +127,7 @@ int terrain_type_to_nesw_array( oter_id terrain_type, std::array<bool, 4> &array
 
 // perform dist counterclockwise rotations on a nesw or neswx array
 template<typename T, size_t N>
-void nesw_array_rotate( std::array<T, N> &array, size_t dist )
+static void nesw_array_rotate( std::array<T, N> &array, size_t dist )
 {
     static_assert( N == 8 || N == 4, "Only arrays of size 4 and 8 are supported" );
     if( N == 4 ) {

--- a/src/mapgenformat.cpp
+++ b/src/mapgenformat.cpp
@@ -42,7 +42,7 @@ void formatted_set_simple( map *m, const point_bub_ms &start, const char *cstr,
 
 template<typename ID>
 format_effect<ID>::format_effect( const std::string &chars, std::vector<ID> dets )
-    : characters( chars ), determiners( dets )
+    : characters( chars ), determiners( std::move( dets ) )
 {
     characters.erase( std::remove_if( characters.begin(), characters.end(), isspace ),
                       characters.end() );

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -192,8 +192,8 @@ void ma_technique::finalize_all()
 
 // To avoid adding empty entries
 template <typename Container>
-void add_if_exists( const JsonObject &jo, Container &cont, bool was_loaded,
-                    const std::string &json_key, const typename Container::key_type &id )
+static void add_if_exists( const JsonObject &jo, Container &cont, bool was_loaded,
+                           const std::string &json_key, const typename Container::key_type &id )
 {
     if( jo.has_member( json_key ) ) {
         mandatory( jo, was_loaded, json_key, cont[id] );

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -1053,6 +1053,9 @@ math_exp::math_exp( math_exp const &other ) :
           std::make_unique<math_exp_impl>() ) {}
 math_exp &math_exp::operator=( math_exp const &other )
 {
+    if( this == &other ) {
+        return *this;
+    }
     impl = other.impl ? std::make_unique<math_exp_impl>( *other.impl ) :
            std::make_unique<math_exp_impl>();
     return *this;

--- a/src/math_parser_diag_value.cpp
+++ b/src/math_parser_diag_value.cpp
@@ -72,6 +72,7 @@ constexpr R _diag_value_helper( diag_value::impl_t const &data, const_dialogue c
         {
             if constexpr( std::is_same_v<std::decay_t<decltype( v )>, C> )
             {
+                // NOLINTNEXTLINE(bugprone-return-const-ref-from-parameter)
                 return v;
             } else if constexpr( std::is_same_v<std::decay_t<decltype( v )>, diag_value::legacy_value> )
             {

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -1297,7 +1297,7 @@ int gun_actor::get_max_range()  const
 {
     int max_range = 0;
     for( const auto &e : ranges ) {
-        max_range = std::max( std::max( max_range, e.first.first ), e.first.second );
+        max_range = std::max( { max_range, e.first.first, e.first.second } );
     }
 
     add_msg_debug( debugmode::DF_MATTACK, "Max range %d", max_range );

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -461,7 +461,7 @@ void mission_ui_impl::draw_selected_description( std::vector<mission *> missions
 void mission_ui_impl::draw_selected_description( std::vector<point_of_interest> points_of_interest,
         const int &selected_mission ) const
 {
-    point_of_interest selected_point_of_interest = points_of_interest[selected_mission];
+    const point_of_interest &selected_point_of_interest = points_of_interest[selected_mission];
     ImGui::TextWrapped( _( "Point of Interest: %s" ), selected_point_of_interest.text.c_str() );
     ImGui::Separator();
     draw_location( _( "Target:" ), selected_point_of_interest.pos );

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -111,8 +111,8 @@ void mission_type::reset()
 }
 
 template <typename Fun>
-void assign_function( const JsonObject &jo, const std::string &id, Fun &target,
-                      const std::map<std::string, Fun> &cont )
+static void assign_function( const JsonObject &jo, const std::string &id, Fun &target,
+                             const std::map<std::string, Fun> &cont )
 {
     if( jo.has_string( id ) ) {
         const auto iter = cont.find( jo.get_string( id ) );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1198,7 +1198,7 @@ bool mattack::smash( monster *z )
  */
 template <size_t N = 1>
 std::pair < std::array < tripoint_bub_ms, ( 2 * N + 1 ) * ( 2 * N + 1 ) >, size_t >
-find_empty_neighbors( const tripoint_bub_ms &origin )
+static find_empty_neighbors( const tripoint_bub_ms &origin )
 {
     constexpr int r = static_cast<int>( N );
 
@@ -1221,7 +1221,7 @@ find_empty_neighbors( const tripoint_bub_ms &origin )
  */
 template <size_t N = 1>
 std::pair < std::array < tripoint_bub_ms, ( 2 * N + 1 ) * ( 2 * N + 1 ) >, size_t >
-find_empty_neighbors( const Creature &c )
+static find_empty_neighbors( const Creature &c )
 {
     return find_empty_neighbors<N>( c.pos_bub() );
 }
@@ -1240,7 +1240,7 @@ static size_t get_random_index( const size_t size )
  * Get a size_t value in the closed interval [0, c.size() - 1]; a convenience to avoid messy casting.
  */
 template <typename Container>
-size_t get_random_index( const Container &c )
+static size_t get_random_index( const Container &c )
 {
     return get_random_index( c.size() );
 }

--- a/src/npc.h
+++ b/src/npc.h
@@ -938,7 +938,7 @@ class npc : public Character
         void form_opinion( const Character &you );
         npc_opinion get_opinion_values( const Character &you ) const;
         std::string pick_talk_topic( const Character &u );
-        std::string const &get_specified_talk_topic( std::string const &topic_id );
+        std::string get_specified_talk_topic( std::string const &topic_id );
         float character_danger( const Character &u ) const;
         float vehicle_danger( int radius ) const;
         void pretend_fire( npc *source, int shots, item &gun ); // fake ranged attack for hallucination

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -59,7 +59,7 @@ void npc_class::reset_npc_classes()
 
 // Copies the value under the key "ALL" to all unassigned skills
 template <typename T>
-void apply_all_to_unassigned( T &skills )
+static void apply_all_to_unassigned( T &skills )
 {
     auto iter = std::find_if( skills.begin(), skills.end(),
     []( decltype( *begin( skills ) ) &pr ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4575,7 +4575,7 @@ void npc::pick_up_item()
 }
 
 template <typename T>
-std::list<item> npc_pickup_from_stack( npc &who, T &items )
+static std::list<item> npc_pickup_from_stack( npc &who, T &items )
 {
     std::list<item> picked_up;
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2251,7 +2251,8 @@ int talk_trial::calc_chance( const_dialogue const &d ) const
     int chance = difficulty;
     switch( type ) {
         case NUM_TALK_TRIALS:
-            dbg( D_ERROR ) << "called calc_chance with invalid talk_trial value: " << type;
+            dbg( D_ERROR ) << "called calc_chance with invalid talk_trial value: "
+                           << static_cast<unsigned int>( type );
             break;
         case TALK_TRIAL_NONE:
             chance = 100;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4763,7 +4763,7 @@ talk_effect_fun_t::func f_explosion( const JsonObject &jo, std::string_view memb
 talk_effect_fun_t::func f_query_tile( const JsonObject &jo, std::string_view member,
                                       std::string_view, bool is_npc )
 {
-    std::string type = jo.get_string( member.data() );
+    std::string type = jo.get_string( member );
     var_info target_var = read_var_info( jo.get_object( "target_var" ) );
     std::string message;
     if( jo.has_member( "message" ) ) {
@@ -7213,7 +7213,7 @@ talk_effect_fun_t::func f_switch( const JsonObject &jo, std::string_view member,
 talk_effect_fun_t::func f_foreach( const JsonObject &jo, std::string_view member,
                                    std::string_view src )
 {
-    std::string type = jo.get_string( member.data() );
+    std::string type = jo.get_string( member );
     var_info itr = read_var_info( jo.get_object( "var" ) );
     talk_effect_t effect;
     effect.load_effect( jo, "effect", src );
@@ -7264,7 +7264,7 @@ talk_effect_fun_t::func f_foreach( const JsonObject &jo, std::string_view member
         }
 
         for( std::string_view str : list ) {
-            write_var_value( itr.type, itr.name, &d, str.data() );
+            write_var_value( itr.type, itr.name, &d, std::string{ str } );
             effect.apply( d );
         }
     };
@@ -8176,7 +8176,7 @@ talk_effect_fun_t::func f_wants_to_talk( bool is_npc )
 talk_effect_fun_t::func f_trigger_event( const JsonObject &jo, std::string_view member,
         std::string_view )
 {
-    std::string const type_str = jo.get_string( member.data() );
+    std::string const type_str = jo.get_string( member );
     JsonArray const &jargs = jo.get_array( "args" );
 
     event_type type = io::string_to_enum<event_type>( type_str );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -9272,7 +9272,7 @@ std::string npc::pick_talk_topic( const Character &/*u*/ )
     return chatbin.talk_stranger_neutral;
 }
 
-std::string const &npc::get_specified_talk_topic( std::string const &topic_id )
+std::string npc::get_specified_talk_topic( std::string const &topic_id )
 {
     static const dialogue_chatbin default_chatbin;
     std::vector<std::pair<std::string const &, std::string const &>> const talk_topics = {

--- a/src/npctalk_rules.cpp
+++ b/src/npctalk_rules.cpp
@@ -315,7 +315,7 @@ void follower_rules_ui_impl::checkbox( int rule_number, const T &this_rule,
 }
 
 template<typename T>
-void follower_rules_ui_impl::radio_group( const std::string header_id, const char *title, T *rule,
+void follower_rules_ui_impl::radio_group( const std::string &header_id, const char *title, T *rule,
         std::map<T, std::string> &values, input_event &assigned_hotkey, const input_event &pressed_key )
 {
     ImGui::Separator();

--- a/src/npctalk_rules.h
+++ b/src/npctalk_rules.h
@@ -55,7 +55,7 @@ class follower_rules_ui_impl : public cataimgui::window
 
         // makes one radio button per option in the map
         template<typename T>
-        void radio_group( std::string header_id, const char *title, T *rule,
+        void radio_group( const std::string &header_id, const char *title, T *rule,
                           std::map<T, std::string> &values, input_event &assigned_hotkey, const input_event &pressed_key );
 
         // Prepares for a rule option with multiple valid selections. Advances and wraps through

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1592,7 +1592,7 @@ static std::string trim( std::string_view s, Predicate pred )
 }
 
 template<typename Prep>
-std::string trim_trailing( std::string_view s, Prep prep )
+static std::string trim_trailing( std::string_view s, Prep prep )
 {
     return std::string( s.begin(), std::find_if_not(
     s.rbegin(), s.rend(), [&prep]( int c ) {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -2751,11 +2751,12 @@ using RatingVector = std::vector<std::tuple<double, char, std::string>>;
 template std::string get_labeled_bar<RatingVector::iterator>( const double val, const int width,
         const std::string &label,
         RatingVector::iterator begin, RatingVector::iterator end,
-        std::function<std::string( RatingVector::iterator, int )> printer );
+        const std::function<std::string( RatingVector::iterator, int )> &printer );
 
 template<typename BarIterator>
 std::string get_labeled_bar( const double val, const int width, const std::string &label,
-                             BarIterator begin, BarIterator end, std::function<std::string( BarIterator, int )> printer )
+                             BarIterator begin, BarIterator end,
+                             const std::function<std::string( BarIterator, int )> &printer )
 {
     std::string result;
 

--- a/src/output.h
+++ b/src/output.h
@@ -739,6 +739,8 @@ std::string enumerate_as_string( const Container &values,
  * @param conj Choose how to separate the last elements.
  */
 template<typename FIter, typename F>
+// Iterator pair by value is idiomatic for STL-style templates.
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 std::string enumerate_as_string( FIter first, FIter last, F &&string_for,
                                  enumeration_conjunction conj = enumeration_conjunction::and_ )
 {
@@ -798,7 +800,8 @@ std::string get_labeled_bar( double val, int width, const std::string &label,
  */
 template<typename BarIterator>
 std::string get_labeled_bar( double val, int width, const std::string &label,
-                             BarIterator begin, BarIterator end, std::function<std::string( BarIterator, int )> printer );
+                             BarIterator begin, BarIterator end,
+                             const std::function<std::string( BarIterator, int )> &printer );
 
 /**
  * @return String containing the bar. Example: "Label [************]".

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -2921,6 +2921,6 @@ void ui::omap::path_mark(
 void ui::omap::force_quit()
 {
     overmap_ui::generated_omts.clear();
-    g->overmap_data.ui.reset();
+    g->overmap_data.ui = nullptr;
     g->overmap_data.fast_traveling = false;
 }

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1131,7 +1131,7 @@ pf::simple_path<tripoint_abs_omt> overmapbuffer::get_travel_path(
 
     constexpr int radius = 4 * OMAPX; // radius of search in OMTs = 4 overmaps
     const pf::simple_path<tripoint_abs_omt> &path = pf::find_overmap_path( src, dest, radius, estimate,
-            g->display_om_pathfinding_progress, std::nullopt, params.allow_diagonal );
+            game::display_om_pathfinding_progress, std::nullopt, params.allow_diagonal );
     return path;
 }
 

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -572,6 +572,8 @@ void panel_manager::deserialize( const JsonArray &ja )
             for( auto it2 = layout.begin() + std::distance( layout.begin(), it ); it2 != layout.end(); ++it2 ) {
                 if( it2->get_id() == id ) {
                     if( it->get_id() != id ) {
+                        // Copy is intentional: layout.erase( it2 ) below invalidates *it2.
+                        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
                         window_panel panel = *it2;
                         layout.erase( it2 );
                         it = layout.insert( it, panel );

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -78,6 +78,7 @@ struct pathfinder {
         for( int i = minz; i <= maxz; ++i ) {
             std::unique_ptr< path_data_layer > &ptr = path_data[i + OVERMAP_DEPTH];
             if( ptr != nullptr ) {
+                // NOLINTNEXTLINE(readability-ambiguous-smartptr-reset-call) calls path_data_layer::reset
                 path_data[i + OVERMAP_DEPTH]->reset();
             }
         }

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -408,7 +408,7 @@ float player_activity::exertion_level() const
 }
 
 template <typename T>
-bool containers_equal( const T &left, const T &right )
+static bool containers_equal( const T &left, const T &right )
 {
     if( left.size() != right.size() ) {
         return false;

--- a/src/popup.h
+++ b/src/popup.h
@@ -90,14 +90,14 @@ class query_popup
          */
         template <typename ...Args>
         query_popup &message( const std::string &fmt, Args &&... args ) {
-            assert_format( fmt, std::forward<Args>( args )... );
+            assert_format<Args...>( fmt );
             invalidate_ui();
             text = string_format( fmt, std::forward<Args>( args )... );
             return *this;
         }
         template <typename ...Args>
         query_popup &message( const char *const fmt, Args &&... args ) {
-            assert_format( fmt, std::forward<Args>( args )... );
+            assert_format<Args...>( fmt );
             invalidate_ui();
             text = string_format( fmt, std::forward<Args>( args )... );
             return *this;
@@ -107,28 +107,28 @@ class query_popup
          **/
         template <typename ...Args>
         query_popup &wait_message( const nc_color &bar_color, const std::string &fmt, Args &&... args ) {
-            assert_format( fmt, std::forward<Args>( args )... );
+            assert_format<Args...>( fmt );
             invalidate_ui();
             text = wait_text( string_format( fmt, std::forward<Args>( args )... ), bar_color );
             return *this;
         }
         template <typename ...Args>
         query_popup &wait_message( const nc_color &bar_color, const char *const fmt, Args &&... args ) {
-            assert_format( fmt, std::forward<Args>( args )... );
+            assert_format<Args...>( fmt );
             invalidate_ui();
             text = wait_text( string_format( fmt, std::forward<Args>( args )... ), bar_color );
             return *this;
         }
         template <typename ...Args>
         query_popup &wait_message( const std::string &fmt, Args &&... args ) {
-            assert_format( fmt, std::forward<Args>( args )... );
+            assert_format<Args...>( fmt );
             invalidate_ui();
             text = wait_text( string_format( fmt, std::forward<Args>( args )... ) );
             return *this;
         }
         template <typename ...Args>
         query_popup &wait_message( const char *const fmt, Args &&... args ) {
-            assert_format( fmt, std::forward<Args>( args )... );
+            assert_format<Args...>( fmt );
             invalidate_ui();
             text = wait_text( string_format( fmt, std::forward<Args>( args )... ) );
             return *this;
@@ -237,7 +237,7 @@ class query_popup
         void invalidate_ui() const;
 
         template <typename ...Args>
-        static void assert_format( const std::string_view, Args &&... ) {
+        static void assert_format( const std::string_view ) {
             static_assert( sizeof...( Args ) > 0,
                            "Format string should take at least one argument.  "
                            "If your message is not a format string, "

--- a/src/profession.h
+++ b/src/profession.h
@@ -133,7 +133,7 @@ class profession
         std::vector<matype_id> ma_known() const;
         std::vector<matype_id> ma_choices() const;
         bool allows_hobby( const string_id<profession> &hobby )const;
-        int ma_choice_amount;
+        int ma_choice_amount = 0;
         StartingSkillList skills() const;
         const std::vector<mission_type_id> &missions() const;
         static constexpr int DEFAULT_PROF_AGE_LOWER = 21;

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -56,6 +56,9 @@ projectile::projectile( const projectile &other )
 
 projectile &projectile::operator=( const projectile &other )
 {
+    if( this == &other ) {
+        return *this;
+    }
     impact = other.impact;
     speed = other.speed;
     range = other.range;

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -113,7 +113,7 @@ const recipe &recipe_dictionary::get_craft( const itype_id &id )
 
 // searches for left-anchored partial match in the relevant recipe requirements set
 template <class group>
-bool search_reqs( const group &gp, std::string_view txt )
+static bool search_reqs( const group &gp, std::string_view txt )
 {
     return std::any_of( gp.begin(), gp.end(), [&]( const typename group::value_type & opts ) {
         return std::any_of( opts.begin(),

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -370,8 +370,8 @@ void region_settings::reset()
 }
 
 template<typename T>
-void read_and_set_or_throw( const JsonObject &jo, const std::string &member, T &target,
-                            bool required )
+static void read_and_set_or_throw( const JsonObject &jo, const std::string &member, T &target,
+                                   bool required )
 {
     T tmp;
     if( !jo.read( member, tmp ) ) {

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -668,8 +668,8 @@ void requirement_data::check_consistency()
 }
 
 template <typename T>
-void inline_requirements( std::vector<std::vector<T>> &list,
-                          const std::function<const std::vector<std::vector<T>> & ( const requirement_data & )> &getter )
+static void inline_requirements( std::vector<std::vector<T>> &list,
+                                 const std::function<const std::vector<std::vector<T>> & ( const requirement_data & )> &getter )
 {
     // add a single component to the vector. If component already exists, chooses min count
     const auto add_component = []( const T & comp, std::vector<T> &accum ) {

--- a/src/ret_val.h
+++ b/src/ret_val.h
@@ -61,21 +61,21 @@ class ret_val : public ret_val_common
         ret_val() = delete;
 
         static ret_val make_success( T val = default_success::value ) {
-            return make_success( val, std::string() );
+            return make_success( std::move( val ), std::string() );
         }
 
         static ret_val make_failure( T val = default_failure::value ) {
-            return make_failure( val, std::string() );
+            return make_failure( std::move( val ), std::string() );
         }
 
         template<class... A, typename S = std::string, typename = is_convertible_to_string<S>>
         static ret_val make_success( T val, const S &msg, A && ... args ) {
-            return ret_val( string_format( msg, std::forward<A>( args )... ), val, true );
+            return ret_val( string_format( msg, std::forward<A>( args )... ), std::move( val ), true );
         }
 
         template<class... A, typename S = std::string, typename = is_convertible_to_string<S>>
         static ret_val make_failure( T val, const S &msg, A && ... args ) {
-            return ret_val( string_format( msg, std::forward<A>( args )... ), val, false );
+            return ret_val( string_format( msg, std::forward<A>( args )... ), std::move( val ), false );
         }
 
         template<class... A, typename S = std::string, typename = is_convertible_to_string<S>>
@@ -94,7 +94,7 @@ class ret_val : public ret_val_common
 
     private:
         ret_val( const std::string &msg, T val, bool succ )
-            : ret_val_common( msg, succ ), val( val ) {}
+            : ret_val_common( msg, succ ), val( std::move( val ) ) {}
 
         T val;
 };

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -403,17 +403,17 @@ BitmapFont::BitmapFont(
     }
     Uint32 key = MapRGB( asciiload, 0xFF, 0, 0xFF );
     SetColorKey( asciiload, 1, key );
-    std::array<SDL_Surface_Ptr, std::tuple_size<decltype( ascii )>::value> ascii_surf;
+    std::array<SDL_Surface_Ptr, std::tuple_size_v<decltype( ascii )>> ascii_surf;
     ascii_surf[0] = ConvertSurfaceFormat( asciiload, pixel_format );
     SetSurfaceRLE( ascii_surf[0], 1 );
     asciiload.reset();
 
-    for( size_t a = 1; a < std::tuple_size<decltype( ascii )>::value; ++a ) {
+    for( size_t a = 1; a < std::tuple_size_v<decltype( ascii )>; ++a ) {
         ascii_surf[a] = ConvertSurfaceFormat( ascii_surf[0], pixel_format );
         SetSurfaceRLE( ascii_surf[a], 1 );
     }
 
-    for( size_t a = 0; a < std::tuple_size<decltype( ascii )>::value - 1; ++a ) {
+    for( size_t a = 0; a < std::tuple_size_v<decltype( ascii )> - 1; ++a ) {
         throwErrorIf( LockSurface( ascii_surf[a] ) != 0, "SDL_LockSurface failed" );
         int size = ascii_surf[a]->h * ascii_surf[a]->w;
         Uint32 *pixels = static_cast<Uint32 *>( ascii_surf[a]->pixels );
@@ -428,7 +428,7 @@ BitmapFont::BitmapFont(
     tilewidth = ascii_surf[0]->w / width;
 
     //convert ascii_surf to SDL_Texture
-    for( size_t a = 0; a < std::tuple_size<decltype( ascii )>::value; ++a ) {
+    for( size_t a = 0; a < std::tuple_size_v<decltype( ascii )>; ++a ) {
         ascii[a] = CreateTextureFromSurface( renderer, ascii_surf[a] );
     }
 }

--- a/src/shadowcasting.cpp
+++ b/src/shadowcasting.cpp
@@ -162,7 +162,7 @@ template<int xx_transform, int xy_transform, int yx_transform, int yy_transform,
          T( *calc )( const T &, const T &, const int & ),
          bool( *is_transparent )( const T &, const T & ),
          T( *accumulate )( const T &, const T &, const int & )>
-void cast_horizontal_zlight_segment(
+static void cast_horizontal_zlight_segment(
     const array_of_grids_of<T> &output_caches,
     const array_of_grids_of<const T> &input_arrays,
     const array_of_grids_of<const bool> &floor_caches,
@@ -359,7 +359,7 @@ template<int x_transform, int y_transform, int z_transform, typename T,
          T( *calc )( const T &, const T &, const int & ),
          bool( *is_transparent )( const T &, const T & ),
          T( *accumulate )( const T &, const T &, const int & )>
-void cast_vertical_zlight_segment(
+static void cast_vertical_zlight_segment(
     const array_of_grids_of<T> &output_caches,
     const array_of_grids_of<const T> &input_arrays,
     const array_of_grids_of<const bool> &floor_caches,

--- a/src/simple_pathfinding.h
+++ b/src/simple_pathfinding.h
@@ -87,7 +87,7 @@ directed_path<point> greedy_path( const point &source, const point &dest, const 
  */
 template<typename Point, typename = std::enable_if_t<Point::dimension == 2>>
 directed_path<Point> greedy_path( const Point &source, const Point &dest, const Point &max,
-                                  two_node_scoring_fn<Point> scorer )
+                                  const two_node_scoring_fn<Point> &scorer )
 {
     directed_path<Point> res;
     const two_node_scoring_fn<point> point_scorer

--- a/src/stats_tracker.h
+++ b/src/stats_tracker.h
@@ -148,7 +148,7 @@ class watcher_set
 
         template<typename Class, typename... FnArgs, typename... Args>
         void send_to_all( void ( Class::*mem_fn )( FnArgs... ), Args &&... args ) const {
-            static_assert( std::is_base_of<Class, Watcher>::value,
+            static_assert( std::is_base_of_v<Class, Watcher>,
                            "Watcher must be derived from Class" );
             // Sending an event to a watcher can cause it to be erased, so we
             // need to always ensure we have the next iterator prepared in

--- a/src/string_id_utils.h
+++ b/src/string_id_utils.h
@@ -37,7 +37,7 @@ std::vector<std::pair<K, V>> sorted_lex( Col col )
 template<typename Col,
          typename El = std::decay_t<decltype( *std::declval<const Col &>().begin() )>,
          std::enable_if_t<std::is_same_v<El, string_id<typename El::value_type>>, int> = 0>
-std::vector<El> sorted_lex( Col col )
+std::vector<El> sorted_lex( const Col &col )
 {
     std::vector<El> ret;
     ret.insert( ret.begin(), col.begin(), col.end() );

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -334,7 +334,8 @@ void string_input_popup::query( const bool loop, const bool draw_only )
 }
 
 template<typename T>
-std::optional<T> query_int_impl( string_input_popup &p, const bool loop, const bool draw_only )
+static std::optional<T> query_int_impl( string_input_popup &p, const bool loop,
+                                        const bool draw_only )
 {
     do {
         const std::string &queried_string = p.query_string( loop, draw_only );

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -407,7 +407,7 @@ static std::string trim_by_width( std::string_view text, float width )
         width = ImGui::GetContentRegionAvail().x;
     }
 
-    float text_width = ImGui::CalcTextSize( text.data(), nullptr, true ).x;
+    float text_width = ImGui::CalcTextSize( text.data(), text.data() + text.size(), true ).x;
 
     if( text_width < width ) {
         return std::string( text );

--- a/src/translations.h
+++ b/src/translations.h
@@ -49,6 +49,7 @@ std::string select_language();
 template<typename T>
 inline const T &translation_argument_identity( const T &t )
 {
+    // NOLINTNEXTLINE(bugprone-return-const-ref-from-parameter)
     return t;
 }
 

--- a/src/value_ptr.h
+++ b/src/value_ptr.h
@@ -90,6 +90,9 @@ struct heap {
             *this = rhs;
         }
         heap &operator=( heap const &rhs ) {
+            if( this == &rhs ) {
+                return *this;
+            }
             // This should always be true, however, sanity says do the right thing.
             if( rhs.heaped_ ) {
                 heaped_.reset( new T{ *rhs.heaped_ } );

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -582,7 +582,7 @@ void vehicles::parts::finalize()
 {
     vpart_info_factory.finalize();
 
-    for( const itype *const item : item_controller->find( mountable_gun_filter ) ) {
+    for( const itype *const item : Item_factory::find( mountable_gun_filter ) ) {
         vpart_info new_part = *vpart_turret_generic; // copy from generic
         const itype_id item_id = item->get_id();
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4086,7 +4086,7 @@ int vehicle::ground_acceleration( map &here, const bool fueled, int at_vel_in_vm
     if( !( engine_on || skidding ) ) {
         return 0;
     }
-    int target_vmiph = std::max( at_vel_in_vmi, std::max( 1000, max_velocity( here, fueled ) / 4 ) );
+    int target_vmiph = std::max( { at_vel_in_vmi, 1000, max_velocity( here, fueled ) / 4 } );
     int cmps = vmiph_to_cmps( target_vmiph );
     double weight = to_kilogram( total_mass( here ) );
     if( is_towing() ) {
@@ -4118,8 +4118,7 @@ int vehicle::water_acceleration( map &here, const bool fueled, int at_vel_in_vmi
     if( !( engine_on || skidding ) ) {
         return 0;
     }
-    int target_vmiph = std::max( at_vel_in_vmi, std::max( 1000,
-                                 max_water_velocity( here, fueled ) / 4 ) );
+    int target_vmiph = std::max( { at_vel_in_vmi, 1000, max_water_velocity( here, fueled ) / 4 } );
     int cmps = vmiph_to_cmps( target_vmiph );
     double weight = to_kilogram( total_mass( here ) );
     if( is_towing() ) {
@@ -4632,8 +4631,8 @@ double vehicle::coeff_air_drag() const
         c_air_drag_c += ( dc.pro > dc.hboard ) ? c_air_mod : 0;
         // not having halfboards in front of any windshields or fullboards moderately worsens
         // air drag
-        c_air_drag_c += ( std::max( std::max( dc.hboard, dc.fboard ),
-                                    dc.shield ) != dc.hboard ) ? 2 * c_air_mod : 0;
+        c_air_drag_c += ( std::max( { dc.hboard, dc.fboard, dc.shield } ) != dc.hboard ) ? 2 * c_air_mod :
+                        0;
         // not having windshields in front of seats severely worsens air drag
         c_air_drag_c += ( dc.shield < dc.seat ) ? 3 * c_air_mod : 0;
         // missing roofs and open doors severely worsen air drag

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -267,7 +267,7 @@ turret_cpu::~turret_cpu() = default;
 // NOLINTNEXTLINE(bugprone-unhandled-self-assignment,cert-oop54-cpp)
 turret_cpu &turret_cpu::operator=( const turret_cpu & )
 {
-    brain.reset();
+    brain = nullptr;
     return *this;
 }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2619,7 +2619,7 @@ bool vehicle::split_vehicles( map &here,
         if( split_parts.empty() ) {
             continue;
         }
-        std::vector<point_rel_ms> split_mounts = new_mounts[ i ];
+        const std::vector<point_rel_ms> &split_mounts = new_mounts[ i ];
         did_split = true;
 
         vehicle *new_vehicle = nullptr;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -263,6 +263,8 @@ vehicle::~vehicle() = default;
 
 turret_cpu::~turret_cpu() = default;
 
+// rhs is intentionally ignored; assignment resets the cached brain.
+// NOLINTNEXTLINE(bugprone-unhandled-self-assignment,cert-oop54-cpp)
 turret_cpu &turret_cpu::operator=( const turret_cpu & )
 {
     brain.reset();

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1876,7 +1876,7 @@ std::string widget::layout( const avatar &ava, unsigned int max_width, int label
             // Total widget width w/o padding
             const int total_widget_width = std::accumulate( wgts.begin(), wgts.end(), 0,
             [child_width]( int sum, const widget_id & wid ) {
-                widget cur_child = wid.obj();
+                const widget &cur_child = wid.obj();
                 return sum + ( cur_child._style == "layout" &&
                                cur_child._width > 0 ? cur_child._width : child_width );
             } );

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -344,7 +344,7 @@ void debug_menu::wishmutate( Character *you )
 
 void debug_menu::wishbionics( Character *you )
 {
-    std::vector<const itype *> cbm_items = item_controller->find( []( const itype & itm ) -> bool {
+    std::vector<const itype *> cbm_items = Item_factory::find( []( const itype & itm ) -> bool {
         return itm.can_use( "install_bionic" );
     } );
     std::sort( cbm_items.begin(), cbm_items.end(), []( const itype * a, const itype * b ) {

--- a/src/wound.cpp
+++ b/src/wound.cpp
@@ -188,7 +188,7 @@ void wound_fix::finalize()
     for( const wound_type_id &fid : wounds_removed ) {
         const_cast<wound_type &>( *fid ).fixes.emplace( id );
     }
-    requirements->finalize();
+    requirement_data::finalize();
 }
 
 void wound_proficiency::deserialize( const JsonObject &jo )

--- a/src/zzip.cpp
+++ b/src/zzip.cpp
@@ -768,6 +768,9 @@ bool zzip::update_footer( JsonObject const &original_footer,
     flexbuffers::Builder builder;
     size_t root_start = builder.StartMap();
     size_t total_content_size = 0;
+    // The k*Key constants are constexpr string_views built from string literals, so
+    // their underlying buffer is null-terminated and safe for the const char* APIs.
+    // NOLINTBEGIN(bugprone-suspicious-stringview-data-usage)
     {
         size_t entries_start = builder.StartMap( kEntriesKey.data() );
         // NOLINTNEXTLINE(cata-almost-never-auto)
@@ -783,7 +786,7 @@ bool zzip::update_footer( JsonObject const &original_footer,
                 processed_files.insert( new_filename );
             }
         }
-        for( JsonMember entry : original_footer.get_object( kEntriesKey.data() ) ) {
+        for( JsonMember entry : original_footer.get_object( kEntriesKey ) ) {
             std::string old_filename = entry.name();
             if( !processed_files.count( old_filename ) ) {
                 size_t entry_map = builder.StartMap( old_filename.c_str() );
@@ -805,6 +808,7 @@ bool zzip::update_footer( JsonObject const &original_footer,
         builder.UInt( kMetaTotalContentSizeKey.data(), total_content_size );
         builder.EndMap( meta_start );
     }
+    // NOLINTEND(bugprone-suspicious-stringview-data-usage)
     builder.EndMap( root_start );
     builder.Finish();
     auto buf = builder.GetBuffer();

--- a/tests/battery_density_test.cpp
+++ b/tests/battery_density_test.cpp
@@ -124,7 +124,7 @@ static bool is_battery( const itype &type )
 
 TEST_CASE( "battery_density_check" )
 {
-    for( const itype *id : item_controller->find( is_battery ) ) {
+    for( const itype *id : Item_factory::find( is_battery ) ) {
         auto chemistry_name = battery_to_chemistry.find( id->get_id() );
         battery_chemistry_family chemistry;
         if( chemistry_name == battery_to_chemistry.end() ) {

--- a/tests/cata_utility_test.cpp
+++ b/tests/cata_utility_test.cpp
@@ -18,7 +18,7 @@
 // tests both variants of string_starts_with
 template <std::size_t N>
 // NOLINTNEXTLINE(modernize-avoid-c-arrays)
-bool test_string_starts_with( const std::string &s1, const char( &s2 )[N] )
+static bool test_string_starts_with( const std::string &s1, const char( &s2 )[N] )
 {
     CAPTURE( s1, s2, N );
     bool r1 =  string_starts_with( s1, s2 );
@@ -30,7 +30,7 @@ bool test_string_starts_with( const std::string &s1, const char( &s2 )[N] )
 // tests both variants of string_ends_with
 template <std::size_t N>
 // NOLINTNEXTLINE(modernize-avoid-c-arrays)
-bool test_string_ends_with( const std::string &s1, const char( &s2 )[N] )
+static bool test_string_ends_with( const std::string &s1, const char( &s2 )[N] )
 {
     CAPTURE( s1, s2, N );
     bool r1 =  string_ends_with( s1, s2 );

--- a/tests/json_test.cpp
+++ b/tests/json_test.cpp
@@ -51,7 +51,7 @@ static const spell_id spell_test_spell_json( "test_spell_json" );
 static const trait_id trait_test_trait( "test_trait" );
 
 template<typename T>
-void test_serialization( const T &val, const std::string &s )
+static void test_serialization( const T &val, const std::string &s )
 {
     CAPTURE( val );
     {

--- a/tests/memorial_test.cpp
+++ b/tests/memorial_test.cpp
@@ -34,7 +34,8 @@ static const spell_id spell_pain_damage( "pain_damage" );
 static const trap_str_id tr_pit( "tr_pit" );
 
 template<event_type Type, typename... Args>
-static void check_memorial( memorial_logger &m, event_bus &b, const std::string &ref, Args... args )
+static void check_memorial( memorial_logger &m, event_bus &b, const std::string &ref,
+                            const Args &... args )
 {
     CAPTURE( io::enum_to_string( Type ) );
     CAPTURE( ref );

--- a/tests/memorial_test.cpp
+++ b/tests/memorial_test.cpp
@@ -34,7 +34,7 @@ static const spell_id spell_pain_damage( "pain_damage" );
 static const trap_str_id tr_pit( "tr_pit" );
 
 template<event_type Type, typename... Args>
-void check_memorial( memorial_logger &m, event_bus &b, const std::string &ref, Args... args )
+static void check_memorial( memorial_logger &m, event_bus &b, const std::string &ref, Args... args )
 {
     CAPTURE( io::enum_to_string( Type ) );
     CAPTURE( ref );

--- a/tests/new_character_test.cpp
+++ b/tests/new_character_test.cpp
@@ -5,7 +5,6 @@
 #include <set>
 #include <sstream>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -134,9 +133,10 @@ TEST_CASE( "starting_items", "[slow]" )
         trait_WOOLALLERGY
     };
     // Prof/scen combinations that need to be checked.
-    std::unordered_map<const scenario *, std::vector<string_id<profession>>> scen_prof_combos;
+    std::vector<std::pair<const scenario *, std::vector<string_id<profession>>>> scen_prof_combos;
+    scen_prof_combos.emplace_back( scenario::generic(), std::vector<string_id<profession>> {} );
     for( const auto &id : scenario::generic()->permitted_professions() ) {
-        scen_prof_combos[scenario::generic()].push_back( id );
+        scen_prof_combos.back().second.push_back( id );
     }
 
     std::set<failure> failures;

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -419,7 +419,7 @@ static bool tally_items( std::unordered_map<itype_id, float> &global_item_count,
 
 TEST_CASE( "enumerate_items", "[.]" )
 {
-    for( const itype *id : item_controller->find(
+    for( const itype *id : Item_factory::find(
     []( const itype & type ) -> bool {
     return !!type.gun;
 } ) ) {
@@ -437,7 +437,7 @@ static void finalize_item_counts( std::unordered_map<itype_id, float> &item_coun
         // Ammo has a lot of things in it we don't consider "real ammo" so there's a list
         // of item types to ignore that are applied here.
         if( category.first == "ammo" ) {
-            for( const itype *id : item_controller->find( []( const itype & type ) -> bool {
+            for( const itype *id : Item_factory::find( []( const itype & type ) -> bool {
             return !!type.ammo;
         } ) ) {
                 if( category.second.ignored_items.find( id->get_id() ) != category.second.ignored_items.end() ) {
@@ -459,7 +459,7 @@ static void finalize_item_counts( std::unordered_map<itype_id, float> &item_coun
                 }
             }
         } else if( category.first == "gun" ) {
-            for( const itype *id : item_controller->find( []( const itype & type ) -> bool {
+            for( const itype *id : Item_factory::find( []( const itype & type ) -> bool {
             return !!type.gun;
         } ) ) {
                 if( category.second.ignored_items.find( id->get_id() ) != category.second.ignored_items.end() ) {

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -110,7 +110,7 @@ class Threshold
 };
 
 template < class T >
-std::ostream &operator <<( std::ostream &os, const std::vector<T> &v )
+static std::ostream &operator <<( std::ostream &os, const std::vector<T> &v )
 {
     os << "[";
     for( typename std::vector<T>::const_iterator ii = v.begin(); ii != v.end(); ++ii ) {
@@ -694,8 +694,8 @@ TEST_CASE( "shot_custom_damage_type", "[gun]" "[slow]" )
 static constexpr float fudge_factor = 0.025;
 
 template<typename T, typename W>
-std::map<T, float> hit_distribution( const targeting_graph<T, W> &graph,
-                                     std::optional<float> guess = std::nullopt, int iters = 100000 )
+static std::map<T, float> hit_distribution( const targeting_graph<T, W> &graph,
+        std::optional<float> guess = std::nullopt, int iters = 100000 )
 {
     std::map<T, float> hits;
     for( int i = 0; i < iters; ++i ) {

--- a/tests/reloading_test.cpp
+++ b/tests/reloading_test.cpp
@@ -67,8 +67,6 @@ static const itype_id itype_water_clean( "water_clean" );
 
 static void test_reloading( item &target, item &ammo, bool expect_success = true )
 {
-    item target_copy( target );
-
     Character &dummy = get_avatar();
 
     clear_avatar();
@@ -92,7 +90,7 @@ static void test_reloading( item &target, item &ammo, bool expect_success = true
 
     // Quick and dirty check to see if anything was actually reloaded.
     // Doesn't check if right thing went to right place. But something did go somewhere
-    item_contents contents_before = target.get_contents();
+    const item_contents &contents_before = target.get_contents();
     item_contents contents_after = dummy.get_wielded_item()->get_contents();
     bool contents_changed = !contents_before.same_contents( contents_after );
     if( expect_success ) {

--- a/tests/shadowcasting_test.cpp
+++ b/tests/shadowcasting_test.cpp
@@ -139,7 +139,7 @@ static bool is_nonzero( const four_quadrants &x )
 }
 
 template<typename Exp>
-bool grids_are_equivalent(
+static bool grids_are_equivalent(
     const cata::mdarray<float, point_bub_ms> &control,
     const cata::mdarray<Exp, point_bub_ms> &experiment )
 {
@@ -156,7 +156,7 @@ bool grids_are_equivalent(
 }
 
 template<typename Exp>
-void print_grid_comparison(
+static void print_grid_comparison(
     const point_bub_ms &offset,
     cata::mdarray<float, point_bub_ms> &transparency_cache,
     const cata::mdarray<float, point_bub_ms> &control,

--- a/tests/start_date_test.cpp
+++ b/tests/start_date_test.cpp
@@ -26,7 +26,7 @@ TEST_CASE( "Test_start_dates" )
     } };
 
     SECTION( "Scenario with custom game start date" ) {
-        scenario scen = scenario_test_custom_game.obj();
+        const scenario &scen = scenario_test_custom_game.obj();
         set_scenario( &scen );
         g->start_calendar();
 
@@ -39,7 +39,7 @@ TEST_CASE( "Test_start_dates" )
     }
 
     SECTION( "Scenario has game start date before cataclysm start date" ) {
-        scenario scen = scenario_test_custom_game_invalid.obj();
+        const scenario &scen = scenario_test_custom_game_invalid.obj();
         set_scenario( &scen );
         g->start_calendar();
 
@@ -47,7 +47,7 @@ TEST_CASE( "Test_start_dates" )
     }
 
     SECTION( "Scenario with custom cataclysm start date" ) {
-        scenario scen = scenario_test_custom_cataclysm.obj();
+        const scenario &scen = scenario_test_custom_cataclysm.obj();
         set_scenario( &scen );
         g->start_calendar();
 
@@ -60,7 +60,7 @@ TEST_CASE( "Test_start_dates" )
     }
 
     SECTION( "Scenario with custom cataclysm start date and game start date" ) {
-        scenario scen = scenario_test_custom_both.obj();
+        const scenario &scen = scenario_test_custom_both.obj();
         set_scenario( &scen );
         g->start_calendar();
 

--- a/tests/string_formatter_test.cpp
+++ b/tests/string_formatter_test.cpp
@@ -16,14 +16,14 @@
 
 // Same as @ref string_format, but does not swallow errors and throws them instead.
 template<typename ...Args>
-std::string throwing_string_format( fmt::string_view format, Args &&...args )
+static std::string throwing_string_format( fmt::string_view format, Args &&...args )
 {
     return fmt::vsprintf( format, fmt::make_printf_args( args... ) );
 }
 
 template<typename ...Args>
-void importet_test( const int serial, const char *const expected, const char *const format,
-                    Args &&... args )
+static void importet_test( const int serial, const char *const expected, const char *const format,
+                           Args &&... args )
 {
     CAPTURE( serial );
     CAPTURE( format );
@@ -38,7 +38,8 @@ void importet_test( const int serial, const char *const expected, const char *co
 }
 
 template<typename ...Args>
-void test_for_expected( const std::string &expected, const char *const format, Args &&... args )
+static void test_for_expected( const std::string &expected, const char *const format,
+                               Args &&... args )
 {
     CAPTURE( format );
     CAPTURE( std::setlocale( LC_ALL, nullptr ), std::locale().name() );
@@ -50,7 +51,7 @@ void test_for_expected( const std::string &expected, const char *const format, A
 }
 
 template<typename ...Args>
-void test_for_error( const char *const format, Args &&... args )
+static void test_for_error( const char *const format, Args &&... args )
 {
     CAPTURE( format );
     CAPTURE( std::setlocale( LC_ALL, nullptr ), std::locale().name() );
@@ -62,8 +63,8 @@ void test_for_error( const char *const format, Args &&... args )
 // old_pattern in both). Test whether the new pattern (if any) yields the same
 // output via string_formatter (not used on raw printf).
 template<typename ...Args>
-void test_new_old_pattern( const char *const old_pattern, const char *const new_pattern,
-                           Args &&...args )
+static void test_new_old_pattern( const char *const old_pattern, const char *const new_pattern,
+                                  Args &&...args )
 {
     CAPTURE( old_pattern );
     CAPTURE( new_pattern );
@@ -80,7 +81,7 @@ void test_new_old_pattern( const char *const old_pattern, const char *const new_
 }
 // Test that supplying `T&&`, `T&` and `const T&` as arguments will work the same.
 template<typename T>
-void test_lvalues( const std::string &expected, const char *const pattern, const T &value )
+static void test_lvalues( const std::string &expected, const char *const pattern, const T &value )
 {
     test_for_expected( expected, pattern, T( value ) ); // T &&
     T lvalue( value );
@@ -94,14 +95,15 @@ void test_lvalues( const std::string &expected, const char *const pattern, const
 // string_formatter, which may be different (e.g. "%lli" requires a long long int
 // in raw printf, but string_formatter will accept an int as well.
 template<typename T>
-void test_typed_printf( const char *const old_pattern, const char *const new_pattern )
+static void test_typed_printf( const char *const old_pattern, const char *const new_pattern )
 {
     test_new_old_pattern( old_pattern, new_pattern, std::numeric_limits<T>::min() );
     test_new_old_pattern( old_pattern, new_pattern, std::numeric_limits<T>::max() );
 }
 
 template<typename T>
-void mingw_test( const char *const old_pattern, const char *const new_pattern, const T &value )
+static void mingw_test( const char *const old_pattern, const char *const new_pattern,
+                        const T &value )
 {
     CAPTURE( old_pattern );
     CAPTURE( new_pattern );

--- a/tests/test_statistics.h
+++ b/tests/test_statistics.h
@@ -132,14 +132,14 @@ class statistics
         }
         double upper() const {
             double result = avg() + margin_of_error();
-            if( std::is_same<T, bool>::value ) {
+            if( std::is_same_v<T, bool> ) {
                 result = std::min( result, 1.0 );
             }
             return result;
         }
         double lower() const {
             double result = avg() - margin_of_error();
-            if( std::is_same<T, bool>::value ) {
+            if( std::is_same_v<T, bool> ) {
                 result = std::max( result, 0.0 );
             }
             return result;

--- a/tests/try_parse_integer_test.cpp
+++ b/tests/try_parse_integer_test.cpp
@@ -11,7 +11,7 @@
 #include "try_parse_integer.h"
 
 template<typename TestType>
-void try_parse_int_simple_parsing()
+static void try_parse_int_simple_parsing()
 {
     CAPTURE( demangle( typeid( TestType ).name() ) );
     std::locale const &oldloc = std::locale();
@@ -86,7 +86,7 @@ TEST_CASE( "try_parse_int_simple_parsing", "[try_parse_integer]" )
 }
 
 template<typename TestType>
-void try_parse_int_locale_parsing()
+static void try_parse_int_locale_parsing()
 {
     CAPTURE( demangle( typeid( TestType ).name() ) );
     std::locale const &oldloc = std::locale();

--- a/tests/unseal_and_spill_test.cpp
+++ b/tests/unseal_and_spill_test.cpp
@@ -56,7 +56,7 @@ class enum_tuple
 
         template<int ind>
         void increment() {
-            using enum_t = typename std::tuple_element<ind, tuple_type>::type;
+            using enum_t = std::tuple_element_t<ind, tuple_type>;
             enum_t &val = std::get<ind>( enums );
             if( val != enum_t::end ) {
                 val = static_cast<enum_t>( static_cast<int>( val ) + 1 );
@@ -81,7 +81,7 @@ class enum_tuple
 
         enum_tuple operator++() {
             // *INDENT-OFF*
-            increment<std::tuple_size<tuple_type>::value - 1>();
+            increment<std::tuple_size_v<tuple_type> - 1>();
             // *INDENT-ON*
             return *this;
         }

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -108,7 +108,7 @@ TEST_CASE( "vehicle_parts_boardable_openable_parts_have_door_flag", "[vehicle][v
 TEST_CASE( "vehicle_parts_have_at_least_one_category", "[vehicle][vehicle_parts]" )
 {
     // check parts have at least one category
-    const std::vector<vpart_category> categories = vpart_category::all();
+    const std::vector<vpart_category> &categories = vpart_category::all();
     std::set<std::string> all_cat_ids;
     for( const vpart_category &cat : categories ) {
         all_cat_ids.insert( cat.get_id() );

--- a/tests/weighted_list_test.cpp
+++ b/tests/weighted_list_test.cpp
@@ -12,7 +12,7 @@ static constexpr int MAX_CONVERGENCE_TRIALS = 100000;
 
 // returns true if T is picked from list in trials attempts
 template<typename W, typename T>
-bool picked_in_trials( const weighted_list<W, T> &list, T value, int trials )
+static bool picked_in_trials( const weighted_list<W, T> &list, T value, int trials )
 {
     for( int i = 0; i < trials; ++i ) {
         const T *picked = list.pick();
@@ -25,7 +25,7 @@ bool picked_in_trials( const weighted_list<W, T> &list, T value, int trials )
 }
 
 template<typename W, typename T>
-void list_check_add( weighted_list<W, T> &list, T value, W weight, bool succeeds )
+static void list_check_add( weighted_list<W, T> &list, T value, W weight, bool succeeds )
 {
     T *ret = list.add( value, weight );
     if( !succeeds ) {
@@ -37,7 +37,7 @@ void list_check_add( weighted_list<W, T> &list, T value, W weight, bool succeeds
 }
 
 template<typename W, typename T>
-void list_check_add_replace( weighted_list<W, T> &list, T value, W weight, bool succeeds )
+static void list_check_add_replace( weighted_list<W, T> &list, T value, W weight, bool succeeds )
 {
     T *ret = list.add_or_replace( value, weight );
     if( !succeeds ) {

--- a/tests/zzip_test.cpp
+++ b/tests/zzip_test.cpp
@@ -34,6 +34,7 @@ std::string_view _view( const std::vector<std::byte> &bytes )
 std::vector<std::byte> make_bytes( size_t count )
 {
     std::vector<std::byte> bytes;
+    bytes.reserve( count );
     for( size_t i = 0; i < count; ++i ) {
         // NOLINTNEXTLINE(cata-determinism,cert-msc30-c,cert-msc50-cpp)
         bytes.push_back( static_cast<std::byte>( rand() %


### PR DESCRIPTION
#### Summary
Infrastructure "Fix lint findings reported by clang-tidy 21"

#### Purpose of change
Followup to #86917, which did the plugin/script compat work but left the actual lint findings unfixed. This PR resolves what clang-tidy 21 reports against a full project pass (683 TUs), one commit per check category.

#### Describe the solution
Real fixes:
- `bugprone-use-after-move` in `creature.h` / `popup.h` (drop double-forwarding) and a NOLINT block on `input_context::reassign` (per-member moves from same source are intentional).
- `bugprone-suspicious-stringview-data-usage` in `npctalk` / `cata_utility` / `item_factory` / `text` / `zzip`. Also adds a `JsonObject::get_string( std::string_view )` overload so callers don't have to round-trip through `.data()`.
- `bugprone-return-const-ref-from-parameter`: `npc::get_specified_talk_topic` returns by value; NOLINTs on `translation_argument_identity` and the bodygraph mirror recursion.
- `bugprone-nondeterministic-pointer-iteration-order`: sort vehicle pointers by `pos_abs()` in `map::resolve_off_map_grid_generation` and `map::vehmove`, replace `unordered_map<const scenario *, ...>` with a vector in `new_character_test`.
- `bugprone-unintended-char-ostream-output`: cast `talk_trial_type` to `unsigned int` before stream output.
- `bugprone-unhandled-self-assignment` / `cert-oop54-cpp`: explicit `if(this == &other)` guards in `clone_ptr`, `math_exp`, `projectile`, `value_ptr`; NOLINTs on `basecamp_map` / `turret_cpu` operators that intentionally ignore rhs.
- `bugprone-pointer-arithmetic-on-polymorphic-object`: `m[0]` -> `*m` in explosion damage calls.
- `misc-redundant-expression`: NOLINTs on `determine_wall_corner` NESW switch cases that match existing siblings.
- `misc-use-internal-linkage`: mark 33 TU-local helpers static.
- `modernize-type-traits`: `_v` aliases.
- `modernize-min-max-use-initializer-list`: collapse nested `std::max` chains.
- `performance-unnecessary-copy-initialization`: const refs where lifetime allows; NOLINTs where the copy is intentional (panel iterator invalidation, takeoff invalidating worn_item).
- `performance-unnecessary-value-param`: const ref or `std::move` per case; NOLINT on the STL-style iterator pair.
- `performance-inefficient-vector-operation`: reserve in `zzip_test`.
- `readability-static-accessed-through-instance`: call `Item_factory::find`, `requirement_data::finalize`, `harvest_list::entries` statically. Also fixes a real bug in `butchery::roll_butchery_skill` which called `harvest_list::get_all().size()` (the global static) where it meant `entries().size()`.
- `readability-ambiguous-smartptr-reset-call`: assign `nullptr` to release smart pointers (clearer intent); NOLINT where `->reset()` calls the pointee method.
- `clang-analyzer-optin.cplusplus.UninitializedObject`: default-init plain fields in `pulp_data`, `hacksaw_activity_actor`, `insert_item_activity_actor`, `iexamine_functions`, `profession`, `projectile_attack_results`.
- `clang-analyzer-optin.cplusplus.VirtualCall`: switch hacksaw deserialize to `make_unique`, NOLINT generic_factory's load-on-local-stack-object pattern.
- `clang-analyzer-core.StackAddressEscape`: NOLINT analyzer false positive on the bash forwarding overload.

Also adds a TODO marking the latent `projectile_attack_results::wp` deref through the non-monster path; lint exposed it but the proper API change is out of scope here.

#### Describe alternatives you've considered
The `readability-enum-initial-value` / `cert-int09-c` 13-enum sweep is deferred. Mechanically rewriting numeric enumerator values is contract-sensitive and the scope here is lint plumbing, not enum redesign. A future PR will bump CI clang-tidy to LLVM 21 and disable that check there until someone wants to do the audit.

#### Testing
Verified with a full clang-tidy 21 pass over all 683 src/tests TUs after the fixes. Only remaining findings are the deferred enum sweep. Full test suite passed locally.

#### Additional context
Followup to #86917. Next PR will be the CI bump to LLVM 21 plus `ExcludeHeaderFilterRegex` for the vendored plf colony/list headers.