### PR TITLE
Fix multimag integral magazine display, reload, and fire bugs

### DIFF
--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -42,6 +42,7 @@
 #include "inventory.h"
 #include "item.h"
 #include "item_contents.h"
+#include "item_factory.h"
 #include "item_location.h"
 #include "item_pocket.h"
 #include "item_stack.h"
@@ -1604,8 +1605,73 @@ std::string Character::weapname_mode() const
 
 std::string Character::weapname_ammo() const
 {
-    // TODO(multimag): HUD '(empty)' indicator and ammo count summarize the
-    // first MAGAZINE_WELL only. Multi-well guns need a per-well summary.
+    // Per-pocket summary for multimag guns. Single-well aggregation
+    // resolves ammo_capacity(NULL_ID) == 0 on an empty projectile
+    // pocket and prints "/0".
+    if( weapon.uses_firing_requirements() && weapon.is_gun() ) {
+        std::vector<std::string> parts;
+        for( const item_pocket *p : weapon.get_pockets( []( const item_pocket & ) {
+        return true;
+    } ) ) {
+            int cur = 0;
+            int max = 0;
+            if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                if( const item *mag = p->magazine_current() ) {
+                    cur = mag->ammo_remaining( );
+                    const itype *adata = mag->ammo_data();
+                    max = adata
+                          ? mag->ammo_capacity( adata->ammo->type )
+                          : ( !mag->ammo_default().is_null()
+                              ? mag->ammo_capacity( item_controller->find_template(
+                                                        mag->ammo_default() )->ammo->type )
+                              : 0 );
+                } else {
+                    const pocket_data *pd = p->get_pocket_data();
+                    if( pd && !pd->default_magazine.is_null() && pd->default_magazine->magazine ) {
+                        max = pd->default_magazine->magazine->capacity;
+                    }
+                }
+            } else if( p->is_type( pocket_type::MAGAZINE ) ) {
+                for( const item *e : p->all_items_top() ) {
+                    if( e->has_flag( flag_CASING ) ) {
+                        continue;
+                    }
+                    cur += e->charges > 0 ? e->charges : 1;
+                }
+                const pocket_data *pd = p->get_pocket_data();
+                if( pd != nullptr && !pd->ammo_restriction.empty() ) {
+                    max = pd->ammo_restriction.begin()->second;
+                }
+            } else {
+                continue;
+            }
+            nc_color color = c_white;
+            if( cur == 0 ) {
+                color = c_light_red;
+            } else if( max > 0 && cur < max ) {
+                const double ratio = static_cast<double>( cur ) / static_cast<double>( max );
+                if( ratio < 1.0 / 3.0 ) {
+                    color = c_red;
+                } else if( ratio < 2.0 / 3.0 ) {
+                    color = c_yellow;
+                } else {
+                    color = c_light_green;
+                }
+            }
+            parts.emplace_back( colorize( string_format( "%i/%i", cur, max ), color ) );
+        }
+        if( parts.empty() ) {
+            return std::string();
+        }
+        std::string joined;
+        for( size_t i = 0; i < parts.size(); ++i ) {
+            if( i > 0 ) {
+                joined += ", ";
+            }
+            joined += parts[i];
+        }
+        return "(" + joined + ")";
+    }
     if( weapon.is_gun() ) {
         gun_mode current_mode = weapon.gun_current_mode();
         const bool no_mode = !current_mode.target;

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -3293,6 +3293,8 @@ item::reload_option game_menus::inv::select_ammo( Character &you, const item_loc
                     //~ %1$s is owner+well description, %2$d is 1-indexed well number on that owner
                     label = string_format( _( "%1$s (well %2$d)" ), label, n );
                 }
+            } else if( rt.kind == reload_target::kind::integral_magazine ) {
+                label = string_format( _( "%s: integral magazine" ), rt.owner->tname() );
             } else {
                 //~ %1$s is the gun or gunmod that holds the magazine, %2$s is the magazine's tname
                 label = string_format( _( "%1$s: top up %2$s" ), rt.owner->tname(),

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3973,6 +3973,7 @@ std::vector<reload_target> get_possible_reload_targets( const item_location &tar
     auto append_owner = [&opts]( const item_location & owner ) {
         // pocket_index is the position in contents (stable across empty
         // wells), not the position in magazines_current().
+        const bool multimag = owner->uses_firing_requirements();
         int idx = 0;
         for( const item_pocket *p : owner->get_pockets( []( const item_pocket & ) {
         return true;
@@ -3995,19 +3996,32 @@ std::vector<reload_target> get_possible_reload_targets( const item_location &tar
                     mag_target.kind = reload_target::kind::loaded_mag;
                     opts.push_back( mag_target );
                 }
+            } else if( multimag && p->is_type( pocket_type::MAGAZINE ) &&
+                       p->get_pocket_data() != nullptr &&
+                       !p->get_pocket_data()->ammo_restriction.empty() ) {
+                // Integral MAGAZINE on a multimag host: surface as its own
+                // target so loose ammo reaches it past sibling wells.
+                reload_target mag_pocket;
+                mag_pocket.target = owner;
+                mag_pocket.owner = owner;
+                mag_pocket.pocket_index = idx;
+                mag_pocket.ui_well_index = idx;
+                mag_pocket.kind = reload_target::kind::integral_magazine;
+                opts.push_back( mag_pocket );
             }
             ++idx;
         }
-        // No MAGAZINE_WELL (integral mag, watertight container): target the
-        // owner directly so loose ammo discovery has a destination.
-        bool has_well = false;
+        // Owner-level fallback for hosts without a pocket-level target
+        // (integral mag, watertight container) so loose ammo discovery
+        // still has a destination.
+        bool has_dest = false;
         for( const reload_target &rt : opts ) {
             if( rt.owner == owner ) {
-                has_well = true;
+                has_dest = true;
                 break;
             }
         }
-        if( !has_well ) {
+        if( !has_dest ) {
             reload_target self;
             self.target = owner;
             self.owner = owner;
@@ -4026,12 +4040,12 @@ std::vector<reload_target> get_possible_reload_targets( const item_location &tar
     return opts;
 }
 
-// Well entries require owner-level (gun ammo type) AND pocket-level
-// (item id, fullness) compatibility. Loaded-mag entries delegate to the
-// magazine's own can_reload_with.
+// Well and integral-magazine entries gate on owner-level (gun ammo type) AND
+// pocket-level (item id, fullness) compatibility. Loaded-mag delegates.
 static bool reload_target_accepts( const reload_target &rt, const item_location &ammo )
 {
-    if( rt.kind == reload_target::kind::well ) {
+    if( rt.kind == reload_target::kind::well ||
+        rt.kind == reload_target::kind::integral_magazine ) {
         if( !rt.owner.can_reload_with( ammo, true ) ) {
             return false;
         }
@@ -4040,7 +4054,11 @@ static bool reload_target_accepts( const reload_target &rt, const item_location 
         return true;
     } ) ) {
             if( idx == rt.pocket_index ) {
-                return p->is_type( pocket_type::MAGAZINE_WELL ) &&
+                if( rt.kind == reload_target::kind::well ) {
+                    return p->is_type( pocket_type::MAGAZINE_WELL ) &&
+                           p->can_reload_with( *ammo, true );
+                }
+                return p->is_type( pocket_type::MAGAZINE ) &&
                        p->can_reload_with( *ammo, true );
             }
             ++idx;

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -1041,6 +1041,9 @@ struct reload_target {
     enum class kind {
         well,
         loaded_mag,
+        // Integral MAGAZINE on a multimag host: target is the host item,
+        // pocket_index points at the MAGAZINE pocket for direct deposit.
+        integral_magazine,
     };
 
     item_location target;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1577,43 +1577,92 @@ std::string item::display_name( unsigned int quantity ) const
         amount = get_remaining_chapters( player_character );
     } else if( magazine_current() || get_pockets( []( const item_pocket & p ) {
     return p.is_type( pocket_type::MAGAZINE_WELL );
-    } ).size() > 1 ) {
+    } ).size() > 1 || ( uses_firing_requirements() && get_pockets( []( const item_pocket & p ) {
+        return p.is_type( pocket_type::MAGAZINE_WELL ) ||
+               p.is_type( pocket_type::MAGAZINE );
+    } ).size() > 1 ) ) {
         const std::vector<const item_pocket *> well_pockets = get_pockets(
         []( const item_pocket & p ) {
             return p.is_type( pocket_type::MAGAZINE_WELL );
         } );
-        if( well_pockets.size() > 1 ) {
-            // Multi-well: show every well, loaded or not. Per-well ammo
-            // labels are essential when distinct ammotypes share the same
-            // host item, so they ignore AMMO_IN_NAMES.
+        // Multimag hosts also segment integral MAGAZINE pockets.
+        const bool multimag = uses_firing_requirements();
+        const std::vector<const item_pocket *> ammo_pockets = multimag
+        ? get_pockets( []( const item_pocket & p ) {
+            return p.is_type( pocket_type::MAGAZINE_WELL ) ||
+                   p.is_type( pocket_type::MAGAZINE );
+        } )
+            : well_pockets;
+        if( ammo_pockets.size() > 1 ) {
+            // Distinct ammotypes share the host, so per-pocket ammo names
+            // always render regardless of AMMO_IN_NAMES.
             const bool show_ammo_name = true;
             std::vector<std::string> segments;
-            for( const item_pocket *p : well_pockets ) {
-                const item *mag = p->magazine_current();
+            for( const item_pocket *p : ammo_pockets ) {
                 int well_amount = 0;
                 int well_max = 0;
                 const itype *ammo_for_name = nullptr;
                 itype_id ammo_id_for_name;
-                if( mag != nullptr ) {
-                    well_amount = mag->ammo_remaining();
-                    const itype *adata = mag->ammo_data();
-                    well_max = adata
-                               ? mag->ammo_capacity( adata->ammo->type )
-                               : mag->ammo_capacity( item_controller->find_template(
-                                                         mag->ammo_default() )->ammo->type );
-                    ammo_for_name = adata;
-                    ammo_id_for_name = mag->ammo_current();
-                    if( ammo_id_for_name.is_null() ) {
-                        ammo_id_for_name = mag->ammo_default();
+                if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                    const item *mag = p->magazine_current();
+                    if( mag != nullptr ) {
+                        well_amount = mag->ammo_remaining();
+                        const itype *adata = mag->ammo_data();
+                        well_max = adata
+                                   ? mag->ammo_capacity( adata->ammo->type )
+                                   : mag->ammo_capacity( item_controller->find_template(
+                                                             mag->ammo_default() )->ammo->type );
+                        ammo_for_name = adata;
+                        ammo_id_for_name = mag->ammo_current();
+                        if( ammo_id_for_name.is_null() ) {
+                            ammo_id_for_name = mag->ammo_default();
+                        }
+                    } else {
+                        const itype_id default_mag = p->magazine_default();
+                        if( !default_mag.is_null() && default_mag->magazine ) {
+                            const itype_id &default_ammo = default_mag->magazine->default_ammo;
+                            if( !default_ammo.is_null() && default_ammo->ammo ) {
+                                well_max = default_mag->magazine->capacity;
+                                ammo_for_name = &*default_ammo;
+                                ammo_id_for_name = default_ammo;
+                            }
+                        }
                     }
                 } else {
-                    const itype_id default_mag = p->magazine_default();
-                    if( !default_mag.is_null() && default_mag->magazine ) {
-                        const itype_id &default_ammo = default_mag->magazine->default_ammo;
-                        if( !default_ammo.is_null() && default_ammo->ammo ) {
-                            well_max = default_mag->magazine->capacity;
-                            ammo_for_name = &*default_ammo;
-                            ammo_id_for_name = default_ammo;
+                    // Integral MAGAZINE: capacity is per-ammotype. With
+                    // alternative-ammo pockets, summing entries overstates
+                    // the real cap; pick the loaded ammo's entry instead.
+                    ammotype loaded_ammotype;
+                    bool has_loaded_ammo = false;
+                    for( const item *e : p->all_items_top() ) {
+                        if( e->has_flag( flag_CASING ) ) {
+                            continue;
+                        }
+                        well_amount += e->charges > 0 ? e->charges : 1;
+                        if( ammo_for_name == nullptr && e->is_ammo() ) {
+                            ammo_for_name = e->type;
+                            ammo_id_for_name = e->typeId();
+                            loaded_ammotype = e->ammo_type();
+                            has_loaded_ammo = true;
+                        }
+                    }
+                    if( p->get_pocket_data() != nullptr ) {
+                        const std::map<ammotype, int> &restrictions =
+                            p->get_pocket_data()->ammo_restriction;
+                        if( has_loaded_ammo ) {
+                            const auto it = restrictions.find( loaded_ammotype );
+                            if( it != restrictions.end() ) {
+                                well_max = it->second;
+                            }
+                        } else if( !restrictions.empty() ) {
+                            const std::pair<const ammotype, int> &first = *restrictions.begin();
+                            well_max = first.second;
+                            ammo_id_for_name = first.first->default_ammotype();
+                            if( !ammo_id_for_name.is_null() &&
+                                !ammo_id_for_name.is_empty() &&
+                                item::type_is_defined( ammo_id_for_name ) ) {
+                                ammo_for_name = &*ammo_id_for_name;
+                            }
                         }
                     }
                 }
@@ -1633,7 +1682,8 @@ std::string item::display_name( unsigned int quantity ) const
                 }
                 std::string segment = colorize( string_format( "%i/%i", well_amount, well_max ),
                                                 color );
-                if( show_ammo_name && !ammo_id_for_name.is_null() ) {
+                if( show_ammo_name && !ammo_id_for_name.is_null() &&
+                    !ammo_id_for_name.is_empty() ) {
                     std::string ammoname = ammo_id_for_name->nname( 1 );
                     if( ammoname.empty() && ammo_for_name && ammo_for_name->ammo ) {
                         ammoname = ammo_for_name->ammo->type->name();

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3039,10 +3039,16 @@ const itype *Item_factory::find_template( const itype_id &id ) const
 
     //If we didn't find the item maybe it is a building instead!
     const recipe_id &making_id = recipe_id( id.c_str() );
-    if( oter_str_id( id.c_str() ).is_valid() ||
-        ( making_id.is_valid() && making_id.obj().is_blueprint() ) ) {
-        return add_runtime( id, no_translation( string_format( "DEBUG: %s", id.c_str() ) ),
-                            making_id.obj().description );
+    const bool oter_match = oter_str_id( id.c_str() ).is_valid();
+    if( oter_match || ( making_id.is_valid() && making_id.obj().is_blueprint() ) ) {
+        // oter match alone makes the outer condition true; guard the
+        // making_id.obj() call so an invalid recipe id does not trigger
+        // a spurious "invalid recipe id" debugmsg.
+        translation desc;
+        if( making_id.is_valid() ) {
+            desc = making_id.obj().description;
+        }
+        return add_runtime( id, no_translation( string_format( "DEBUG: %s", id.c_str() ) ), desc );
     }
 
     debugmsg( "Missing item definition: %s", id.c_str() );

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -1909,6 +1909,11 @@ bool item::has_ammo() const
     if( mag ) {
         return mag->has_ammo();
     }
+    // Multimag gun identity is anchored to the projectile pocket; never
+    // borrow sibling-pocket ammo (e.g. battery wells) when it is empty.
+    if( uses_firing_requirements() && is_gun() ) {
+        return false;
+    }
 
     if( is_ammo() ) {
         return true;
@@ -1934,6 +1939,9 @@ bool item::has_ammo_data() const
     if( mag ) {
         return mag->has_ammo_data();
     }
+    if( uses_firing_requirements() && is_gun() ) {
+        return false;
+    }
 
     if( is_ammo() ) {
         return true;
@@ -1958,6 +1966,9 @@ const itype *item::ammo_data() const
     const item *mag = ammo_identity_mag();
     if( mag ) {
         return mag->ammo_data();
+    }
+    if( uses_firing_requirements() && is_gun() ) {
+        return nullptr;
     }
 
     if( is_ammo() ) {
@@ -1996,7 +2007,15 @@ const item &item::loaded_ammo() const
 {
     const item *mag = ammo_identity_mag();
     if( mag ) {
+        // Integral MAGAZINE primary returns the bare ammo item itself, not
+        // a containing magazine; recursing on bare ammo lands at null.
+        if( mag->is_ammo() ) {
+            return *mag;
+        }
         return mag->loaded_ammo();
+    }
+    if( uses_firing_requirements() && is_gun() ) {
+        return null_item_reference();
     }
 
     if( is_magazine() ) {
@@ -2283,8 +2302,14 @@ int item::ammo_remaining_in_pocket( const std::string &id ) const
         return mag ? mag->ammo_remaining( ) : 0;
     }
     if( p->is_type( pocket_type::MAGAZINE ) ) {
+        // Exclude spent casings - cycle_action force-inserts them into
+        // the integral pocket after a shot, and they shouldn't count as
+        // loaded ammo for feasibility / display.
         int total = 0;
         for( const item *e : p->all_items_top() ) {
+            if( e->has_flag( flag_CASING ) ) {
+                continue;
+            }
             total += e->charges;
         }
         return total;
@@ -2381,8 +2406,14 @@ const item *item::ammo_identity_mag() const
             return p->magazine_current();
         }
         // Integral MAGAZINE pocket: the ammo itself drives identity.
-        const std::list<const item *> contents_top = p->all_items_top();
-        return contents_top.empty() ? nullptr : contents_top.front();
+        // cycle_action leaves spent casings in the pocket; skip them.
+        for( const item *e : p->all_items_top() ) {
+            if( e->has_flag( flag_CASING ) ) {
+                continue;
+            }
+            return e;
+        }
+        return nullptr;
     }
     return magazine_current();
 }
@@ -2460,9 +2491,15 @@ static std::string format_entry_name( const item &host, const pocket_consumption
         if( !display.empty() ) {
             return display;
         }
-        if( !pd->default_magazine.is_null() && pd->default_magazine->magazine ) {
+        // is_null compares to NULL_ID ("null"); the generic optional()
+        // JSON loader resets string_id fields to default-constructed
+        // empty string when the JSON field is absent, which slips past
+        // is_null. Treat empty the same as null so we don't deref a
+        // missing itype.
+        if( !pd->default_magazine.is_null() && !pd->default_magazine.is_empty() &&
+            pd->default_magazine->magazine ) {
             const itype_id &default_ammo = pd->default_magazine->magazine->default_ammo;
-            if( !default_ammo.is_null() && default_ammo->ammo ) {
+            if( !default_ammo.is_null() && !default_ammo.is_empty() && default_ammo->ammo ) {
                 return default_ammo->nname( qty );
             }
         }
@@ -3063,10 +3100,23 @@ int item::reload_option::moves() const
 
 void item::reload_option::qty( int val )
 {
-    // Pocket-targeted reloads swap exactly one magazine.
+    item_pocket *integral_pocket = nullptr;
     if( pocket_index >= 0 ) {
-        qty_ = 1;
-        return;
+        // MAGAZINE_WELL targeted reload swaps one magazine. Integral
+        // MAGAZINE targeted reload loads loose ammo and follows the
+        // general capacity math below, scoped to that pocket so sibling
+        // wells do not poison the count on multimag hosts.
+        const std::vector<item_pocket *> pockets = target->get_pockets(
+        []( const item_pocket & ) {
+            return true;
+        } );
+        if( pocket_index < static_cast<int>( pockets.size() ) &&
+            pockets[pocket_index]->is_type( pocket_type::MAGAZINE ) ) {
+            integral_pocket = pockets[pocket_index];
+        } else {
+            qty_ = 1;
+            return;
+        }
     }
 
     bool ammo_in_container = ammo->is_ammo_container();
@@ -3083,9 +3133,16 @@ void item::reload_option::qty( int val )
 
     // Checking ammo capacity implicitly limits guns with removable magazines to capacity 0.
     // This gets rounded up to 1 later.
-    int remaining_capacity = target->is_watertight_container() ?
+    int remaining_capacity;
+    if( integral_pocket != nullptr ) {
+        remaining_capacity = ammo_obj.is_ammo()
+                             ? integral_pocket->remaining_ammo_capacity( ammo_obj.ammo_type() )
+                             : 0;
+    } else {
+        remaining_capacity = target->is_watertight_container() ?
                              target->get_remaining_capacity_for_liquid( ammo_obj, true ) :
                              target->remaining_ammo_capacity();
+    }
     if( ammo_obj.type->ammo ) {
         if( ammo_obj.ammo_type() == ammo_plutonium ) {
             remaining_capacity = remaining_capacity / PLUTONIUM_CHARGES +
@@ -3141,7 +3198,7 @@ bool item::reload( Character &u, item_location ammo, int qty, int pocket_index )
         return false;
     }
 
-    // Swap the magazine in the targeted MAGAZINE_WELL only; other wells untouched.
+    // Targeted reload: MAGAZINE_WELL swap, or loose ammo into integral MAGAZINE.
     if( pocket_index >= 0 ) {
         std::vector<item_pocket *> all_pockets = get_pockets(
         []( const item_pocket & ) {
@@ -3152,10 +3209,18 @@ bool item::reload( Character &u, item_location ammo, int qty, int pocket_index )
             return false;
         }
         item_pocket *target_pocket = all_pockets[pocket_index];
-        if( !target_pocket->is_type( pocket_type::MAGAZINE_WELL ) ) {
-            debugmsg( "reload: pocket_index %d on %s is not a MAGAZINE_WELL",
+        const bool integral_magazine = target_pocket->is_type( pocket_type::MAGAZINE );
+        if( !target_pocket->is_type( pocket_type::MAGAZINE_WELL ) && !integral_magazine ) {
+            debugmsg( "reload: pocket_index %d on %s is not a MAGAZINE_WELL or MAGAZINE",
                       pocket_index, tname() );
             return false;
+        }
+        if( integral_magazine ) {
+            // Eject casings before the compatibility gate; a spent shell
+            // fills the pocket and would make can_reload_with refuse.
+            casings_handle( [&u]( item & e ) {
+                return u.i_add_or_drop( e );
+            } );
         }
         if( !target_pocket->can_reload_with( *ammo.get_item(), true ) ) {
             return false;
@@ -3164,6 +3229,32 @@ bool item::reload( Character &u, item_location ammo, int qty, int pocket_index )
         const bool ammo_from_map = !ammo.held_by( u );
         if( ammo->has_flag( flag_SPEEDLOADER ) || ammo->has_flag( flag_SPEEDLOADER_CLIP ) ) {
             ammo = item_location( ammo, &ammo->first_ammo() );
+        }
+
+        if( integral_magazine ) {
+            const ammotype loose_type = ammo->ammo_type();
+            const int limit = target_pocket->remaining_ammo_capacity( loose_type );
+            if( limit <= 0 ) {
+                return false;
+            }
+            const int take = std::min( { qty, ammo->charges, limit } );
+            if( take <= 0 ) {
+                return false;
+            }
+            item item_copy( *ammo );
+            item_copy.charges = take;
+            ret_val<item *> ins = target_pocket->insert_item( item_copy );
+            if( !ins.success() ) {
+                return false;
+            }
+            ammo->charges -= take;
+            if( ammo->charges == 0 ) {
+                ammo.remove_item();
+            }
+            if( ammo_from_map ) {
+                u.invalidate_weight_carried_cache();
+            }
+            return true;
         }
 
         item magazine_removed;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1163,6 +1163,11 @@ int Character::fire_gun( map &here, const tripoint_bub_ms &target, int shots, it
     int curshot = 0;
     int hits = 0; // total shots on target
     int delay = 0; // delayed recoil that has yet to be applied
+    // Snapshot the gun slot. The wielded item can stop being a gun
+    // mid-loop (recoil-induced unwield, fire transforms), and the
+    // post-shot hurt_part / skill-practice blocks still need to read
+    // it for the shots that already fired.
+    const islot_gun *const original_gun = gun.is_gun() ? gun.type->gun.get() : nullptr;
     while( curshot != shots ) {
         // Special handling for weapons where we supply the ammo separately (i.e. ammo is populated)
         // instead of it being loaded into the weapon, reload right before firing.
@@ -1316,18 +1321,23 @@ int Character::fire_gun( map &here, const tripoint_bub_ms &target, int shots, it
     // Use different amounts of time depending on the type of gun and our skill
     mod_moves( -attack_moves );
 
-    const islot_gun &firing = *gun.type->gun;
-    for( const std::pair<const bodypart_str_id, int> &hurt_part : firing.hurt_part_when_fired ) {
-        apply_damage( nullptr, bodypart_id( hurt_part.first ), hurt_part.second );
-        add_msg_player_or_npc( _( "Your %s is hurt by the recoil!" ),
-                               _( "<npcname>'s %s is hurt by the recoil!" ),
-                               body_part_name_accusative( bodypart_id( hurt_part.first ) ) );
+    const islot_gun *firing = original_gun;
+    if( !firing && gun.is_gun() ) {
+        firing = gun.type->gun.get();
+    }
+    if( firing != nullptr ) {
+        for( const std::pair<const bodypart_str_id, int> &hurt_part : firing->hurt_part_when_fired ) {
+            apply_damage( nullptr, bodypart_id( hurt_part.first ), hurt_part.second );
+            add_msg_player_or_npc( _( "Your %s is hurt by the recoil!" ),
+                                   _( "<npcname>'s %s is hurt by the recoil!" ),
+                                   body_part_name_accusative( bodypart_id( hurt_part.first ) ) );
+        }
     }
 
     // Preventing using a trapped creature as an infinite training dummy.
-    if( times_shot_target < 100 ) {
+    if( times_shot_target < 100 && curshot > 0 ) {
         // Practice the base gun skill proportionally to number of hits, but always by one.
-        if( !gun.has_flag( flag_WONT_TRAIN_MARKSMANSHIP ) ) {
+        if( firing != nullptr && !gun.has_flag( flag_WONT_TRAIN_MARKSMANSHIP ) ) {
             practice( skill_gun, ( hits + 1 ) * 5 );
         }
         // launchers train weapon skill for both hits and misses.

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -598,7 +598,9 @@ item visitable::remove_item( item &it )
         return obj.front();
 
     } else {
-        debugmsg( "Tried removing item from object which did not contain it" );
+        debugmsg( "Tried removing item '%s' (typeId=%s, charges=%d) "
+                  "from object which did not contain it",
+                  it.tname(), it.typeId().str(), it.charges );
         return item();
     }
 }

--- a/tests/multimag_matrix_test.cpp
+++ b/tests/multimag_matrix_test.cpp
@@ -1,0 +1,619 @@
+#include <algorithm>
+#include <climits>
+#include <cstddef>
+#include <functional>
+#include <initializer_list>
+#include <list>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "ammo.h"
+#include "avatar.h"
+#include "calendar.h"
+#include "cata_catch.h"
+#include "character.h"
+#include "color.h"
+#include "coordinates.h"
+#include "debug.h"
+#include "flag.h"
+#include "item.h"
+#include "item_factory.h"
+#include "item_location.h"
+#include "item_pocket.h"
+#include "itype.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "output.h"
+#include "player_helpers.h"
+#include "pocket_type.h"
+#include "point.h"
+#include "ret_val.h"
+#include "translation.h"
+#include "type_id.h"
+#include "units.h"
+#include "value_ptr.h"
+
+// Cartesian product of 1-3 pockets over the ammotype palette, installed
+// as runtime itypes. Same-ammo tuples are intentional: they exercise
+// sibling-pocket-borrow regressions.
+
+static const ammotype ammo_9mm( "9mm" );
+static const ammotype ammo_battery( "battery" );
+static const ammotype ammo_graphite( "graphite" );
+static const ammotype ammo_lamp_oil( "lamp_oil" );
+static const ammotype ammo_oxygen( "oxygen" );
+static const ammotype ammo_water( "water" );
+
+static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );
+
+static const material_id material_steel( "steel" );
+
+static const skill_id skill_pistol( "pistol" );
+
+namespace
+{
+
+// Liquid/gas projectile pockets exist in shipping data (e.g. watercannon).
+// ensure_synth marks those pockets watertight/airtight to match.
+const std::vector<ammotype> &palette()
+{
+    static const std::vector<ammotype> r = {
+        ammo_9mm, ammo_battery, ammo_water, ammo_oxygen, ammo_lamp_oil, ammo_graphite
+    };
+    return r;
+}
+
+// Bullets fit one per chamber; everything else gets tank-like capacity.
+int pocket_cap_for( const ammotype &at )
+{
+    return at == ammo_9mm ? 1 : 50;
+}
+
+// Battery draws are larger per use to mimic the railgun pattern.
+int pocket_qty_for( const ammotype &at )
+{
+    return at == ammo_battery ? 5 : 1;
+}
+
+struct synth_spec {
+    itype_id id;
+    bool is_gun;
+    std::vector<ammotype> pockets;
+};
+
+itype_id synth_id_for( bool is_gun, const std::vector<ammotype> &pockets )
+{
+    std::string s = is_gun ? "mm_mx_gun" : "mm_mx_tool";
+    for( const ammotype &a : pockets ) {
+        s += "__" + a.str();
+    }
+    return itype_id( s );
+}
+
+// item ctor's qty maps to charges only for count_by_charges itypes;
+// set charges explicitly so both representations carry the same amount.
+item make_synth_ammo( const itype_id &id, int qty )
+{
+    item r( id, calendar::turn, qty );
+    if( r.count_by_charges() ) {
+        r.charges = qty;
+    }
+    return r;
+}
+
+// Sum of live charges across a pocket's top items, excluding spent
+// casings (those remain in the pocket after fire but should not count
+// toward loaded ammo for matrix invariants).
+int pocket_live_charges( const item_pocket *p )
+{
+    int n = 0;
+    for( const item *e : p->all_items_top() ) {
+        if( e->has_flag( flag_CASING ) ) {
+            continue;
+        }
+        n += e->charges > 0 ? e->charges : 1;
+    }
+    return n;
+}
+
+const itype *ensure_synth( const synth_spec &spec )
+{
+    if( item::type_is_defined( spec.id ) ) {
+        return &*spec.id;
+    }
+    const itype *ct = item_controller->add_runtime(
+                          spec.id,
+                          no_translation( "synth multimag matrix item" ),
+                          no_translation( "Runtime-built multimag item for matrix tests." ) );
+    // const_cast: add_runtime returns const* and the factory exposes no
+    // mutable accessor. Safe here - nothing observes the entry until
+    // find_template hands it out.
+    itype *t = const_cast<itype *>( ct );
+
+    t->weight = 1000_gram;
+    t->volume = 1500_ml;
+    // finalize_pre is skipped for runtime types; populate the fields it
+    // would have set so generic all-items iteration tests don't trip.
+    t->longest_side = 200_mm;
+    t->materials[material_steel] = 1;
+    t->mat_portion_total = 1;
+    t->using_legacy_to_hit = false;
+    t->sym = "(";
+    t->color = c_light_gray;
+
+    if( spec.is_gun ) {
+        t->gun = cata::make_value<islot_gun>();
+        t->gun->skill_used = skill_pistol;
+        for( const ammotype &a : spec.pockets ) {
+            t->gun->ammo.insert( a );
+        }
+        t->gun->modes[gun_mode_DEFAULT] =
+            gun_modifier_data( to_translation( "default" ), 1, std::set<std::string> {} );
+    } else {
+        t->tool = cata::make_value<islot_tool>();
+    }
+
+    int idx = 0;
+    for( const ammotype &a : spec.pockets ) {
+        pocket_data pd( pocket_type::MAGAZINE );
+        pd.rigid = true;
+        pd.pocket_id = "p" + std::to_string( idx );
+        pd.ammo_restriction[a] = pocket_cap_for( a );
+        // Liquid into a non-watertight pocket spills, leaving stragglers
+        // that surface later as remove_item debug noise. Gas needs
+        // airtight for the same reason.
+        if( a == ammo_water || a == ammo_lamp_oil ) {
+            pd.watertight = true;
+        }
+        if( a == ammo_oxygen ) {
+            pd.airtight = true;
+        }
+        t->pockets.push_back( pd );
+        ++idx;
+    }
+
+    for( size_t i = 0; i < spec.pockets.size(); ++i ) {
+        pocket_consumption_entry e;
+        e.pocket = "p" + std::to_string( i );
+        e.qty = pocket_qty_for( spec.pockets[i] );
+        t->firing_requirements.per_mode[gun_mode_DEFAULT].push_back( e );
+    }
+
+    return ct;
+}
+
+const std::vector<synth_spec> &synth_registry()
+{
+    static const std::vector<synth_spec> r = []() {
+        std::vector<synth_spec> out;
+        const std::vector<ammotype> &pal = palette();
+        for( bool is_gun : {
+                 true, false
+             } ) {
+            for( const ammotype &a : pal ) {
+                out.push_back( { synth_id_for( is_gun, { a } ), is_gun, { a } } );
+            }
+            for( const ammotype &a : pal ) {
+                for( const ammotype &b : pal ) {
+                    std::vector<ammotype> pockets = { a, b };
+                    out.push_back( { synth_id_for( is_gun, pockets ), is_gun, pockets } );
+                }
+            }
+            for( const ammotype &a : pal ) {
+                for( const ammotype &b : pal ) {
+                    for( const ammotype &c : pal ) {
+                        std::vector<ammotype> pockets = { a, b, c };
+                        out.push_back( { synth_id_for( is_gun, pockets ), is_gun, pockets } );
+                    }
+                }
+            }
+        }
+        return out;
+    }
+    ();
+    return r;
+}
+
+void install_all_synth_types()
+{
+    static bool installed = false;
+    if( installed ) {
+        return;
+    }
+    for( const synth_spec &spec : synth_registry() ) {
+        ensure_synth( spec );
+    }
+    installed = true;
+}
+
+// Bypasses item::reload and item::ammo_set on purpose: those are
+// host-level APIs that can route to a different pocket or reset others
+// on multimag hosts. The matrix wants each pocket exercised in
+// isolation against its own ammo_restriction.
+bool load_pocket( item_location &host, int pocket_idx,
+                  const ammotype &at, int qty, std::string &api_used )
+{
+    const itype_id ammo_id = at->default_ammotype();
+    if( ammo_id.is_null() || !item::type_is_defined( ammo_id ) ) {
+        api_used = "no_default_ammo";
+        return false;
+    }
+    std::vector<item_pocket *> pockets = host->get_pockets(
+    []( const item_pocket & ) {
+        return true;
+    } );
+    if( pocket_idx >= static_cast<int>( pockets.size() ) ) {
+        api_used = "pocket_index_out_of_range";
+        return false;
+    }
+    item synth = make_synth_ammo( ammo_id, qty );
+    ret_val<item *> ins = pockets[pocket_idx]->insert_item( synth );
+    if( ins.success() ) {
+        api_used = "pocket_insert";
+        return true;
+    }
+    api_used = "pocket_insert_rejected:" + std::string( ins.str() );
+    return false;
+}
+
+int pocket_count_for( const item &it )
+{
+    int n = 0;
+    for( const item_pocket *p : it.get_pockets( []( const item_pocket & ) {
+    return true;
+} ) ) {
+        if( p->is_type( pocket_type::MAGAZINE ) || p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+            ++n;
+        }
+    }
+    return n;
+}
+
+int segments_in_display( std::string_view display )
+{
+    const std::size_t lparen = display.rfind( '(' );
+    const std::size_t rparen = display.rfind( ')' );
+    if( lparen == std::string_view::npos || rparen == std::string_view::npos ||
+        rparen <= lparen ) {
+        return 0;
+    }
+    int commas = 0;
+    for( std::size_t i = lparen + 1; i < rparen; ++i ) {
+        if( display[i] == ',' ) {
+            ++commas;
+        }
+    }
+    return commas + 1;
+}
+
+} // namespace
+
+TEST_CASE( "multimag_matrix_display_name_structural", "[multimag][matrix][display]" )
+{
+    install_all_synth_types();
+    for( const synth_spec &spec : synth_registry() ) {
+        CAPTURE( spec.id.str() );
+        item it( spec.id );
+        const int pc = pocket_count_for( it );
+        REQUIRE( pc == static_cast<int>( spec.pockets.size() ) );
+
+        const std::string name_empty = remove_color_tags( it.display_name() );
+        INFO( "empty: " << name_empty );
+        // 1-pocket multimag tnames may render a single bare "(X/Y)" or
+        // skip the parens entirely depending on display_name code paths,
+        // so segments_in_display >= 1 is the conservative assertion.
+        if( pc == 1 ) {
+            CHECK( segments_in_display( name_empty ) >= 1 );
+        } else {
+            CHECK( segments_in_display( name_empty ) == pc );
+        }
+        CHECK( name_empty.find( "invalid" ) == std::string::npos );
+    }
+}
+
+TEST_CASE( "multimag_matrix_load_then_display", "[multimag][matrix][load][display]" )
+{
+    install_all_synth_types();
+    clear_avatar();
+    Character &chr = get_player_character();
+
+    for( const synth_spec &spec : synth_registry() ) {
+        CAPTURE( spec.id.str() );
+        item_location host = chr.i_add( item( spec.id ) );
+        REQUIRE( host );
+
+        for( size_t i = 0; i < spec.pockets.size(); ++i ) {
+            CAPTURE( i );
+            CAPTURE( spec.pockets[i].str() );
+            std::string api_used;
+            const bool loaded = load_pocket( host, static_cast<int>( i ),
+                                             spec.pockets[i], 1, api_used );
+            CAPTURE( api_used );
+            CHECK( loaded );
+        }
+
+        const std::string name_loaded = remove_color_tags( host->display_name() );
+        INFO( "loaded: " << name_loaded );
+        const int pc = pocket_count_for( *host );
+        if( pc == 1 ) {
+            CHECK( segments_in_display( name_loaded ) >= 1 );
+        } else {
+            CHECK( segments_in_display( name_loaded ) == pc );
+        }
+        CHECK( name_loaded.find( "invalid" ) == std::string::npos );
+        // "0/0" segment indicates the per-pocket renderer fell back to a
+        // zero-capacity branch; never legitimate for a loaded host.
+        CHECK( name_loaded.find( "0/0" ) == std::string::npos );
+    }
+}
+
+TEST_CASE( "multimag_matrix_tool_consume_drains_each_pocket",
+           "[multimag][matrix][consume]" )
+{
+    install_all_synth_types();
+    map &here = get_map();
+
+    for( const synth_spec &spec : synth_registry() ) {
+        if( spec.is_gun ) {
+            continue;
+        }
+        CAPTURE( spec.id.str() );
+        // Fresh avatar per shape: accumulating synth tools loaded with
+        // comestible ammo seeds active_item_cache stragglers that
+        // surface later as remove_item debug noise.
+        // TODO: active_item_cache holds raw pointers; pocket/item
+        // destruction doesn't deregister, so stale refs linger.
+        clear_avatar();
+        Character &chr = get_player_character();
+        const tripoint_bub_ms pos = chr.pos_bub( here );
+        item_location host = chr.i_add( item( spec.id ) );
+        REQUIRE( host );
+
+        for( size_t i = 0; i < spec.pockets.size(); ++i ) {
+            const int cap = pocket_cap_for( spec.pockets[i] );
+            std::string api_used;
+            const bool loaded = load_pocket( host, static_cast<int>( i ),
+                                             spec.pockets[i], cap, api_used );
+            CAPTURE( i );
+            CAPTURE( spec.pockets[i].str() );
+            CAPTURE( api_used );
+            REQUIRE( loaded );
+        }
+
+        std::vector<int> before;
+        for( const item_pocket *p : host->get_pockets( []( const item_pocket & ) {
+        return true;
+    } ) ) {
+            if( p->is_type( pocket_type::MAGAZINE ) ) {
+                before.push_back( pocket_live_charges( p ) );
+            }
+        }
+        REQUIRE( before.size() == spec.pockets.size() );
+
+        const int got = host->consume_tool_uses( 1, here, pos, &chr );
+        CHECK( got == 1 );
+
+        std::vector<int> after;
+        for( const item_pocket *p : host->get_pockets( []( const item_pocket & ) {
+        return true;
+    } ) ) {
+            if( p->is_type( pocket_type::MAGAZINE ) ) {
+                after.push_back( pocket_live_charges( p ) );
+            }
+        }
+        for( size_t i = 0; i < before.size(); ++i ) {
+            CAPTURE( i );
+            CAPTURE( spec.pockets[i].str() );
+            CAPTURE( before[i] );
+            CAPTURE( after[i] );
+            CHECK( after[i] < before[i] );
+        }
+    }
+}
+
+TEST_CASE( "multimag_matrix_reload_pocket_index_loads_target",
+           "[multimag][matrix][reload]" )
+{
+    install_all_synth_types();
+
+    for( const synth_spec &spec : synth_registry() ) {
+        if( !spec.is_gun ) {
+            continue;
+        }
+        CAPTURE( spec.id.str() );
+        for( size_t target_idx = 0; target_idx < spec.pockets.size(); ++target_idx ) {
+            CAPTURE( target_idx );
+            CAPTURE( spec.pockets[target_idx].str() );
+
+            // item::reload(pocket_index) is the bullet/charge-style path.
+            // Liquid (water, lamp_oil) and gas (oxygen) pockets load via
+            // item::fill_with; their default ammotype itype is a
+            // comestible whose is_ammo() is false, so dispatching them
+            // through reload refuses and leaks the source comestible.
+            const itype_id ammo_id = spec.pockets[target_idx]->default_ammotype();
+            if( ammo_id.is_null() || !item::type_is_defined( ammo_id ) ) {
+                continue;
+            }
+            if( !item( ammo_id ).is_ammo() ) {
+                continue;
+            }
+
+            // Fresh avatar per iteration so prior stacked ammo doesn't
+            // invalidate the per-call item_location handle.
+            clear_avatar();
+            Character &chr = get_player_character();
+            item_location host = chr.i_add( item( spec.id ) );
+            REQUIRE( host );
+
+            const int qty = pocket_cap_for( spec.pockets[target_idx] );
+            item_location ammo_loc = chr.i_add( make_synth_ammo( ammo_id, qty ) );
+            REQUIRE( ammo_loc );
+
+            const bool reloaded = host->reload( chr, ammo_loc, qty, target_idx );
+            CAPTURE( reloaded );
+
+            std::vector<item_pocket *> pockets = host->get_pockets(
+            []( const item_pocket & ) {
+                return true;
+            } );
+            REQUIRE( target_idx < pockets.size() );
+            const int loaded_target = pocket_live_charges( pockets[target_idx] );
+
+            for( size_t i = 0; i < pockets.size(); ++i ) {
+                if( i == target_idx ) {
+                    continue;
+                }
+                const int sibling = pocket_live_charges( pockets[i] );
+                CAPTURE( i );
+                CAPTURE( sibling );
+                CHECK( sibling == 0 );
+            }
+
+            if( reloaded ) {
+                CHECK( loaded_target >= 1 );
+            } else {
+                // Reload refused must leave the pocket untouched - no
+                // partial state.
+                CHECK( loaded_target == 0 );
+            }
+        }
+    }
+}
+
+TEST_CASE( "multimag_matrix_unload_action_rated_good_when_loaded",
+           "[multimag][matrix][unload]" )
+{
+    install_all_synth_types();
+    clear_avatar();
+    Character &chr = get_player_character();
+
+    for( const synth_spec &spec : synth_registry() ) {
+        CAPTURE( spec.id.str() );
+        item host( spec.id );
+        std::vector<item_pocket *> pockets = host.get_pockets(
+        []( const item_pocket & ) {
+            return true;
+        } );
+
+        const hint_rating empty_rating = chr.rate_action_unload( host );
+        CAPTURE( static_cast<int>( empty_rating ) );
+        CHECK( empty_rating != hint_rating::good );
+
+        for( size_t i = 0; i < spec.pockets.size(); ++i ) {
+            ret_val<item *> ins = pockets[i]->insert_item(
+                                      make_synth_ammo( spec.pockets[i]->default_ammotype(), 1 ) );
+            REQUIRE( ins.success() );
+        }
+        const hint_rating loaded_rating = chr.rate_action_unload( host );
+        CAPTURE( static_cast<int>( loaded_rating ) );
+        CHECK( loaded_rating == hint_rating::good );
+    }
+}
+
+TEST_CASE( "multimag_matrix_fire_gun_no_invalid_or_shortage",
+           "[multimag][matrix][fire]" )
+{
+    install_all_synth_types();
+
+    // Fire is the most expensive setup (clear_map + clear_avatar +
+    // wield + capture_debugmsg per case), so sample a representative
+    // subset instead of the full Cartesian: every 1-pocket gun shape,
+    // plus the two-pocket bullet+power "railgun" pattern, plus one
+    // 3-pocket exotic. The shape-coverage axes (display, load, reload,
+    // unload) stay exhaustive in the other TEST_CASEs.
+    std::set<itype_id> fire_shapes;
+    for( const ammotype &a : palette() ) {
+        fire_shapes.insert( synth_id_for( /*is_gun=*/true, { a } ) );
+    }
+    for( const ammotype &a : palette() ) {
+        fire_shapes.insert( synth_id_for( true, { a, ammo_battery } ) );
+    }
+    fire_shapes.insert( synth_id_for( true, { ammo_9mm, ammo_battery, ammo_water } ) );
+
+    for( const synth_spec &spec : synth_registry() ) {
+        if( !spec.is_gun || fire_shapes.find( spec.id ) == fire_shapes.end() ) {
+            continue;
+        }
+        CAPTURE( spec.id.str() );
+
+        // Fresh avatar + map per shape so prior fire effects (catching
+        // fire, recoil-induced unwield) don't carry over and drop the
+        // synth gun mid-shot in the next iteration.
+        clear_map();
+        clear_avatar();
+        avatar &dummy = get_avatar();
+        dummy.set_body();
+        dummy.clear_worn();
+        dummy.remove_weapon();
+        dummy.setpos( get_map(), tripoint_bub_ms( point_bub_ms::zero, 0 ) );
+
+        item gun( spec.id );
+        std::vector<item_pocket *> pockets = gun.get_pockets(
+        []( const item_pocket & ) {
+            return true;
+        } );
+        REQUIRE( pockets.size() == spec.pockets.size() );
+        for( size_t i = 0; i < spec.pockets.size(); ++i ) {
+            const int cap = pocket_cap_for( spec.pockets[i] );
+            ret_val<item *> ins = pockets[i]->insert_item(
+                                      make_synth_ammo( spec.pockets[i]->default_ammotype(), cap ) );
+            REQUIRE( ins.success() );
+        }
+        dummy.set_wielded_item( gun );
+        REQUIRE( dummy.get_wielded_item() );
+
+        map &here = get_map();
+        const tripoint_bub_ms target = dummy.pos_bub( here ) + point( 5, 0 );
+        const std::string dmsg = capture_debugmsg_during( [&]() {
+            dummy.fire_gun( here, target, 1, *dummy.get_wielded_item() );
+        } );
+        INFO( "debugmsg: " << dmsg );
+        CHECK( dmsg.find( "invalid recipe id" ) == std::string::npos );
+        CHECK( dmsg.find( "Unexpected shortage of ammo" ) == std::string::npos );
+        CHECK( dmsg.find( "Unexpected shortage of energy" ) == std::string::npos );
+    }
+}
+
+TEST_CASE( "multimag_matrix_tool_uses_remaining_local_after_load",
+           "[multimag][matrix][charges]" )
+{
+    install_all_synth_types();
+    for( const synth_spec &spec : synth_registry() ) {
+        if( spec.is_gun ) {
+            continue;
+        }
+        CAPTURE( spec.id.str() );
+        item tool( spec.id );
+
+        std::vector<item_pocket *> pockets = tool.get_pockets(
+        []( const item_pocket & ) {
+            return true;
+        } );
+        REQUIRE( pockets.size() == spec.pockets.size() );
+
+        // Canonical multimag math: floor(local / qty) per pocket, then
+        // min across pockets. tool_uses_remaining_local() recomputes the
+        // same invariant from the host's own state.
+        int expected = INT_MAX;
+        for( size_t i = 0; i < spec.pockets.size(); ++i ) {
+            const int cap = pocket_cap_for( spec.pockets[i] );
+            const int qty = pocket_qty_for( spec.pockets[i] );
+            ret_val<item *> ins = pockets[i]->insert_item(
+                                      make_synth_ammo( spec.pockets[i]->default_ammotype(), cap ) );
+            REQUIRE( ins.success() );
+            expected = std::min( expected, cap / qty );
+        }
+        if( expected == INT_MAX ) {
+            expected = 0;
+        }
+
+        const int local = tool.tool_uses_remaining_local();
+        CAPTURE( expected );
+        CAPTURE( local );
+        CHECK( local == expected );
+    }
+}

--- a/tests/multimag_test.cpp
+++ b/tests/multimag_test.cpp
@@ -1696,3 +1696,197 @@ TEST_CASE( "multimag_fire_skips_incompatible_ammo_gate", "[multimag][fire]" )
         CHECK( msg.second.find( "incompatible ammunition" ) == std::string::npos );
     }
 }
+
+// Multimag gun with integral MAGAZINE + battery MAGAZINE_WELL: render one
+// segment per pocket. Aggregate forms like "1501/1500" are wrong.
+TEST_CASE( "display_name_integral_magazine_per_pocket_segments", "[multimag][display]" )
+{
+    item gun( itype_test_multimag_gun_integral_ammo );
+    REQUIRE( gun.uses_firing_requirements() );
+
+    SECTION( "slug only" ) {
+        REQUIRE( gun.put_in( item( itype_9mm, calendar::turn, 1 ),
+                             pocket_type::MAGAZINE ).success() );
+        const std::string name = remove_color_tags( gun.display_name() );
+        INFO( name );
+        // Slug pocket loaded; battery pocket renders as "0/<cap>".
+        CHECK( name.find( "1/1" ) != std::string::npos );
+        // Per-pocket renderer must not print "1/0" - that is the aggregate
+        // path applying slug count against an empty battery capacity.
+        CHECK( name.find( "1/0" ) == std::string::npos );
+    }
+
+    SECTION( "slug + battery does not aggregate" ) {
+        REQUIRE( gun.put_in( item( itype_9mm, calendar::turn, 1 ),
+                             pocket_type::MAGAZINE ).success() );
+        item battery( itype_heavy_battery_cell );
+        battery.ammo_set( itype_battery, 100 );
+        REQUIRE( gun.put_in( battery, pocket_type::MAGAZINE_WELL ).success() );
+
+        const std::string name = remove_color_tags( gun.display_name() );
+        INFO( name );
+        // Slug pocket shows 1/1, battery pocket shows 100/<cap>. The
+        // aggregate "101/<cap>" or "1/100" forms must never appear.
+        CHECK( name.find( "1/1" ) != std::string::npos );
+        CHECK( name.find( "100/" ) != std::string::npos );
+    }
+
+    SECTION( "battery only does not borrow slug count" ) {
+        item battery( itype_heavy_battery_cell );
+        battery.ammo_set( itype_battery, 50 );
+        REQUIRE( gun.put_in( battery, pocket_type::MAGAZINE_WELL ).success() );
+        const std::string name = remove_color_tags( gun.display_name() );
+        INFO( name );
+        CHECK( name.find( "0/1" ) != std::string::npos );
+        CHECK( name.find( "50/" ) != std::string::npos );
+    }
+}
+
+// Ammo identity accessors must not fall back to a non-projectile pocket on
+// a multimag gun. Battery-only must report no ammo so downstream callers
+// (sounds, projectile, event bus) do not borrow the battery itype.
+TEST_CASE( "multimag_loaded_ammo_does_not_borrow_sibling_pocket",
+           "[multimag][ammo_data]" )
+{
+    item gun( itype_test_multimag_gun_integral_ammo );
+    REQUIRE( gun.uses_firing_requirements() );
+
+    item battery( itype_heavy_battery_cell );
+    battery.ammo_set( itype_battery, 100 );
+    REQUIRE( gun.put_in( battery, pocket_type::MAGAZINE_WELL ).success() );
+
+    CHECK_FALSE( gun.has_ammo() );
+    CHECK_FALSE( gun.has_ammo_data() );
+    CHECK( gun.ammo_data() == nullptr );
+    CHECK( gun.loaded_ammo().is_null() );
+    CHECK( gun.ammo_current() == itype_id::NULL_ID() );
+
+    // After loading the slug pocket, identity is anchored to the projectile
+    // and loaded_ammo() must resolve to the slug, not null.
+    REQUIRE( gun.put_in( item( itype_9mm, calendar::turn, 1 ),
+                         pocket_type::MAGAZINE ).success() );
+    CHECK( gun.has_ammo() );
+    CHECK( gun.has_ammo_data() );
+    REQUIRE( gun.ammo_data() != nullptr );
+    CHECK( gun.ammo_current() == itype_9mm );
+    const item &loaded = gun.loaded_ammo();
+    CHECK_FALSE( loaded.is_null() );
+    CHECK( loaded.typeId() == itype_9mm );
+}
+
+// Firing a multimag gun with only the power source loaded must abort cleanly
+// (shots_remaining = 0) without emitting "invalid recipe id" or ammo-shortage
+// debugmsgs anywhere in the fire path.
+TEST_CASE( "multimag_fire_without_projectile_does_not_crash", "[multimag][fire]" )
+{
+    clear_map();
+    avatar &dummy = get_avatar();
+    dummy.set_body();
+    dummy.clear_worn();
+    dummy.remove_weapon();
+    dummy.setpos( get_map(), tripoint_bub_ms( point_bub_ms::zero, 0 ) );
+
+    item gun( itype_test_multimag_gun_integral_ammo );
+    item battery( itype_heavy_battery_cell );
+    battery.ammo_set( itype_battery, 100 );
+    REQUIRE( gun.put_in( battery, pocket_type::MAGAZINE_WELL ).success() );
+
+    dummy.set_wielded_item( gun );
+    REQUIRE( dummy.get_wielded_item() );
+
+    map &here = get_map();
+    const tripoint_bub_ms target = dummy.pos_bub( here ) + point( 5, 0 );
+    const std::string dmsg = capture_debugmsg_during( [&]() {
+        dummy.fire_gun( here, target, 1, *dummy.get_wielded_item() );
+    } );
+    INFO( "debugmsg: " << dmsg );
+    CHECK( dmsg.find( "invalid recipe id" ) == std::string::npos );
+    CHECK( dmsg.find( "Unexpected shortage of ammo" ) == std::string::npos );
+}
+
+// Reload menu must surface integral MAGAZINE as its own target on a multimag
+// gun; otherwise loose ammo has no reachable destination.
+TEST_CASE( "multimag_reload_targets_include_integral_pocket", "[multimag][reload]" )
+{
+    clear_avatar();
+    avatar &dummy = get_avatar();
+    item &gun = *dummy.i_add( item( itype_test_multimag_gun_integral_ammo ) );
+    item_location gun_loc( dummy, &gun );
+
+    const std::vector<reload_target> targets = get_possible_reload_targets( gun_loc );
+    bool saw_integral = false;
+    bool saw_well = false;
+    for( const reload_target &rt : targets ) {
+        if( rt.kind == reload_target::kind::integral_magazine ) {
+            saw_integral = true;
+        }
+        if( rt.kind == reload_target::kind::well ) {
+            saw_well = true;
+        }
+    }
+    CHECK( saw_integral );
+    CHECK( saw_well );
+
+    // Loose slug must be accepted by *some* reload_target.
+    item slug( itype_9mm, calendar::turn, 1 );
+    item_location slug_loc( dummy, &slug );
+    const reload_target *match = find_matching_reload_target( targets, slug_loc );
+    REQUIRE( match != nullptr );
+    CHECK( match->kind == reload_target::kind::integral_magazine );
+}
+
+// Targeted reload into an integral MAGAZINE pocket must deposit ammo there
+// without disturbing loaded sibling magazines.
+TEST_CASE( "multimag_item_reload_into_integral_magazine_pocket", "[multimag][reload]" )
+{
+    clear_avatar();
+    avatar &dummy = get_avatar();
+
+    item gun( itype_test_multimag_gun_integral_ammo );
+    item battery( itype_heavy_battery_cell );
+    battery.ammo_set( itype_battery, 80 );
+    REQUIRE( gun.put_in( battery, pocket_type::MAGAZINE_WELL ).success() );
+
+    item_location held_loc = dummy.i_add( gun );
+    item_location slug_loc = dummy.i_add( item( itype_9mm, calendar::turn, 1 ) );
+    REQUIRE( held_loc );
+    REQUIRE( slug_loc );
+    item &held_gun = *held_loc;
+
+    int slug_pocket_index = -1;
+    int idx = 0;
+    for( const item_pocket *p : held_gun.get_pockets( []( const item_pocket & ) {
+    return true;
+} ) ) {
+        if( p->is_type( pocket_type::MAGAZINE ) ) {
+            slug_pocket_index = idx;
+            break;
+        }
+        ++idx;
+    }
+    REQUIRE( slug_pocket_index >= 0 );
+
+    const bool reloaded = held_gun.reload( dummy, slug_loc, 1, slug_pocket_index );
+    CHECK( reloaded );
+
+    // Slug pocket loaded.
+    int slug_count = 0;
+    int battery_count = 0;
+    for( const item_pocket *p : held_gun.get_pockets( []( const item_pocket & ) {
+    return true;
+} ) ) {
+        if( p->is_type( pocket_type::MAGAZINE ) ) {
+            for( const item *e : p->all_items_top() ) {
+                slug_count += e->charges > 0 ? e->charges : 1;
+            }
+        } else if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+            const item *m = p->magazine_current();
+            if( m ) {
+                battery_count = m->ammo_remaining();
+            }
+        }
+    }
+    CHECK( slug_count == 1 );
+    // Battery pocket undisturbed.
+    CHECK( battery_count == 80 );
+}


### PR DESCRIPTION
#### Summary
Bugfixes "Fix multimag integral magazine display, reload, and fire bugs"

#### Purpose of change
Followup on the multimag firing-requirements work (#85928, #86943). Integral-magazine
multimag guns showed bogus aggregate ammo counts like "1501/1500", refused to reload
the slug pocket from the reload UI, and emitted "invalid recipe id" on the first shot.
Matrix testing also surfaced a `fire_gun` null deref when the wielded item drops
mid-shot.

#### Describe the solution
Display, ammo accessors and the reload UI now treat each pocket on a multimag host as
its own thing instead of summing them. Integral pockets eject spent casings before
reload so the next round actually loads. Sidebar gets a compact `(x/cap, y/cap)`
per-pocket summary; inventory keeps full names.

The "invalid recipe id" came from an empty `itype_id` slipping past `is_null`. The
generic factory `optional()` loader resets missing fields to default-constructed `""`
instead of `NULL_ID()`. Guarded locally in `find_template` and `format_entry_name`.

`fire_gun` caches the gun slot before the firing loop so post-shot bookkeeping survives
a recoil-induced unwield.

Adds `tests/multimag_matrix_test.cpp`: 516 synthetic itypes via `add_runtime` sweeping
six ammotypes across 1-3 pockets x {gun, tool}.

#### Describe alternatives you've considered
Real upstream fix for the empty-id case is auditing `optional()` call sites with
in-class `NULL_ID()` defaults and switching the risky 4-arg form to 5-arg with an
explicit default. Out of scope, left as followup.

#### Testing
Verified in-game with a debug-spawned multimag railgun. Existing multimag tests plus
new matrix cases pass.

#### Additional context
N/A