### PR TITLE
Fix gas mask filter drain and multimag fire gate

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5864,6 +5864,36 @@
     }
   },
   {
+    "id": "test_multimag_gun_integral_ammo",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "test integral-mag multimag gun" },
+    "description": "Test gun: integral 9mm magazine + battery well, dual firing requirements (SGG-5 shape).",
+    "weight": "1000 g",
+    "volume": "1500 ml",
+    "longest_side": "400 mm",
+    "material": [ "steel" ],
+    "symbol": "(",
+    "color": "light_gray",
+    "ammo": [ "9mm" ],
+    "skill": "pistol",
+    "range": 10,
+    "ranged_damage": { "damage_type": "bullet", "amount": 10 },
+    "dispersion": 480,
+    "durability": 10,
+    "flags": [ "NO_TURRET" ],
+    "pocket_data": [
+      { "id": "ammo", "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "9mm": 1 } },
+      {
+        "id": "power",
+        "magazine_well": "500 ml",
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "heavy_battery_cell" ]
+      }
+    ],
+    "firing_requirements": { "DEFAULT": [ { "pocket": "ammo", "qty": 1 }, { "pocket": "power", "qty": 5 } ] }
+  },
+  {
     "id": "test_multimag_tool_consume",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -822,8 +822,10 @@ void avatar_action::fire_wielded_weapon( avatar &you )
         return;
     } else if( !weapon->is_gun() ) {
         return;
-    } else if( weapon->has_ammo_data() &&
+    } else if( !weapon->uses_firing_requirements() && weapon->has_ammo_data() &&
                !weapon->ammo_types().count( weapon->loaded_ammo().ammo_type() ) ) {
+        // Multimag guns enforce per-pocket ammo at load time; this gate is for
+        // single-mag guns whose accepted ammo can shift via gunmod conversion.
         add_msg( m_info, _( "The %s can't be fired while loaded with incompatible ammunition %s" ),
                  weapon->tname(), weapon->ammo_current()->nname( 1 ) );
         return;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4020,7 +4020,7 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint_bub_ms 
             }
         }
         if( it->get_var( "gas_absorbed", 0 ) >= 60 ) {
-            it->consume_tool_uses( 1, get_map(), pos, p );
+            it->ammo_consume( 1, pos, p );
             it->set_var( "gas_absorbed", 0 );
             if( it->ammo_remaining( ) < 10 ) {
                 p->add_msg_player_or_npc(

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -3,6 +3,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "avatar.h"
 #include "bodypart.h"
@@ -67,7 +68,9 @@ static const itype_id itype_atomic_coffee( "atomic_coffee" );
 static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_coffee( "coffee" );
 static const itype_id itype_diazepam( "diazepam" );
+static const itype_id itype_gasfilter_med( "gasfilter_med" );
 static const itype_id itype_inhaler( "inhaler" );
+static const itype_id itype_mask_gas( "mask_gas" );
 static const itype_id itype_oxygen( "oxygen" );
 static const itype_id itype_oxygen_tank( "oxygen_tank" );
 static const itype_id itype_panacea( "panacea" );
@@ -1079,4 +1082,34 @@ TEST_CASE( "water_tablet_purification_test", "[iuse][pur_tablets]" )
         }
 
     }
+}
+
+// Gas mask has no charges_per_use; iuse::gasmask must drain the filter via
+// ammo_consume directly. consume_tool_uses bails out without draining when
+// charges_to_use() is zero.
+TEST_CASE( "gasmask_filter_drains_on_full_absorption", "[iuse][gasmask]" )
+{
+    avatar dummy;
+    dummy.normalize();
+    map &here = get_map();
+    const tripoint_bub_ms pos = dummy.pos_bub( here );
+
+    item mask( itype_mask_gas );
+    REQUIRE( mask.put_in( item( itype_gasfilter_med ), pocket_type::MAGAZINE_WELL ).success() );
+    const int charges_before = mask.ammo_remaining();
+    REQUIRE( charges_before > 0 );
+
+    item_location mask_loc = dummy.i_add( mask );
+    REQUIRE( dummy.wear( mask_loc, false ) );
+    item *worn_mask = dummy.worn.top_items_loc( dummy ).front().get_item();
+    REQUIRE( worn_mask != nullptr );
+    REQUIRE( dummy.is_worn( *worn_mask ) );
+
+    worn_mask->active = true;
+    worn_mask->set_var( "gas_absorbed", 60 );
+
+    iuse::gasmask( &dummy, worn_mask, pos );
+
+    CHECK( worn_mask->ammo_remaining() == charges_before - 1 );
+    CHECK( worn_mask->get_var( "gas_absorbed", -1 ) == 0 );
 }

