### PR TITLE
Fix typo that caused New England Church to like Elf mutants

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/godco_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/godco_npc_eocs.json
@@ -23,7 +23,7 @@
             "THRESH_CEPHALOPOD",
             "THRESH_SPIDER",
             "THRESH_RAT",
-            "THRESH_ELPHA",
+            "THRESH_ELFA",
             "THRESH_CHIMERA",
             "THRESH_RAPTOR",
             "THRESH_BATRACHIAN",

--- a/data/mods/MindOverMatter/powers/photokinesis_eocs.json
+++ b/data/mods/MindOverMatter/powers/photokinesis_eocs.json
@@ -42,7 +42,7 @@
         "THRESH_CEPHALOPOD",
         "THRESH_SPIDER",
         "THRESH_RAT",
-        "THRESH_ELPHA",
+        "THRESH_ELFA",
         "THRESH_CHIMERA",
         "THRESH_RAPTOR",
         "THRESH_BATRACHIAN",


### PR DESCRIPTION
#### Summary

Bugfixes "Fix New England Church (which condemns mutations) not fearing the Elf mutants"

#### Purpose of change

They are supposed to fear any visible mutations (not alpha/medical), but elves were tolerated because of this typo.

#### Describe the solution

Fix the typo: THRESH_ELPHA (incorrect) -> THRESH_ELFA.

#### Describe alternatives you've considered

Allowing the Church to be tolerant to elves. It would require adding some dialogue that explains why they don't consider you a sinner. (there is no way that they wouldn't notice or comment on your inhuman appearance)

#### Testing

Talked to Church NPCs as a post-threshold elf. Heard the angry things that they tell to mutants.

Talked to Church NPCs as a character who is not a post-threshold mutant. They are still friendly.

#### Additional context

