### PR TITLE
auditing some recipes. making power hammer a bit slower

### DIFF
--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -324,7 +324,7 @@
     "name": { "str": "power hammer" },
     "copy-from": "fake_appliance_tool",
     "charges_per_use": 20,
-    "charged_qualities": [ { "id": "HAMMER", "level": 5, "speed": 0.2 }, { "id": "ANVIL", "level": 1, "speed": 1.0 } ],
+    "charged_qualities": [ { "id": "HAMMER", "level": 5, "speed": 0.33 }, { "id": "ANVIL", "level": 1, "speed": 1.0 } ],
     "extend": { "flags": [ "ALLOWS_REMOTE_USE" ] }
   },
   {

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -2010,7 +2010,7 @@
       },
       {
         "name": "Cutting off excess and squaring the steel stock",
-        "time": "2 h 10",
+        "time": "2 h 10 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "using": [ [ "hotcut_any", 1 ] ],

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -101,7 +101,7 @@
         "qualities": [ { "id": "CUT", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_carving", "time_multiplier": 1.5 } ]
       },
-      { "name": "Smoke-curing wood", "time": "4 h", "activity_level": "NO_EXERCISE" },
+      { "name": "Smoke-curing wood", "time": "4 h", "activity_level": "NO_EXERCISE", "attention": "unattended" },
       { "name": "Applying sealant", "time": "30 m", "activity_level": "NO_EXERCISE" }
     ]
   },
@@ -1933,7 +1933,7 @@
       },
       {
         "name": "Punching and drifting the eye",
-        "time": "1 h 30 m",
+        "time": "1 h 50 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_toolsmithing" } ]
@@ -2010,7 +2010,7 @@
       },
       {
         "name": "Cutting off excess and squaring the steel stock",
-        "time": "1 h 40 m",
+        "time": "2 h 10",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "using": [ [ "hotcut_any", 1 ] ],
@@ -2018,21 +2018,21 @@
       },
       {
         "name": "Punching and drifting the eye",
-        "time": "1 h 35 m",
+        "time": "2 h 35 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_toolsmithing" } ]
       },
       {
         "name": "Drawing out and curving steel for the beak",
-        "time": "1 h 30 m",
+        "time": "2 h",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_bladesmith" } ]
       },
       {
         "name": "Drawing out langets and forge welding them to the head",
-        "time": "1 h",
+        "time": "1 h 20 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_metalworking" } ]
@@ -2047,7 +2047,7 @@
       { "name": "Normalizing the hammer head", "time": "40 m", "activity_level": "NO_EXERCISE" },
       {
         "name": "Rough grinding and shaping the spike and face",
-        "time": "2 h",
+        "time": "2 h 20 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "GRIND", "level": 2 }, { "id": "FILE", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_metalworking" } ]
@@ -2075,7 +2075,7 @@
         "time": "1 h 40 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "FILE", "level": 2 } ],
-        "proficiencies": [ { "proficiency": "prof_hardening" } ]
+        "proficiencies": [ { "proficiency": "prof_blacksmithing" } ]
       },
       {
         "name": "Sawing plank and shaping the wooden handle",
@@ -2086,7 +2086,7 @@
       },
       {
         "name": "Fitting and wedging the head to the handle.  Attaching langets",
-        "time": "30 m",
+        "time": "40 m",
         "activity_level": "LIGHT_EXERCISE",
         "tools": [ [ [ "hammer", -1 ] ] ],
         "qualities": [ { "id": "DRILL", "level": 2 } ]
@@ -2114,7 +2114,7 @@
       },
       {
         "name": "Cutting off excess and squaring the steel stock",
-        "time": "1 h 40 m",
+        "time": "2 h 30 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "using": [ [ "hotcut_any", 1 ] ],
@@ -2122,28 +2122,28 @@
       },
       {
         "name": "Carefully punching and drifting the eye",
-        "time": "2 h",
+        "time": "3 h",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_toolsmithing" } ]
       },
       {
         "name": "Drawing out and curving steel for the beak",
-        "time": "1 h 30 m",
+        "time": "1 h 50 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_bladesmith" } ]
       },
       {
         "name": "Drawing out langets and forge welding them to the head",
-        "time": "1 h",
+        "time": "1 h 40 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_metalworking" } ]
       },
       {
         "name": "Forming the hammer face and chiseling grooves.  Chiseling your touchmark on the hammer",
-        "time": "1 h 20 m",
+        "time": "1 h 50 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_toolsmithing" } ]
@@ -2151,14 +2151,14 @@
       { "name": "Normalizing the hammer head", "time": "40 m", "activity_level": "NO_EXERCISE" },
       {
         "name": "Rough grinding and shaping the spike and face",
-        "time": "2 h",
+        "time": "2 h 30 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "GRIND", "level": 2 }, { "id": "FILE", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_metalworking" } ]
       },
       {
         "name": "Heating and thorough-hardening hammer head",
-        "time": "30 m",
+        "time": "20 m",
         "activity_level": "NO_EXERCISE",
         "proficiencies": [ { "proficiency": "prof_hardening" } ]
       },
