### PR TITLE
Fix segfault when reloading torch with welding tank

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -7903,6 +7903,12 @@ void reload_activity_actor::start( player_activity &act, Character &/*who*/ )
 
 void reload_activity_actor::reload_msg( Character &who, bool finished )
 {
+    // Item may have been dropped from inventory between turns (e.g. pocket
+    // overflow after the reload increased its size); the location is then
+    // stale and dereferencing it would crash.
+    if( !target_loc ) {
+        return;
+    }
     item &reloadable = *target_loc;
     const std::string reloadable_name = reloadable.tname();
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix segfault when reloading a torch that gets dropped mid-activity"

#### Purpose of change
Fixes #86709. Reloading an acetylene torch with a welding tank crashes when the loaded torch is too big for the pocket holding it.

#### Describe the solution
The reload finishes, the oversized torch falls to the ground via `drop_invalid_inventory` between turns, and the actor's `target_loc` goes stale. Then `reload_msg` derefs it and crashes. Add a null guard. The "falls to the ground" message already tells the player what happened, so skipping the redundant reload line is fine.

#### Describe alternatives you've considered
Suppress the mid-activity drop entirely. Bad idea: autosave runs before `process_turn`, so we'd risk persisting bad inventory state.

Cache enough item state to print a real message after the drop. Too much work for a line that's redundant.

`reload()` does have its own fit check that's supposed to handle this, but it only looks at volume and weight, while `item_pocket::overflow` runs full `can_contain`. Aligning those is a separate followup.

#### Testing
Verified in-game with the save from #86709.

#### Additional context
N/A