### PR TITLE
Fix bullet points not being rendered in Crafting UI

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -393,6 +393,7 @@ static void AddGlyphRangesMisc( UNUSED ImFontGlyphRangesBuilder *b )
     // NOLINTNEXTLINE(modernize-avoid-c-arrays)
     static ImWchar superscripts[] = { 0x00B9, 0x00B9, 0x00B2, 0x00B3, 0x2070, 0x208E, 0x0000 };
     b->AddRanges( &superscripts[0] );
+    b->AddChar( 0x2022 ); // bullet point, used in crafting ui
 }
 
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix bullet points not being rendered in Crafting UI"

#### Purpose of change
The ImGui crafting menu is showing question marks instead of bullet points.

#### Describe the solution
Add the bullet point character to the font set when building.

#### Describe alternatives you've considered
None.

#### Testing
Compiled in Windows.
Loaded a game, verified bullet points were shown in Crafting UI.

#### Additional context

