### PR TITLE
Move appliance infobox to imgui

### DIFF
--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -218,16 +218,12 @@ void veh_app_interact::init_ui_windows( map &here )
     if( !veh->accessories.empty() ) {
         height_info++;
     }
-    const int width_info = win_width - 2;
     const int height_input = app_actions.size();
     const int win_height = height_info + 2;
     const int full_height = win_height + height_input;
 
-    // Center the UI
+    // NOTE: This offset is retained even though the header moved to uilist itself.
     point topleft( TERMX / 2 - win_width / 2, TERMY / 2 - full_height / 2 );
-    w_border = catacurses::newwin( win_height, win_width, topleft );
-    //NOLINTNEXTLINE(cata-use-named-point-constants)
-    w_info = catacurses::newwin( height_info, width_info, topleft + point( 1, 1 ) );
 
     // Try to align the imgui window to be below the header.
     // to that end, we have some awkward math translating character positions to screen positions here:
@@ -302,16 +298,18 @@ static void draw_appliance_connections( vehicle *veh )
 }
 #endif
 
-void veh_app_interact::draw_info( map &here )
+std::string veh_app_interact::draw_info_imgui_header( map &here )
 {
-    werase( w_info );
+    // Always print this warning and only this warning if we don't have a grid.
+    // We should not pretend anything is functional without a battery, because it's not!
+    if( !has_battery_in_grid( here, veh ) ) {
+        return colorize( _( "Appliance has no connection to a battery." ), c_light_red );
+    }
 
-    int row = 0;
-    // Fuel indicators
-    veh->print_fuel_indicators( here, w_info, point( 0, row ), 0, true, true, true, true );
-    row += veh->get_printable_fuel_types( here ).size();
+    std::string ret = veh->print_fuel_indicators( here, 0 );
 
     // Onboard battery power
+    // Pre-existing issue: If the specific appliance we selected isn't *itself* a battery, this is considered empty!
     if( !veh->batteries.empty() ) {
         std::pair<int, int> battery = veh->battery_power_level( );
         nc_color batt_col = c_yellow;
@@ -319,12 +317,12 @@ void veh_app_interact::draw_info( map &here )
             batt_col = battery.first == 0 ? c_light_red :
                        battery.first == battery.second ? c_light_green : c_yellow;
         }
-        mvwprintz( w_info, point( 0, row ), c_white, _( "Onboard battery power: " ) );
-        wprintz( w_info, batt_col, string_format( "%d/%d", battery.first, battery.second ) );
-        row++;
+        // Bad, but pre-existing.
+        ret += colorize( string_format( _( "Onboard battery power: " ) ), c_white );
+        ret += colorize( string_format( "%d/%d", battery.first, battery.second ), batt_col );
     }
 
