### PR TITLE
Block in-place transform when result wouldn't fit parent pocket

### DIFF
--- a/data/mods/TEST_DATA/transform_test_items.json
+++ b/data/mods/TEST_DATA/transform_test_items.json
@@ -26,6 +26,22 @@
     "melee_damage": { "bash": 10 }
   },
   {
+    "id": "test_transform_timed_baton",
+    "type": "ITEM",
+    "category": "weapons",
+    "name": { "str": "test timed baton" },
+    "description": "Test baton that transforms via countdown_action.",
+    "weight": "600 g",
+    "volume": "140 ml",
+    "longest_side": "24 cm",
+    "symbol": "/",
+    "color": "dark_gray",
+    "material": [ "steel" ],
+    "countdown_action": { "type": "transform", "target": "test_transform_baton_long" },
+    "countdown_interval": "1 seconds",
+    "melee_damage": { "bash": 4 }
+  },
+  {
     "id": "test_transform_short_vest",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],

--- a/data/mods/TEST_DATA/transform_test_items.json
+++ b/data/mods/TEST_DATA/transform_test_items.json
@@ -1,0 +1,78 @@
+[
+  {
+    "id": "test_transform_baton",
+    "type": "ITEM",
+    "category": "weapons",
+    "name": { "str": "test telescoping baton" },
+    "description": "Test baton, collapsed.",
+    "weight": "600 g",
+    "volume": "140 ml",
+    "longest_side": "24 cm",
+    "symbol": "/",
+    "color": "dark_gray",
+    "material": [ "steel" ],
+    "use_action": { "menu_text": "Expand", "type": "transform", "target": "test_transform_baton_long", "msg": "snap" },
+    "melee_damage": { "bash": 4 }
+  },
+  {
+    "id": "test_transform_baton_long",
+    "type": "ITEM",
+    "copy-from": "test_transform_baton",
+    "name": { "str": "test telescoping baton (extended)" },
+    "description": "Test baton, extended.",
+    "volume": "260 ml",
+    "longest_side": "60 cm",
+    "use_action": { "menu_text": "Collapse", "type": "transform", "target": "test_transform_baton", "msg": "snap" },
+    "melee_damage": { "bash": 10 }
+  },
+  {
+    "id": "test_transform_short_vest",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "test short-pocket vest" },
+    "description": "Test vest with one short pocket.",
+    "weight": "1000 g",
+    "volume": "1000 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "nylon" ],
+    "symbol": "[",
+    "color": "dark_gray",
+    "material_thickness": 2,
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1000 ml",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "30 cm"
+      }
+    ],
+    "flags": [ "BELTED", "WATER_FRIENDLY" ],
+    "armor": [ { "encumbrance": 2, "coverage": 100, "covers": [ "torso" ] } ]
+  },
+  {
+    "id": "test_transform_long_pack",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "test long-pocket pack" },
+    "description": "Test pack with one large pocket.",
+    "weight": "2000 g",
+    "volume": "14000 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "nylon" ],
+    "symbol": "[",
+    "color": "dark_gray",
+    "material_thickness": 2,
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "50 L",
+        "max_contains_weight": "50 kg",
+        "max_item_length": "70 cm"
+      }
+    ],
+    "flags": [ "BELTED", "WATER_FRIENDLY" ],
+    "armor": [ { "encumbrance": 2, "coverage": 100, "covers": [ "torso" ] } ]
+  }
+]

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4667,6 +4667,11 @@ bool item::process_internal( map &here, Character *carrier, const tripoint_bub_m
             } else {
                 return true;
             }
