### PR TITLE
Re-enable cata-large-stack-object on LLVM 22

### DIFF
--- a/build-scripts/clang-tidy-wrapper.sh
+++ b/build-scripts/clang-tidy-wrapper.sh
@@ -6,11 +6,19 @@ set -o pipefail
 build_dir=${CATA_BUILD_DIR:-build}
 plugin=${build_dir}/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so
 
+# Tolerate GCC-built compile_commands driving clang-tidy (silence unknown
+# -W flags) and dodge the clang>=22 c2y-extension warning on Catch2
+# __COUNTER__ macros (llvm/llvm-project#189645).
+extra_args=(
+    --extra-arg=-Wno-unknown-warning-option
+    --extra-arg=-DCATCH_CONFIG_NO_COUNTER
+)
+
 if [ -f "$plugin" ]
 then
     set -x
-    LD_PRELOAD=$plugin ${CATA_CLANG_TIDY} --enable-check-profile --store-check-profile=clang-tidy-trace "$@"
+    LD_PRELOAD=$plugin ${CATA_CLANG_TIDY} --enable-check-profile --store-check-profile=clang-tidy-trace "${extra_args[@]}" "$@"
 else
     set -x
-    ${CATA_CLANG_TIDY} "$@"
+    ${CATA_CLANG_TIDY} "${extra_args[@]}" "$@"
 fi

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,13 @@ if (BUILD_TESTING)
     # Enabling benchmarks
     add_definitions(-DCATCH_CONFIG_ENABLE_BENCHMARKING)
 
+    # Workaround clang>=22 flagging __COUNTER__ as c2y-extension
+    # (llvm/llvm-project#189645). Mirrors tests/Makefile.
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang"
+            AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 22)
+        add_definitions(-DCATCH_CONFIG_NO_COUNTER)
+    endif ()
+
     if(LOCALIZE)
         # Need to build the test .mo file for the tests to pass.
         # Unfortunately we currently need to put this in the source dir, not the

--- a/tools/clang-tidy-plugin/LargeStackObjectCheck.cpp
+++ b/tools/clang-tidy-plugin/LargeStackObjectCheck.cpp
@@ -63,12 +63,13 @@ static void CheckDecl( LargeStackObjectCheck &Check, const MatchFinder::MatchRes
     }
 
 #if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR >= 22
-    // ASTContext::getTypeInfoImpl recurses without bound on some complete
-    // CTAD-deduced template instantiations (e.g. restore_on_out_of_scope
-    // wrapping std::optional<units::quantity<...>>) and crashes the process.
-    // The matcher fires on every varDecl, so we cannot keep the check
-    // partially active without misclassifying safe types.
-    return;
+    // LLVM 22 getTypeInfoImpl segfaults on DTS with null deduced type
+    // (CTAD aborted by earlier compile errors).
+    if( const auto *DTS = dyn_cast<DeducedTemplateSpecializationType>( T ) ) {
+        if( DTS->getDeducedType().isNull() ) {
+            return;
+        }
+    }
 #endif
 
 #if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR >= 17


### PR DESCRIPTION
#### Summary
Infrastructure "Re-enable cata-large-stack-object check on LLVM 22"

#### Purpose of change

The check was disabled wholesale on LLVM 22 because it crashed clang-tidy on one TU. Comment said infinite recursion; coredump says NULL deref in `getTypeInfoImpl`. Different bug, narrower fix possible.

#### Describe the solution

Skip `DeducedTemplateSpecializationType` with null deduced type. That's the only shape clang 22 chokes on, and it only happens after enough earlier errors that CTAD never finishes for the variable.

To stop those earlier errors from piling up, define `CATCH_CONFIG_NO_COUNTER` for clang 22+ (Catch2 falls back off `__COUNTER__`, dodges llvm/llvm-project#189645). Same workaround `tests/Makefile` already has, just for the cmake test target too.

Wrapper also passes `-Wno-unknown-warning-option` plus the same define so a GCC-built compile DB driving clang-tidy 22 doesn't trip on either.

#### Describe alternatives you've considered

N/A

#### Testing

Ran clang-tidy 22 + plugin over all 685 src/tests TUs. No crashes, including the original repro.

#### Additional context

N/A