-    auto print_charge = [this]( const std::string & lbl, units::power rate, int row ) {
+    auto print_charge = []( const std::string & lbl, units::power rate, std::string & ret ) {
         std::string rstr;
         if( rate > 10_kW || rate < -10_kW ) {
             //~ Power in killoWatts. %+4.1f is a 4 digit number with 1 decimal point (ex: 2198.3 kW)
@@ -335,66 +333,59 @@ void veh_app_interact::draw_info( map &here )
         }
         nc_color rcol = rate < 0_W ? c_light_red :
                         rate > 0_W ? c_light_green : c_yellow;
-        mvwprintz( w_info, point( 0, row ), c_white, lbl );
-        wprintz( w_info, rcol, rstr );
+        ret += colorize( lbl, c_white );
+        ret += colorize( rstr, rcol );
+        ret += "\n";
     };
-
-    if( !has_battery_in_grid( here, veh ) ) {
-        mvwprintz( w_info, point( 0, row ), c_light_red, _( "Appliance has no connection to a battery." ) );
-        row++;
-    }
 
     // Battery power output
     units::power grid_flow = 0_W;
     for( const std::pair<vehicle *const, float> &pair : veh->search_connected_vehicles( here ) ) {
         grid_flow += pair.first->net_battery_charge_rate( here, /* include_reactors = */ true );
     }
-    print_charge( _( "Grid battery power flow: " ), grid_flow, row );
-    row++;
+    // Always start printing this on its own line
+    ret += "\n";
+    print_charge( _( "Grid battery power flow: " ), grid_flow, ret );
 
     // Reactor power output
     if( !veh->reactors.empty() ) {
         const units::power rate = veh->active_reactor_epower( here );
-        print_charge( _( "Reactor power output: " ), rate, row );
-        row++;
+        print_charge( _( "Reactor power output: " ), rate, ret );
     }
 
     // Wind power output
     if( !veh->wind_turbines.empty() ) {
         units::power rate = veh->total_wind_epower( here );
-        print_charge( _( "Wind power output: " ), rate, row );
-        row++;
+        print_charge( _( "Wind power output: " ), rate, ret );
     }
 
     // Solar power output
     if( !veh->solar_panels.empty() ) {
         units::power rate = veh->total_solar_epower( here );
-        print_charge( _( "Solar power output: " ), rate, row );
-        row++;
+        print_charge( _( "Solar power output: " ), rate, ret );
     }
 
     // Water power output
     if( !veh->water_wheels.empty() ) {
         units::power rate = veh->total_water_wheel_epower( here );
-        print_charge( _( "Water power output: " ), rate, row );
-        row++;
+        print_charge( _( "Water power output: " ), rate, ret );
     }
 
     // Alternator power output
     if( !veh->alternators.empty() ) {
         units::power rate = veh->total_alternator_epower( here );
-        print_charge( _( "Alternator power output: " ), rate, row );
-        row++;
+        print_charge( _( "Alternator power output: " ), rate, ret );
     }
 
     // Other power output
     if( !veh->accessories.empty() || veh->has_part( "RECHARGE" ) ) {
         units::power rate = veh->total_accessory_epower() + veh->recharge_epower_this_turn;
-        print_charge( _( "Appliance power consumption: " ), rate, row );
-        row++;
+        print_charge( _( "Appliance power consumption: " ), rate, ret );
     }
 
-    wnoutrefresh( w_info );
+
+
+    return ret;
 }
 
 bool veh_app_interact::can_refill( )
@@ -637,6 +628,8 @@ void veh_app_interact::populate_app_actions( map &here )
 
     const std::string ctxt_letters = ctxt.get_available_single_char_hotkeys();
     imenu.entries.clear();
+    imenu.title = veh->name;
+    imenu.text = draw_info_imgui_header( here );
     app_actions.clear();
 
     /******************** General actions ********************/
@@ -722,14 +715,11 @@ shared_ptr_fast<ui_adaptor> veh_app_interact::create_or_get_ui_adaptor( map &her
             cui.position_from_window( catacurses::stdscr );
         } );
         current_ui->mark_resize();
-        current_ui->on_redraw( [&here, this]( const ui_adaptor & ) {
-            draw_border( w_border, c_white, veh->name, c_white );
-            wnoutrefresh( w_border );
-            draw_info( here );
 #if defined(TILES)
+        current_ui->on_redraw( [this]( const ui_adaptor & ) {
             draw_appliance_connections( veh );
-#endif
         } );
+#endif
     }
     return current_ui;
 }

--- a/src/veh_appliance.h
+++ b/src/veh_appliance.h
@@ -65,25 +65,22 @@ class veh_app_interact
         weak_ptr_fast<ui_adaptor> ui;
         // Functions corresponding to the actions listed in imenu.entries.
         std::vector<std::function<void()>> app_actions;
-        // Curses window to represent the whole drawing area of the interaction UI.
-        catacurses::window w_border;
-        // Curses window to represent the upper portion that displays
-        // the appliance's usage info.
-        catacurses::window w_info;
         // Input menu in the lower portion. Handles input and draws the list
-        // of possible actions. The menu's internal window is modified by
-        // init_ui_windows() to integrate with the rest of the UI.
+        // of possible actions. Various stats about the appliance are added
+        // to the uilist header by draw_info_imgui_header();
         uilist imenu;
 
         /**
-         * Sets up the window parameters to fit the amount of text to be displayed.
+         * Does a bunch of offsetting that used to make room for a ncurses window.
+         * Nowadays largely redundant.
+         * TODO: Get rid of me?
          * The setup calls populate_app_actions() to initialize the content.
         */
         void init_ui_windows( map &here );
         /**
-         * Draws the upper portion, representing the appliance's usage info.
+         * Creates the header text, representing the appliance's usage info.
         */
