### PR TITLE
Fix "<name> helps with crafting" message not using the new name of renamed NPCs

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1806,7 +1806,7 @@ Character::craft_roll_data Character::recipe_success_roll_data( const recipe &ma
             const float helper_skill_average = std::max( guy->get_recipe_weighted_skill_average( making ),
                                                0.0f );
             helpers_weighted_average += std::pow( helper_skill_average, 2 );
-            add_msg_if_player( m_info, _( "%s helps with crafting…" ), guy->name );
+            add_msg_if_player( m_info, _( "%s helps with crafting…" ), guy->get_name() );
         }
     }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix 'N helps with crafting' message not using the new name of NPCs who were renamed by player"

#### Purpose of change

When you were crafting items and had an NPC follower, "[name] helps with crafting" message was using the pre-Cataclysm name of this NPC, even if the player has renamed this NPC.

#### Describe the solution

If NPC was renamed, then new name will be used.

#### Describe alternatives you've considered

N/A

#### Testing

1. Renamed NPC to "Imoen", told that NPC to follow me. Started crafting items. Saw the correct message "Imoen helps with crafting".
2. Regression test: told an NPC who was never renamed (Donovan Hand) to follow me. Started crafting items. Saw the correct message "Donovan Hand helps with crafting".

#### Additional context