--- a/tests/multimag_test.cpp
+++ b/tests/multimag_test.cpp
@@ -10,6 +10,7 @@
 
 #include "activity_actor_definitions.h"
 #include "avatar.h"
+#include "avatar_action.h"
 #include "calendar.h"
 #include "cata_catch.h"
 #include "cata_utility.h"
@@ -29,6 +30,7 @@
 #include "json.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "messages.h"
 #include "options_helpers.h"
 #include "output.h"
 #include "player_helpers.h"
@@ -63,6 +65,7 @@ static const itype_id itype_stanag30( "stanag30" );
 static const itype_id itype_sw_619( "sw_619" );
 static const itype_id itype_test_multimag_gun( "test_multimag_gun" );
 static const itype_id itype_test_multimag_gun_consume( "test_multimag_gun_consume" );
+static const itype_id itype_test_multimag_gun_integral_ammo( "test_multimag_gun_integral_ammo" );
 static const itype_id itype_test_multimag_gun_same_type( "test_multimag_gun_same_type" );
 static const itype_id itype_test_multimag_tool_consume( "test_multimag_tool_consume" );
 static const itype_id itype_test_multimag_tool_factor( "test_multimag_tool_factor" );
@@ -1659,4 +1662,37 @@ TEST_CASE( "ammo_consume_on_item_without_charges_per_use_drains_raw_count",
     const int consumed = legacy.ammo_consume( 4, pos, nullptr );
     CHECK( consumed == 4 );
     CHECK( legacy.ammo_remaining() == 11 );
+}
+
+// Multimag gun with integral MAGAZINE ammo pocket trips the single-mag
+// "incompatible ammunition" gate in fire_wielded_weapon: loaded_ammo()
+// recurses into a bare round and returns null_item_reference, so its
+// ammo_type() never matches gun.ammo. Pocket restrictions already enforce
+// per-pocket ammo at load time, so the gate must skip multimag guns.
+TEST_CASE( "multimag_fire_skips_incompatible_ammo_gate", "[multimag][fire]" )
+{
+    clear_map();
+    avatar &dummy = get_avatar();
+    dummy.set_body();
+    dummy.clear_worn();
+    dummy.remove_weapon();
+
+    item gun( itype_test_multimag_gun_integral_ammo );
+    REQUIRE( gun.uses_firing_requirements() );
+    REQUIRE( gun.put_in( item( itype_9mm, calendar::turn, 1 ),
+                         pocket_type::MAGAZINE ).success() );
+    item battery( itype_heavy_battery_cell );
+    battery.ammo_set( itype_battery, 100 );
+    REQUIRE( gun.put_in( battery, pocket_type::MAGAZINE_WELL ).success() );
+
+    dummy.set_wielded_item( gun );
+    REQUIRE( dummy.get_wielded_item() );
+
+    Messages::clear_messages();
+    avatar_action::fire_wielded_weapon( dummy );
+
+    for( const auto &msg : Messages::recent_messages( 0 ) ) {
+        INFO( "message: " << msg.second );
+        CHECK( msg.second.find( "incompatible ammunition" ) == std::string::npos );
+    }
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Gas mask filters drain again; multimag guns can fire when fully loaded"

#### Purpose of change

Two regressions from the multimag rollout (#86790 / #86845).

Closes #86939: gas masks and PBA masks stopped consuming filter charges. The migration to consume_tool_uses bails out without draining when the item has no charges_per_use.

https://github.com/CleverRaven/Cataclysm-DDA/issues/85928#issuecomment-4414061828: multimag guns with an integral MAGAZINE ammo pocket fail with "incompatible ammunition" because loaded_ammo() resolves to null_item_reference for that shape.

#### Describe the solution

- Revert iuse::gasmask filter drain to ammo_consume.
- Skip the incompatible-ammo gate in fire_wielded_weapon for guns that use firing_requirements. Pocket restrictions already enforce per-pocket ammo at load time.

#### Describe alternatives you've considered

Fixing loaded_ammo() for integral-MAGAZINE multimag guns would also clear several downstream callers (character_guns, npc value, inventory color). Wider blast radius; separate PR.

#### Testing

Two new regression tests, existing tests pass.

#### Additional context

N/A