-        void draw_info( map &here );
+        std::string draw_info_imgui_header( map &here );
         /**
          * Populates the list of available actions for this appliance. The action display
          * names are stored as uilist entries in imenu, and the associated functions

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -870,6 +870,11 @@ class vehicle
         bool do_environmental_effects( map &here ) const;
 
         // Vehicle fuel indicator (by fuel)
+        // Returns a string for appliance info box.
+        std::string print_fuel_indicator( map &here, const itype_id &fuel_type,
+                                          std::map<itype_id, units::energy> fuel_usages );
+
+        // Vehicle fuel indicator (by fuel)
         // TODO: Figure out what coordinate system "point" is in and type it.
         void print_fuel_indicator( map &here, const catacurses::window &w, const point &p,
                                    const itype_id &fuel_type,
@@ -1462,6 +1467,10 @@ class vehicle
 
         // Get all printable fuel types
         std::vector<itype_id> get_printable_fuel_types( map &here ) const;
+
+        // Vehicle fuel indicators (all of them)
+        // Returns a string for appliance info box.
+        std::string print_fuel_indicators( map &here, int start_index = 0 );
 
         // Vehicle fuel indicators (all of them)
         // TODO: Figure out what coordinate system this uses and convert to it.

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
+#include <iterator>
 #include <optional>
 #include <set>
 #include <string>
@@ -343,6 +344,24 @@ std::vector<itype_id> vehicle::get_printable_fuel_types( map &here ) const
     return res;
 }
 
+std::string vehicle::print_fuel_indicators( map &here, int start_index )
+{
+    std::string ret;
+
+    auto fuels = get_printable_fuel_types( here );
+    if( fuels.empty() ) {
+        return "";
+    }
+
+    for( int i = start_index; i < static_cast<int>( fuels.size() ); i++ ) {
+        const itype_id &f = fuels[i];
+        ret += print_fuel_indicator( here, f, fuel_used_last_turn );
+        ret += "\n";
+    }
+
+    return ret;
+}
+
 /**
  * Prints all of the fuel indicators of the vehicle
  * @param win Pointer to the window to draw in.
@@ -392,6 +411,90 @@ void vehicle::print_fuel_indicators( map &here, const catacurses::window &win, c
     }
 }
 
+std::string vehicle::print_fuel_indicator( map &here, const itype_id &fuel_type,
+        std::map<itype_id, units::energy> fuel_usages )
+{
+    const std::string linebreak = "\n";
+    // The old window re-drew a symbol over the indicator. That's unreliable, so we simply use a lookup table
+    // to figure out which of the 5 possible combinations to draw before printing anything at all.
+    std::map<int, std::string> fuel_indicator = {
+        {0, "E\\.··.F"},
+        {20, "E.\\··.F"},
+        {40, "E.·|·.F"},
+        {60, "E.··/.F"},
+        {80, "E.··./F"}
+    };
+    int cap = fuel_capacity( here, fuel_type );
+    int f_left = fuel_left( here, fuel_type );
+    nc_color f_color = item::find_type( fuel_type )->color;
+    int pct_amount = cap > 0 ? f_left * 99 / cap : 0;
+    auto fuel_string = fuel_indicator.rbegin();
+    while( fuel_string != fuel_indicator.rend() && pct_amount < fuel_string->first ) {
+        fuel_string++;
+    }
+    std::string ret = fuel_string->second;
+
+    if( debug_mode || cap == 0 ) {
+        // Space is intentional.
+        ret += colorize( string_format( " %d/%d", f_left, cap ), f_color );
+    } else {
+        // Space is intentional.
+        ret += colorize( string_format( " %d", f_left * 100 / cap ), f_color );
+        // This uses a separate color, for some reason!
+        ret += colorize( "%%", c_light_gray );
+    }
+
+    // previously handled by the 'desc' bool
+    ret += colorize( string_format( " - %s", item::nname( fuel_type ) ), c_light_gray );
+
+    // previously handled by the 'verbose' bool
+    auto fuel_data = fuel_usages.find( fuel_type );
+    int rate = 0;
+    std::string units;
+    if( fuel_data != fuel_usages.end() ) {
+        rate = consumption_per_hour( fuel_type, fuel_data->second );
+        units = _( "mL" );
+    }
+    if( fuel_type == itype_battery ) {
+        rate += power_to_energy_bat( net_battery_charge_rate( here,/* include_reactors = */ true ),
+                                     1_hours );
+        units = _( "kJ" );
+    }
+    if( rate != 0 && cap != 0 ) {
+        int tank_use = 0;
+        nc_color tank_color = c_light_green;
+        std::string tank_goal = _( "full" );
+        if( rate > 0 ) {
+            tank_use = cap - f_left;
+            if( !tank_use ) {
+                return ret;
+            }
+        } else {
+            if( !f_left ) {
+                return ret;
+            }
+            tank_use = f_left;
+            tank_color = c_light_red;
+            tank_goal = _( "empty" );
+        }
+
+        // promote to double so esimate doesn't overflow for high fuel values
+        // 3600 * tank_use overflows signed 32 bit when tank_use is over ~596523
+        double turns = to_turns<double>( 60_minutes );
+        time_duration estimate = time_duration::from_turns( turns * tank_use / std::abs( rate ) );
+
+        if( debug_mode ) {
+            ret += colorize( string_format( _( ", %d %s(%4.2f%%)/hour, %s until %s" ), rate, units,
+                                            100.0 * rate / cap, to_string_clipped( estimate ), tank_goal ), tank_color );
+        } else {
+            ret += colorize( string_format( _( ", %3.1f%% / hour, %s until %s" ), 100.0 * rate  / cap,
+                                            to_string_clipped( estimate ), tank_goal ), tank_color );
+        }
+    }
+
+    return ret;
+}
+
 /**
  * Prints a fuel gauge for a vehicle
  * @param win Pointer to the window to draw in.
@@ -428,6 +531,7 @@ void vehicle::print_fuel_indicator( map &here, const catacurses::window &win, co
             mvwprintz( win, p + point( 6, 0 ), f_color, "%d/%d", f_left, cap );
         } else {
             mvwprintz( win, p + point( 6, 0 ), f_color, "%d", f_left * 100 / cap );
+            // Unicode character 045 AKA the percent sign.
             wprintz( win, c_light_gray, "%c", 045 );
         }
     }


### PR DESCRIPTION
#### Summary
Interface "Move appliance infobox to imgui"

#### Purpose of change
* Followup to #85768

The infobox wasn't imgui, so lines drew in front of it.

#### Describe the solution
Put it in the uilist's `text`(header).

Minor additional change: The infobox refuses to give any other information if a battery is missing. Many newer players have been confused by the need for a battery. So if we don't have one we just say that and don't tell them anything else misleading, even if there is some "power flow".

Minor additional fix: The fuel indicator hasn't worked in... years, at least as far back as 0.H. I fixed it while I was here, but only for the appliance window. (The proper vehicle menu still uses the old print_fuel_indicator() function)

#### Describe alternatives you've considered


#### Testing
Note: For the purposes of comparison the ncurses infobox has been retained in these first images. It is not present in the pushed code.

Fridge w/ no connections
<img width="482" height="286" alt="image" src="https://github.com/user-attachments/assets/85a48741-d689-404c-8eb8-caa9bcf6da30" />

Fridge w/ basic power setup (solar)
<img width="486" height="360" alt="image" src="https://github.com/user-attachments/assets/c01a57a2-fd54-49b4-81cb-dd358eaa1c23" />

Fridge w/ ASRG
<img width="481" height="401" alt="image" src="https://github.com/user-attachments/assets/68bb6da5-1e84-476e-ab3d-9c0110947450" />

Fridge w/ wind turbine
<img width="487" height="354" alt="image" src="https://github.com/user-attachments/assets/816470ad-44b2-4b1a-82a0-1b526c5262ec" />

"Proper" view with the old ncurses infobox removed:
<img width="482" height="278" alt="image" src="https://github.com/user-attachments/assets/96244852-406b-4ec9-94db-61f5c941413b" />

#### Additional context

Known issues:

-The uilist is still offset from the center of the screen, expecting the ncurses window to be there. I didn't bother changing that because this offset allows easier viewing of the cable connections for small grids (otherwise the uilist is often on top of the appliances).
