### PR TITLE
Skip deferred move mode switch when currently disallowed

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2348,14 +2348,16 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
     int desired_move_mode_cost = 0;
     if( player_character.is_waiting_to_change_mode_mode() && !is_actions_move_mode ) {
         move_mode_id desired_move = player_character.get_desired_move_mode();
-        desired_move_mode_cost = player_character.move_mode_switch_cost( player_character.move_mode,
-                                 desired_move );
-        player_character.set_movement_mode( desired_move );
-        if( player_character.move_mode == desired_move ) {
-            player_character.mod_moves( -desired_move_mode_cost );
-        } else {
-            debugmsg( "Player unable to change from move_mode(%s) to desired_move_mode(%s)",
-                      player_character.move_mode.c_str(), desired_move.c_str() );
+        if( player_character.can_switch_to( desired_move ) ) {
+            desired_move_mode_cost = player_character.move_mode_switch_cost( player_character.move_mode,
+                                     desired_move );
+            player_character.set_movement_mode( desired_move );
+            if( player_character.move_mode == desired_move ) {
+                player_character.mod_moves( -desired_move_mode_cost );
+            } else {
+                debugmsg( "Player unable to change from move_mode(%s) to desired_move_mode(%s)",
+                          player_character.move_mode.c_str(), desired_move.c_str() );
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix debug message when stamina runs out while running"

#### Purpose of change
Closes #86918. Running into zero stamina pops a debugmsg. Stamina-out forces move_mode back to walk, desired stays at run, deferred switch fails on next action.

#### Describe the solution
Guard the deferred switch with `can_switch_to(desired)`. Wait until stamina recovers, then it goes through.

#### Describe alternatives you've considered
N/A

#### Testing
Sprinted in circles until winded. No more debugmsg.

#### Additional context
N/A