### PR TITLE
Fix Charm spells to give feedback

### DIFF
--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1623,7 +1623,7 @@ void spell_effect::charm_monster( const spell &sp, Creature &caster, const tripo
         if( success ) {
             add_msg_if_player_sees( potential_target, m_good, _( "You charm the %s!" ), mon->name() );
         } else {
-            add_msg_if_player_sees( potential_target, m_bad, _( "The %s resists your spell." ), mon->name() );
+            add_msg_if_player_sees( potential_target, m_bad, _( "The %s resists your charm attempt." ), mon->name() );
         }
     }
 }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1623,7 +1623,8 @@ void spell_effect::charm_monster( const spell &sp, Creature &caster, const tripo
         if( success ) {
             add_msg_if_player_sees( potential_target, m_good, _( "You charm the %s!" ), mon->name() );
         } else {
-            add_msg_if_player_sees( potential_target, m_bad, _( "The %s resists your charm attempt." ), mon->name() );
+            add_msg_if_player_sees( potential_target, m_bad, _( "The %s resists your charm attempt." ),
+                                    mon->name() );
         }
     }
 }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1609,6 +1609,7 @@ void spell_effect::charm_monster( const spell &sp, Creature &caster, const tripo
             continue;
         }
         sp.make_sound( potential_target, caster );
+        bool success = false;
         if( ( mon->friendly == 0 || ( mon->friendly != 0 && sp.has_flag( spell_flag::RECHARM ) ) ) &&
             mon->get_hp() <= sp.damage( caster ) ) {
             mon->unset_dest();
@@ -1617,6 +1618,12 @@ void spell_effect::charm_monster( const spell &sp, Creature &caster, const tripo
                 mon->friendly = -1;
                 mon->add_effect( effect_pet, 1_turns, true );
             }
+            success = true;
+        }
+        if( success ) {
+            add_msg_if_player_sees( potential_target, m_good, _( "You charm the %s!" ), mon->name() );
+        } else {
+            add_msg_if_player_sees( potential_target, m_bad, _( "The %s resists your spell." ), mon->name() );
         }
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Storm mentioned charm spells can't tell you if they succeed or fail without incredibly tedious EOC work.  So I looked at the C++ and saw that almost all our spells have no pass fail messages coded whether it would be useful or not.  (It is going to be useful in almost every case except attack spells which clearly succeed or fail and have messages iirc)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added messages.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Lazy
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<img width="331" height="141" alt="failed to beastmaster moose" src="https://github.com/user-attachments/assets/8ec13f8b-fef3-4a4e-8feb-eff5ab6e76ff" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
