### PR TITLE
Diving boots no longer impose a speed penalty for wearing no shoes

### DIFF
--- a/data/json/items/armor/swimming.json
+++ b/data/json/items/armor/swimming.json
@@ -591,13 +591,12 @@
     "volume": "1 L",
     "price": "68 USD",
     "price_postapoc": "2 USD 50 cent",
-    "material": [ "neoprene", "nylon", "rubber" ],
     "symbol": "[",
     "looks_like": "boots_rubber",
     "color": "dark_gray",
     "warmth": 30,
     "environmental_protection": 10,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF", "SKINTIGHT", "TOUGH_FEET", "SOFT" ],
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "WATERPROOF" ],
     "armor": [
       {
         "covers": [ "foot_l", "foot_r" ],
@@ -659,8 +658,6 @@
     "weight": "160 g",
     "warmth": 50,
     "environmental_protection": 12,
-    "extend": { "flags": [ "NORMAL" ] },
-    "delete": { "flags": [ "TOUGH_FEET", "SOFT" ] },
     "armor": [
       {
         "covers": [ "foot_l", "foot_r" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #86854 (although it refers to version 0.H). In the master branch, all kevlar wetsuit stuff has been removed.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Some flags on diving boots were set not quite correctly I think.

1. `SKINTIGHT` is intended for a thin undergarment layer. Diving boots/socks, while worn close to the skin, are closer to sneakers. The [documentation](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/design-balance-lore/ARMOR_BALANCE_AND_DESIGN.md#layer) also mentions taking material thickness (3mm and 5mm) into account.
2. Due to the `SOFT` flag, the player can wear multiple pairs of diving socks. The relatively stiff sole and thick neoprene layer make them rather rigid code-wise. Even without the flag, they are still considered comfortable to wear due to the soft materials.
3. If these two flags are removed, `TOUGH_FEET` becomes unnecessary.
4. The `material` field is also unnecessary, as materials are already specified in `armor`, from where they are also used for repair.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Revert all these changes and simply add the `TOUGH_FEET` flag to the boots.
Change the game code so that footwear with these flags counts as proper footwear. But why?
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Diving boots/socks no longer impose a penalty and occupy the `NORMAL` layer.
<img width="439" height="189" alt="dive1" src="https://github.com/user-attachments/assets/345cef88-46e9-4763-915f-16280877e69f" />
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Diving boots have a mounting point for swim fins, but they don't provide a swimming bonus unless the fins are worn directly...
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
