### PR TITLE
Unattended crafting: correctness follow-ups

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6327,9 +6327,14 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
             if( craft.get_passive_started_at() == calendar::before_time_starts ) {
                 craft_stamp_passive_entry( craft, crafter, calendar::turn, craft_item );
                 mode_ = derive_mode();
-                // Carrying step_progress forward (recipe-edit migration) can
-                // back-date passive_started_at past ready_at; advance inline
-                // instead of waiting for a queued ready_check.
+                // Back-dated entry can leave alarm and/or ready already due.
+                // Alarm runs first; the alarm handler elides itself if ready
+                // also fires same turn.
+                if( craft.get_alarm_at() != calendar::before_time_starts &&
+                    calendar::turn >= craft.get_alarm_at() ) {
+                    craft_actualize_scheduled( craft, item_wakeup_kind::alarm,
+                                               calendar::turn, craft_item );
+                }
                 if( craft.get_ready_at() != calendar::before_time_starts &&
                     calendar::turn >= craft.get_ready_at() ) {
                     craft_actualize_scheduled( craft, item_wakeup_kind::ready_check,

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6327,6 +6327,15 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
             if( craft.get_passive_started_at() == calendar::before_time_starts ) {
                 craft_stamp_passive_entry( craft, crafter, calendar::turn, craft_item );
                 mode_ = derive_mode();
+                // Carrying step_progress forward (recipe-edit migration) can
+                // back-date passive_started_at past ready_at; advance inline
+                // instead of waiting for a queued ready_check.
+                if( craft.get_ready_at() != calendar::before_time_starts &&
+                    calendar::turn >= craft.get_ready_at() ) {
+                    craft_actualize_scheduled( craft, item_wakeup_kind::ready_check,
+                                               calendar::turn, craft_item );
+                    return;
+                }
             }
 
             if( plan.choice == step_choice::do_wait ) {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -48,6 +48,7 @@
 #include "item.h"
 #include "item_components.h"
 #include "item_location.h"
+#include "item_uid.h"
 #include "itype.h"
 #include "iuse.h"
 #include "line.h"
@@ -1244,6 +1245,7 @@ static void craft_actualize_fail( item &craft, time_point now,
         return;
     }
     end_live_wait_for( loc );
+    get_item_wakeups().cancel_all( craft.uid().get_value() );
     item_location mut_loc = loc;
     mut_loc.remove_item();
 }
@@ -1256,6 +1258,7 @@ static void finalize_passive_craft( item &craft, const item_location &loc )
                   "destroying craft for recipe %s",
                   craft.get_crafter_id().get_value(),
                   craft.get_making().ident().str() );
+        get_item_wakeups().cancel_all( craft.uid().get_value() );
         item_location mut_loc = loc;
         mut_loc.remove_item();
         return;
@@ -1263,6 +1266,7 @@ static void finalize_passive_craft( item &craft, const item_location &loc )
     end_live_wait_for( loc );
     item craft_copy = craft;
     const std::optional<tripoint_bub_ms> finalize_loc = craft_loc_for_complete( loc );
+    get_item_wakeups().cancel_all( craft.uid().get_value() );
     item_location mut_loc = loc;
     mut_loc.remove_item();
     crafter->complete_craft( craft_copy, finalize_loc );
@@ -1299,6 +1303,14 @@ static void craft_actualize_ready( item &craft, time_point now, const item_locat
         return;
     }
 
+    // Fail before ready: queue ordering dispatches ready first, but an
+    // overdue fail must short-circuit instead of advancing the step.
+    if( craft.get_fail_at() != calendar::before_time_starts &&
+        now >= craft.get_fail_at() ) {
+        craft_actualize_fail( craft, now, loc );
+        return;
+    }
+
     if( !env_satisfied_for_step( step, craft, loc ) ) {
         if( craft.get_pause_started_at() == calendar::before_time_starts ) {
             craft.set_pause_started_at( now );
@@ -1315,6 +1327,8 @@ static void craft_actualize_ready( item &craft, time_point now, const item_locat
 
     if( craft.get_pause_started_at() != calendar::before_time_starts ) {
         const time_duration paused_for = now - craft.get_pause_started_at();
+        // Restored fail_at is always in the future: pause entry is gated by
+        // the top-of-handler fail guard, so saved_fail_at > pause_started_at.
         craft.set_ready_at( craft.get_saved_ready_at() + paused_for );
         if( craft.get_saved_alarm_at() != calendar::before_time_starts ) {
             craft.set_alarm_at( craft.get_saved_alarm_at() + paused_for );
@@ -1326,6 +1340,11 @@ static void craft_actualize_ready( item &craft, time_point now, const item_locat
         craft.set_saved_ready_at( calendar::before_time_starts );
         craft.set_saved_alarm_at( calendar::before_time_starts );
         craft.set_saved_fail_at( calendar::before_time_starts );
+        // Already-due alarm fires inline, not one queue tick late.
+        if( craft.get_alarm_at() != calendar::before_time_starts &&
+            now >= craft.get_alarm_at() ) {
+            craft_actualize_alarm( craft, now, loc );
+        }
         if( now < craft.get_ready_at() ) {
             get_item_wakeups().rebuild_for_item( loc );
             return;
@@ -1416,22 +1435,37 @@ void craft_stamp_passive_entry( item &craft, const Character &crafter, time_poin
     const attention_plan plan = idx < static_cast<int>( plans.size() ) ? plans[idx] :
                                 attention_plan{};
 
-    craft.set_passive_started_at( now );
     const crafting_cost_context passive_ctx{ crafter.book_bonuses_nearby(),
             compute_tool_speeds( rec, crafter ) };
     const int64_t step_moves = static_cast<int64_t>( rec.step_budget_moves(
                                    crafter, idx, craft.get_making_batch_size(),
                                    passive_ctx, recipe_time_flag::ignore_proficiencies ) );
-    craft.set_ready_at( now + time_duration::from_moves( step_moves ) );
+    // Carry step_progress as a fraction of the active (prof-aware) budget
+    // and back-date entry by that fraction of the passive budget; preserves
+    // prior work when an active step becomes unattended via recipe edit.
+    time_point entry_time = now;
+    if( craft.get_step_progress() > 0.0 ) {
+        const double active_budget = rec.step_budget_moves(
+                                         crafter, idx, craft.get_making_batch_size(), passive_ctx );
+        if( active_budget > 0.0 && step_moves > 0 ) {
+            const double fraction = std::min( 1.0,
+                                              craft.get_step_progress() / active_budget );
+            const int64_t elapsed_passive_moves = static_cast<int64_t>(
+                    fraction * static_cast<double>( step_moves ) );
+            entry_time = now - time_duration::from_moves( elapsed_passive_moves );
+        }
+    }
+    craft.set_passive_started_at( entry_time );
+    craft.set_ready_at( entry_time + time_duration::from_moves( step_moves ) );
     if( cur_step.max_time.has_value() ) {
         time_duration fail_dur = *cur_step.max_time;
         if( cur_step.grace_period.has_value() ) {
             fail_dur += *cur_step.grace_period;
         }
-        craft.set_fail_at( now + fail_dur );
+        craft.set_fail_at( entry_time + fail_dur );
     }
     if( plan.choice == step_choice::set_timer && plan.alarm_offset.has_value() ) {
-        craft.set_alarm_at( now + *plan.alarm_offset );
+        craft.set_alarm_at( entry_time + *plan.alarm_offset );
     }
     // Counter bounds derive from prior steps' budgets (default flags) so any
     // active-step overshoot in item_counter does not carry into this passive
@@ -3718,7 +3752,8 @@ static bool is_anyone_crafting( const item_location &itm, const Character *you =
 {
     for( const npc &guy : g->all_npcs() ) {
         if( !( you && you->getID() == guy.getID() ) &&
-            guy.activity.id() == ACT_CRAFT ) {
+            ( guy.activity.id() == ACT_CRAFT || guy.activity.id() == ACT_CRAFT_WAIT ) &&
+            !guy.activity.targets.empty() ) {
             item_location target = guy.activity.targets.back();
             if( target == itm ) {
                 return true;

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -233,8 +233,13 @@ std::string craft( item const &it, unsigned int /* quantity */,
         const int start_counter = it.get_passive_start_counter();
         const int end_counter = it.get_passive_end_counter();
         if( pstart != calendar::before_time_starts && ready > pstart && end_counter > start_counter ) {
+            // Freeze projection at pause time so a stalled craft does not
+            // keep ticking up.
+            const time_point pause_start = it.get_pause_started_at();
+            const time_point eff_now = pause_start != calendar::before_time_starts
+                                       ? pause_start : calendar::turn;
             const time_duration step_dur = ready - pstart;
-            time_duration elapsed = calendar::turn - pstart;
+            time_duration elapsed = eff_now - pstart;
             if( elapsed < 0_seconds ) {
                 elapsed = 0_seconds;
             }

--- a/tests/craft_attention_test.cpp
+++ b/tests/craft_attention_test.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -14,6 +15,8 @@
 #include "item.h"
 #include "item_components.h"
 #include "item_location.h"
+#include "item_uid.h"
+#include "item_wakeup.h"
 #include "json.h"
 #include "json_loader.h"
 #include "map.h"
@@ -488,3 +491,197 @@ TEST_CASE( "craft_resolve_overdue_passive_chains_preserve_wall_time",
         CHECK( on_map.get_ready_at() == calendar::turn + 20_minutes );
     }
 }
+
+TEST_CASE( "craft_actualize_ready_fail_at_precedes_ready",
+           "[craft][attention][overdue][fail]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_timeout_recipe.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+
+    on_map.set_current_step( 1 );
+    on_map.set_passive_started_at( calendar::turn );
+    on_map.set_ready_at( calendar::turn + 10_minutes );
+    on_map.set_fail_at( calendar::turn + 25_minutes );
+    on_map.set_crafter_id( u.getID() );
+    std::vector<attention_plan> plans( 2 );
+    on_map.set_step_plans( plans );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+
+    craft_resolve_overdue_passive( on_map, calendar::turn + 30_minutes, loc );
+
+    CHECK( loc.get_item() == nullptr );
+}
+
+TEST_CASE( "craft_stamp_passive_entry_carries_step_progress_fraction",
+           "[craft][attention][migration]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+
+    on_map.set_current_step( 1 );
+    std::vector<attention_plan> plans( 2 );
+    on_map.set_step_plans( plans );
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+
+    SECTION( "no prior progress: fresh full-duration stamp" ) {
+        on_map.set_step_progress( 0.0 );
+        craft_stamp_passive_entry( on_map, u, calendar::turn, loc );
+        CHECK( on_map.get_passive_started_at() == calendar::turn );
+        CHECK( on_map.get_ready_at() > calendar::turn );
+    }
+
+    SECTION( "half-step prior progress: passive entry back-dated half-step" ) {
+        const recipe &rec = recipe_cudgel_test_unattended_simple.obj();
+        const crafting_cost_context ctx = crafting_cost_context::for_recipe( u, rec );
+        const double active_budget = rec.step_budget_moves(
+                                         u, 1, on_map.get_making_batch_size(), ctx );
+        REQUIRE( active_budget > 0.0 );
+        on_map.set_step_progress( active_budget * 0.5 );
+
+        craft_stamp_passive_entry( on_map, u, calendar::turn, loc );
+
+        // Entry back-dated; full passive duration preserved.
+        CHECK( on_map.get_passive_started_at() < calendar::turn );
+        const time_duration step_dur = on_map.get_ready_at() -
+                                       on_map.get_passive_started_at();
+        const time_duration elapsed = calendar::turn -
+                                      on_map.get_passive_started_at();
+        CHECK( elapsed > 0_seconds );
+        CHECK( elapsed < step_dur );
+    }
+
+    SECTION( "step_progress at or beyond budget: clamped to full step elapsed" ) {
+        const recipe &rec = recipe_cudgel_test_unattended_simple.obj();
+        const crafting_cost_context ctx = crafting_cost_context::for_recipe( u, rec );
+        const double active_budget = rec.step_budget_moves(
+                                         u, 1, on_map.get_making_batch_size(), ctx );
+        REQUIRE( active_budget > 0.0 );
+        on_map.set_step_progress( active_budget * 2.0 );
+
+        craft_stamp_passive_entry( on_map, u, calendar::turn, loc );
+
+        // Fraction clamps at 1.0; ready_at lands at now.
+        CHECK( on_map.get_ready_at() == calendar::turn );
+    }
+}
+
+TEST_CASE( "craft_tname_freezes_projection_during_env_pause",
+           "[craft][attention][display]" )
+{
+    item ingredient( itype_2x4, calendar::turn );
+    item built( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    REQUIRE( built.is_craft() );
+
+    const time_point t0 = calendar::turn;
+    built.item_counter = 0;
+    built.set_passive_start_counter( 1000000 );
+    built.set_passive_end_counter( 9000000 );
+
+    // Entered 5m ago, paused 2m ago.  Elapsed clamps to 3m of 10m = 30%
+    // of the 1M..9M window -> 3.4M -> 34%.
+    built.set_passive_started_at( t0 - 5_minutes );
+    built.set_pause_started_at( t0 - 2_minutes );
+    built.set_ready_at( t0 + 1_minutes );
+    built.set_saved_ready_at( t0 + 5_minutes );
+
+    const std::string name = built.tname();
+    CHECK( name.find( "34%" ) != std::string::npos );
+}
+
+TEST_CASE( "craft_terminal_removal_cancels_pending_wakeups",
+           "[craft][attention][wakeup]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_timeout_recipe.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+
+    on_map.set_current_step( 1 );
+    on_map.set_passive_started_at( calendar::turn );
+    on_map.set_ready_at( calendar::turn + 10_minutes );
+    on_map.set_fail_at( calendar::turn + 25_minutes );
+    on_map.set_crafter_id( u.getID() );
+    std::vector<attention_plan> plans( 2 );
+    plans[1].choice = step_choice::set_timer;
+    plans[1].alarm_offset = 5_minutes;
+    on_map.set_step_plans( plans );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+    on_map.set_alarm_at( calendar::turn + 5_minutes );
+    get_item_wakeups().rebuild_for_item( loc );
+    const int64_t uid = on_map.uid().get_value();
+    REQUIRE( get_item_wakeups().is_scheduled( uid, item_wakeup_kind::ready_check ) );
+    REQUIRE( get_item_wakeups().is_scheduled( uid, item_wakeup_kind::fail_check ) );
+    REQUIRE( get_item_wakeups().is_scheduled( uid, item_wakeup_kind::alarm ) );
+
+    craft_resolve_overdue_passive( on_map, calendar::turn + 30_minutes, loc );
+
+    REQUIRE( loc.get_item() == nullptr );
+    CHECK_FALSE( get_item_wakeups().is_scheduled( uid, item_wakeup_kind::ready_check ) );
+    CHECK_FALSE( get_item_wakeups().is_scheduled( uid, item_wakeup_kind::fail_check ) );
+    CHECK_FALSE( get_item_wakeups().is_scheduled( uid, item_wakeup_kind::alarm ) );
+}
+
+TEST_CASE( "craft_env_unpause_alarm_clears_when_already_due",
+           "[craft][attention][resume][alarm]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+
+    on_map.set_current_step( 1 );
+    on_map.set_crafter_id( u.getID() );
+    std::vector<attention_plan> plans( 2 );
+    plans[1].choice = step_choice::set_timer;
+    plans[1].alarm_offset = 5_minutes;
+    on_map.set_step_plans( plans );
+
+    // saved_alarm_at < pause_started_at: slid alarm_at lands in the past
+    // after restore; must fire inline.
+    const time_point t0 = calendar::turn;
+    on_map.set_passive_started_at( t0 );
+    on_map.set_ready_at( t0 + 1_minutes );
+    on_map.set_saved_ready_at( t0 + 30_minutes );
+    on_map.set_pause_started_at( t0 + 5_minutes );
+    on_map.set_saved_alarm_at( t0 + 2_minutes );
+    on_map.set_alarm_at( calendar::before_time_starts );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+
+    craft_actualize_scheduled( on_map, item_wakeup_kind::ready_check,
+                               t0 + 10_minutes, loc );
+
+    CHECK( on_map.get_alarm_at() == calendar::before_time_starts );
+    CHECK( on_map.get_pause_started_at() == calendar::before_time_starts );
+}
+


### PR DESCRIPTION
#### Summary
Bugfixes "Unattended crafting follow-up bugs"

#### Purpose of change
Follow-up to #86907. Found several problems after it landed -- correctness bugs in the unattended-step machinery plus some queue and display hygiene.

#### Describe the solution
Six small fixes, all localized to the unattended-step machinery.

- `fail_at` takes precedence over ready in `craft_actualize_ready`. A late wakeup with both deadlines overdue would otherwise advance the step instead of failing the craft.
- `craft_stamp_passive_entry` carries `step_progress` forward as a fraction of the active prof-aware budget when an active step becomes unattended via recipe edit. Old saves no longer restart the wait clock from zero.
- `is_anyone_crafting` matches `ACT_CRAFT_WAIT` as well. NPCs parked on an unattended craft via the wait activity are no longer invisible to the dedup check.
- Item tname projection freezes at `pause_started_at` while env-paused, so the displayed percentage stops climbing on a stalled craft.
- Wakeup queue gets `cancel_all` before terminal removal in `finalize_passive_craft` and `craft_actualize_fail`. No orphan entries left to drain.
- Already-due alarm fires inline on env unpause and on back-dated first-entry instead of one wakeup tick late.

#### Describe alternatives you've considered
N/A

#### Testing
Five new test cases in `craft_attention_test.cpp`. Existing craft attention tests still pass.

#### Additional context
Two commits, split so the alarm catch-up is reviewable on its own.