+            // Result may not fit current pocket; queue overflow to spill
+            // into a fitting ancestor pocket or onto the ground.
+            if( carrier ) {
+                carrier->invalidate_inventory_validity_cache();
+            }
         }
 
         for( const emit_id &e : type->emits ) {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -196,26 +196,102 @@ item_location form_loc_recursive( T &loc, item &it )
 template item_location form_loc_recursive<Character>( Character &loc, item &it );
 template item_location form_loc_recursive<npc>( npc &loc, item &it );
 
-static item_location form_loc( Character &you, map *here, const tripoint_bub_ms &p, item &it )
+static std::optional<item_location> try_form_loc( Character &you, map *here,
+        const tripoint_bub_ms &p, item &it )
 {
     if( you.has_item( it ) ) {
         return form_loc_recursive( you, it );
     }
-    map_cursor mc( here, p );
-    if( mc.has_item( it ) ) {
-        return form_loc_recursive( mc, it );
-    }
-    const optional_vpart_position vp = here->veh_at( p );
-    if( vp ) {
-        vehicle_cursor vc( vp->vehicle(), vp->part_index() );
-        if( vc.has_item( it ) ) {
-            return form_loc_recursive( vc, it );
+    if( here ) {
+        map_cursor mc( here, p );
+        if( mc.has_item( it ) ) {
+            return form_loc_recursive( mc, it );
+        }
+        const optional_vpart_position vp = here->veh_at( p );
+        if( vp ) {
+            vehicle_cursor vc( vp->vehicle(), vp->part_index() );
+            if( vc.has_item( it ) ) {
+                return form_loc_recursive( vc, it );
+            }
         }
     }
+    return std::nullopt;
+}
 
+static item_location form_loc( Character &you, map *here, const tripoint_bub_ms &p, item &it )
+{
+    if( std::optional<item_location> loc = try_form_loc( you, here, p, it ) ) {
+        return *loc;
+    }
     debugmsg( "Couldn't find item %s to form item_location, forming dummy location to ensure minimum functionality",
               it.display_name() );
     return item_location( you, &it );
+}
+
+// Like parents_can_contain_recursive but with replacement semantics: an
+// in-place transform swaps `it` out, so each level credits `it`'s footprint.
+static ret_val<void> transform_fits_parent_pocket( const Character &p, const item &it,
+        const item &result, map *here, const tripoint_bub_ms &pos )
+{
+    const std::optional<item_location> loc = try_form_loc(
+                const_cast<Character &>( p ), here, pos, const_cast<item &>( it ) );
+    if( !loc || !loc->has_parent() ) {
+        return ret_val<void>::make_success();
+    }
+
+    units::mass result_weight = result.weight();
+    units::volume result_volume = result.volume();
+    units::length result_length = result.length();
+    units::mass it_weight = it.weight();
+    units::volume it_volume = it.volume();
+    units::length it_length = it.length();
+    const std::vector<const item_pocket *> innermost = loc->get_item()->get_standard_pockets();
+    const item_pocket *current_pocket = innermost.empty() ? nullptr : innermost.front();
+    const pocket_data *current_pocket_data = current_pocket ? current_pocket->get_pocket_data()
+            : nullptr;
+
+    item_location current = *loc;
+    while( current.has_parent() ) {
+        const item_pocket *parent_pocket = current.parent_pocket();
+        if( parent_pocket == nullptr ) {
+            break;
+        }
+        if( current_pocket && current_pocket->rigid() ) {
+            result_volume = 0_ml;
+            result_length = 0_mm;
+            it_volume = 0_ml;
+            it_length = 0_mm;
+        }
+        if( current_pocket_data ) {
+            result_weight = result_weight * current_pocket_data->weight_multiplier;
+            result_volume = result_volume * current_pocket_data->volume_multiplier;
+            result_length = result_length * std::cbrt( current_pocket_data->volume_multiplier );
+            it_weight = it_weight * current_pocket_data->weight_multiplier;
+            it_volume = it_volume * current_pocket_data->volume_multiplier;
+            it_length = it_length * std::cbrt( current_pocket_data->volume_multiplier );
+        }
+
+        if( result_weight - it_weight > parent_pocket->remaining_weight() ) {
+            return ret_val<void>::make_failure(
+                       _( "The %1$s would not fit in its container after transforming: item is too heavy for a parent pocket" ),
+                       result.tname() );
+        }
+        if( result_volume - it_volume > parent_pocket->remaining_volume() ) {
+            return ret_val<void>::make_failure(
+                       _( "The %1$s would not fit in its container after transforming: item is too big for a parent pocket" ),
+                       result.tname() );
+        }
+        if( result_length > parent_pocket->get_pocket_data()->max_item_length ) {
+            return ret_val<void>::make_failure(
+                       _( "The %1$s would not fit in its container after transforming: item is too long for a parent pocket" ),
+                       result.tname() );
+        }
+
+        current_pocket = parent_pocket;
+        current_pocket_data = current_pocket->get_pocket_data();
+        current = current.parent_item();
+    }
+    return ret_val<void>::make_success();
 }
 
 std::unique_ptr<iuse_actor> iuse_transform::clone() const
@@ -359,7 +435,7 @@ std::optional<int> iuse_transform::use( Character *p, item &it, map *,
 }
 
 ret_val<void> iuse_transform::can_use( const Character &p, const item &it,
-                                       map *here, const tripoint_bub_ms & ) const
+                                       map *here, const tripoint_bub_ms &pos ) const
 {
     if( need_worn && !p.is_worn( it ) ) {
         return ret_val<void>::make_failure( _( "You need to wear the %1$s before activating it." ),
@@ -372,6 +448,16 @@ ret_val<void> iuse_transform::can_use( const Character &p, const item &it,
     if( need_empty && !it.empty() ) {
         return ret_val<void>::make_failure( _( "You need to empty the %1$s before activating it." ),
                                             it.tname() );
+    }
+
+    if( transform.target_group.is_empty() && !transform.target.is_empty() ) {
+        const item result = transform.container.is_empty()
+                            ? item( transform.target )
+                            : item( transform.container );
+        ret_val<void> fits = transform_fits_parent_pocket( p, it, result, here, pos );
+        if( !fits.success() ) {
+            return fits;
+        }
     }
 
     if( p.is_worn( it ) ) {

--- a/tests/iuse_actor_test.cpp
+++ b/tests/iuse_actor_test.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <functional>
+#include <list>
 #include <map>
 #include <memory>
 #include <optional>
@@ -63,6 +64,10 @@ static const itype_id itype_rubber_harness_dog( "rubber_harness_dog" );
 static const itype_id itype_stick( "stick" );
 static const itype_id itype_stick_long( "stick_long" );
 static const itype_id itype_tazer( "tazer" );
+static const itype_id itype_test_transform_baton( "test_transform_baton" );
+static const itype_id itype_test_transform_baton_long( "test_transform_baton_long" );
+static const itype_id itype_test_transform_long_pack( "test_transform_long_pack" );
+static const itype_id itype_test_transform_short_vest( "test_transform_short_vest" );
 static const itype_id itype_touring_suit( "touring_suit" );
 static const itype_id itype_under_armor( "under_armor" );
 static const itype_id itype_voltmeter( "voltmeter" );
@@ -154,6 +159,74 @@ TEST_CASE( "tool_transform_when_activated", "[iuse][tool][transform]" )
             }
             THEN( "name indicates (on) status" ) {
                 CHECK( flashlight.tname() == "flashlight (on)" );
+            }
+        }
+    }
+}
+
+TEST_CASE( "transform_blocked_when_result_too_long_for_parent_pocket",
+           "[iuse_actor][transform][pocket]" )
+{
+    Character &dummy = get_avatar();
+    clear_avatar();
+
+    // Vest has a single 30 cm pocket; the test baton extends from 24 cm to 60 cm.
+    item baton( itype_test_transform_baton );
+    REQUIRE( baton.length() <= 30_cm );
+    REQUIRE( item( itype_test_transform_baton_long ).length() > 30_cm );
+
+    GIVEN( "a baton stashed in a pocket too small for the extended form" ) {
+        item vest( itype_test_transform_short_vest );
+        REQUIRE( vest.put_in( baton, pocket_type::CONTAINER ).success() );
+        auto vest_iter = dummy.wear_item( vest, false, false );
+        REQUIRE( vest_iter.has_value() );
+        item &worn_vest = **vest_iter;
+        item &stashed_baton = worn_vest.only_item();
+        REQUIRE( dummy.has_item( stashed_baton ) );
+
+        const use_function *use = stashed_baton.type->get_use( "transform" );
+        REQUIRE( use != nullptr );
+        const iuse_transform *actor = dynamic_cast<const iuse_transform *>
+                                      ( use->get_actor_ptr() );
+        REQUIRE( actor != nullptr );
+
+        WHEN( "checking if the transform can be invoked" ) {
+            ret_val<void> can = actor->can_use( dummy, stashed_baton, &get_map(),
+                                                dummy.pos_bub() );
+            THEN( "the transform is rejected" ) {
+                CHECK_FALSE( can.success() );
+            }
+        }
+
+        WHEN( "the player tries to invoke the transform" ) {
+            dummy.invoke_item( &stashed_baton );
+            THEN( "the baton is not transformed" ) {
+                CHECK( stashed_baton.typeId() == itype_test_transform_baton );
+                CHECK( worn_vest.only_item().typeId() == itype_test_transform_baton );
+            }
+        }
+    }
+
+    GIVEN( "a baton stashed in a pocket large enough for the extended form" ) {
+        item bag( itype_test_transform_long_pack );
+        REQUIRE( bag.put_in( baton, pocket_type::CONTAINER ).success() );
+        auto bag_iter = dummy.wear_item( bag, false, false );
+        REQUIRE( bag_iter.has_value() );
+        item &worn_bag = **bag_iter;
+        item &stashed_baton = worn_bag.only_item();
+        REQUIRE( dummy.has_item( stashed_baton ) );
+
+        const use_function *use = stashed_baton.type->get_use( "transform" );
+        REQUIRE( use != nullptr );
+        const iuse_transform *actor = dynamic_cast<const iuse_transform *>
+                                      ( use->get_actor_ptr() );
+        REQUIRE( actor != nullptr );
+
+        WHEN( "checking if the transform can be invoked" ) {
+            ret_val<void> can = actor->can_use( dummy, stashed_baton, &get_map(),
+                                                dummy.pos_bub() );
+            THEN( "the transform is allowed" ) {
+                CHECK( can.success() );
             }
         }
     }

--- a/tests/iuse_actor_test.cpp
+++ b/tests/iuse_actor_test.cpp
@@ -68,6 +68,7 @@ static const itype_id itype_test_transform_baton( "test_transform_baton" );
 static const itype_id itype_test_transform_baton_long( "test_transform_baton_long" );
 static const itype_id itype_test_transform_long_pack( "test_transform_long_pack" );
 static const itype_id itype_test_transform_short_vest( "test_transform_short_vest" );
+static const itype_id itype_test_transform_timed_baton( "test_transform_timed_baton" );
 static const itype_id itype_touring_suit( "touring_suit" );
 static const itype_id itype_under_armor( "under_armor" );
 static const itype_id itype_voltmeter( "voltmeter" );
@@ -227,6 +228,65 @@ TEST_CASE( "transform_blocked_when_result_too_long_for_parent_pocket",
                                                 dummy.pos_bub() );
             THEN( "the transform is allowed" ) {
                 CHECK( can.success() );
+            }
+        }
+    }
+}
+
+TEST_CASE( "timed_transform_spills_oversize_result_out_of_parent_pocket",
+           "[iuse_actor][transform][pocket]" )
+{
+    clear_map();
+    Character &dummy = get_avatar();
+    clear_avatar();
+
+    GIVEN( "a timed-transform baton stashed in a pocket too small for the result" ) {
+        item vest( itype_test_transform_short_vest );
+        REQUIRE( vest.put_in( item( itype_test_transform_timed_baton ),
+                              pocket_type::CONTAINER ).success() );
+        auto vest_iter = dummy.wear_item( vest, false, false );
+        REQUIRE( vest_iter.has_value() );
+        item &worn_vest = **vest_iter;
+        item &stashed_baton = worn_vest.only_item();
+        REQUIRE( dummy.has_item( stashed_baton ) );
+
+        WHEN( "the countdown fires and the inventory is reconciled" ) {
+            stashed_baton.active = true;
+            stashed_baton.countdown_point = calendar::turn - 1_seconds;
+            stashed_baton.process( get_map(), &dummy, dummy.pos_bub() );
+            dummy.drop_invalid_inventory();
+            THEN( "the extended baton has spilled out onto the ground" ) {
+                CHECK( worn_vest.empty_container() );
+                bool spilled_to_ground = false;
+                for( const item &i : get_map().i_at( dummy.pos_bub() ) ) {
+                    if( i.typeId() == itype_test_transform_baton_long ) {
+                        spilled_to_ground = true;
+                        break;
+                    }
+                }
+                CHECK( spilled_to_ground );
+            }
+        }
+    }
+
+    GIVEN( "a timed-transform baton stashed in a pocket large enough for the result" ) {
+        item bag( itype_test_transform_long_pack );
+        REQUIRE( bag.put_in( item( itype_test_transform_timed_baton ),
+                             pocket_type::CONTAINER ).success() );
+        auto bag_iter = dummy.wear_item( bag, false, false );
+        REQUIRE( bag_iter.has_value() );
+        item &worn_bag = **bag_iter;
+        item &stashed_baton = worn_bag.only_item();
+        REQUIRE( dummy.has_item( stashed_baton ) );
+
+        WHEN( "the countdown fires and the inventory is reconciled" ) {
+            stashed_baton.active = true;
+            stashed_baton.countdown_point = calendar::turn - 1_seconds;
+            stashed_baton.process( get_map(), &dummy, dummy.pos_bub() );
+            dummy.drop_invalid_inventory();
+            THEN( "the extended baton stays in the pocket" ) {
+                REQUIRE_FALSE( worn_bag.empty_container() );
+                CHECK( worn_bag.only_item().typeId() == itype_test_transform_baton_long );
             }
         }
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Block in-place transform when the result wouldn't fit the parent pocket"

#### Purpose of change
Fixes #86743. Expanding a baton inside a pocket too short for the extended form succeeds in-place, but on save/reload the new item fails the pocket length check, drops into the migration pocket, and overflows out next turn (or just goes missing).

#### Describe the solution
`iuse_transform::can_use` now refuses the action if the resulting item wouldn't fit its parent pocket; the fit check lives in `transform_fits_parent_pocket`. The walk mirrors `item_location::parents_can_contain_recursive` (multiplier and rigid-pocket propagation) but uses replacement semantics: weight and volume credit back the existing item's footprint at every level, since the transform swaps in place rather than inserting alongside. A small `try_form_loc` helper resolves character, map, and vehicle parents without the debugmsg fallback. Timed (non-player) transforms in `item::process` bypass `can_use`, so they instead invalidate the carrier's inventory after the countdown fires; the next `drop_invalid_inventory` walk spills the now-oversized result into a fitting ancestor pocket or onto the ground via the existing overflow path.

#### Describe alternatives you've considered
Reusing `parents_can_contain_recursive` as-is. It uses insertion semantics, so it would over-reject transforms that grow but still fit after the original is removed.

#### Testing
Added regression tests in `iuse_actor_test.cpp` covering both rejection (player path, 24 cm baton in a 30 cm test pocket) and a 60 cm test pocket as positive control, plus a timed-transform test that verifies the spill lands on the ground when no ancestor fits. Test-only items live in `data/mods/TEST_DATA/transform_test_items.json` so base-game item changes don't affect the assertions. Existing iuse and pocket tests still pass.

#### Additional context
N/A