@@ -2191,7 +2191,7 @@
       },
       {
         "name": "Fitting and wedging the head to the handle.  Attaching langets",
-        "time": "30 m",
+        "time": "40 m",
         "activity_level": "LIGHT_EXERCISE",
         "tools": [ [ [ "hammer", -1 ] ] ],
         "qualities": [ { "id": "DRILL", "level": 2 } ]
@@ -2373,7 +2373,7 @@
       },
       {
         "name": "Forging and shaping symmetrical flanges",
-        "time": "2 h",
+        "time": "3 h 10 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_metalworking" } ]
@@ -2408,7 +2408,7 @@
       },
       {
         "name": "Grinding scale off roughly to observe temper colours",
-        "time": "40 m",
+        "time": "30 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "GRIND", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" } ]
@@ -2607,7 +2607,12 @@
         "qualities": [ { "id": "CUT", "level": 2 }, { "id": "SAW_W", "level": 2 }, { "id": "FILE", "level": 1 } ],
         "proficiencies": [ { "proficiency": "prof_carving", "skill_penalty": 0.5 } ]
       },
-      { "name": "Oiling staff.  Watching the proverbial paint dry", "time": "4 h", "activity_level": "NO_EXERCISE" }
+      {
+        "name": "Oiling staff.  Watching the proverbial paint dry",
+        "time": "4 h",
+        "activity_level": "NO_EXERCISE",
+        "attention": "unattended"
+      }
     ]
   },
   {

--- a/data/json/recipes/weapon/cutting.json
+++ b/data/json/recipes/weapon/cutting.json
@@ -99,15 +99,15 @@
     "steps": [
       {
         "name": "Forge welding and drawing out steel, forging blade blank and tang",
-        "time": "2 h 40 m",
+        "time": "3 h 40 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "using": [ [ "hotcut_any", 1 ] ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_bladesmith" } ]
       },
       {
-        "name": "Forging the knucklebow guard from remaining steel",
-        "time": "1 h",
+        "name": "Forging the guard from remaining steel",
+        "time": "1 h 50 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_metalworking" } ]
@@ -119,8 +119,8 @@
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_bladesmith" } ]
       },
       {
-        "name": "Rough grinding and establishing the edge geometry",
-        "time": "2 h 30 m",
+        "name": "Rough grinding and establishing the edge geometry.  Truing",
+        "time": "3 h",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "GRIND", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]
@@ -176,15 +176,15 @@
     "steps": [
       {
         "name": "Forge welding and drawing out steel, forging blade blank and tang",
-        "time": "3 h 20 m",
+        "time": "3 h 50 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "using": [ [ "hotcut_any", 1 ] ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_bladesmith" } ]
       },
       {
-        "name": "Forging the knucklebow guard from remaining steel",
-        "time": "1 h 40 m",
+        "name": "Forging intricate guard from remaining steel",
+        "time": "2 h",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_metalworking" } ]
@@ -197,7 +197,7 @@
       },
       {
         "name": "Rough grinding and establishing the edge geometry",
-        "time": "3 h",
+        "time": "3 h 30 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "GRIND", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]
@@ -224,7 +224,7 @@
       },
       {
         "name": "Final sanding and polishing",
-        "time": "3 h",
+        "time": "3 h 20 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "FILE", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]
@@ -1168,8 +1168,8 @@
         "proficiencies": [ { "proficiency": "prof_blacksmithing" } ]
       },
       {
-        "name": "Drawing out steel, forging the blade blank, and drawing out the hidden tang",
-        "time": "3 h 50 m",
+        "name": "Drawing out steel, forging the blade blank, and drawing out the hidden tang.  Using remaining steel to forge simple pommel",
+        "time": "4 h 40 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "using": [ [ "hotcut_any", 1 ] ],
@@ -1183,7 +1183,7 @@
       },
       {
         "name": "Rough grinding and filing the fuller",
-        "time": "2 h 50 m",
+        "time": "4 h",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "GRIND", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]
@@ -1209,7 +1209,7 @@
       },
       {
         "name": "Final sharpening, sanding, and polishing",
-        "time": "1 h 45 m",
+        "time": "2 h 30 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "FILE", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]
@@ -1239,7 +1239,7 @@
       },
       {
         "name": "Drawing out steel, forging the blade blank, and drawing out the hidden threaded tang.  Using remaining steel to forge pommel",
-        "time": "3 h 50 m",
+        "time": "4 h 50 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "using": [ [ "hotcut_any", 1 ] ],
@@ -1253,7 +1253,7 @@
       },
       {
         "name": "Rough grinding and filing the fuller",
-        "time": "4 h 15 m",
+        "time": "4 h 40 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "GRIND", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]
@@ -1279,14 +1279,14 @@
       },
       {
         "name": "Tempering",
-        "time": "4 h 30 m",
+        "time": "5 h 30 m",
         "activity_level": "NO_EXERCISE",
         "qualities": [ { "id": "TEMPER", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_tempering" } ]
       },
       {
         "name": "Final sharpening, sanding, and polishing",
-        "time": "2 h",
+        "time": "3 h 30 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "FILE", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]
@@ -1877,7 +1877,7 @@
       },
       {
         "name": "Drawing out steel, forging the blade blank, and drawing out the hidden threaded tang.  Using remaining steel to forge pommel",
-        "time": "2 h 20 m",
+        "time": "4 h 20 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "using": [ [ "hotcut_any", 1 ] ],
@@ -1891,7 +1891,7 @@
       },
       {
         "name": "Rough grinding and filing the fuller",
-        "time": "1 h 30 m",
+        "time": "3 h 30 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "GRIND", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]
@@ -1904,7 +1904,7 @@
       },
       {
         "name": "Final sharpening, sanding, and polishing",
-        "time": "1 h 30 m",
+        "time": "2 h 30 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "FILE", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]
@@ -1934,7 +1934,7 @@
       },
       {
         "name": "Drawing out steel, forging the blade blank, and drawing out the hidden threaded tang.  Using remaining steel to forge pommel",
-        "time": "2 h 55 m",
+        "time": "4 h 55 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "using": [ [ "hotcut_any", 1 ] ],
@@ -1948,7 +1948,7 @@
       },
       {
         "name": "Rough grinding and filing the fuller",
-        "time": "2 h",
+        "time": "4 h",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "GRIND", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]
@@ -1981,7 +1981,7 @@
       },
       {
         "name": "Final sharpening, sanding, and polishing",
-        "time": "1 h 30 m",
+        "time": "2 h 30 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "FILE", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]
@@ -2379,7 +2379,7 @@
       },
       {
         "name": "Truing the profile and rough grinding the bevels",
-        "time": "2 h",
+        "time": "2 h 30 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "GRIND", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]
@@ -2405,7 +2405,7 @@
       },
       {
         "name": "Final grinding",
-        "time": "1 h 30 m",
+        "time": "2 h ",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "FILE", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]
@@ -2433,7 +2433,7 @@
     "steps": [
       {
         "name": "Cutting steel.  Forging the blade to shape and drawing out the tang",
-        "time": "2 h",
+        "time": "2 h 40 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "using": [ [ "hotcut_any", 1 ] ],
@@ -2447,7 +2447,7 @@
       },
       {
         "name": "Truing the profile and rough grinding the bevels",
-        "time": "2 h 40 m",
+        "time": "2 h 50 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "GRIND", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]
@@ -2467,7 +2467,7 @@
       },
       {
         "name": "Final grinding",
-        "time": "1 h 30 m",
+        "time": "2 h 20 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "FILE", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]
@@ -2554,7 +2554,7 @@
     "steps": [
       {
         "name": "Cutting steel.  Forging the blade straight and drawing out the tang",
-        "time": "2 h 40 m",
+        "time": "3 h 40 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "using": [ [ "hotcut_any", 1 ] ],
@@ -2622,7 +2622,7 @@
     "steps": [
       {
         "name": "Cutting steel.  Forging the blade to shape and drawing out the tang",
-        "time": "3 h 50 m",
+        "time": "4 h 30 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "using": [ [ "hotcut_any", 1 ] ],
@@ -2636,7 +2636,7 @@
       },
       {
         "name": "Truing the profile and rough grinding the bevels",
-        "time": "3 h 40 m",
+        "time": "4 h 30 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "GRIND", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]
@@ -2764,7 +2764,7 @@
     "steps": [
       {
         "name": "Forging the blank ensuring consistent grain flow",
-        "time": "5 h 40 m",
+        "time": "6 h",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_bladesmith" } ]
@@ -2777,7 +2777,7 @@
       },
       {
         "name": "Rough grinding",
-        "time": "4 h",
+        "time": "5 h 30 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "GRIND", "level": 2 } ],
         "proficiencies": [ { "proficiency": "prof_bladesmith" } ]

--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -2290,26 +2290,26 @@
     "difficulty": 9,
     "book_learn": [ [ "textbook_weapwest", 8 ] ],
     "using": [ [ "blacksmithing_standard", 8 ], [ "mc_steel_standard", 3 ], [ "quench", 120 ] ],
-    "components": [ [ [ "scrap_kevlar", 2 ], [ "plastic_chunk", 1 ] ] ],
+    "components": [ [ [ "scrap_kevlar", 2 ], [ "plastic_chunk", 1 ] ], [ [ "hc_wire", 2 ] ] ],
     "byproducts": [ [ "water", 120 ] ],
     "steps": [
       {
-        "name": "Forge welding steel for the blade, tang, pommel and hilt",
-        "time": "55 m",
+        "name": "Forge welding and cutting steel for the blade, tang, pommel and hilt",
+        "time": "1 h 30 m",
         "activity_level": "BRISK_EXERCISE",
         "using": [ [ "hotcut_any", 1 ] ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_metalworking" } ]
       },
       {
         "name": "Drawing out the blade with a diamond cross section",
-        "time": "4 h 10 m",
+        "time": "5 h 30 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_bladesmith" } ]
       },
       {
         "name": "Forging hilt",
-        "time": "1 h 20 m",
+        "time": "2 h 30 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" } ]
@@ -2357,26 +2357,26 @@
     "difficulty": 10,
     "book_learn": [ [ "textbook_weapwest", 8 ] ],
     "using": [ [ "blacksmithing_standard", 8 ], [ "mc_steel_standard", 3 ], [ "quench", 120 ] ],
-    "components": [ [ [ "scrap_kevlar", 2 ], [ "plastic_chunk", 1 ] ] ],
+    "components": [ [ [ "scrap_kevlar", 2 ], [ "plastic_chunk", 1 ] ], [ [ "hc_wire", 2 ] ] ],
     "byproducts": [ [ "water", 120 ] ],
     "steps": [
       {
         "name": "Forge welding steel for the blade, tang, pommel and hilt",
-        "time": "1 h 10 m",
+        "time": "1 h 50 m",
         "activity_level": "BRISK_EXERCISE",
         "using": [ [ "hotcut_any", 1 ] ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_metalworking" } ]
       },
       {
         "name": "Drawing out the blade with a diamond cross section",
-        "time": "4 h 10 m",
+        "time": "5 h 50 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" }, { "proficiency": "prof_bladesmith" } ]
       },
       {
-        "name": "Forging hilt.  Etching touchmark in hilt",
-        "time": "2 h 10 m",
+        "name": "Forging swept hilt.  Etching touchmark in hilt",
+        "time": "3 h 10 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "HAMMER", "level": 3 } ],
         "proficiencies": [ { "proficiency": "prof_blacksmithing" } ]
@@ -2415,7 +2415,7 @@
       },
       {
         "name": "Final grinding and polishing",
-        "time": "1 h 50 m",
+        "time": "2 h 30 m",
         "activity_level": "BRISK_EXERCISE",
         "qualities": [ { "id": "FILE", "level": 2 } ]
       },


### PR DESCRIPTION
#### Summary
Balance "Go through the recipes I stepped and adjust some stuff. Make power hammer a bit slower"

#### Purpose of change

I went over the things I stepped so far, and gave a couple recipes a bit of a do-over, mostly by increasing crafting times. The power hammer was a bit too strong

#### Describe the solution

Crafting times for sabre, broadsword, longsword, katana, wakizashi, nodachi, and war hammer slightly increased to better portray what it would be like crafting them with no power tools. 

The power hammer is good. A bit _too_ good with my long term testing, being a full 5x faster than the old hammer. IRL this is more than realistic, when it comes to moving metal the power hammer is incredibly fast, but I found it made crafting times a bit... too low. The raw power of the hammer shouldn't push 4 hours of hammering down to 48 mins, it's too fast. This is making forging take way too little time in some cases. There's many other factors to consider when forging and you always have to go in with the manual hammer to correct faults and for more delicate work. To better portray this the power hammer speed has been decreased from 0.2 down to 0.33. 

#### Describe alternatives you've considered

Leave the power hammer and recipes as is

#### Testing

Very simple json edits

#### Additional context
Thoughts would be appreciated on if you think I should decrease the speed more