### PR TITLE
Add translation contexts for colors

### DIFF
--- a/data/json/snippets/snippets.json
+++ b/data/json/snippets/snippets.json
@@ -472,7 +472,7 @@
       { "id": "dog_name_0016", "text": "Benji" },
       { "id": "dog_name_0017", "text": "Bentley" },
       { "id": "dog_name_0018", "text": "Bingo" },
-      { "id": "dog_name_0019", "text": "Blue" },
+      { "id": "dog_name_0019", "text": { "ctxt": "dog_name", "str": "Blue" } },
       { "id": "dog_name_0020", "text": "Bo" },
       { "id": "dog_name_0021", "text": "Bonnie" },
       { "id": "dog_name_0022", "text": "Boomer" },

--- a/data/mods/DinoMod/NPC/NC_Red.json
+++ b/data/mods/DinoMod/NPC/NC_Red.json
@@ -2,7 +2,7 @@
   {
     "type": "npc",
     "id": "old_guard_red",
-    "name_unique": "Red",
+    "name_unique": { "ctxt": "NPC Name", "str": "Red" },
     "class": "NC_SOLDIER",
     "attitude": 0,
     "mission": 3,

--- a/data/mods/DinoMod/achievements/achievements.json
+++ b/data/mods/DinoMod/achievements/achievements.json
@@ -27,7 +27,7 @@
   {
     "id": "achievement_kill_10000_dinos",
     "type": "achievement",
-    "name": "Red",
+    "name": { "ctxt": "achievement", "str": "Red" },
     "hidden_by": [ "achievement_kill_1000_dinos" ],
     "requirements": [ { "event_statistic": "num_avatar_dino_kills", "is": ">=", "target": 10000 } ]
   },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/86946

#### Describe the solution
Add translation contexts

#### Testing
```
lang/update_pot.sh
grep -B4 Blue lang/po/cataclysm-dda.pot
grep -B4 Red lang/po/cataclysm-dda.pot
```

```
#. ~ EOC option name
#: data/json/effects_on_condition/bionic_eocs.json
msgid "Blue"
--

#. ~ Snippet in category '<dog_name>'
#: data/json/snippets/snippets.json
msgctxt "dog_name"
msgid "Blue"
```
```
#. ~ EOC option name
#: data/json/effects_on_condition/bionic_eocs.json
msgid "Red"
--

#. ~ Name of achievement
#: data/mods/DinoMod/achievements/achievements.json
msgctxt "achievement"
msgid "Red"
--

#. ~ Unique name of an NPC
#: data/mods/DinoMod/NPC/NC_Red.json
msgctxt "NPC Name"
msgid "Red"
```