### PR TITLE
Aftershock: Sol turrets and Veles robots guns dont set things on fire.

### DIFF
--- a/data/mods/aftershock_exoplanet/items/gun/laser.json
+++ b/data/mods/aftershock_exoplanet/items/gun/laser.json
@@ -45,9 +45,9 @@
     "id": "afs_light_cannon_mon",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "copy-from": "afs_v29",
+    "copy-from": "afs_av22",
     "name": { "str": "light cannon" },
-    "ranged_damage": { "damage_type": "afs_laser", "amount": 25 },
+    "ranged_damage": { "damage_type": "afs_laser", "amount": 15 },
     "energy_drain": "0 kJ",
     "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "NO_TURRET" ]
   },
@@ -158,6 +158,7 @@
     "energy_drain": "10 kJ",
     "valid_mod_locations": [ [ "emitter", 1 ], [ "grip", 1 ], [ "lens", 1 ], [ "rail", 1 ], [ "sights", 1 ], [ "stock", 1 ], [ "underbarrel", 1 ] ],
     "default_mods": [ "red_dot_sight" ],
+    "ammo_effects": [ "LASER" ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -313,6 +314,7 @@
     "ammo_to_fire": 0,
     "extend": { "flags": [ "NO_TURRET" ] },
     "delete": { "flags": [ "NO_UNLOAD", "USE_UPS" ] },
+    "ammo_effects": [ "LASER" ],
     "energy_drain": "5 kJ",
     "valid_mod_locations": [ [ "emitter", 1 ], [ "grip", 1 ], [ "lens", 1 ], [ "rail", 1 ], [ "sights", 1 ], [ "stock", 1 ], [ "underbarrel", 1 ] ],
     "pocket_data": [
@@ -339,6 +341,7 @@
     "ammo_to_fire": 0,
     "extend": { "flags": [ "NO_TURRET" ] },
     "delete": { "flags": [ "NO_UNLOAD", "USE_UPS" ] },
+    "ammo_effects": [ "LASER" ],
     "energy_drain": "120 kJ",
     "modes": [ [ "DEFAULT", "pulse", 1 ], [ "BURST", "2s sequence", 2 ] ],
     "ranged_damage": { "damage_type": "afs_laser", "amount": 25, "armor_penetration": 4 },


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Sol turrets and Veles robots guns dont set things on fire."

#### Purpose of change
Being set on fire is incredibly deadly, and these two enemies are only meant to be mildly dangerous.

#### Describe the solution
The setting on fire ammo effect was getting copied from the vanilla guns, I'm overwriting it here.

#### Describe alternatives you've considered
Making being set on fire not as deadly.

#### Testing
Got shot,

#### Additional context
I'll probably add a new laser gunmod to make the guns set things on fire once again.