### PR TITLE
Bump clang-tidy CI to LLVM 21

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -124,6 +124,8 @@ Checks: [
     -readability-use-std-min-max,                       # if/else clamp idiom is preferred to std::min/max here
 
     # ====  Disabled noise from checks introduced in LLVM 21+  ====
+    -readability-enum-initial-value,                    # 13 enums mix explicit and defaulted values; mechanical sweep deferred
+    -cert-int09-c,                                      # alias of readability-enum-initial-value
     -readability-use-concise-preprocessor-directives,
 
     # ====  Disabled noise from checks introduced in LLVM 22+  ====
@@ -138,6 +140,7 @@ Checks: [
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '(src|test|tools).*'
+ExcludeHeaderFilterRegex: '.*src/(colony|list)\.h$'
 FormatStyle:     none
 CheckOptions:
   - key: cata-large-inline-function.MaxStatements

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,4 +1,4 @@
-name: Clang-tidy 18
+name: Clang-tidy 21
 
 on:
   push:
@@ -37,7 +37,8 @@ jobs:
         fail-fast: true
     runs-on: ubuntu-24.04
     env:
-        COMPILER: clang++-18
+        COMPILER: clang++-21
+        LLVM_VERSION: '21'
     steps:
     - name: checkout repository
       if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
@@ -50,13 +51,14 @@ jobs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so
-        key: clang-tidy-plugin-llvm18-ubuntu2404-${{ hashFiles('tools/clang-tidy-plugin/**', 'build-scripts/clang-tidy-build.sh', 'CMakeLists.txt', 'CMakeModules/**') }}
-    - name: install LLVM 18
+        key: clang-tidy-plugin-llvm21-ubuntu2404-${{ hashFiles('tools/clang-tidy-plugin/**', 'build-scripts/clang-tidy-build.sh', 'CMakeLists.txt', 'CMakeModules/**') }}
+    - name: install LLVM 21
       if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && steps.plugin-cache.outputs.cache-hit != 'true' }}
       run: |
-          sudo apt-get update
-          sudo apt install llvm-18 llvm-18-dev llvm-18-tools clang-18 clang-tidy-18 clang-tools-18 libclang-18-dev
-          sudo apt install python3-pip ninja-build cmake
+          wget -O llvm.sh https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 21 all
+          sudo apt-get install -y python3-pip ninja-build cmake
           pip3 install --user lit
     - uses: ammaraskar/gcc-problem-matcher@0f9c86f9e693db67dacf53986e1674de5f2e5f28 # master
     - name: build clang-tidy plugin
@@ -87,8 +89,9 @@ jobs:
 
     runs-on: ubuntu-24.04
     env:
-        COMPILER: clang++-18
-        CATA_CLANG_TIDY: clang-tidy-18
+        COMPILER: clang++-21
+        CATA_CLANG_TIDY: clang-tidy-21
+        LLVM_VERSION: '21'
         CATA_CLANG_TIDY_SUBSET: ${{ matrix.subset }}
         TILES: 1
         SOUND: 1
@@ -97,9 +100,11 @@ jobs:
     steps:
     - name: install dependencies
       run: |
-          sudo apt-get update
-          sudo apt install clang-18 clang-tidy-18 cmake ccache jq
-          sudo apt install libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev gettext
+          wget -O llvm.sh https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 21
+          sudo apt-get install -y clang-tidy-21 cmake ccache jq
+          sudo apt-get install -y libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev gettext
     - name: checkout repository
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:

--- a/tools/clang-tidy-plugin/NoStaticTranslationCheck.cpp
+++ b/tools/clang-tidy-plugin/NoStaticTranslationCheck.cpp
@@ -1,6 +1,7 @@
 #include "NoStaticTranslationCheck.h"
 
 #include <clang/AST/Expr.h>
+#include <clang/AST/ExprCXX.h>
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 #include <clang/ASTMatchers/ASTMatchers.h>
 #include <clang/ASTMatchers/ASTMatchersInternal.h>
@@ -48,8 +49,16 @@ void NoStaticTranslationCheck::check( const MatchFinder::MatchResult &Result )
     if( !translationCall ) {
         return;
     }
+    // CXXOperatorCallExpr::getBeginLoc points at the operator parens in clang
+    // 21+; anchor to the receiver so the column stays stable across versions.
+    SourceLocation loc = translationCall->getBeginLoc();
+    if( const auto *opCall = dyn_cast<CXXOperatorCallExpr>( translationCall ) ) {
+        if( opCall->getOperator() == OO_Call && opCall->getNumArgs() > 0 ) {
+            loc = opCall->getArg( 0 )->getBeginLoc();
+        }
+    }
     diag(
-        translationCall->getBeginLoc(),
+        loc,
         "Translation functions should not be called when initializing a static variable.  "
         "See the `### Static string variables` section in `doc/TRANSLATING.md` for details."
     );


### PR DESCRIPTION
#### Summary
Infrastructure "Bump clang-tidy CI baseline from LLVM 18 to LLVM 21"

#### Purpose of change
Plugin builds clean against 19-22 after #86917, master is lint-clean against 21 after #86927. Time to flip CI over.

#### Describe the solution
Workflow installs LLVM 21 via apt.llvm.org's `llvm.sh` (24.04's stock repos stop at 18) and points `COMPILER`, `CATA_CLANG_TIDY`, `LLVM_VERSION` at 21. Cache key bumped so the plugin rebuilds.

`.clang-tidy` adds `ExcludeHeaderFilterRegex` for vendored `colony.h` and `list.h`. That key is 19+ only, which is why this PR drops 18.

Also disables `readability-enum-initial-value`. Fires on 13 enums that mix explicit and defaulted values; fixing each one means deciding whether to add or strip initializers, and the numbers matter for serialization. Cleaner as its own PR.

Also pins the column for `cata-no-static-translation` on `translated_less()(a, b)` style calls. clang 21 moved `CXXOperatorCallExpr::getBeginLoc()` from the receiver to the operator parens, so the check now anchors to the receiver explicitly.

#### Describe alternatives you've considered
Bumping through 19 and 20 first. No new signal, just more CI-yaml PRs.

Folding the 13 enum fixes in here. Adds a per-enum review surface to a workflow bump.

#### Testing
N/A, CI is the test.

#### Additional context
Follows #86917 and #86927.