### PR TITLE
LLVM 22 clang-tidy cleanup

### DIFF
--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -76,6 +76,8 @@ bool string_id<achievement>::is_valid() const
     return achievement_factory.is_valid( *this );
 }
 
+namespace
+{
 enum class requirement_visibility : int {
     always,
     when_requirement_completed,
@@ -83,6 +85,7 @@ enum class requirement_visibility : int {
     never,
     last
 };
+} // namespace
 
 template<>
 struct enum_traits<requirement_visibility> {

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -974,6 +974,8 @@ void hacking_activity_actor::start( player_activity &act, Character & )
     act.moves_left = to_moves<int>( 5_minutes );
 }
 
+namespace
+{
 enum class hack_result : int {
     UNABLE,
     FAIL,
@@ -987,6 +989,7 @@ enum class hack_type : int {
     GAS,
     NONE
 };
+} // namespace
 
 static int hack_level( const Character &who, item_location &tool )
 {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -298,6 +298,8 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, Character *yo
     }
 }
 
+namespace
+{
 enum class repeat_type : int {
     // INIT should be zero. In some scenarios (vehicle welder), activity value default to zero.
     INIT = 0,       // Haven't found repeat value yet.
@@ -311,20 +313,21 @@ enum class repeat_type : int {
 };
 
 using I = std::underlying_type_t<repeat_type>;
-static constexpr bool operator>=( const I &lhs, const repeat_type &rhs )
+constexpr bool operator>=( const I &lhs, const repeat_type &rhs )
 {
     return lhs >= static_cast<I>( rhs );
 }
 
-static constexpr bool operator<=( const I &lhs, const repeat_type &rhs )
+constexpr bool operator<=( const I &lhs, const repeat_type &rhs )
 {
     return lhs <= static_cast<I>( rhs );
 }
 
-static constexpr I operator-( const repeat_type &lhs, const repeat_type &rhs )
+constexpr I operator-( const repeat_type &lhs, const repeat_type &rhs )
 {
     return static_cast<I>( lhs ) - static_cast<I>( rhs );
 }
+} // namespace
 
 static repeat_type repeat_menu( const std::string &title, repeat_type last_selection,
                                 const bool can_refit )
@@ -358,6 +361,8 @@ static repeat_type repeat_menu( const std::string &title, repeat_type last_selec
 // HACK: This is a part of a hack to provide pseudo items for long repair activity
 // Note: similar hack could be used to implement all sorts of vehicle pseudo-items
 //  and possibly CBM pseudo-items too.
+namespace
+{
 struct weldrig_hack {
     std::optional<vpart_reference> part;
     item pseudo;
@@ -429,6 +434,7 @@ struct weldrig_hack {
         clean_up();
     }
 };
+} // namespace
 
 void activity_handlers::repair_item_finish( player_activity *act, Character *you )
 {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -230,6 +230,8 @@ static item_location find_study_book( const tripoint_abs_ms &zone_pos, Character
     return item_location();
 }
 
+namespace
+{
 /** Activity-associated item */
 struct act_item {
     /// inventory item
@@ -244,6 +246,7 @@ struct act_item {
           count( count ),
           consumed_moves( consumed_moves ) {}
 };
+} // namespace
 
 namespace multi_activity_actor
 {

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -557,6 +557,8 @@ void advanced_inventory::print_items( side p, bool active )
     }
 }
 
+namespace
+{
 struct advanced_inv_sorter {
     advanced_inv_sortby sortby;
     explicit advanced_inv_sorter( advanced_inv_sortby sort ) {
@@ -692,6 +694,7 @@ struct advanced_inv_sorter {
         return localized_compare( sort_key( d1 ), sort_key( d2 ) );
     }
 };
+} // namespace
 
 int advanced_inventory::print_header( advanced_inventory_pane &pane, aim_location sel )
 {
@@ -2111,6 +2114,8 @@ void advanced_inventory::display()
     }
 }
 
+namespace
+{
 class query_destination_callback : public uilist_callback
 {
     private:
@@ -2129,6 +2134,7 @@ class query_destination_callback : public uilist_callback
             return rv;
         }
 };
+} // namespace
 
 void query_destination_callback::draw_squares( const uilist *menu )
 {

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -9,6 +9,8 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <string>
+#include <string_view>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -889,7 +891,7 @@ void game::draw_zones( const tripoint_bub_ms &start, const tripoint_bub_ms &end,
 #endif
 
 #if defined(TILES)
-void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id,
+void game::draw_async_anim( const tripoint_bub_ms &p, std::string_view tile_id,
                             const std::string &ncstr,
                             const nc_color &nccol )
 {
@@ -915,11 +917,11 @@ void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id
         return;
     }
 
-    tilecontext->init_draw_async_anim( p, tile_id );
+    tilecontext->init_draw_async_anim( p, std::string( tile_id ) );
     g->invalidate_main_ui_adaptor();
 }
 #else
-void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &,
+void game::draw_async_anim( const tripoint_bub_ms &p, std::string_view,
                             const std::string &ncstr,
                             const nc_color &nccol )
 {

--- a/src/behavior.cpp
+++ b/src/behavior.cpp
@@ -124,14 +124,14 @@ void tree::add( const node_t *new_node )
 
 // Now for the generic_factory definition
 
+namespace
+{
 // This struct only exists to hold node data until finalization.
 struct node_data {
     string_id<node_t> id;
     std::vector<std::string> children;
 };
 
-namespace
-{
 generic_factory<behavior::node_t> behavior_factory( "behavior" );
 std::list<node_data> temp_node_data;
 } // namespace

--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -243,6 +243,8 @@ void bodygraph::check() const
 using part_tuple =
     std::tuple<bodypart_id, const sub_body_part_type *, const bodygraph_part *, bool>;
 
+namespace
+{
 struct bodygraph_display {
     const Character *u;
     bodygraph_id id;
@@ -285,6 +287,7 @@ struct bodygraph_display {
     void draw_info();
     void display();
 };
+} // namespace
 
 bodygraph_display::bodygraph_display( const Character *u, const bodygraph_id &id ) :
     u( u ), id( id ), ctxt( "BODYGRAPH" )

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -295,6 +295,8 @@ const std::vector<body_part_type> &body_part_type::get_all()
     return body_part_factory.get_all();
 }
 
+namespace
+{
 class encumbrance_per_weight_reader : public generic_typed_reader<encumbrance_per_weight_reader>
 {
     public:
@@ -338,6 +340,7 @@ struct limb_type_reader : generic_typed_reader<limb_type_reader> {
         return ret;
     }
 };
+} // namespace
 
 void body_part_type::load( const JsonObject &jo, std::string_view )
 {

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -32,6 +32,8 @@ static ImGuiKey cata_key_to_imgui( int cata_key );
 
 #include "color_loader.h"
 
+namespace
+{
 struct RGBTuple {
     uint8_t Blue;
     uint8_t Green;
@@ -46,6 +48,7 @@ struct pairs {
 ImVec4 impalette[256] = {};
 std::array<RGBTuple, color_loader<RGBTuple>::COLOR_NAMES_COUNT> rgbPalette;
 std::array<pairs, 100> colorpairs;   //storage for paired colors
+} // namespace
 
 static ImVec4 compute_color( uint8_t index )
 {
@@ -89,7 +92,10 @@ ImVec4 cataimgui::imvec4_from_color( const nc_color &color )
     return impalette[palette_index];
 }
 
+namespace
+{
 std::vector<std::pair<int, ImTui::mouse_event>> imtui_events;
+} // namespace
 
 static int GetFallbackStrWidth( const char *s_begin, const char *s_end,
                                 const float scale )

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -967,10 +967,10 @@ bool cataimgui::window::is_bounds_changed()
     return p_impl->is_resized;
 }
 
-size_t cataimgui::window::get_text_width( const std::string &text )
+size_t cataimgui::window::get_text_width( std::string_view text )
 {
 #ifndef TUI
-    return ImGui::CalcTextSize( text.c_str() ).x;
+    return ImGui::CalcTextSize( text.data(), text.data() + text.size() ).x;
 #else
     return utf8_width( text );
 #endif

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -201,14 +201,14 @@ void cataimgui::client::process_input( void *input )
                         break;
                 }
             }
-            imtui_events.push_back( std::pair<int, ImTui::mouse_event>( KEY_MOUSE, new_mouse_event ) );
+            imtui_events.emplace_back( KEY_MOUSE, new_mouse_event );
         } else {
             int ch = curses_input->get_first_input();
             if( ch != UNKNOWN_UNICODE ) {
                 if( ch > 127 && ch < 245 ) { // Values between 127 and 245 indicate UTF-8
                     ch = utf8_wrapper( curses_input->text ).at( 0 );
                 }
-                imtui_events.push_back( std::pair<int, ImTui::mouse_event>( ch, new_mouse_event ) );
+                imtui_events.emplace_back( ch, new_mouse_event );
             }
         }
     }

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -2,6 +2,7 @@
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 #include <unordered_map>
 
@@ -146,7 +147,7 @@ class window
         virtual void draw();
         virtual void on_resized() {}
         bool is_bounds_changed();
-        size_t get_text_width( const std::string &text );
+        size_t get_text_width( std::string_view text );
         size_t get_text_height( const char *text );
         size_t str_width_to_pixels( size_t len );
         size_t str_height_to_pixels( size_t len );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4022,11 +4022,14 @@ std::string Character::age_string( time_point when ) const
     return string_format( unformatted, age( when ) );
 }
 
+namespace
+{
 struct HeightLimits {
     int min_height = 0;
     int base_height = 0;
     int max_height = 0;
 };
+} // namespace
 
 /** Min and max heights in cm for each size category */
 static const std::map<creature_size, HeightLimits> size_category_height_limits {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -2304,6 +2304,8 @@ void construct::failure_deconstruct( const tripoint_bub_ms & )
     add_msg( m_info, _( "You cannot deconstruct this!" ) );
 }
 
+namespace
+{
 template <typename Fn>
 struct construction_special_reader : generic_typed_reader<construction_special_reader<Fn>> {
     const std::map<std::string, Fn> &possible;
@@ -2325,6 +2327,7 @@ struct construction_special_reader : generic_typed_reader<construction_special_r
         }
     }
 };
+} // namespace
 
 void load_construction( const JsonObject &jo, const std::string &src )
 {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -251,6 +251,8 @@ static input_context make_crafting_context( bool highlight_unread_recipes )
     return ctxt;
 }
 
+namespace
+{
 class recipe_result_info_cache
 {
         Character &crafter;
@@ -282,6 +284,7 @@ class recipe_result_info_cache
             return item_info_data( "", "", info, {}, scroll_pos );
         }
 };
+} // namespace
 
 std::pair<std::vector<const recipe *>, bool> recipes_from_cat( const recipe_subset
         &available_recipes, const crafting_category_id &cat, const std::string &subcat )
@@ -376,6 +379,8 @@ static bool filter_crafting_recipes( std::string &filterstring )
 // ImGui crafting UI implementation
 // ---------------------------------------------------------------------------
 
+namespace
+{
 class crafting_ui_impl : public cataimgui::window
 {
     public:
@@ -523,6 +528,7 @@ class crafting_ui_impl : public cataimgui::window
         void recalculate_unread();
         void invalidate_info_panels();
 };
+} // namespace
 
 // --- Constructor ---
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -985,6 +985,7 @@ static std::optional<uintptr_t> debug_compute_load_offset(
     for( const char *nm_variant : nm_variants ) {
         std::ostringstream cmd;
         cmd << nm_variant << ' ' << binary << " 2>&1";
+        // NOLINTNEXTLINE(bugprone-command-processor): debug-only symbol resolution
         FILE *nm = popen( cmd.str().c_str(), "re" );
         if( !nm ) {
             out << "    backtrace: popen(nm) failed: " << strerror( errno ) << "\n";
@@ -1345,6 +1346,7 @@ void debug_write_backtrace( std::ostream &out )
             cmd << " 0x" << ( address - load_offset );
         }
         cmd << " 2>&1";
+        // NOLINTNEXTLINE(bugprone-command-processor): debug-only address symbolization
         FILE *addr2line = popen( cmd.str().c_str(), "re" );
         if( addr2line == nullptr ) {
             out << "    backtrace: popen(addr2line) failed\n";
@@ -1641,6 +1643,7 @@ static std::string shell_exec( const std::string &command )
     std::vector<char> buffer( 512 );
     std::string output;
     try {
+        // NOLINTNEXTLINE(bugprone-command-processor): crash-handler shells out by design
         std::unique_ptr<FILE, FILEDeleter> pipe( popen( command.c_str(), "r" ) );
         if( pipe ) {
             while( fgets( buffer.data(), buffer.size(), pipe.get() ) != nullptr ) {

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -171,6 +171,8 @@ static uintptr_t get_image_base( const char *const path )
  * Class for capturing debugmsg,
  * used by capture_debugmsg_during.
  */
+namespace
+{
 class capture_debugmsg
 {
     public:
@@ -178,6 +180,7 @@ class capture_debugmsg
         std::string dmsg();
         ~capture_debugmsg();
 };
+} // namespace
 
 std::string capture_debugmsg_during( const std::function<void()> &func )
 {
@@ -278,6 +281,8 @@ std::string filter_name( debug_filter value )
 }
 } // namespace debugmode
 
+namespace
+{
 struct buffered_prompt_info {
     std::string filename;
     std::string line;
@@ -285,6 +290,7 @@ struct buffered_prompt_info {
     std::string text;
     bool forced;
 };
+} // namespace
 
 namespace
 {
@@ -432,6 +438,8 @@ void replay_buffered_debugmsg_prompts()
     buffered_prompts().clear();
 }
 
+namespace
+{
 struct time_info {
     int hours;
     int minutes;
@@ -452,9 +460,12 @@ struct time_info {
         return out;
     }
 };
+} // namespace
 
 static time_info get_time() noexcept;
 
+namespace
+{
 struct repetition_folder {
     const char *m_filename = nullptr;
     const char *m_line = nullptr;
@@ -515,6 +526,7 @@ struct repetition_folder {
         return ( now_raw - old_raw ) > timeout_raw;
     }
 };
+} // namespace
 
 static repetition_folder rep_folder;
 static void output_repetitions( std::ostream &out );
@@ -610,6 +622,8 @@ void limitDebugClass( int class_bitmask )
 // Null OStream                                                     {{{2
 // ---------------------------------------------------------------------
 
+namespace
+{
 class NullStream : public std::ostream
 {
     public:
@@ -617,6 +631,7 @@ class NullStream : public std::ostream
         NullStream( const NullStream & ) = delete;
         NullStream( NullStream && ) = delete;
 };
+} // namespace
 
 // DebugFile OStream Wrapper                                        {{{2
 // ---------------------------------------------------------------------
@@ -718,6 +733,8 @@ struct OutputDebugStreamA : public std::ostream {
 };
 #endif
 
+namespace
+{
 struct DebugFile {
     void init( DebugOutput, const cata_path &filename );
     void deinit();
@@ -734,6 +751,7 @@ struct DebugFile {
     std::shared_ptr<std::ostream> file = std::make_shared<std::ostringstream>();
     cata_path filename;
 };
+} // namespace
 
 // DebugFile OStream Wrapper                                        {{{2
 // ---------------------------------------------------------------------
@@ -1625,6 +1643,8 @@ std::string game_info::operating_system()
 }
 
 #if !defined(EMSCRIPTEN) && !defined(__CYGWIN__) && !defined (__ANDROID__) && ( defined (__linux__) || defined(unix) || defined(__unix__) || defined(__unix) || ( defined(__APPLE__) && defined(__MACH__) ) || defined(CATA_IS_ON_BSD) ) // linux; unix; MacOs; BSD
+namespace
+{
 class FILEDeleter
 {
     public:
@@ -1632,6 +1652,7 @@ class FILEDeleter
             pclose( f );
         }
 };
+} // namespace
 
 /** Execute a command with the shell by using `popen()`.
  * @param command The full command to execute.

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -548,7 +548,7 @@ time_accuracy diary::time_acc() const
 
 void diary::new_page()
 {
-    std::unique_ptr<diary_page> page( new diary_page() );
+    std::unique_ptr<diary_page> page = std::make_unique<diary_page>();
     page -> m_text = std::string();
     page -> turn = calendar::turn;
     page -> kills = g ->get_kill_tracker().kills;
@@ -690,7 +690,7 @@ void diary::deserialize( const JsonValue &jsin )
         pages.clear();
         add_summary_page();
         for( JsonObject elem : data.get_array( "pages" ) ) {
-            std::unique_ptr<diary_page> page( new diary_page() );
+            std::unique_ptr<diary_page> page = std::make_unique<diary_page>();
             page->m_text = elem.get_string( "text" );
             elem.read( "turn", page->turn );
             elem.read( "time_accuracy", page->time_acc );

--- a/src/distraction_manager.cpp
+++ b/src/distraction_manager.cpp
@@ -17,12 +17,15 @@
 namespace distraction_manager
 {
 
+namespace
+{
 struct configurable_distraction {
     bool *state;
     std::string name;
     std::string description;
     bool is_toggle = false;
 };
+} // namespace
 
 static const std::vector<configurable_distraction> &get_configurable_distractions()
 {

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -19,6 +19,8 @@ struct int_distribution_impl {
     int bhi = INT_MAX;
 };
 
+namespace
+{
 struct fixed_distribution : int_distribution_impl {
     int value;
 
@@ -112,6 +114,7 @@ struct poisson_distribution : int_distribution_impl {
         return string_format( "Poisson(%.0f)", dist.mean() );
     }
 };
+} // namespace
 
 int_distribution::int_distribution()
     : impl_( make_shared_fast<fixed_distribution>( 0 ) )

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -1017,6 +1017,8 @@ std::optional<int_id<T_t>> editmap_brush::select_feature()
 /*
  * edit items in target square. WIP
  */
+namespace
+{
 enum editmap_imenu_ent {
     imenu_bday,
     imenu_damage,
@@ -1027,6 +1029,7 @@ enum editmap_imenu_ent {
     imenu_savetest,
     imenu_exit,
 };
+} // namespace
 
 void editmap_ui::edit_items()
 {

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -808,6 +808,8 @@ std::string effect::disp_name() const
     return ret;
 }
 
+namespace
+{
 // Used in disp_desc()
 struct desc_freq {
     double chance;
@@ -818,6 +820,7 @@ struct desc_freq {
     desc_freq( double c, int v, const std::string &pos, const std::string &neg ) : chance( c ),
         val( v ), pos_string( pos ), neg_string( neg ) {}
 };
+} // namespace
 
 std::string effect::disp_desc( bool reduced ) const
 {

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -184,6 +184,8 @@ class event_statistic::impl
         virtual std::unique_ptr<impl> clone() const = 0;
 };
 
+namespace
+{
 struct value_constraint {
     enum comparator { lt, lteq, gteq, gt };
     std::vector<cata_variant> equals_any_;
@@ -430,6 +432,7 @@ struct event_transformation_event_source : event_source {
         return std::make_unique<event_transformation_event_source>( *this );
     }
 };
+} // namespace
 
 std::unique_ptr<event_source> event_source::load( const JsonObject &jo )
 {
@@ -447,6 +450,8 @@ std::unique_ptr<event_source> event_source::load( const JsonObject &jo )
     }
 }
 
+namespace
+{
 struct event_transformation_impl : public event_transformation::impl {
     template<typename NewFields, typename Constraints, typename DropFields>
     event_transformation_impl( const string_id<event_transformation> &id,
@@ -702,6 +707,7 @@ struct event_transformation_impl : public event_transformation::impl {
         return std::make_unique<event_transformation_impl>( *this );
     }
 };
+} // namespace
 
 event_multiset event_transformation::value( stats_tracker &stats ) const
 {
@@ -745,6 +751,8 @@ monotonically event_transformation::monotonicity() const
     return impl_->monotonicity();
 }
 
+namespace
+{
 struct event_statistic_count : event_statistic::impl {
     event_statistic_count( const string_id<event_statistic> &i, std::unique_ptr<event_source> s ) :
         id( i ),
@@ -1218,6 +1226,7 @@ struct event_statistic_last_value : event_statistic_field_summary<false> {
         return std::make_unique<event_statistic_last_value>( *this );
     }
 };
+} // namespace
 
 cata_variant event_statistic::value( stats_tracker &stats ) const
 {

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -122,6 +122,8 @@ static constexpr float MIN_EFFECTIVE_VELOCITY = 70.0f;
 static constexpr float MIN_FRAGMENT_DENSITY = 0.001f;
 
 
+namespace
+{
 //reads shrapnel data as object or int
 class shrapnel_reader : public generic_typed_reader<shrapnel_reader>
 {
@@ -141,6 +143,7 @@ class shrapnel_reader : public generic_typed_reader<shrapnel_reader>
             return ret;
         }
 };
+} // namespace
 
 void explosion_data::deserialize( const JsonObject &jo )
 {

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -245,11 +245,14 @@ static const std::string cook_recipe_group_string = "COOK";
 static const std::string farm_recipe_group_string = "FARM";
 static const std::string smith_recipe_group_string = "SMITH";
 
+namespace
+{
 struct mass_volume {
     units::mass wgt = 0_gram;
     units::volume vol = 0_ml;
     int count = 0;
 };
+} // namespace
 
 namespace base_camps
 {

--- a/src/flexbuffer_cache.cpp
+++ b/src/flexbuffer_cache.cpp
@@ -90,12 +90,12 @@ std::vector<uint8_t> parse_json_to_flexbuffer_(
             // Format is "(filename:)?(EOF:|line:col:) message"
             // But filename might be C:something
             int scanned_chars = 0;
-            // NOLINTNEXTLINE(cert-err34-c)
+            // NOLINTNEXTLINE(cert-err34-c,bugprone-unchecked-string-to-number-conversion)
             if( sscanf( parser.error_.c_str(), "%*[^:]:%*[^:]:%zu:%zu: %n", &line, &col,
                         &scanned_chars ) != 2 &&
-                // NOLINTNEXTLINE(cert-err34-c)
+                // NOLINTNEXTLINE(cert-err34-c,bugprone-unchecked-string-to-number-conversion)
                 sscanf( parser.error_.c_str(), "%*[^:]:%zu:%zu: %n", &line, &col, &scanned_chars ) != 2 &&
-                // NOLINTNEXTLINE(cert-err34-c)
+                // NOLINTNEXTLINE(cert-err34-c,bugprone-unchecked-string-to-number-conversion)
                 sscanf( parser.error_.c_str(), "%zu:%zu: %n", &line, &col, &scanned_chars ) != 2 ) {
                 line = 0;
                 col = 0;

--- a/src/flexbuffer_cache.cpp
+++ b/src/flexbuffer_cache.cpp
@@ -130,6 +130,8 @@ std::vector<uint8_t> parse_json_to_flexbuffer_(
 
 } // namespace
 
+namespace
+{
 struct flexbuffer_vector_storage : flexbuffer_storage {
     std::vector<uint8_t> buffer_;
 
@@ -156,6 +158,7 @@ struct flexbuffer_mmap_storage : flexbuffer_storage {
         return mmap_handle_->len();
     }
 };
+} // namespace
 
 parsed_flexbuffer::parsed_flexbuffer( std::shared_ptr<flexbuffer_storage> storage )
     : storage_{ std::move( storage ) }
@@ -163,6 +166,8 @@ parsed_flexbuffer::parsed_flexbuffer( std::shared_ptr<flexbuffer_storage> storag
     // TODO assert?
 }
 
+namespace
+{
 struct file_flexbuffer : parsed_flexbuffer {
         file_flexbuffer(
             std::shared_ptr<flexbuffer_storage> &&storage,
@@ -204,7 +209,10 @@ struct file_flexbuffer : parsed_flexbuffer {
         std::filesystem::file_time_type mtime_;
         std::streampos offset_;
 };
+} // namespace
 
+namespace
+{
 struct string_flexbuffer : parsed_flexbuffer {
         string_flexbuffer( std::shared_ptr<flexbuffer_storage> &&storage, std::string &&source )
             : parsed_flexbuffer{ std::move( storage ) },
@@ -229,7 +237,9 @@ struct string_flexbuffer : parsed_flexbuffer {
     private:
         std::string source_;
 };
+} // namespace
 
+// NOLINTNEXTLINE(misc-use-internal-linkage): forward-declared in flexbuffer_cache.h
 class flexbuffer_disk_cache
 {
     public:

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -26,6 +26,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <unordered_map>
@@ -6497,9 +6498,9 @@ int game::get_user_action_counter() const
 }
 
 #if defined(TILES)
-bool game::take_screenshot( const std::string &path ) const
+bool game::take_screenshot( std::string_view path ) const
 {
-    return save_screenshot( path );
+    return save_screenshot( std::string( path ) );
 }
 
 bool game::take_screenshot() const
@@ -6526,7 +6527,7 @@ bool game::take_screenshot() const
     }
 }
 #else
-bool game::take_screenshot( const std::string &/*path*/ ) const
+bool game::take_screenshot( std::string_view /*path*/ ) const
 {
     return false;
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3025,6 +3025,8 @@ void game::display_faction_epilogues()
     }
 }
 
+namespace
+{
 struct npc_dist_to_player {
     const tripoint_abs_omt ppos{};
     npc_dist_to_player() : ppos( get_player_character().pos_abs_omt() ) { }
@@ -3037,6 +3039,7 @@ struct npc_dist_to_player {
                square_dist( ppos.xy(), bpos.xy() );
     }
 };
+} // namespace
 
 void game::disp_NPCs()
 {
@@ -7101,6 +7104,8 @@ void game::reload( item_location &loc, bool prompt, bool empty )
 }
 
 
+namespace
+{
 class reload_selector_preset : public inventory_selector_preset
 {
     public:
@@ -7114,6 +7119,7 @@ class reload_selector_preset : public inventory_selector_preset
     private:
         const Character &you;
 };
+} // namespace
 
 // Reload something.
 void game::reload_item()

--- a/src/game.h
+++ b/src/game.h
@@ -804,7 +804,7 @@ class game
         * @note: Only works for SDL/TILES (otherwise the function returns `false`). A window (more precisely, a viewport) must already exist and the SDL renderer must be valid.
         * @returns `true` if the screenshot generation was successful, `false` otherwise.
         */
-        bool take_screenshot( const std::string &file_path ) const;
+        bool take_screenshot( std::string_view file_path ) const;
         /** Saves a screenshot of the current viewport, as a PNG file. Filesystem location is derived from the current world and character.
         * @note: Only works for SDL/TILES (otherwise the function returns `false`). A window (more precisely, a viewport) must already exist and the SDL renderer must be valid.
         * @returns `true` if the screenshot generation was successful, `false` otherwise.
@@ -874,7 +874,7 @@ class game
         // TILES only, in curses this does nothing
         void draw_highlight( const tripoint_bub_ms &p );
         // Draws an asynchronous animation at p with tile_id as its sprite. If ncstr is specified, it will also be displayed in curses.
-        void draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id,
+        void draw_async_anim( const tripoint_bub_ms &p, std::string_view tile_id,
                               const std::string &ncstr = "",
                               const nc_color &nccol = c_black );
         void draw_radiation_override( const tripoint_bub_ms &p, int rad );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -365,6 +365,8 @@ item_location game_menus::inv::titled_menu( Character &you, const std::string &t
     return inv_internal( you, inventory_selector_preset(), title, -1, msg );
 }
 
+namespace
+{
 class armor_inventory_preset: public inventory_selector_preset
 {
     public:
@@ -417,7 +419,10 @@ class armor_inventory_preset: public inventory_selector_preset
 
         const std::string color;
 };
+} // namespace
 
+namespace
+{
 class wear_inventory_preset: public armor_inventory_preset
 {
     public:
@@ -446,6 +451,7 @@ class wear_inventory_preset: public armor_inventory_preset
         const bodypart_id &bp;
 
 };
+} // namespace
 
 item_location game_menus::inv::wear( Character &you, const bodypart_id &bp )
 {
@@ -453,6 +459,8 @@ item_location game_menus::inv::wear( Character &you, const bodypart_id &bp )
                          _( "You have nothing to wear." ) );
 }
 
+namespace
+{
 class take_off_inventory_preset: public armor_inventory_preset
 {
     public:
@@ -474,6 +482,7 @@ class take_off_inventory_preset: public armor_inventory_preset
             return std::string();
         }
 };
+} // namespace
 
 item_location game_menus::inv::take_off()
 {
@@ -502,6 +511,8 @@ item_location game::inv_map_splice( const item_location_filter &filter, const st
                          title, radius, none_message );
 }
 
+namespace
+{
 class liquid_inventory_selector_preset : public inventory_selector_preset
 {
     public:
@@ -533,6 +544,7 @@ class liquid_inventory_selector_preset : public inventory_selector_preset
         const item &liquid;
         const item *const avoid;
 };
+} // namespace
 
 item_location game_menus::inv::container_for( Character &you, const item &liquid, int radius,
         const item *const avoid )
@@ -544,6 +556,8 @@ item_location game_menus::inv::container_for( Character &you, const item &liquid
                                         liquid.tname() ) );
 }
 
+namespace
+{
 class pickup_inventory_preset : public inventory_selector_preset
 {
     public:
@@ -674,6 +688,7 @@ class disassemble_inventory_preset : public inventory_selector_preset
         const Character &you;
         const inventory &inv;
 };
+} // namespace
 
 item_location game_menus::inv::disassemble( Character &you )
 {
@@ -682,6 +697,8 @@ item_location game_menus::inv::disassemble( Character &you )
                          _( "You don't have any items you could disassemble." ) );
 }
 
+namespace
+{
 class comestible_inventory_preset : public inventory_selector_preset
 {
     public:
@@ -932,6 +949,7 @@ class comestible_inventory_preset : public inventory_selector_preset
     private:
         const Character &you;
 };
+} // namespace
 
 static std::string get_consume_needs_hint( Character &you )
 {
@@ -1035,6 +1053,8 @@ static std::string get_consume_needs_hint( Character &you )
     return hint;
 }
 
+namespace
+{
 class comestible_filtered_inventory_preset : public comestible_inventory_preset
 {
     public:
@@ -1052,6 +1072,7 @@ class comestible_filtered_inventory_preset : public comestible_inventory_preset
     private:
         std::function<bool( const item &it )> predicate;
 };
+} // namespace
 
 
 item_location game_menus::inv::consume( const std::string &comestible_type_filter,
@@ -1093,6 +1114,8 @@ item_location game_menus::inv::consume( const std::string &comestible_type_filte
     return returned_location;
 }
 
+namespace
+{
 class activatable_inventory_preset : public pickup_inventory_preset
 {
     public:
@@ -1209,6 +1232,7 @@ class activatable_inventory_preset : public pickup_inventory_preset
     private:
         const Character &you;
 };
+} // namespace
 
 item_location game_menus::inv::use()
 {
@@ -1217,6 +1241,8 @@ item_location game_menus::inv::use()
                          _( "You don't have any items you can use." ) );
 }
 
+namespace
+{
 class gunmod_inventory_preset : public inventory_selector_preset
 {
     public:
@@ -1280,6 +1306,7 @@ class gunmod_inventory_preset : public inventory_selector_preset
         const Character &you;
         const item &gunmod;
 };
+} // namespace
 
 item_location game_menus::inv::gun_to_modify( Character &you, const item &gunmod )
 {
@@ -1288,6 +1315,8 @@ item_location game_menus::inv::gun_to_modify( Character &you, const item &gunmod
                          _( "You don't have any guns to modify." ) );
 }
 
+namespace
+{
 class gunmod_remove_inventory_preset : public inventory_selector_preset
 {
     public:
@@ -1337,6 +1366,7 @@ class gunmod_remove_inventory_preset : public inventory_selector_preset
         const Character &you;
         const item &gun;
 };
+} // namespace
 
 item_location game_menus::inv::gunmod_to_remove( Character &you, item &gun )
 {
@@ -1361,6 +1391,8 @@ item_location game_menus::inv::gunmod_to_remove( Character &you, item &gun )
     return location;
 }
 
+namespace
+{
 class ereader_inventory_preset : public pickup_inventory_preset
 {
     public:
@@ -1410,6 +1442,7 @@ class ereader_inventory_preset : public pickup_inventory_preset
     private:
         const Character &you;
 };
+} // namespace
 
 item_location game_menus::inv::ereader_to_use( Character &you )
 {
@@ -1417,6 +1450,8 @@ item_location game_menus::inv::ereader_to_use( Character &you )
     return inv_internal( you, ereader_inventory_preset( you ), _( "Select e-reader." ), 1, msg );
 }
 
+namespace
+{
 class read_inventory_preset: public pickup_inventory_preset
 {
     public:
@@ -1593,6 +1628,7 @@ class ebookread_inventory_preset : public read_inventory_preset
             return std::string();
         }
 };
+} // namespace
 
 item_location game_menus::inv::read( Character &you )
 {
@@ -1890,6 +1926,8 @@ drop_locations game_menus::inv::efile_select( Character &who, item_location &use
     return selected_efiles;
 }
 
+namespace
+{
 class steal_inventory_preset : public pickup_inventory_preset
 {
     public:
@@ -1903,6 +1941,7 @@ class steal_inventory_preset : public pickup_inventory_preset
     private:
         const Character &victim;
 };
+} // namespace
 
 item_location game_menus::inv::steal( Character &victim )
 {
@@ -1911,6 +1950,8 @@ item_location game_menus::inv::steal( Character &victim )
                          string_format( _( "%s's inventory is empty." ), victim.get_name() ) );
 }
 
+namespace
+{
 class weapon_inventory_preset: public inventory_selector_preset
 {
     public:
@@ -2015,6 +2056,7 @@ class weapon_inventory_preset: public inventory_selector_preset
 
         const Character &you;
 };
+} // namespace
 
 item_location game_menus::inv::wield()
 {
@@ -2107,6 +2149,8 @@ drop_locations game_menus::inv::unload_container()
     return dropped;
 }
 
+namespace
+{
 class saw_barrel_inventory_preset: public weapon_inventory_preset
 {
     public:
@@ -2162,7 +2206,10 @@ class saw_stock_inventory_preset : public weapon_inventory_preset
         const item &tool;
         const saw_stock_actor &actor;
 };
+} // namespace
 
+namespace
+{
 class target_practice_inventory_preset: public weapon_inventory_preset
 {
     public:
@@ -2227,7 +2274,10 @@ class attach_veh_tool_inventory_preset : public inventory_selector_preset
     private:
         const std::set<itype_id> allowed_types;
 };
+} // namespace
 
+namespace
+{
 class salvage_inventory_preset: public inventory_selector_preset
 {
     public:
@@ -2247,6 +2297,7 @@ class salvage_inventory_preset: public inventory_selector_preset
     private:
         const salvage_actor *actor;
 };
+} // namespace
 
 item_location game_menus::inv::salvage( Character &you, const salvage_actor *actor )
 {
@@ -2255,6 +2306,8 @@ item_location game_menus::inv::salvage( Character &you, const salvage_actor *act
                          _( "You have nothing to cut up." ) );
 }
 
+namespace
+{
 class repair_inventory_preset: public inventory_selector_preset
 {
     public:
@@ -2333,6 +2386,7 @@ class repair_inventory_preset: public inventory_selector_preset
         const item *main_tool;
         Character &character;
 };
+} // namespace
 
 static std::string get_repair_hint( const Character &you, const repair_item_actor *actor,
                                     const item *main_tool )
@@ -2517,6 +2571,8 @@ drop_locations game_menus::inv::pickup( const std::set<tripoint_bub_ms> &targets
     return pick_s.execute();
 }
 
+namespace
+{
 class smokable_selector_preset : public inventory_selector_preset
 {
     public:
@@ -2524,6 +2580,7 @@ class smokable_selector_preset : public inventory_selector_preset
             return !location->rotten() && location->is_smokable();
         }
 };
+} // namespace
 
 drop_locations game_menus::inv::smoke_food( Character &you, units::volume total_capacity,
         units::volume used_capacity )
@@ -2831,6 +2888,8 @@ static item_location autodoc_internal( Character &you, Character &patient,
     } while( true );
 }
 
+namespace
+{
 // Menu used by Autodoc when installing a bionic
 class bionic_install_preset: public inventory_selector_preset
 {
@@ -2991,6 +3050,7 @@ class bionic_install_surgeon_preset : public inventory_selector_preset
             return format_money( npc_trading::bionic_install_price( you, pa, loc ) );
         }
 };
+} // namespace
 
 item_location game_menus::inv::install_bionic( Character &installer, Character &patron,
         Character &patient, bool surgeon )
@@ -3004,6 +3064,8 @@ item_location game_menus::inv::install_bionic( Character &installer, Character &
 
 }
 
+namespace
+{
 class change_sprite_inventory_preset: public inventory_selector_preset
 {
     public:
@@ -3031,6 +3093,7 @@ class change_sprite_inventory_preset: public inventory_selector_preset
     protected:
         Character &you;
 };
+} // namespace
 
 item_location game_menus::inv::change_sprite( Character &you )
 {
@@ -3039,6 +3102,8 @@ item_location game_menus::inv::change_sprite( Character &you )
                          _( "You have nothing to wear." ) );
 }
 
+namespace
+{
 class unload_selector_preset : public inventory_selector_preset
 {
     public:
@@ -3052,6 +3117,7 @@ class unload_selector_preset : public inventory_selector_preset
     private:
         const Character &you;
 };
+} // namespace
 
 std::pair<item_location, bool> game_menus::inv::unload( Character &you )
 {
@@ -3076,6 +3142,8 @@ std::pair<item_location, bool> game_menus::inv::unload( Character &you )
     return inv_s.execute();
 }
 
+namespace
+{
 class select_ammo_inventory_preset : public inventory_selector_preset
 {
     public:
@@ -3204,6 +3272,7 @@ class select_ammo_inventory_preset : public inventory_selector_preset
         const item_location target;
         bool empty;
 };
+} // namespace
 
 item::reload_option game_menus::inv::select_ammo( Character &you, const item_location &loc,
         bool prompt, bool empty )

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -184,6 +184,8 @@ extern bool add_key_to_quick_shortcuts( int key, const std::string &category, bo
 
 static bool has_vehicle_control( avatar &player_character );
 
+namespace
+{
 class user_turn
 {
 
@@ -234,6 +236,7 @@ class user_turn
         }
 
 };
+} // namespace
 
 input_context game::get_player_input( std::string &action )
 {

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -163,6 +163,8 @@ bool harvest_entry::operator==( const harvest_entry &rhs ) const
     return drop == rhs.drop;
 }
 
+namespace
+{
 class harvest_entry_reader : public generic_typed_reader<harvest_entry_reader>
 {
     public:
@@ -181,6 +183,7 @@ class harvest_entry_reader : public generic_typed_reader<harvest_entry_reader>
             return ret;
         }
 };
+} // namespace
 
 void harvest_list::finalize()
 {

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -80,6 +80,8 @@ class keybindings_ui : public cataimgui::window
 
 static const std::string default_context_id( "default" );
 
+namespace
+{
 template <class T1, class T2>
 struct ContainsPredicate {
     const T1 &container;
@@ -91,6 +93,7 @@ struct ContainsPredicate {
         return std::find( container.begin(), container.end(), c ) != container.end();
     }
 };
+} // namespace
 
 bool input_context::action_uses_input( const std::string &action_id,
                                        const input_event &event ) const

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -242,6 +242,8 @@ struct inventory_input {
     inventory_entry *entry;
 };
 
+namespace
+{
 struct container_data {
     units::volume actual_capacity;
     units::volume total_capacity;
@@ -256,12 +258,15 @@ struct container_data {
                               unit_to_string( max_containable_length, true ) );
     }
 };
+} // namespace
 
 bool inventory_entry::operator==( const inventory_entry &other ) const
 {
     return get_category_ptr() == other.get_category_ptr() && locations == other.locations;
 }
 
+namespace
+{
 class selection_column_preset : public inventory_selector_preset
 {
     public:
@@ -304,6 +309,7 @@ class selection_column_preset : public inventory_selector_preset
             return inventory_selector_preset::get_color( entry );
         }
 };
+} // namespace
 
 void inventory_selector_save_state::serialize( JsonOut &json ) const
 {

--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -60,6 +60,8 @@ static std::optional<input_event> key_bound_to( const input_context &ctxt,
     }
 }
 
+namespace
+{
 class actmenu_cb : public uilist_callback
 {
     private:
@@ -81,6 +83,7 @@ class actmenu_cb : public uilist_callback
             return false;
         }
 };
+} // namespace
 
 item_action_generator::item_action_generator() = default;
 

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -47,6 +47,8 @@ static const flag_id json_flag_CASING( "CASING" );
 static const flag_id json_flag_MAG_DESTROY( "MAG_DESTROY" );
 static const flag_id json_flag_MAG_EJECT( "MAG_EJECT" );
 
+namespace
+{
 class pocket_favorite_callback : public uilist_callback
 {
     private:
@@ -78,6 +80,7 @@ class pocket_favorite_callback : public uilist_callback
         }
         bool key( const input_context &, const input_event &event, int entnum, uilist *menu ) override;
 };
+} // namespace
 
 void pocket_favorite_callback::refresh( uilist *menu )
 {

--- a/src/item_degrade.cpp
+++ b/src/item_degrade.cpp
@@ -88,6 +88,8 @@ static bool goes_bad_cache_is_for( const item *i )
     return goes_bad_temp_cache_for == i;
 }
 
+namespace
+{
 struct scoped_goes_bad_cache {
     explicit scoped_goes_bad_cache( item *i ) {
         goes_bad_cache_set( i );
@@ -96,6 +98,7 @@ struct scoped_goes_bad_cache {
         goes_bad_cache_unset();
     }
 };
+} // namespace
 } // namespace item_internal
 
 static const item *get_most_rotten_component( const item &craft )

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -75,6 +75,8 @@ template <typename T> struct enum_traits;
 // new object {"id": "CUT", "level": 1, "speed": 0.5} formats.
 // Produces std::pair<quality_id, itype::item_quality> for use with optional()
 // so that copy-from / extend / delete / proportional / relative all work.
+namespace
+{
 class item_quality_reader : public generic_typed_reader<item_quality_reader>
 {
     public:
@@ -125,6 +127,7 @@ class item_quality_reader : public generic_typed_reader<item_quality_reader>
             iter->second.level += parsed.second.level;
         }
 };
+} // namespace
 
 static const ammo_effect_str_id ammo_effect_COOKOFF( "COOKOFF" );
 static const ammo_effect_str_id ammo_effect_INCENDIARY( "INCENDIARY" );
@@ -1865,6 +1868,8 @@ Item_factory::~Item_factory() = default;
 
 Item_factory::Item_factory() = default;
 
+namespace
+{
 class iuse_function_wrapper : public iuse_actor
 {
     private:
@@ -1902,6 +1907,7 @@ class iuse_function_wrapper_with_info : public iuse_function_wrapper
             return std::make_unique<iuse_function_wrapper_with_info>( *this );
         }
 };
+} // namespace
 
 use_function::use_function( const std::string &type, const use_function_pointer f )
     : use_function( std::make_unique<iuse_function_wrapper>( type, f ) ) {}
@@ -2003,6 +2009,8 @@ static std::pair<std::string, use_function> use_function_reader_helper(
 }
 
 //reads use_function as either an object, array, or string into a map
+namespace
+{
 class use_function_reader_map : public generic_typed_reader<use_function_reader_map>
 {
     public:
@@ -2014,8 +2022,11 @@ class use_function_reader_map : public generic_typed_reader<use_function_reader_
             return use_function_reader_helper( ammo_scale, src, val );
         }
 };
+} // namespace
 
 //reads use_function as either an object, array, or string
+namespace
+{
 class use_function_reader_single : public generic_typed_reader<use_function_reader_single>
 {
     public:
@@ -2028,6 +2039,7 @@ class use_function_reader_single : public generic_typed_reader<use_function_read
             return use_function_reader_helper( ammo_scale, src, val ).second;
         }
 };
+} // namespace
 
 void Item_factory::init()
 {
@@ -2248,6 +2260,8 @@ void Item_factory::init()
 }
 
 //reads snippet as array or string
+namespace
+{
 class snippet_reader : public generic_typed_reader<snippet_reader>
 {
     public:
@@ -2269,6 +2283,7 @@ class snippet_reader : public generic_typed_reader<snippet_reader>
             return "";
         }
 };
+} // namespace
 
 void conditional_name::deserialize( const JsonObject &jo )
 {
@@ -3303,6 +3318,8 @@ void firing_requirement_set::deserialize_consumption_per_use(
 * Reads an array of gun modes in the following format:
 * [ gun_mode_id, display name, shots, flag ]
 */
+namespace
+{
 class gun_modes_reader : public generic_typed_reader<gun_modes_reader>
 {
     public:
@@ -3335,6 +3352,7 @@ class gun_modes_reader : public generic_typed_reader<gun_modes_reader>
             return std::pair<gun_mode_id, gun_modifier_data>( gun_mode_id::NULL_ID(), gun_modifier_data() );
         }
 };
+} // namespace
 
 void islot_gun::deserialize( const JsonObject &jo )
 {
@@ -3610,6 +3628,8 @@ void islot_tool::deserialize( const JsonObject &jo )
 * Reads an array of toolmod ammo-to-itype maps in the following format:
 * [ [ ammotype, [itype1, itype2, ..] ], .. ]
 */
+namespace
+{
 class magazine_adaptor_reader : public generic_typed_reader<magazine_adaptor_reader>
 {
     public:
@@ -3621,6 +3641,7 @@ class magazine_adaptor_reader : public generic_typed_reader<magazine_adaptor_rea
             return ret;
         }
 };
+} // namespace
 
 void islot_mod::deserialize( const JsonObject &jo )
 {
@@ -3653,6 +3674,8 @@ void islot_book::deserialize( const JsonObject &jo )
  * Format must be an array of array-pairs: [[a,b],[c,d]]
  * where a/c are string_id, b/d are int OR vitamin_units::mass string
  */
+namespace
+{
 class vitamins_reader : public generic_typed_reader<vitamins_reader>
 {
     public:
@@ -3675,6 +3698,7 @@ class vitamins_reader : public generic_typed_reader<vitamins_reader>
             val.throw_error( "vitamins reader read non-array" );
         }
 };
+} // namespace
 
 void islot_comestible::deserialize( const JsonObject &jo )
 {
@@ -3719,6 +3743,8 @@ void islot_comestible::deserialize( const JsonObject &jo )
     }
 }
 
+namespace
+{
 struct generic_result_reader : generic_typed_reader<generic_result_reader> {
     static constexpr bool read_objects = true;
     std::pair<std::pair<itype_id, std::string>, int> get_next( const JsonValue &jv ) const {
@@ -3743,6 +3769,7 @@ struct generic_result_reader : generic_typed_reader<generic_result_reader> {
         return ret;
     }
 };
+} // namespace
 
 void islot_brewable::deserialize( const JsonObject &jo )
 {
@@ -4076,6 +4103,8 @@ void Item_factory::add_special_pockets( itype &def )
     }
 }
 
+namespace
+{
 enum class grip_val : int {
     BAD = 0,
     NONE = 1,
@@ -4083,20 +4112,26 @@ enum class grip_val : int {
     WEAPON = 3,
     LAST = 4
 };
+} // namespace
 template<>
 struct enum_traits<grip_val> {
     static constexpr grip_val last = grip_val::LAST;
 };
+namespace
+{
 enum class length_val : int {
     HAND = 0,
     SHORT = 1,
     LONG = 2,
     LAST = 3
 };
+} // namespace
 template<>
 struct enum_traits<length_val> {
     static constexpr length_val last = length_val::LAST;
 };
+namespace
+{
 enum class surface_val : int {
     POINT = 0,
     LINE = 1,
@@ -4104,10 +4139,13 @@ enum class surface_val : int {
     EVERY = 3,
     LAST = 4
 };
+} // namespace
 template<>
 struct enum_traits<surface_val> {
     static constexpr surface_val last = surface_val::LAST;
 };
+namespace
+{
 enum class balance_val : int {
     CLUMSY = 0,
     UNEVEN = 1,
@@ -4115,6 +4153,7 @@ enum class balance_val : int {
     GOOD = 3,
     LAST = 4
 };
+} // namespace
 template<>
 struct enum_traits<balance_val> {
     static constexpr balance_val last = balance_val::LAST;
@@ -4242,6 +4281,8 @@ std::string enum_to_string<balance_val>( balance_val val )
 } // namespace io
 
 //a collection of int values that are summed to determine melee to_hit
+namespace
+{
 struct melee_accuracy {
     grip_val grip = grip_val::WEAPON;
     length_val length = length_val::HAND;
@@ -4310,6 +4351,7 @@ class melee_accuracy_reader : public generic_typed_reader<melee_accuracy_reader>
             return false;
         }
 };
+} // namespace
 
 static void replace_materials( const JsonObject &jo, itype &def )
 {

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -495,11 +495,14 @@ double item::effective_dps( const Character &guy, Creature &mon ) const
     return total_damage * to_moves<double>( 1_seconds ) / total_moves;
 }
 
+namespace
+{
 struct dps_comp_data {
     mtype_id mon_id;
     bool display;
     bool evaluate;
 };
+} // namespace
 
 static const std::vector<std::pair<translation, dps_comp_data>> dps_comp_monsters = {
     { to_translation( "Best" ), { pseudo_debug_mon, true, false } },

--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -1984,6 +1984,8 @@ void item::pet_armor_protection_info( std::vector<iteminfo> &info,
     }
 }
 
+namespace
+{
 // simple struct used for organizing encumbrance in an ordered set
 struct armor_encumb_data {
     int encumb;
@@ -2003,10 +2005,11 @@ struct armor_encumb_data {
     }
 };
 
-static bool operator<( const armor_encumb_data &lhs, const armor_encumb_data &rhs )
+bool operator<( const armor_encumb_data &lhs, const armor_encumb_data &rhs )
 {
     return lhs.encumb < rhs.encumb;
 }
+} // namespace
 
 void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                        bool debug ) const

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -808,6 +808,8 @@ void effect_data::deserialize( const JsonObject &jo )
 
 } // namespace iuse
 
+namespace
+{
 class drug_vitamin_reader : public generic_typed_reader<drug_vitamin_reader>
 {
     public:
@@ -824,6 +826,7 @@ class drug_vitamin_reader : public generic_typed_reader<drug_vitamin_reader>
             return std::pair<vitamin_id, std::pair<int, int>>( ja.get_string( 0 ), std::make_pair( lo, hi ) );
         }
 };
+} // namespace
 
 void consume_drug_iuse::load( const JsonObject &obj, const std::string & )
 {
@@ -1324,6 +1327,8 @@ std::unique_ptr<iuse_actor> reveal_map_actor::clone() const
     return std::make_unique<reveal_map_actor>( *this );
 }
 
+namespace
+{
 class omt_reveal_type_reader : public generic_typed_reader<omt_reveal_type_reader>
 {
     public:
@@ -1339,6 +1344,7 @@ class omt_reveal_type_reader : public generic_typed_reader<omt_reveal_type_reade
                                    jo.get_enum_value<ot_match_type>( "om_terrain_match_type", ot_match_type::contains ) );
         }
 };
+} // namespace
 
 void reveal_map_actor::load( const JsonObject &obj, const std::string & )
 {

--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -22,6 +22,8 @@
 #include "cursesdef.h"
 #endif // TILES
 
+namespace
+{
 struct ui_state {
     ui_adaptor *ui;
     background_pane *bg;
@@ -46,6 +48,7 @@ struct ui_state {
     std::string context;
     std::string step;
 };
+} // namespace
 
 static ui_state *gLUI = nullptr;
 

--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -96,15 +96,15 @@ static void redraw()
     ImGui::PopStyleVar();
 
 #else
-    int x = ( TERMX - static_cast<int>( gLUI->splash_width ) ) / 2;
-    int y = 0;
+    point cursor( ( TERMX - static_cast<int>( gLUI->splash_width ) ) / 2, 0 );
     nc_color white = c_white;
     for( const std::string &line : gLUI->splash ) {
         if( !line.empty() && line[0] == '#' ) {
             continue;
         }
-        print_colored_text( catacurses::stdscr, point( x, y++ ), white,
+        print_colored_text( catacurses::stdscr, cursor, white,
                             white, line );
+        cursor.y++;
     }
     mvwprintz( catacurses::stdscr, point( 0, TERMY - 1 ), c_black, gLUI->blanks );
     center_print( catacurses::stdscr, TERMY - 1, c_white, string_format( "%s %s",

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2750,6 +2750,8 @@ static void refresh_favorite( uilist *menu, std::vector<spell *> known_spells )
     }
 }
 
+namespace
+{
 class spellcasting_callback : public uilist_callback
 {
     private:
@@ -2833,6 +2835,7 @@ class spellcasting_callback : public uilist_callback
             }
         }
 };
+} // namespace
 
 const std::set<int> spellcasting_callback::reserved_invlets { 'I', '=', '*' };
 

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -107,6 +107,8 @@ static const trait_id trait_PACIFIST( "PACIFIST" );
 
 namespace spell_detail
 {
+namespace
+{
 struct line_iterable {
     const std::vector<point_rel_ms> &delta_line;
     point_rel_ms cur_origin;
@@ -135,6 +137,7 @@ struct line_iterable {
         index = 0;
     }
 };
+} // namespace
 // Orientation of point C relative to line AB
 static int side_of( const point_rel_ms &a, const point_rel_ms &b, const point_rel_ms &c )
 {

--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -173,6 +173,8 @@ void teleporter_list::deserialize( const JsonObject &data )
     }
 }
 
+namespace
+{
 class teleporter_callback : public uilist_callback
 {
     private:
@@ -194,6 +196,7 @@ class teleporter_callback : public uilist_callback
             }
         }
 };
+} // namespace
 
 std::optional<tripoint_abs_omt> teleporter_list::choose_teleport_location()
 {

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -65,6 +65,8 @@
 static const mod_id MOD_INFORMATION_dda( "dda" );
 static const mod_id MOD_INFORMATION_dda_tutorial( "dda_tutorial" );
 
+namespace
+{
 enum class main_menu_opts : int {
     MOTD = 0,
     NEWCHAR,
@@ -77,6 +79,7 @@ enum class main_menu_opts : int {
     QUIT,
     NUM_MENU_OPTS,
 };
+} // namespace
 
 std::string main_menu::queued_world_to_load;
 std::string main_menu::queued_save_id_to_load;

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -49,6 +49,8 @@ static std::string find_region_filename( const tripoint &p )
     return string_format( "%d.%d.%d.mmr", p.x, p.y, p.z );
 }
 
+namespace
+{
 /**
  * Helper class for converting global sm coord into
  * global mm_region coord + sm coord within the region.
@@ -61,6 +63,7 @@ struct reg_coord_pair {
         reg = tripoint( sm_to_mmr_remain( sm_loc.x(), sm_loc.y() ), p.z() );
     }
 };
+} // namespace
 
 mm_submap::mm_submap( bool make_valid ) : valid( make_valid ) {}
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -411,6 +411,8 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
     set_abs_sub( p_sm_base );
 }
 
+namespace
+{
 class spawn_data_ammo_reader : public generic_typed_reader<spawn_data_ammo_reader>
 {
     public:
@@ -436,6 +438,7 @@ class spawn_data_patrol_reader : public generic_typed_reader<spawn_data_patrol_r
             return point_rel_ms( ptx.get(), pty.get() );
         }
 };
+} // namespace
 
 void spawn_data::deserialize( const JsonObject &jo )
 {
@@ -475,6 +478,8 @@ void mapgen_function_builtin::generate( mapgendata &mgd )
 ///// mapgen_function class.
 ///// all sorts of ways to apply our hellish reality to a grid-o-squares
 
+namespace
+{
 class mapgen_basic_container
 {
     private:
@@ -662,6 +667,7 @@ class mapgen_factory
                                                    string_format( "map special %s", key ) );
         }
 };
+} // namespace
 
 static mapgen_factory oter_mapgen;
 
@@ -1888,6 +1894,8 @@ ret_val<void> jmapgen_piece_with_has_vehicle_collision::has_vehicle_collision(
 }
 
 
+namespace
+{
 /**
  * This is a generic mapgen piece, the template parameter PieceType should be another specific
  * type of jmapgen_piece. This class contains a vector of those objects and will chose one of
@@ -2542,6 +2550,7 @@ class jmapgen_monster_group : public jmapgen_piece
             id.check( oter_name, parameters );
         }
 };
+} // namespace
 /**
  * Place spawn points for a specific monster.
  * "monster": id of the monster. or "group": id of the monster group.
@@ -2689,6 +2698,8 @@ class jmapgen_monster : public jmapgen_piece
         }
 };
 
+namespace
+{
 /**
  * Place a vehicle.
  * "vehicle": id of the vehicle.
@@ -3954,6 +3965,7 @@ class jmapgen_nested : public jmapgen_piece
             return ret_val<void>::make_success();
         }
 };
+} // namespace
 
 jmapgen_objects::jmapgen_objects( const tripoint_rel_ms &offset, const point_rel_ms &mapsize,
                                   const point_rel_ms &tot_size )
@@ -4588,6 +4600,8 @@ void update_mapgen_function_json::finalize_parameters()
     finalize_parameters_common();
 }
 
+namespace
+{
 struct phase_comparator {
     mapgen_phase get_phase( mapgen_phase p ) const {
         return p;
@@ -4607,6 +4621,7 @@ struct phase_comparator {
         return get_phase( l ) < get_phase( r );
     }
 };
+} // namespace
 
 static const phase_comparator compare_phases{};
 
@@ -7608,6 +7623,8 @@ ret_val<void> update_mapgen_function_json::update_map(
     return u;
 }
 
+namespace
+{
 class rotation_guard
 {
     public:
@@ -7631,6 +7648,7 @@ class rotation_guard
         const mapgendata &md;
         const int rotation;
 };
+} // namespace
 
 ret_val<void> update_mapgen_function_json::update_map( const mapgendata &md,
         const tripoint_rel_ms &offset,

--- a/src/mapgen_post_process.cpp
+++ b/src/mapgen_post_process.cpp
@@ -276,6 +276,8 @@ void pp_sub_generator::check( const std::string &ctx ) const
     }
 }
 
+namespace
+{
 enum class blood_trail_direction : int {
     first = 1,
     NORTH = 1,
@@ -284,6 +286,7 @@ enum class blood_trail_direction : int {
     WEST = 4,
     last = 4
 };
+} // namespace
 
 static tripoint_bub_ms get_point_from_direction( int direction,
         const tripoint_bub_ms &current_tile )

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -200,6 +200,8 @@ static void add_if_exists( const JsonObject &jo, Container &cont, bool was_loade
     }
 }
 
+namespace
+{
 class ma_skill_reader : public generic_typed_reader<ma_skill_reader>
 {
     public:
@@ -230,6 +232,7 @@ class ma_weapon_damage_reader : public generic_typed_reader<ma_weapon_damage_rea
             } );
         }
 };
+} // namespace
 
 tech_effect_data load_tech_effect_data( const JsonObject &e )
 {
@@ -239,6 +242,8 @@ tech_effect_data load_tech_effect_data( const JsonObject &e )
                              json_character_flag( e.get_string( "req_flag", "NULL" ) ) );
 }
 
+namespace
+{
 class tech_effect_reader : public generic_typed_reader<tech_effect_reader>
 {
     public:
@@ -254,6 +259,7 @@ class tech_effect_reader : public generic_typed_reader<tech_effect_reader>
             } );
         }
 };
+} // namespace
 
 void ma_requirements::load( const JsonObject &jo, std::string_view )
 {
@@ -420,6 +426,8 @@ void martialart::finalize_all()
     martialarts.finalize();
 }
 
+namespace
+{
 class ma_buff_reader : public generic_typed_reader<ma_buff_reader>
 {
     public:
@@ -432,6 +440,7 @@ class ma_buff_reader : public generic_typed_reader<ma_buff_reader>
             return mabuff_id( jsobj.get_string( "id" ) );
         }
 };
+} // namespace
 
 void martialart::load( const JsonObject &jo, std::string_view src )
 {
@@ -611,6 +620,8 @@ void check_martialarts()
  * Note: this class must not contain any new members, it will be converted to a plain
  * effect_type later and that would slice the new members of.
  */
+namespace
+{
 class ma_buff_effect_type : public effect_type
 {
     public:
@@ -634,6 +645,7 @@ class ma_buff_effect_type : public effect_type
             apply_msgs.emplace_back( no_translation( "" ), m_good );
         }
 };
+} // namespace
 
 void finalize_martial_arts()
 {
@@ -2217,6 +2229,8 @@ std::string ma_technique::get_description() const
     return dump;
 }
 
+namespace
+{
 class ma_details_ui
 {
         friend class ma_details_ui_impl;
@@ -2542,6 +2556,7 @@ void ma_details_ui_impl::draw_controls()
 
     draw_ma_details_text();
 }
+} // namespace
 
 static void show_ma_details_ui( const matype_id &style_selected )
 {

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -64,11 +64,14 @@ static const trait_id trait_SUNLIGHT_DEPENDENT( "SUNLIGHT_DEPENDENT" );
 
 template <typename T> struct enum_traits;
 
+namespace
+{
 enum class medical_tab_mode {
     TAB_LIMBS,
     TAB_SUMMARY,
     last
 };
+} // namespace
 
 template<>
 struct enum_traits<medical_tab_mode> {
@@ -76,6 +79,8 @@ struct enum_traits<medical_tab_mode> {
     static constexpr medical_tab_mode first = medical_tab_mode::TAB_LIMBS;
 };
 
+namespace
+{
 class medical_ui : public cataimgui::window
 {
     public:
@@ -124,6 +129,7 @@ class medical_ui : public cataimgui::window
             return ImGui::GetWindowSize().x / 2;
         }
 };
+} // namespace
 
 bool Character::disp_medical()
 {
@@ -696,12 +702,15 @@ void medical_ui::draw_controls()
     }
 }
 
+namespace
+{
 struct healing_option {
     wound_type_id wd;
     wound_fix_id fix;
     bool doable;
     time_duration time_to_apply;
 };
+} // namespace
 
 bool Character::pick_wound_fix( const bodypart_id &bp_id )
 {

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -521,6 +521,8 @@ static bool msg_type_from_name( game_message_type &type, const std::string &name
 
 namespace Messages
 {
+namespace
+{
 // NOLINTNEXTLINE(cata-xy)
 class dialog
 {
@@ -586,6 +588,7 @@ class dialog
 
         bool first_init = true;
 };
+} // namespace
 } // namespace Messages
 
 Messages::dialog::dialog()

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -176,10 +176,13 @@ static const std::string camp_upgrade_expansion_npc_string = "_faction_upgrade_e
 static const std::string caravan_commune_center_job_assign_parameter = "Assign";
 static const std::string caravan_commune_center_job_active_parameter = "Active";
 
+namespace
+{
 struct miss_data {
     std::string serialize_id;  // Serialized string for enum
     translation action;        // Optional extended UI description of task for return.
 };
+} // namespace
 namespace io
 {
 

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -32,6 +32,8 @@
 
 static const faction_id faction_no_faction( "no_faction" );
 
+namespace
+{
 enum class mission_ui_tab_enum : int {
     ACTIVE = 0,
     COMPLETED,
@@ -39,6 +41,7 @@ enum class mission_ui_tab_enum : int {
     POINTS_OF_INTEREST,
     num_tabs
 };
+} // namespace
 
 static mission_ui_tab_enum &operator++( mission_ui_tab_enum &c )
 {
@@ -58,6 +61,8 @@ static mission_ui_tab_enum &operator--( mission_ui_tab_enum &c )
     return c;
 }
 
+namespace
+{
 class mission_ui
 {
         friend class mission_ui_impl;
@@ -487,6 +492,7 @@ void mission_ui_impl::draw_location( const std::string &label,
         draw_label_with_value( _( "Distance:" ), distance_str );
     }
 }
+} // namespace
 
 void game::list_missions()
 {

--- a/src/mmap_file.cpp
+++ b/src/mmap_file.cpp
@@ -41,6 +41,8 @@ struct mmap_file::impl {
     virtual void *base() const = 0;
 };
 
+namespace
+{
 struct malloc_impl : mmap_file::impl {
     explicit malloc_impl( size_t size ) {
         if( ( base_ = malloc( size ) ) ) {
@@ -289,6 +291,7 @@ struct file_impl : mmap_file::impl {
         return true;
     }
 };
+} // namespace
 
 std::unique_ptr<mmap_file> mmap_file::map_file_generic(
     const std::filesystem::path &file_path,

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4402,10 +4402,13 @@ bool mattack::kamikaze( monster *z )
     return true;
 }
 
+namespace
+{
 struct grenade_helper_struct {
     std::string message;
     int chance = 1;
 };
+} // namespace
 
 // Returns 0 if this should be retired, 1 if it was successful, and -1 if something went horribly wrong
 static int grenade_helper( monster *const z, Creature *const target, const int dist,

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -554,7 +554,7 @@ mtype MonsterGenerator::generate_fake_pseudo_dormant_monster( const mtype &mon )
     }
     // add the special attack.
     // first make a new mon_spellcasting_actor actor
-    std::unique_ptr<mon_spellcasting_actor> new_actor( new mon_spellcasting_actor() );
+    std::unique_ptr<mon_spellcasting_actor> new_actor = std::make_unique<mon_spellcasting_actor>();
     new_actor->allow_no_target = true;
     new_actor->cooldown = 1;
     new_actor->spell_data.id = spell_pseudo_dormant_trap_setup;

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -276,6 +276,8 @@ static creature_size volume_to_size( const units::volume &vol )
     return creature_size::huge;
 }
 
+namespace
+{
 struct monster_adjustment {
     species_id species;
     std::string stat;
@@ -285,6 +287,7 @@ struct monster_adjustment {
     std::string special;
     void apply( mtype &mon ) const;
 };
+} // namespace
 
 void monster_adjustment::apply( mtype &mon ) const
 {
@@ -1256,6 +1259,8 @@ mtype_id MonsterGenerator::get_valid_hallucination() const
     return random_entry( hallucination_monsters );
 }
 
+namespace
+{
 class mattack_hardcoded_wrapper : public mattack_actor
 {
     private:
@@ -1275,6 +1280,7 @@ class mattack_hardcoded_wrapper : public mattack_actor
 
         void load_internal( const JsonObject &, const std::string & ) override {}
 };
+} // namespace
 
 mtype_special_attack::mtype_special_attack( const mattack_id &id, const mon_action_attack f )
     : mtype_special_attack( std::make_unique<mattack_hardcoded_wrapper>( id, f ) ) {}

--- a/src/mutation_type.cpp
+++ b/src/mutation_type.cpp
@@ -2,9 +2,12 @@
 
 #include "flexbuffer_json.h"
 
+namespace
+{
 struct mutation_type {
     std::string id;
 };
+} // namespace
 
 static std::map<std::string, mutation_type> mutation_types;
 

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -19,6 +19,8 @@
 #include "string_formatter.h"
 #include "translations.h"
 #include "ui_manager.h"
+namespace
+{
 enum class mutation_menu_mode {
     activating,
     examining,
@@ -30,6 +32,7 @@ enum class mutation_tab_mode {
     passive,
     none
 };
+} // namespace
 // '!' and '=' are uses as default bindings in the menu
 static const invlet_wrapper
 mutation_chars( "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\"#&()*+./:;@[\\]^_{|}" );

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -72,7 +72,7 @@ int get_window_height()
 catacurses::window catacurses::newwin( const int nlines, const int ncols, const point &begin )
 {
     // TODO: check for errors
-    const auto w = ::newwin( nlines, ncols, begin.y, begin.x );
+    ::WINDOW *const w = ::newwin( nlines, ncols, begin.y, begin.x );
     return catacurses::window( std::shared_ptr<void>( w, []( void *const w ) {
         ::curses_check_result( ::delwin( static_cast<::WINDOW *>( w ) ), OK, "delwin" );
     } ) );
@@ -332,9 +332,8 @@ catacurses::window catacurses::newscr;
 void catacurses::resizeterm()
 {
 #if !defined(USE_PDCURSES)
-    const int new_x = ::getmaxx( stdscr.get<::WINDOW>() );
-    const int new_y = ::getmaxy( stdscr.get<::WINDOW>() );
-    if( ::is_term_resized( new_x, new_y ) )
+    const point new_size( ::getmaxx( stdscr.get<::WINDOW>() ), ::getmaxy( stdscr.get<::WINDOW>() ) );
+    if( ::is_term_resized( new_size.x, new_size.y ) )
 #endif
     {
         game_ui::init_ui();
@@ -621,8 +620,8 @@ void check_encoding()
         int key = ERR;
         do {
             const char *unicode_error_msg =
-                _( "You don't seem to have a valid Unicode locale. You may see some weird "
-                   "characters (e.g. empty boxes or question marks). You have been warned." );
+                _( "You don't seem to have a valid Unicode locale.  You may see some weird "
+                   "characters (e.g. empty boxes or question marks).  You have been warned." );
             catacurses::erase();
             const int maxx = getmaxx( catacurses::stdscr );
             fold_and_print( catacurses::stdscr, point::zero, maxx, c_white, unicode_error_msg );

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -569,8 +569,8 @@ bool nc_color::is_blink() const
     return attribute_value & A_BLINK;
 }
 
-void ensure_term_size(); // NOLINT(cata-static-declarations)
-void check_encoding(); // NOLINT(cata-static-declarations)
+void ensure_term_size(); // NOLINT(cata-static-declarations,misc-use-internal-linkage)
+void check_encoding(); // NOLINT(cata-static-declarations,misc-use-internal-linkage)
 
 void ensure_term_size()
 {
@@ -632,6 +632,7 @@ void check_encoding()
     }
 }
 
+// NOLINTNEXTLINE(cata-use-string_view): signature mirrors sdltiles/wincurse impls
 void set_title( const std::string & )
 {
     // curses does not seem to have a portable way of setting the window title.

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -83,7 +83,7 @@ void catacurses::wnoutrefresh( const window &win )
     if( !win ) {
         return;
     }
-    return curses_check_result( ::wnoutrefresh( win.get<::WINDOW>() ), OK, "wnoutrefresh" );
+    curses_check_result( ::wnoutrefresh( win.get<::WINDOW>() ), OK, "wnoutrefresh" );
 }
 
 void catacurses::wrefresh( const window &win )
@@ -91,7 +91,7 @@ void catacurses::wrefresh( const window &win )
     if( !win ) {
         return;
     }
-    return curses_check_result( ::wrefresh( win.get<::WINDOW>() ), OK, "wrefresh" );
+    curses_check_result( ::wrefresh( win.get<::WINDOW>() ), OK, "wrefresh" );
 }
 
 void catacurses::werase( const window &win )
@@ -99,7 +99,7 @@ void catacurses::werase( const window &win )
     if( !win ) {
         return;
     }
-    return curses_check_result( ::werase( win.get<::WINDOW>() ), OK, "werase" );
+    curses_check_result( ::werase( win.get<::WINDOW>() ), OK, "werase" );
 }
 
 int catacurses::getmaxx( const window &win )
@@ -155,7 +155,7 @@ void catacurses::wattroff( const window &win, const nc_color attrs )
     if( !win ) {
         return;
     }
-    return curses_check_result( ::wattroff( win.get<::WINDOW>(), attrs.to_int() ), OK, "wattroff" );
+    curses_check_result( ::wattroff( win.get<::WINDOW>(), attrs.to_int() ), OK, "wattroff" );
 }
 
 void catacurses::wattron( const window &win, const nc_color &attrs )
@@ -163,7 +163,7 @@ void catacurses::wattron( const window &win, const nc_color &attrs )
     if( !win ) {
         return;
     }
-    return curses_check_result( ::wattron( win.get<::WINDOW>(), attrs.to_int() ), OK, "wattron" );
+    curses_check_result( ::wattron( win.get<::WINDOW>(), attrs.to_int() ), OK, "wattron" );
 }
 
 void catacurses::wmove( const window &win, const point &p )
@@ -171,7 +171,7 @@ void catacurses::wmove( const window &win, const point &p )
     if( !win ) {
         return;
     }
-    return curses_check_result( ::wmove( win.get<::WINDOW>(), p.y, p.x ), OK, "wmove" );
+    curses_check_result( ::wmove( win.get<::WINDOW>(), p.y, p.x ), OK, "wmove" );
 }
 
 void catacurses::mvwprintw( const window &win, const point &p, const std::string &text )
@@ -179,8 +179,8 @@ void catacurses::mvwprintw( const window &win, const point &p, const std::string
     if( !win ) {
         return;
     }
-    return curses_check_result( ::mvwprintw( win.get<::WINDOW>(), p.y, p.x, "%s", text.c_str() ),
-                                OK, "mvwprintw" );
+    curses_check_result( ::mvwprintw( win.get<::WINDOW>(), p.y, p.x, "%s", text.c_str() ),
+                         OK, "mvwprintw" );
 }
 
 void catacurses::wprintw( const window &win, const std::string &text )
@@ -188,13 +188,13 @@ void catacurses::wprintw( const window &win, const std::string &text )
     if( !win ) {
         return;
     }
-    return curses_check_result( ::wprintw( win.get<::WINDOW>(), "%s", text.c_str() ),
-                                OK, "wprintw" );
+    curses_check_result( ::wprintw( win.get<::WINDOW>(), "%s", text.c_str() ),
+                         OK, "wprintw" );
 }
 
 void catacurses::refresh()
 {
-    return curses_check_result( ::refresh(), OK, "refresh" );
+    curses_check_result( ::refresh(), OK, "refresh" );
 }
 
 void refresh_display()
@@ -211,23 +211,23 @@ void refresh_mouse_config()
 
 void catacurses::doupdate()
 {
-    return curses_check_result( ::doupdate(), OK, "doupdate" );
+    curses_check_result( ::doupdate(), OK, "doupdate" );
 }
 
 void catacurses::clear()
 {
-    return curses_check_result( ::clear(), OK, "clear" );
+    curses_check_result( ::clear(), OK, "clear" );
 }
 
 void catacurses::erase()
 {
-    return curses_check_result( ::erase(), OK, "erase" );
+    curses_check_result( ::erase(), OK, "erase" );
 }
 
 void catacurses::endwin()
 {
     ui_manager::reset();
-    return curses_check_result( ::endwin(), OK, "endwin" );
+    curses_check_result( ::endwin(), OK, "endwin" );
 }
 
 void catacurses::wborder( const window &win, const chtype ls, const chtype rs, const chtype ts,
@@ -236,8 +236,8 @@ void catacurses::wborder( const window &win, const chtype ls, const chtype rs, c
     if( !win ) {
         return;
     }
-    return curses_check_result( ::wborder( win.get<::WINDOW>(), ls, rs, ts, bs, tl, tr, bl, br ), OK,
-                                "wborder" );
+    curses_check_result( ::wborder( win.get<::WINDOW>(), ls, rs, ts, bs, tl, tr, bl, br ), OK,
+                         "wborder" );
 }
 
 void catacurses::mvwhline( const window &win, const point &p, const chtype ch, const int n )
@@ -245,8 +245,8 @@ void catacurses::mvwhline( const window &win, const point &p, const chtype ch, c
     if( !win ) {
         return;
     }
-    return curses_check_result( ::mvwhline( win.get<::WINDOW>(), p.y, p.x, ch, n ), OK,
-                                "mvwhline" );
+    curses_check_result( ::mvwhline( win.get<::WINDOW>(), p.y, p.x, ch, n ), OK,
+                         "mvwhline" );
 }
 
 void catacurses::mvwvline( const window &win, const point &p, const chtype ch, const int n )
@@ -254,8 +254,8 @@ void catacurses::mvwvline( const window &win, const point &p, const chtype ch, c
     if( !win ) {
         return;
     }
-    return curses_check_result( ::mvwvline( win.get<::WINDOW>(), p.y, p.x, ch, n ), OK,
-                                "mvwvline" );
+    curses_check_result( ::mvwvline( win.get<::WINDOW>(), p.y, p.x, ch, n ), OK,
+                         "mvwvline" );
 }
 
 void catacurses::mvwaddch( const window &win, const point &p, const chtype ch )
@@ -263,7 +263,7 @@ void catacurses::mvwaddch( const window &win, const point &p, const chtype ch )
     if( !win ) {
         return;
     }
-    return curses_check_result( ::mvwaddch( win.get<::WINDOW>(), p.y, p.x, ch ), OK, "mvwaddch" );
+    curses_check_result( ::mvwaddch( win.get<::WINDOW>(), p.y, p.x, ch ), OK, "mvwaddch" );
 }
 
 void catacurses::waddch( const window &win, const chtype ch )
@@ -271,7 +271,7 @@ void catacurses::waddch( const window &win, const chtype ch )
     if( !win ) {
         return;
     }
-    return curses_check_result( ::waddch( win.get<::WINDOW>(), ch ), OK, "waddch" );
+    curses_check_result( ::waddch( win.get<::WINDOW>(), ch ), OK, "waddch" );
 }
 
 void catacurses::wredrawln( const window &win, const int beg_line, const int num_lines )
@@ -279,8 +279,8 @@ void catacurses::wredrawln( const window &win, const int beg_line, const int num
     if( !win ) {
         return;
     }
-    return curses_check_result( ::wredrawln( win.get<::WINDOW>(), beg_line, num_lines ), OK,
-                                "wredrawln" );
+    curses_check_result( ::wredrawln( win.get<::WINDOW>(), beg_line, num_lines ), OK,
+                         "wredrawln" );
 }
 
 void catacurses::wclear( const window &win )
@@ -288,12 +288,12 @@ void catacurses::wclear( const window &win )
     if( !win ) {
         return;
     }
-    return curses_check_result( ::wclear( win.get<::WINDOW>() ), OK, "wclear" );
+    curses_check_result( ::wclear( win.get<::WINDOW>() ), OK, "wclear" );
 }
 
 void catacurses::curs_set( const int visibility )
 {
-    return curses_check_result( ::curs_set( visibility ), OK, "curs_set" );
+    curses_check_result( ::curs_set( visibility ), OK, "curs_set" );
 }
 
 // As long as these assertions hold, we can just case base_color into short and
@@ -320,8 +320,8 @@ void catacurses::init_pair( const short pair, const base_color f, const base_col
     if( imclient ) {
         imclient->upload_color_pair( pair, static_cast<int>( f ), static_cast<int>( b ) );
     }
-    return curses_check_result( ::init_pair( pair, static_cast<short>( f ), static_cast<short>( b ) ),
-                                OK, "init_pair" );
+    curses_check_result( ::init_pair( pair, static_cast<short>( f ), static_cast<short>( b ) ),
+                         OK, "init_pair" );
 }
 
 catacurses::window catacurses::stdscr;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -319,6 +319,8 @@ static int has_unspent_points( const Character &u )
     return points_used_total( u ) < point_pool_total();
 }
 
+namespace
+{
 struct multi_pool {
     // The amount of unspent points in the pool without counting the borrowed points
     const int pure_stat_points, pure_trait_points, pure_skill_points;
@@ -337,6 +339,7 @@ struct multi_pool {
     {}
 
 };
+} // namespace
 
 // Toggle this trait and all prereqs, removing upgrades on removal
 void Character::toggle_trait_deps( const trait_id &tr, const std::string &variant )
@@ -1932,6 +1935,8 @@ void draw_scenario_details( const avatar &u )
     }
 }
 
+namespace
+{
 enum description_selector {
     NAME,
     GENDER,
@@ -1941,6 +1946,7 @@ enum description_selector {
     BLOOD,
     LOCATION
 };
+} // namespace
 
 void draw_name( const avatar &you, bool no_name_entered )
 {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -192,9 +192,12 @@ static std::map<std::string, json_talk_topic> json_talk_topics;
 using item_menu = std::function<item_location( const item_location_filter & )>;
 using item_menu_mul = std::function<drop_locations( const item_location_filter & )>;
 
+// NOLINTNEXTLINE(misc-use-internal-linkage): extern template instantiation of non-anon-ns template
 extern template struct value_or_var<diag_value, eoc_math, string_mutator<translation>>;
 using diag_value_or_var = value_or_var<diag_value, eoc_math, string_mutator<translation>>;
 
+namespace
+{
 struct sub_effect_parser {
     using f_t = talk_effect_fun_t::func( * )( const JsonObject &, std::string_view,
                 std::string_view src );
@@ -244,7 +247,10 @@ struct sub_effect_parser {
     std::function<talk_effect_fun_t( const JsonObject &, std::string_view, std::string_view src, bool )>
     f;
 };
+} // namespace
 
+namespace
+{
 struct item_search_data {
 
     std::vector<str_or_var> id;
@@ -469,6 +475,7 @@ struct item_search_data {
         return true;
     }
 };
+} // namespace
 
 #define dbg(x) DebugLog((x),D_GAME) << __FILE__ << ":" << __LINE__ << ": "
 
@@ -517,11 +524,13 @@ static std::vector<effect_on_condition_id> load_eoc_vector( const JsonObject &jo
     return eocs;
 }
 
+namespace
+{
 struct eoc_entry {
     effect_on_condition_id id;
     std::optional<str_or_var> var;
 };
-static std::vector<eoc_entry>
+std::vector<eoc_entry>
 load_eoc_vector_id_and_var(
     const JsonObject &jo, std::string_view member, std::string_view src )
 {
@@ -549,6 +558,7 @@ load_eoc_vector_id_and_var(
     }
     return eocs_entries;
 }
+} // namespace
 
 
 /** Time (in turns) and cost (in cent) for training: */
@@ -659,6 +669,8 @@ int npc_trading::cash_to_favor( const npc &, int cash )
     return roll_remainder( scaled_mission_val );
 }
 
+namespace
+{
 enum npc_chat_menu {
     NPC_CHAT_DONE,
     NPC_CHAT_TALK,
@@ -703,6 +715,7 @@ enum npc_chat_menu {
     NPC_CHAT_ACTIVITIES_VEHICLE_REPAIR,
     NPC_CHAT_ACTIVITIES_UNASSIGN
 };
+} // namespace
 
 // given a vector of NPCs, presents a menu to allow a player to pick one.
 // everyone == true adds another entry at the end to allow selecting all listed NPCs

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3327,6 +3327,8 @@ options_manager::PageItem::fmt_tooltip( const std::string &group_id,
     }
 }
 
+namespace
+{
 /** String with color */
 struct string_col {
     std::string s;
@@ -3335,6 +3337,7 @@ struct string_col {
     string_col() : col( c_black ) { }
     string_col( const std::string &s, nc_color col ) : s( s ), col( col ) { }
 };
+} // namespace
 
 std::string options_manager::show( bool ingame, const bool world_options_only, bool with_tabs )
 {

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -737,6 +737,8 @@ static void draw_camp_labels( const catacurses::window &w, const tripoint_abs_om
     }
 }
 
+namespace
+{
 class map_notes_callback : public uilist_callback
 {
     private:
@@ -832,6 +834,7 @@ class map_notes_callback : public uilist_callback
             ui.invalidate_ui();
         }
 };
+} // namespace
 
 static point_abs_omt draw_notes( const tripoint_abs_omt &origin )
 {
@@ -2407,12 +2410,15 @@ static tripoint_abs_omt display()
 
 } // namespace overmap_ui
 
+namespace
+{
 struct blended_omt {
     oter_id id;
     std::string sym;
     nc_color color;
     std::string name;
 };
+} // namespace
 
 oter_vision::blended_omt oter_vision::get_blended_omt_info( const tripoint_abs_omt &omp,
         om_vision_level vision )

--- a/src/past_games_info.cpp
+++ b/src/past_games_info.cpp
@@ -29,10 +29,13 @@
 
 static void no_op( const achievement *, bool ) {}
 
+namespace
+{
 class too_old_memorial_file_error : std::runtime_error
 {
         using runtime_error::runtime_error;
 };
+} // namespace
 
 past_game_info::past_game_info( const JsonObject &jo )
 {

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -44,6 +44,8 @@ static constexpr int flat_index( const point_bub_ms &p )
     return ( p.x() * MAPSIZE_Y ) + p.y();
 }
 
+namespace
+{
 // Flattened 2D array representing a single z-level worth of pathfinding data
 struct path_data_layer {
     // Closed/open is accessed way more often than all other values here
@@ -125,6 +127,7 @@ struct pathfinder {
         layer.closed[index] = false;
     }
 };
+} // namespace
 
 static pathfinder pf;
 

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -69,6 +69,8 @@ static void show_pickup_message( const PickupMap &mapPickup )
     }
 }
 
+namespace
+{
 struct pickup_count {
     bool pick = false;
     //count is 0 if the whole stack is being picked up, nonzero otherwise.
@@ -82,6 +84,7 @@ enum pickup_answer : int {
     STASH,
     NUM_ANSWERS
 };
+} // namespace
 
 static pickup_answer handle_problematic_pickup( const item &it, const std::string &explain )
 {

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -659,11 +659,14 @@ static void draw_traits_info( const catacurses::window &w_info, const Character 
     wnoutrefresh( w_info );
 }
 
+namespace
+{
 struct bionic_grouping {
     const translation name;
     const translation description;
     const int installed_count;
 };
+} // namespace
 
 static void draw_bionics_tab( ui_adaptor &ui, const catacurses::window &w_bionics,
                               const Character &you, const unsigned line,
@@ -870,12 +873,15 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
     wnoutrefresh( w_skills );
 }
 
+namespace
+{
 struct speedlist_entry {
     bool is_speed;
     std::string description;
     int val;
     bool percent;
 };
+} // namespace
 
 static void draw_speed_info( const catacurses::window &w_info,
                              unsigned int line,

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -487,6 +487,8 @@ static void eff_fun_hallu( Character &u, effect &it )
     }
 }
 
+namespace
+{
 struct temperature_effect {
     int str_pen;
     int dex_pen;
@@ -521,6 +523,7 @@ struct temperature_effect {
         }
     }
 };
+} // namespace
 
 static void eff_fun_cold( Character &u, effect &it )
 {

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -50,7 +50,9 @@ namespace
 generic_factory<profession> all_profs( "profession" );
 } // namespace
 
-static class json_item_substitution
+namespace
+{
+class json_item_substitution
 {
     public:
         void reset();
@@ -81,6 +83,7 @@ static class json_item_substitution
         std::vector<item> get_bonus_items( const std::vector<trait_id> &traits ) const;
         std::vector<item> get_substitution( const item &it, const std::vector<trait_id> &traits ) const;
 } item_substitutions;
+} // namespace
 
 /** @relates string_id */
 template<>
@@ -166,6 +169,8 @@ void profession::finalize_all()
     all_profs.finalize();
 }
 
+namespace
+{
 class skilllevel_reader : public generic_typed_reader<skilllevel_reader>
 {
     public:
@@ -181,7 +186,10 @@ class skilllevel_reader : public generic_typed_reader<skilllevel_reader>
             } );
         }
 };
+} // namespace
 
+namespace
+{
 class addiction_reader : public generic_typed_reader<addiction_reader>
 {
     public:
@@ -219,6 +227,7 @@ class item_reader : public generic_typed_reader<item_reader>
             } );
         }
 };
+} // namespace
 
 void profession::load( const JsonObject &jo, std::string_view )
 {

--- a/src/proficiency_ui.cpp
+++ b/src/proficiency_ui.cpp
@@ -48,6 +48,8 @@
 
 using display_prof_deps = std::pair<display_proficiency, std::vector<proficiency_id>>;
 
+namespace
+{
 struct prof_window {
     input_context ctxt;
     weak_ptr_fast<ui_adaptor> ui;
@@ -83,6 +85,7 @@ struct prof_window {
     void draw_details();
     void run( std::optional<proficiency_id> default_selection = std::nullopt );
 };
+} // namespace
 
 std::vector<display_prof_deps *> &prof_window::get_current_set()
 {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -212,6 +212,8 @@ static int RAS_time( const Character &p, const item_location &loc );
 static void cycle_action( item &weap, const itype_id &ammo, map *here, const tripoint_bub_ms &pos );
 static void make_gun_sound_effect( const Character &p, bool burst, item *weapon );
 
+namespace
+{
 class target_ui
 {
     public:
@@ -472,6 +474,7 @@ class target_ui
         // `harmful` is `false` if using a non-damaging spell
         void on_target_accepted( bool harmful ) const;
 };
+} // namespace
 
 target_handler::trajectory target_handler::mode_select_only( avatar &you, int range )
 {
@@ -1863,12 +1866,15 @@ static void do_aim( Character &you, const item &relevant, const Target_attribute
     }
 }
 
+namespace
+{
 struct confidence_rating {
     double aim_level;
     char symbol;
     std::string color;
     std::string label;
 };
+} // namespace
 
 static int print_steadiness( const catacurses::window &w, int line_number, double steadiness )
 {
@@ -1955,6 +1961,8 @@ Target_attributes::Target_attributes( int rng, double target_size, float light_t
 * struct used to hold the information on entire aim_type prediction;
 * all the properties and odds for every 'confidence' outcome
 */
+namespace
+{
 struct aim_type_prediction {
     struct aim_confidence {
         std::string label;
@@ -1980,6 +1988,7 @@ struct recoil_prediction {
     double recoil;
     int moves;
 };
+} // namespace
 
 /*
 * This method tries to estimate the amount of moves required to reach

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1339,12 +1339,15 @@ std::string recipe::required_proficiencies_string( const Character *c ) const
     return required;
 }
 
+namespace
+{
 struct prof_penalty {
     proficiency_id id;
     float time_mult;
     float skill_penalty;
     bool mitigated = false;
 };
+} // namespace
 
 static std::string profstring( const prof_penalty &prof,
                                std::string &color,

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1273,6 +1273,8 @@ void overmap::serialize_view( std::ostream &fout ) const
     json.end_object();
 }
 
+namespace
+{
 // Compares all fields except position and monsters
 // If any group has monsters, it is never equal to any group (because monsters are unique)
 struct mongroup_bin_eq {
@@ -1302,6 +1304,7 @@ struct mongroup_hash {
         return ret;
     }
 };
+} // namespace
 
 void overmap::save_monster_groups( JsonOut &jout ) const
 {

--- a/src/scores_ui.cpp
+++ b/src/scores_ui.cpp
@@ -31,6 +31,8 @@
 
 template <typename E> struct enum_traits;
 
+namespace
+{
 enum class scores_ui_tab : int {
     achievements = 0,
     conducts,
@@ -38,6 +40,7 @@ enum class scores_ui_tab : int {
     kills,
     num_tabs
 };
+} // namespace
 
 template<>
 struct enum_traits<scores_ui_tab> {
@@ -45,6 +48,8 @@ struct enum_traits<scores_ui_tab> {
     static constexpr scores_ui_tab last = scores_ui_tab::num_tabs;
 };
 
+namespace
+{
 class scores_ui
 {
         friend class scores_ui_impl;
@@ -357,6 +362,7 @@ void scores_ui_impl::draw_controls()
 
     cataimgui::set_scroll( s );
 }
+} // namespace
 
 void show_scores_ui()
 {

--- a/src/sdl_gamepad.cpp
+++ b/src/sdl_gamepad.cpp
@@ -94,6 +94,8 @@ static int triggers_threshold = 16000;
 static int sticks_threshold = 16000;
 static int error_margin = 2000;
 
+namespace
+{
 struct task_t {
     // Millisecond timestamp from GetTicks(), not raw event timestamps.
     // SDL3 event timestamps are nanoseconds (Uint64); using GetTicks() keeps
@@ -104,6 +106,7 @@ struct task_t {
     int state;
     input_event_t type;
 };
+} // namespace
 
 static constexpr int max_tasks           = max_buttons + max_sticks + max_triggers + 1;
 static constexpr int sticks_task_index   = max_buttons;

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -15,6 +15,7 @@
 #include <ostream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <unordered_map>
 #include <utility>
@@ -436,7 +437,7 @@ void musicFinished()
     play_music_file( next.file, next.volume );
 }
 
-void play_music( const std::string &playlist )
+void play_music( std::string_view playlist )
 {
     // Don't interrupt playlist that's already playing.
     if( playlist == current_playlist ) {
@@ -445,7 +446,7 @@ void play_music( const std::string &playlist )
         stop_music();
     }
 
-    const auto iter = playlists.find( playlist );
+    const auto iter = playlists.find( std::string( playlist ) );
     if( iter == playlists.end() ) {
         return;
     }
@@ -649,24 +650,25 @@ static const sound_effect *find_random_effect( const std::string &id, const std:
     return &random_entry_ref( *iter );
 }
 
-bool sfx::has_variant_sound( const std::string &id, const std::string &variant,
-                             const std::string &season, const std::optional<bool> &is_indoors,
+bool sfx::has_variant_sound( std::string_view id, std::string_view variant,
+                             std::string_view season, const std::optional<bool> &is_indoors,
                              const std::optional<bool> &is_night )
 {
-    return find_random_effect( id, variant, season, is_indoors, is_night ) != nullptr;
+    return find_random_effect( std::string( id ), std::string( variant ), std::string( season ),
+                               is_indoors, is_night ) != nullptr;
 }
 
 // Returns a sound effect matching given id and variant.
 // Unlike has_variant_sound(), this doesn't fallback to "default" variants.
-bool sfx::has_exact_variant_sound( const std::string &id, const std::string &variant,
-                                   const std::string &season, const std::optional<bool> &is_indoors,
+bool sfx::has_exact_variant_sound( std::string_view id, std::string_view variant,
+                                   std::string_view season, const std::optional<bool> &is_indoors,
                                    const std::optional<bool> &is_night )
 {
 
-    const std::vector<sound_effect> *iter = sfx_resources.sound_effects.find_no_fallback( id, variant,
-                                            season,
-                                            is_indoors,
-                                            is_night );
+    const std::vector<sound_effect> *iter = sfx_resources.sound_effects.find_no_fallback(
+            std::string( id ), std::string( variant ), std::string( season ),
+            is_indoors,
+            is_night );
 
     return iter != nullptr;
 }
@@ -683,8 +685,8 @@ static bool is_time_slowed()
 }
 
 
-void sfx::play_variant_sound( const std::string &id, const std::string &variant,
-                              const std::string &season, const std::optional<bool> &is_indoors,
+void sfx::play_variant_sound( std::string_view id, std::string_view variant,
+                              std::string_view season, const std::optional<bool> &is_indoors,
                               const std::optional<bool> &is_night, int volume )
 {
     if( test_mode ) {
@@ -696,9 +698,11 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
     if( !check_sound( volume ) ) {
         return;
     }
-    const sound_effect *eff = find_random_effect( id, variant, season, is_indoors, is_night );
+    const std::string id_s( id );
+    const sound_effect *eff = find_random_effect( id_s, std::string( variant ), std::string( season ),
+                              is_indoors, is_night );
     if( eff == nullptr ) {
-        eff = find_random_effect( id, "default", "", std::optional<bool>(), std::optional<bool>() );
+        eff = find_random_effect( id_s, "default", "", std::optional<bool>(), std::optional<bool>() );
         if( eff == nullptr ) {
             return;
         }
@@ -713,8 +717,8 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
     sound_backend::play_oneshot( effect_to_play, opts );
 }
 
-void sfx::play_variant_sound( const std::string &id, const std::string &variant,
-                              const std::string &season, const std::optional<bool> &is_indoors,
+void sfx::play_variant_sound( std::string_view id, std::string_view variant,
+                              std::string_view season, const std::optional<bool> &is_indoors,
                               const std::optional<bool> &is_night, int volume, units::angle angle,
                               double pitch_min, double pitch_max )
 {
@@ -727,7 +731,8 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
     if( !check_sound( volume ) ) {
         return;
     }
-    const sound_effect *eff = find_random_effect( id, variant, season, is_indoors, is_night );
+    const sound_effect *eff = find_random_effect( std::string( id ), std::string( variant ),
+                              std::string( season ), is_indoors, is_night );
     if( eff == nullptr ) {
         return;
     }
@@ -745,8 +750,8 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
     sound_backend::play_oneshot( effect_to_play, opts );
 }
 
-void sfx::play_ambient_variant_sound( const std::string &id, const std::string &variant,
-                                      const std::string &season, const std::optional<bool> &is_indoors,
+void sfx::play_ambient_variant_sound( std::string_view id, std::string_view variant,
+                                      std::string_view season, const std::optional<bool> &is_indoors,
                                       const std::optional<bool> &is_night, int volume,
                                       channel channel, int fade_in_duration, double pitch, int loops )
 {
@@ -759,7 +764,8 @@ void sfx::play_ambient_variant_sound( const std::string &id, const std::string &
     if( is_channel_playing( channel ) ) {
         return;
     }
-    const sound_effect *eff = find_random_effect( id, variant, season, is_indoors, is_night );
+    const sound_effect *eff = find_random_effect( std::string( id ), std::string( variant ),
+                              std::string( season ), is_indoors, is_night );
     if( eff == nullptr ) {
         return;
     }

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -39,6 +39,8 @@
 
 #define dbg(x) DebugLog((x),D_SDL) << __FILE__ << ":" << __LINE__ << ": "
 
+namespace
+{
 struct sfx_args {
     std::string id;
     std::string variant;
@@ -64,9 +66,12 @@ struct sound_effect_resource {
     };
     std::unique_ptr<sound_backend::sfx_audio, deleter> chunk;
 };
+} // namespace
 
 static int add_sfx_path( const std::string &path );
 
+namespace
+{
 struct sound_effect {
     const int volume = 0;
     const int resource_id = 0;
@@ -75,6 +80,7 @@ struct sound_effect {
     sound_effect( int volume, const std::string &path )
         : volume( volume ), resource_id( add_sfx_path( path ) ) {}
 };
+} // namespace
 
 // Sound effects are primarily keyed by id
 // They support a variety of optional 'variations', such as:
@@ -229,6 +235,8 @@ int bool_or( const std::optional<bool> &opt, int defl )
 
 } // namespace
 
+namespace
+{
 struct sfx_map {
         void clear() {
             effects.clear();
@@ -288,6 +296,7 @@ struct music_playlist {
     music_playlist() : shuffle( false ) {
     }
 };
+} // namespace
 /** The music we're currently playing. */
 static sound_backend::music_source *current_music = nullptr;
 static int current_music_track_volume = 0;

--- a/src/sdlsound.h
+++ b/src/sdlsound.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_SDLSOUND_H
 
 #include <string>
+#include <string_view>
 #if defined(SDL_SOUND)
 
 /**
@@ -11,7 +12,7 @@
 bool init_sound();
 void initSDLAudioOnly();
 void shutdown_sound();
-void play_music( const std::string &playlist );
+void play_music( std::string_view playlist );
 void stop_music();
 void update_music_volume();
 void load_soundset();
@@ -24,7 +25,7 @@ inline bool init_sound()
     return false;
 }
 inline void shutdown_sound() { }
-inline void play_music( const std::string &/*playlist*/ )
+inline void play_music( std::string_view /*playlist*/ )
 {
 }
 inline void update_music_volume() { }

--- a/src/shadowcasting.cpp
+++ b/src/shadowcasting.cpp
@@ -14,6 +14,8 @@
 // historically 8 bits is enough for rise and run, as a shadowcasting radius of 60
 // readily fits within that space. larger shadowcasting volumes may require larger
 // storage units; a radius of 120 definitely will not fit.
+namespace
+{
 struct slope {
     slope( int_least8_t rise, int_least8_t run ) {
         // Ensure run is always positive for the inequality operators
@@ -30,16 +32,16 @@ struct slope {
     int_least8_t run;
 };
 
-static bool operator<( const slope &lhs, const slope &rhs )
+bool operator<( const slope &lhs, const slope &rhs )
 {
     // a/b < c/d <=> a*d < c*b if b and d have the same sign.
     return lhs.rise * rhs.run < rhs.rise * lhs.run;
 }
-static bool operator>( const slope &lhs, const slope &rhs )
+bool operator>( const slope &lhs, const slope &rhs )
 {
     return rhs < lhs;
 }
-static bool operator==( const slope &lhs, const slope &rhs )
+bool operator==( const slope &lhs, const slope &rhs )
 {
     // a/b == c/d <=> a*d == c*b
     return lhs.rise * rhs.run == rhs.rise * lhs.run;
@@ -61,6 +63,7 @@ struct span {
     bool skip_first_row;
     bool skip_first_column;
 };
+} // namespace
 
 /**
  * Handle splitting the current span in cast_horizontal_zlight_segment and

--- a/src/shop_cons_rate.cpp
+++ b/src/shop_cons_rate.cpp
@@ -165,6 +165,8 @@ icg_entry icg_entry_reader::get_next( JsonValue &jv )
     return ret;
 }
 
+namespace
+{
 class shopkeeper_cons_rates_reader : public generic_typed_reader<shopkeeper_cons_rates_reader>
 {
     public:
@@ -175,6 +177,7 @@ class shopkeeper_cons_rates_reader : public generic_typed_reader<shopkeeper_cons
             return ret;
         }
 };
+} // namespace
 
 bool shopkeeper_cons_rate_entry::operator==( shopkeeper_cons_rate_entry const &rhs ) const
 {

--- a/src/sound_backend_sdl3.cpp
+++ b/src/sound_backend_sdl3.cpp
@@ -72,6 +72,8 @@ std::atomic<uint32_t> g_music_generation{0};
 const char *tag_for_group( sfx::group g )
 {
     switch( g ) {
+        case sfx::group::none:
+            return nullptr;
         case sfx::group::weather:
             return "weather";
         case sfx::group::time_of_day:

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -208,6 +208,7 @@ struct centroid {
     float weight;
     bool provocative;
 };
+} // namespace
 
 namespace io
 {

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -5,6 +5,8 @@
 #include <cmath>
 #include <cstdlib>
 #include <memory>
+#include <string>
+#include <string_view>
 #include <type_traits>
 #include <unordered_map>
 
@@ -83,18 +85,17 @@ static const efftype_id effect_narcosis( "narcosis" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_slept_through_alarm( "slept_through_alarm" );
 
-static const json_character_flag json_flag_ALARMCLOCK( "ALARMCLOCK" );
-static const json_character_flag json_flag_HEARING_PROTECTION( "HEARING_PROTECTION" );
-static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
-
-static const trait_id trait_HEAVYSLEEPER( "HEAVYSLEEPER" );
-static const trait_id trait_HEAVYSLEEPER2( "HEAVYSLEEPER2" );
-
 #if defined(SDL_SOUND)
 static const itype_id fuel_type_battery( "battery" );
 static const itype_id fuel_type_muscle( "muscle" );
 static const itype_id fuel_type_wind( "wind" );
+#endif
 
+static const json_character_flag json_flag_ALARMCLOCK( "ALARMCLOCK" );
+static const json_character_flag json_flag_HEARING_PROTECTION( "HEARING_PROTECTION" );
+static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
+
+#if defined(SDL_SOUND)
 static const material_id material_bone( "bone" );
 static const material_id material_flesh( "flesh" );
 static const material_id material_hflesh( "hflesh" );
@@ -180,6 +181,9 @@ static const ter_str_id ter_t_trunk( "t_trunk" );
 static const ter_str_id ter_t_underbrush( "t_underbrush" );
 static const ter_str_id ter_t_underbrush_harvested( "t_underbrush_harvested" );
 #endif
+
+static const trait_id trait_HEAVYSLEEPER( "HEAVYSLEEPER" );
+static const trait_id trait_HEAVYSLEEPER2( "HEAVYSLEEPER2" );
 
 namespace
 {
@@ -1380,6 +1384,8 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
 
 namespace sfx
 {
+namespace
+{
 struct sound_thread {
     sound_thread( const item &weapon, const tripoint_bub_ms &source, const tripoint_bub_ms &target,
                   bool hit, bool targ_mon,
@@ -1401,12 +1407,13 @@ struct sound_thread {
     // Operator overload required for thread API.
     void operator()() const;
 };
+} // namespace
 } // namespace sfx
 
 void sfx::generate_melee_sound( const item &weapon, const tripoint_bub_ms &source,
                                 const tripoint_bub_ms &target,
                                 bool hit, bool targ_mon,
-                                const std::string &material )
+                                std::string_view material )
 {
     if( test_mode ) {
         return;
@@ -1415,7 +1422,8 @@ void sfx::generate_melee_sound( const item &weapon, const tripoint_bub_ms &sourc
     // pool or maybe a single thread that works continuously, but that requires a queue or similar
     // to coordinate its work.
     try {
-        std::thread the_thread( sound_thread( weapon, source, target, hit, targ_mon, material ) );
+        std::thread the_thread( sound_thread( weapon, source, target, hit, targ_mon,
+                                              std::string( material ) ) );
         try {
             if( the_thread.joinable() ) {
                 the_thread.detach();
@@ -1843,8 +1851,8 @@ void sfx::do_footstep( const Character &ch )
             ter_t_chainfence,
         };
 
-        const auto play_plmove_sound_variant = [&]( const std::string & variant,
-                                               const std::string & season,
+        const auto play_plmove_sound_variant = [&]( std::string_view variant,
+                                               std::string_view season,
                                                const std::optional<bool> &indoors,
         const std::optional<bool> &night ) {
             play_variant_sound( "plmove", variant, season, indoors, night,
@@ -1903,7 +1911,7 @@ void sfx::do_footstep( const Character &ch )
     }
 }
 
-void sfx::do_obstacle( const std::string &obst )
+void sfx::do_obstacle( std::string_view obst )
 {
     if( test_mode ) {
         return;
@@ -1921,9 +1929,9 @@ void sfx::do_obstacle( const std::string &obst )
         if( sfx::has_variant_sound( "plmove", obst, seas_str, indoors, night ) ) {
             play_variant_sound( "plmove", obst, seas_str, indoors, night,
                                 heard_volume, 0_degrees, 0.8, 1.2 );
-        } else if( ter_str_id( obst ).is_valid() &&
-                   ( ter_id( obst )->has_flag( ter_furn_flag::TFLAG_SHALLOW_WATER ) ||
-                     ter_id( obst )->has_flag( ter_furn_flag::TFLAG_DEEP_WATER ) ) ) {
+        } else if( const ter_str_id obst_id( obst ); obst_id.is_valid() &&
+                   ( obst_id->has_flag( ter_furn_flag::TFLAG_SHALLOW_WATER ) ||
+                     obst_id->has_flag( ter_furn_flag::TFLAG_DEEP_WATER ) ) ) {
             play_variant_sound( "plmove", "walk_water", seas_str, indoors, night,
                                 heard_volume, 0_degrees, 0.8, 1.2 );
         } else {
@@ -1935,15 +1943,15 @@ void sfx::do_obstacle( const std::string &obst )
     }
 }
 
-void sfx::play_activity_sound( const std::string &id, const std::string &variant, int volume )
+void sfx::play_activity_sound( std::string_view id, std::string_view variant, int volume )
 {
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
     play_activity_sound( id, variant, seas_str, volume );
 }
 
-void sfx::play_activity_sound( const std::string &id, const std::string &variant,
-                               const std::string &season, int volume )
+void sfx::play_activity_sound( std::string_view id, std::string_view variant,
+                               std::string_view season, int volume )
 {
     if( test_mode ) {
         return;
@@ -1967,7 +1975,7 @@ void sfx::end_activity_sounds()
     fade_audio_channel( channel::player_activities, 2000 );
 }
 
-void sfx::play_variant_sound( const std::string &id, const std::string &variant, int volume )
+void sfx::play_variant_sound( std::string_view id, std::string_view variant, int volume )
 {
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
@@ -1976,7 +1984,7 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
     play_variant_sound( id, variant, seas_str, indoors, night, volume );
 }
 
-void sfx::play_variant_sound( const std::string &id, const std::string &variant, int volume,
+void sfx::play_variant_sound( std::string_view id, std::string_view variant, int volume,
                               units::angle angle, double pitch_min, double pitch_max )
 {
     const season_type seas = season_of_year( calendar::turn );
@@ -1987,7 +1995,7 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
                         volume, angle, pitch_min, pitch_max );
 }
 
-void sfx::play_ambient_variant_sound( const std::string &id, const std::string &variant, int volume,
+void sfx::play_ambient_variant_sound( std::string_view id, std::string_view variant, int volume,
                                       channel channel, int fade_in_duration, double pitch, int loops )
 {
     const season_type seas = season_of_year( calendar::turn );
@@ -1998,7 +2006,7 @@ void sfx::play_ambient_variant_sound( const std::string &id, const std::string &
                                 volume, channel, fade_in_duration, pitch, loops );
 }
 
-bool sfx::has_variant_sound( const std::string &id, const std::string &variant )
+bool sfx::has_variant_sound( std::string_view id, std::string_view variant )
 {
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
@@ -2007,7 +2015,7 @@ bool sfx::has_variant_sound( const std::string &id, const std::string &variant )
     return has_variant_sound( id, variant, seas_str, indoors, night );
 }
 
-bool sfx::has_exact_variant_sound( const std::string &id, const std::string &variant )
+bool sfx::has_exact_variant_sound( std::string_view id, std::string_view variant )
 {
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
@@ -2023,17 +2031,17 @@ bool sfx::has_exact_variant_sound( const std::string &id, const std::string &var
 void sfx::load_sound_effects( const JsonObject & ) { }
 void sfx::load_sound_effect_preload( const JsonObject & ) { }
 void sfx::load_playlist( const JsonObject & ) { }
-void sfx::play_variant_sound( const std::string &, const std::string &, int, units::angle, double,
+void sfx::play_variant_sound( std::string_view, std::string_view, int, units::angle, double,
                               double ) { }
-void sfx::play_variant_sound( const std::string &, const std::string &, int ) { }
-void sfx::play_ambient_variant_sound( const std::string &, const std::string &, int, channel, int,
+void sfx::play_variant_sound( std::string_view, std::string_view, int ) { }
+void sfx::play_ambient_variant_sound( std::string_view, std::string_view, int, channel, int,
                                       double, int ) { }
-void sfx::play_activity_sound( const std::string &, const std::string &, int ) { }
+void sfx::play_activity_sound( std::string_view, std::string_view, int ) { }
 void sfx::end_activity_sounds() { }
 void sfx::generate_gun_sound( const Character &, const item & ) { }
 void sfx::generate_melee_sound( const item &, const tripoint_bub_ms &, const tripoint_bub_ms &,
                                 bool, bool,
-                                const std::string & ) { }
+                                std::string_view ) { }
 void sfx::do_hearing_loss( int ) { }
 void sfx::remove_hearing_loss() { }
 void sfx::do_projectile_hit( const Creature & ) { }
@@ -2052,11 +2060,11 @@ int sfx::set_channel_volume( channel, int )
 {
     return 0;
 }
-bool sfx::has_variant_sound( const std::string &, const std::string & )
+bool sfx::has_variant_sound( std::string_view, std::string_view )
 {
     return false;
 }
-bool sfx::has_exact_variant_sound( const std::string &, const std::string & )
+bool sfx::has_exact_variant_sound( std::string_view, std::string_view )
 {
     return false;
 }
@@ -2064,8 +2072,8 @@ void sfx::stop_sound_effect_fade( channel, int ) { }
 void sfx::stop_sound_effect_timed( channel, int ) { }
 void sfx::do_player_death_hurt( const Character &, bool ) { }
 void sfx::do_low_stamina_sfx() { }
-void sfx::do_obstacle( const std::string & ) { }
-void sfx::play_variant_sound( const std::string &, const std::string &, const std::string &,
+void sfx::do_obstacle( std::string_view ) { }
+void sfx::play_variant_sound( std::string_view, std::string_view, std::string_view,
                               const std::optional<bool> &, const std::optional<bool> &, int ) { }
 /*@}*/
 

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -60,11 +60,12 @@ static int previous_gear = 0;
 static bool audio_muted = false;
 #endif
 
-static weather_type_id previous_weather;
-#if defined(SDL_SOUND)
-static std::optional<bool> previous_is_night;
-#endif
 static float g_sfx_volume_multiplier = 1.0f;
+
+#if defined(SDL_SOUND)
+static weather_type_id previous_weather;
+static std::optional<bool> previous_is_night;
+
 static std::chrono::high_resolution_clock::time_point start_sfx_timestamp =
     std::chrono::high_resolution_clock::now();
 static std::chrono::high_resolution_clock::time_point end_sfx_timestamp =
@@ -72,6 +73,7 @@ static std::chrono::high_resolution_clock::time_point end_sfx_timestamp =
 static auto sfx_time = end_sfx_timestamp - start_sfx_timestamp;
 static activity_id act;
 static std::pair<std::string, std::string> engine_external_id_and_variant;
+#endif
 
 static const bionic_id bio_sleep_shutdown( "bio_sleep_shutdown" );
 
@@ -81,13 +83,17 @@ static const efftype_id effect_narcosis( "narcosis" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_slept_through_alarm( "slept_through_alarm" );
 
-static const itype_id fuel_type_battery( "battery" );
-static const itype_id fuel_type_muscle( "muscle" );
-static const itype_id fuel_type_wind( "wind" );
-
 static const json_character_flag json_flag_ALARMCLOCK( "ALARMCLOCK" );
 static const json_character_flag json_flag_HEARING_PROTECTION( "HEARING_PROTECTION" );
 static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
+
+static const trait_id trait_HEAVYSLEEPER( "HEAVYSLEEPER" );
+static const trait_id trait_HEAVYSLEEPER2( "HEAVYSLEEPER2" );
+
+#if defined(SDL_SOUND)
+static const itype_id fuel_type_battery( "battery" );
+static const itype_id fuel_type_muscle( "muscle" );
+static const itype_id fuel_type_wind( "wind" );
 
 static const material_id material_bone( "bone" );
 static const material_id material_flesh( "flesh" );
@@ -173,10 +179,10 @@ static const ter_str_id ter_t_stump( "t_stump" );
 static const ter_str_id ter_t_trunk( "t_trunk" );
 static const ter_str_id ter_t_underbrush( "t_underbrush" );
 static const ter_str_id ter_t_underbrush_harvested( "t_underbrush_harvested" );
+#endif
 
-static const trait_id trait_HEAVYSLEEPER( "HEAVYSLEEPER" );
-static const trait_id trait_HEAVYSLEEPER2( "HEAVYSLEEPER2" );
-
+namespace
+{
 struct monster_sound_event {
     int volume;
     bool provocative;

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -4,6 +4,7 @@
 
 #include <optional>
 #include <string> // IWYU pragma: keep
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -136,39 +137,40 @@ enum class channel : int {
 
 //Group Assignments:
 enum class group : int {
-    weather = 1,    //SFX related to weather
+    none = 0,       //unassigned slot
+    weather,        //SFX related to weather
     time_of_day,    //SFX related to time of day
     context_themes, //SFX related to context themes
-    low_stamina         //SFX related to low_stamina
+    low_stamina    //SFX related to low_stamina
 };
 
 void load_sound_effects( const JsonObject &jsobj );
 void load_sound_effect_preload( const JsonObject &jsobj );
 void load_playlist( const JsonObject &jsobj );
-void play_variant_sound( const std::string &id, const std::string &variant, int volume,
+void play_variant_sound( std::string_view id, std::string_view variant, int volume,
                          units::angle angle, double pitch_min = -1.0, double pitch_max = -1.0 );
-void play_variant_sound( const std::string &id, const std::string &variant,
-                         const std::string &season, const std::optional<bool> &is_indoors,
+void play_variant_sound( std::string_view id, std::string_view variant,
+                         std::string_view season, const std::optional<bool> &is_indoors,
                          const std::optional<bool> &is_night, int volume, units::angle angle,
                          double pitch_min = -1.0, double pitch_max = -1.0 );
-void play_variant_sound( const std::string &id, const std::string &variant, int volume );
-void play_variant_sound( const std::string &id, const std::string &variant,
-                         const std::string &season, const std::optional<bool> &is_indoors,
+void play_variant_sound( std::string_view id, std::string_view variant, int volume );
+void play_variant_sound( std::string_view id, std::string_view variant,
+                         std::string_view season, const std::optional<bool> &is_indoors,
                          const std::optional<bool> &is_night, int volume );
-void play_ambient_variant_sound( const std::string &id, const std::string &variant, int volume,
+void play_ambient_variant_sound( std::string_view id, std::string_view variant, int volume,
                                  channel channel, int fade_in_duration, double pitch = -1.0, int loops = -1 );
-void play_ambient_variant_sound( const std::string &id, const std::string &variant,
-                                 const std::string &season, const std::optional<bool> &is_indoors,
+void play_ambient_variant_sound( std::string_view id, std::string_view variant,
+                                 std::string_view season, const std::optional<bool> &is_indoors,
                                  const std::optional<bool> &is_night, int volume,
                                  channel channel, int fade_in_duration, double pitch = -1.0, int loops = -1 );
-void play_activity_sound( const std::string &id, const std::string &variant, int volume );
-void play_activity_sound( const std::string &id, const std::string &variant,
-                          const std::string &season, int volume );
+void play_activity_sound( std::string_view id, std::string_view variant, int volume );
+void play_activity_sound( std::string_view id, std::string_view variant,
+                          std::string_view season, int volume );
 void end_activity_sounds();
 void generate_gun_sound( const Character &source_arg, const item &firing );
 void generate_melee_sound( const item &weapon, const tripoint_bub_ms &source,
                            const tripoint_bub_ms &target, bool hit,
-                           bool targ_mon = false, const std::string &material = "flesh" );
+                           bool targ_mon = false, std::string_view material = "flesh" );
 void do_hearing_loss( int turns = -1 );
 void remove_hearing_loss();
 void do_projectile_hit( const Creature &target );
@@ -182,13 +184,13 @@ void do_vehicle_exterior_engine_sfx();
 void fade_audio_group( group group, int duration );
 void fade_audio_channel( channel channel, int duration );
 bool is_channel_playing( channel channel );
-bool has_variant_sound( const std::string &id, const std::string &variant );
-bool has_variant_sound( const std::string &id, const std::string &variant,
-                        const std::string &season, const std::optional<bool> &is_indoors,
+bool has_variant_sound( std::string_view id, std::string_view variant );
+bool has_variant_sound( std::string_view id, std::string_view variant,
+                        std::string_view season, const std::optional<bool> &is_indoors,
                         const std::optional<bool> &is_night );
-bool has_exact_variant_sound( const std::string &id, const std::string &variant );
-bool has_exact_variant_sound( const std::string &id, const std::string &variant,
-                              const std::string &season, const std::optional<bool> &is_indoors,
+bool has_exact_variant_sound( std::string_view id, std::string_view variant );
+bool has_exact_variant_sound( std::string_view id, std::string_view variant,
+                              std::string_view season, const std::optional<bool> &is_indoors,
                               const std::optional<bool> &is_night );
 void stop_sound_effect_fade( channel channel, int duration );
 void stop_sound_effect_timed( channel channel, int time );
@@ -196,7 +198,7 @@ int set_channel_volume( channel channel, int volume );
 void do_player_death_hurt( const Character &target, bool death );
 void do_low_stamina_sfx();
 // @param obst should be string id of obstacle terrain or vehicle part
-void do_obstacle( const std::string &obst = "" );
+void do_obstacle( std::string_view obst = "" );
 } // namespace sfx
 
 #endif // CATA_SRC_SOUNDS_H

--- a/src/stats_tracker.cpp
+++ b/src/stats_tracker.cpp
@@ -155,6 +155,8 @@ int event_multiset::maximum( const std::string &field ) const
     return maximum;
 }
 
+namespace
+{
 template<time_point event_summary::*Member>
 struct compare_times {
     bool operator()( const event_multiset::summaries_type::value_type &l,
@@ -162,6 +164,7 @@ struct compare_times {
         return l.second.*Member < r.second.*Member;
     }
 };
+} // namespace
 
 std::optional<event_multiset::summaries_type::value_type> event_multiset::first() const
 {

--- a/src/string_editor_window.cpp
+++ b/src/string_editor_window.cpp
@@ -49,11 +49,14 @@ static bool is_word( const uint32_t uc )
     return uc != ' ';
 }
 
+namespace
+{
 struct folded_line {
     int cpts_start;
     int cpts_end;
     std::string str;
 };
+} // namespace
 
 // fold text without truncating spaces or parsing color tags
 class folded_text

--- a/src/study_zone_ui.cpp
+++ b/src/study_zone_ui.cpp
@@ -35,6 +35,8 @@ static int filter_skill_input_callback( ImGuiInputTextCallbackData *data )
     return 0;
 }
 
+namespace
+{
 class study_zone_window : public cataimgui::window
 {
     public:
@@ -297,6 +299,7 @@ class study_zone_window : public cataimgui::window
         float max_npc_name_width = 0.0f;
         input_context ctxt;
 };
+} // namespace
 
 study_zone_ui_result query_study_zone_skills( std::map<std::string, std::set<skill_id>>
         &npc_skill_preferences )

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -46,10 +46,13 @@ static const std::string COSMETICS_SIGNAGE( "SIGNAGE" );
 // Handle GCC warning: 'warning: returning reference to temporary'
 static const std::string STRING_EMPTY;
 
+namespace
+{
 struct cosmetic_find_result {
     bool result = false;
     int ndx = 0;
 };
+} // namespace
 static cosmetic_find_result make_result( bool b, int ndx )
 {
     cosmetic_find_result result;

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -327,11 +327,14 @@ int talker_npc_const::value( const item &it ) const
     return me_npc->value( it );
 }
 
+namespace
+{
 enum consumption_result {
     REFUSED = 0,
     CONSUMED_SOME, // Consumption didn't fail, but don't delete the item
     CONSUMED_ALL   // Consumption succeeded, delete the item
 };
+} // namespace
 
 // Returns true if we destroyed the item through consumption
 // does not try to consume contents

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -75,6 +75,7 @@ ui_adaptor::ui_adaptor( ui_adaptor::debug_message_ui ) : is_imgui( false ),
     ui_stack.emplace_back( *this );
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape): cata_assert may throw on failed invariant by design
 ui_adaptor::~ui_adaptor()
 {
     if( is_shutting_down ) {

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1267,6 +1267,8 @@ static std::pair<std::string, std::string> get_vpart_str_variant( const std::str
            : std::make_pair( vpid.substr( 0, loc ), vpid.substr( loc + 1 ) );
 }
 
+namespace
+{
 struct veh_proto_part_def_reader : generic_typed_reader<veh_proto_part_def_reader> {
     point_rel_ms pos;
 
@@ -1309,6 +1311,7 @@ struct veh_spawn_item_reader : generic_typed_reader<veh_spawn_item_reader> {
         return ret;
     }
 };
+} // namespace
 
 void vehicle_item_spawn::deserialize( const JsonObject &jo )
 {

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -371,6 +371,8 @@ std::vector<uilist_entry> veh_menu::get_uilist_entries() const
     return entries;
 }
 
+namespace
+{
 class veh_menu_cb : public uilist_callback
 {
     public:
@@ -420,6 +422,7 @@ class veh_menu_cb : public uilist_callback
             }
         }
 };
+} // namespace
 
 bool veh_menu::query()
 {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4522,6 +4522,8 @@ static double tile_to_width( int tiles )
 
 static constexpr int minrow = -122;
 static constexpr int maxrow = 122;
+namespace
+{
 struct drag_column {
     int pro = minrow;
     int hboard = minrow;
@@ -4539,6 +4541,7 @@ struct drag_column {
     int last = maxrow;
     int lastpart = maxrow;
 };
+} // namespace
 
 double vehicle::coeff_air_drag() const
 {

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -164,6 +164,8 @@ static constexpr int MAX_GREEDY_SPEED_TPS = 10;
 static constexpr int MAX_AIR_SPEED_TPS = 16;
 static constexpr int VMIPH_PER_TPS = static_cast<int>( vehicles::vmiph_per_tile );
 
+namespace
+{
 /**
  * Data type representing a vehicle orientation, which corresponds to an angle that is
  * a multiple of TURNING_INCREMENT degrees, measured from the x axis.
@@ -201,10 +203,13 @@ struct navigation_step {
     orientation steering_dir;
     int target_speed_tps;
 };
+} // namespace
 
 /**
  * The address of a navigation node, i.e. a position and orientation on the nav map.
  */
+namespace
+{
 // NOLINTNEXTLINE(cata-xy)
 struct node_address {
     int16_t x;
@@ -217,7 +222,10 @@ struct node_address {
         return {x, y};
     }
 };
+} // namespace
 
+namespace
+{
 struct node_address_hasher {
     std::size_t operator()( const node_address &addr ) const {
         std::uint64_t val = addr.x;
@@ -238,7 +246,10 @@ struct scored_address {
         return score > other.score;
     }
 };
+} // namespace
 
+namespace
+{
 /*
  * Data structure representing a navigation node that is known to be reachable. Contains
  * information about the path to get there and enough information about the state of
@@ -282,7 +293,10 @@ struct point_queue {
         }
     }
 };
+} // namespace
 
+namespace
+{
 /**
  * Data structure that caches all the data needed in order to navigate from one
  * OMT to the next OMT along the path to destination. Main components:
@@ -376,6 +390,7 @@ enum class collision_check_result : int {
     close_obstacle,
     slow_down
 };
+} // namespace
 
 class vehicle::autodrive_controller
 {

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -858,6 +858,8 @@ std::list<item> vehicle_selector::remove_items_with( const
     return res;
 }
 
+namespace
+{
 // Per-tool stock for charges_of dedup. Legacy contributes local charges;
 // multimag records per-battery-pocket so shared-pool greedy can bill K uses
 // without re-solving firing_requirements.
@@ -870,6 +872,7 @@ struct tool_stock_entry {
     const item *src = nullptr;
     std::vector<std::pair<int, int>> battery;
 };
+} // namespace
 
 static tool_stock_entry build_multimag_entry( const item &e )
 {

--- a/src/wcwidth.cpp
+++ b/src/wcwidth.cpp
@@ -63,10 +63,13 @@
 
 #include <cstdint>
 
+namespace
+{
 struct interval {
     uint32_t first;
     uint32_t last;
 };
+} // namespace
 
 /* auxiliary function for binary search in interval table */
 static uint32_t bisearch( uint32_t ucs, const struct interval *table, uint32_t max )

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -422,7 +422,7 @@ void wet_character( Character &target, int amount )
     target.drench( amount, drenched_parts, false );
 }
 
-void weather_sound( const translation &sound_message, const std::string &sound_effect )
+void weather_sound( const translation &sound_message, std::string_view sound_effect )
 {
     Character &player_character = get_player_character();
     map &here = get_map();

--- a/src/weather.h
+++ b/src/weather.h
@@ -4,6 +4,7 @@
 
 #include <optional>
 #include <string>
+#include <string_view>
 
 #include "calendar.h"
 #include "catacharset.h"
@@ -193,7 +194,7 @@ float incident_moonlight( const weather_type_id &wtype,
 float incident_sun_irradiance( const weather_type_id &wtype,
                                const time_point &t = calendar::turn );
 
-void weather_sound( const translation &sound_message, const std::string &sound_effect );
+void weather_sound( const translation &sound_message, std::string_view sound_effect );
 
 struct omt_snow_state {
     double depth_mm = 0;

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -79,6 +79,8 @@ void weather_generator::finalize_all()
 {
     weather_generator_factory.finalize();
 }
+namespace
+{
 struct weather_gen_common {
     double x = 0;
     double y = 0;
@@ -87,6 +89,7 @@ struct weather_gen_common {
     unsigned modSEED = 0u;
     season_type season = season_type::SPRING;
 };
+} // namespace
 
 static weather_gen_common get_common_data( const tripoint_abs_ms &location,
         const time_point &real_t,

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -68,6 +68,8 @@ static const efftype_id effect_pet( "pet" );
 
 static const mongroup_id GROUP_ZOMBIE( "GROUP_ZOMBIE" );
 
+namespace
+{
 class wish_mutate_callback: public uilist_callback
 {
     public:
@@ -256,6 +258,7 @@ class wish_mutate_callback: public uilist_callback
 
         ~wish_mutate_callback() override = default;
 };
+} // namespace
 
 void debug_menu::wishmutate( Character *you )
 {
@@ -642,6 +645,8 @@ void debug_menu::wisheffect( Creature &p )
     } while( efmenu.ret != UILIST_CANCEL );
 }
 
+namespace
+{
 class wish_monster_callback: public uilist_callback
 {
     public:
@@ -751,6 +756,7 @@ class wish_monster_callback: public uilist_callback
 
         ~wish_monster_callback() override = default;
 };
+} // namespace
 
 static void setup_wishmonster( uilist &pick_a_monster, std::vector<const mtype *> &mtypes )
 {
@@ -899,6 +905,8 @@ static item wishitem_produce( const itype &type, std::string &flags, bool incont
     return granted;
 }
 
+namespace
+{
 class wish_item_callback: public uilist_callback
 {
     public:
@@ -1093,6 +1101,7 @@ class wish_item_callback: public uilist_callback
             cataimgui::TextKeybinding( ctxt, "QUIT",       _( "Quit" ),       false );
         }
 };
+} // namespace
 
 void debug_menu::wishitem( Character *you )
 {

--- a/tests/addiction_test.cpp
+++ b/tests/addiction_test.cpp
@@ -36,6 +36,8 @@ static const trait_id trait_MUT_JUNKIE( "MUT_JUNKIE" );
 
 static constexpr int max_iters = 100000;
 
+namespace
+{
 struct addict_effect_totals {
     int sleepiness = 0;
     int morale = 0;
@@ -67,6 +69,7 @@ struct addict_effect_totals {
         hallu += u.has_effect( effect_hallu ) ? 1 : 0;
     }
 };
+} // namespace
 
 static void clear_addictions( Character &u )
 {

--- a/tests/battery_density_test.cpp
+++ b/tests/battery_density_test.cpp
@@ -17,10 +17,13 @@
 static const ammotype ammo_battery( "battery" );
 static const flag_id json_flag_DEBUG_ONLY( "DEBUG_ONLY" );
 
+namespace
+{
 struct battery_chemistry_family {
     float max_energy_density_kj_kg;
     float max_energy_density_kj_l;
 };
+} // namespace
 
 // NOLINTBEGIN(cata-static-string_id-constants)
 static const std::map<itype_id, std::string> battery_to_chemistry = {

--- a/tests/cata_generators.cpp
+++ b/tests/cata_generators.cpp
@@ -6,6 +6,9 @@
 #include "point.h"
 #include "rng.h"
 
+namespace
+{
+
 class RandomPointGenerator final :
     public Catch::Generators::IGenerator<point>
 {
@@ -55,6 +58,8 @@ class RandomTripointGenerator final :
         std::uniform_int_distribution<> z_dist;
         tripoint current_point;
 };
+
+} // namespace
 
 Catch::Generators::GeneratorWrapper<point> random_points( int low, int high )
 {

--- a/tests/comestible_test.cpp
+++ b/tests/comestible_test.cpp
@@ -76,9 +76,12 @@ static const std::vector<vitamin_id> mutagen_vit_list{ vitamin_mutagen, vitamin_
 
 static const std::vector<itype_id> marloss_food{ itype_marloss_berry, itype_marloss_gel, itype_marloss_seed };
 
+namespace
+{
 struct all_stats {
     statistics<int> calories;
 };
+} // namespace
 
 // given a list of components, adds all the calories together
 static int comp_calories( const std::vector<item_comp> &components )

--- a/tests/enchantments_test.cpp
+++ b/tests/enchantments_test.cpp
@@ -61,12 +61,17 @@ static void advance_turn( Character &guy )
     calendar::turn += 1_turns;
 }
 
+namespace
+{
+
 struct enchant_test {
     int dex_before;
     int lie_before;
     int persuade_before;
     int intimidate_before;
 };
+
+} // namespace
 
 static void test_generic_ench( avatar &p, enchant_test enc_test )
 {

--- a/tests/encumbrance_test.cpp
+++ b/tests/encumbrance_test.cpp
@@ -83,6 +83,8 @@ static void test_encumbrance(
     test_encumbrance_items( clothing, body_part, expected_encumbrance );
 }
 
+namespace
+{
 struct add_trait {
     explicit add_trait( const std::string &t ) : trait( t ) {}
     explicit add_trait( const trait_id &t ) : trait( t ) {}
@@ -93,6 +95,7 @@ struct add_trait {
 
     trait_id trait;
 };
+} // namespace
 
 static constexpr int postman_shirt_e = 0;
 static constexpr int longshirt_e = 3;

--- a/tests/event_test.cpp
+++ b/tests/event_test.cpp
@@ -26,6 +26,9 @@ TEST_CASE( "construct_event", "[event]" )
     CHECK( e.get<int>( "exp" ) == 100 );
 }
 
+namespace
+{
+
 struct test_subscriber : public event_subscriber {
     using event_subscriber::notify;
     void notify( const cata::event &e ) override {
@@ -34,6 +37,8 @@ struct test_subscriber : public event_subscriber {
 
     std::vector<cata::event> events;
 };
+
+} // namespace
 
 TEST_CASE( "push_event_on_vector", "[event]" )
 {
@@ -80,6 +85,9 @@ TEST_CASE( "destroy_bus_before_subscriber", "[event]" )
     CHECK( sub.events.size() == 1 );
 }
 
+namespace
+{
+
 struct expect_subscriber : public event_subscriber {
     using event_subscriber::notify;
     void notify( const cata::event & ) override {
@@ -87,6 +95,8 @@ struct expect_subscriber : public event_subscriber {
     }
     bool found = false;
 };
+
+} // namespace
 
 TEST_CASE( "notify_subscriber_2", "[event]" )
 {

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -41,9 +41,14 @@ static const damage_type_id damage_bullet( "bullet" );
 
 static const itype_id itype_grenade_act( "grenade_act" );
 
+namespace
+{
+
 enum class outcome_type {
     Kill, Casualty
 };
+
+} // namespace
 
 static float get_damage_vs_target( const std::string &target_id )
 {

--- a/tests/flat_set_test.cpp
+++ b/tests/flat_set_test.cpp
@@ -110,6 +110,7 @@ TEST_CASE( "flat_set_comparison", "[flat_set]" )
     CHECK( int_set{ 6, 0 } < int_set{ 1 } );
 }
 
+// NOLINTNEXTLINE(misc-use-internal-linkage): anon-ns wrap makes friend-operator overloads look unused
 struct int_like {
     int i;
 #define INT_LIKE_OPERATOR( op ) \

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -33,6 +33,8 @@ static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_jeans( "jeans" );
 static const itype_id itype_tshirt( "tshirt" );
 
+namespace
+{
 enum inventory_location {
     GROUND,
     INVENTORY,
@@ -55,6 +57,7 @@ enum test_action {
     REMOVE_1ST_ADD_1ST,
     TEST_ACTION_NUM,
 };
+} // namespace
 
 static void set_id( item &it, const std::string &id )
 {

--- a/tests/item_autopickup_test.cpp
+++ b/tests/item_autopickup_test.cpp
@@ -60,6 +60,9 @@ static const itype_id itype_wrapper( "wrapper" );
 
 static const pocket_type pocket_type_container = pocket_type::CONTAINER;
 
+namespace
+{
+
 class unique_item
 {
     private:
@@ -140,6 +143,8 @@ class unique_item
             return &null_item_reference();
         }
 };
+
+} // namespace
 
 // Add the given item to auto-pickup character rules and check rules.
 static void add_autopickup_rule( const item *what, bool include )

--- a/tests/mapgen_post_process_test.cpp
+++ b/tests/mapgen_post_process_test.cpp
@@ -77,6 +77,9 @@ static const ter_str_id ter_t_wall_wood( "t_wall_wood" );
 static const ter_str_id ter_t_water_dp( "t_water_dp" );
 static const ter_str_id ter_t_wood_stairs_up( "t_wood_stairs_up" );
 
+namespace
+{
+
 // Scan a 24x24 OMT area on a map and collect terrain/field statistics.
 struct pp_scan_result {
     int wall_wood_count = 0;
@@ -89,6 +92,8 @@ struct pp_scan_result {
     int fire_field_count = 0;
     int furniture_count = 0;
 };
+
+} // namespace
 
 static pp_scan_result scan_omt( map &m, int z_level )
 {
@@ -190,6 +195,9 @@ TEST_CASE( "post_process_riot_damage_seeded_smoke", "[mapgen][post_process]" )
     }
 }
 
+namespace
+{
+
 // Capture full tile-by-tile snapshot of a 24x24 OMT for exact comparison.
 struct tile_state {
     ter_id ter;
@@ -197,6 +205,8 @@ struct tile_state {
     int blood_intensity;
     int fire_intensity;
 };
+
+} // namespace
 
 static std::vector<tile_state> snapshot_omt( map &m, int z_level )
 {

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -98,6 +98,9 @@ static int moves_to_destination( const std::string &monster_type,
     return 100000;
 }
 
+namespace
+{
+
 struct track {
     char participant;
     int moves;
@@ -105,7 +108,7 @@ struct track {
     tripoint location;
 };
 
-static std::ostream &operator<<( std::ostream &os, track const &value )
+std::ostream &operator<<( std::ostream &os, track const &value )
 {
     os << value.participant <<
        " l:" << value.location <<
@@ -114,13 +117,15 @@ static std::ostream &operator<<( std::ostream &os, track const &value )
     return os;
 }
 
-static std::ostream &operator<<( std::ostream &os, const std::vector<track> &vec )
+std::ostream &operator<<( std::ostream &os, const std::vector<track> &vec )
 {
     for( const track &track_instance : vec ) {
         os << track_instance << " ";
     }
     return os;
 }
+
+} // namespace
 
 /**
  * Simulate a player running from the monster, checking if it can catch up.

--- a/tests/name_test.cpp
+++ b/tests/name_test.cpp
@@ -6,6 +6,9 @@
 #include "path_info.h"
 #include "text_snippets.h"
 
+namespace
+{
+
 class IsOneOf : public Catch::MatcherBase<std::string>
 {
         std::set< std::string > values;
@@ -23,6 +26,8 @@ class IsOneOf : public Catch::MatcherBase<std::string>
             return s;
         }
 };
+
+} // namespace
 
 TEST_CASE( "name_generation", "[name]" )
 {

--- a/tests/new_character_test.cpp
+++ b/tests/new_character_test.cpp
@@ -85,12 +85,17 @@ static int get_item_count( const std::set<const item *> &items )
     return sum;
 }
 
+namespace
+{
+
 struct failure {
     string_id<profession> prof;
     std::vector<trait_id> mut;
     itype_id item_name;
     std::string reason;
 };
+
+} // namespace
 
 namespace std
 {

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -92,6 +92,9 @@ static const itype_id itype_test_shot_00_fire_damage( "test_shot_00_fire_damage"
 
 using firing_statistics = statistics<bool>;
 
+namespace
+{
+
 class Threshold
 {
     public:
@@ -108,6 +111,8 @@ class Threshold
         double _accuracy;
         double _chance;
 };
+
+} // namespace
 
 template < class T >
 static std::ostream &operator <<( std::ostream &os, const std::vector<T> &v )

--- a/tests/rng_test.cpp
+++ b/tests/rng_test.cpp
@@ -54,11 +54,11 @@ static void check_x_in_y( double x, double y )
 TEST_CASE( "x_in_y_distribution", "[rng]" )
 {
     float y_increment = 0.01f;
-    // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter,cert-flp30-c)
+    // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter,cert-flp30-c,bugprone-float-loop-counter)
     for( float y = 0.1f; y < 500.0f; y += y_increment ) {
         y_increment *= 1.1f;
         float x_increment = 0.1f;
-        // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter,cert-flp30-c)
+        // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter,cert-flp30-c,bugprone-float-loop-counter)
         for( float x = 0.1f; x < y; x += x_increment ) {
             check_x_in_y( x, y );
             x_increment *= 1.1f;

--- a/tests/safe_reference_test.cpp
+++ b/tests/safe_reference_test.cpp
@@ -4,6 +4,9 @@
 
 #include "safe_reference.h"
 
+namespace
+{
+
 struct example {
     safe_reference_anchor anchor;
 
@@ -11,6 +14,8 @@ struct example {
         return anchor.reference_to( this );
     }
 };
+
+} // namespace
 
 TEST_CASE( "safe_reference_returns_correct_object", "[safe_reference]" )
 {

--- a/tests/shadowcasting_test.cpp
+++ b/tests/shadowcasting_test.cpp
@@ -514,6 +514,9 @@ static constexpr float X = LIGHT_TRANSPARENCY_SOLID;
 
 static const tripoint_bub_ms ORIGIN( 65, 65, 11 );
 
+namespace
+{
+
 struct grid_overlay {
     std::vector<std::vector<std::vector<float>>> data;
     std::vector<std::vector<std::vector<bool>>> floor;
@@ -568,6 +571,8 @@ struct grid_overlay {
         return default_floor;
     }
 };
+
+} // namespace
 
 static void run_spot_check( const grid_overlay &test_case, const grid_overlay &expected,
                             bool fov_3d )

--- a/tests/stats_tracker_test.cpp
+++ b/tests/stats_tracker_test.cpp
@@ -404,12 +404,17 @@ TEST_CASE( "stats_tracker_with_event_statistics", "[stats]" )
     }
 }
 
+namespace
+{
+
 struct watch_stat : stat_watcher {
     void new_value( const cata_variant &v, stats_tracker & ) override {
         value = v;
     }
     cata_variant value;
 };
+
+} // namespace
 
 TEST_CASE( "stats_tracker_watchers", "[stats]" )
 {
@@ -916,6 +921,9 @@ TEST_CASE( "stats_tracker_in_game", "[stats]" )
     CHECK( get_stats().get_events( e.type() ).count( e.data() ) == 1 );
 }
 
+namespace
+{
+
 struct stats_test_subscriber : public event_subscriber {
     using event_subscriber::notify;
     void notify( const cata::event &e ) override {
@@ -927,6 +935,8 @@ struct stats_test_subscriber : public event_subscriber {
 
     std::vector<cata::event> events;
 };
+
+} // namespace
 
 TEST_CASE( "achievements_tracker_in_game", "[stats]" )
 {

--- a/tests/submap_load_test.cpp
+++ b/tests/submap_load_test.cpp
@@ -887,6 +887,9 @@ static void load_from_jsin( submap &sm, const JsonValue &jsin )
     }
 }
 
+namespace
+{
+
 struct submap_checks {
     bool terrain = true;
     bool furniture = true;
@@ -900,6 +903,8 @@ struct submap_checks {
     bool construction = true;
     bool computers = true;
 };
+
+} // namespace
 
 //static const submap_checks dont_care;
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -203,6 +203,9 @@ static option_overrides_t extract_option_overrides( const std::string_view optio
     return ret;
 }
 
+namespace
+{
+
 struct CataListener : Catch::TestEventListenerBase {
     using TestEventListenerBase::TestEventListenerBase;
 
@@ -307,6 +310,8 @@ struct CataListener : Catch::TestEventListenerBase {
     }
 
 };
+
+} // namespace
 
 CATCH_REGISTER_LISTENER( CataListener )
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -317,6 +317,7 @@ TEST_CASE( "noop_test", "[.]" )
 }
 
 
+// NOLINTNEXTLINE(bugprone-exception-escape): test runner intentionally lets exceptions propagate
 int main( int argc, const char *argv[] )
 {
     cata::init_allocator();

--- a/tests/throwing_test.cpp
+++ b/tests/throwing_test.cpp
@@ -39,6 +39,8 @@ TEST_CASE( "throwing_distance_test", "[throwing], [balance]" )
     CHECK( thrower.throw_range( grenade ) <= 35 );
 }
 
+namespace
+{
 struct throw_test_data {
     statistics<bool> hits;
     statistics<double> dmg;
@@ -53,11 +55,12 @@ struct throw_test_pstats {
     int per;
 };
 
-static std::ostream &operator<<( std::ostream &stream, const throw_test_pstats &pstats )
+std::ostream &operator<<( std::ostream &stream, const throw_test_pstats &pstats )
 {
     return stream << "STR: " << pstats.str << " DEX: " << pstats.dex <<
            " PER: " << pstats.per << " SKL: " << pstats.skill_lvl;
 }
+} // namespace
 
 static void reset_player( Character &you, const throw_test_pstats &pstats,
                           const tripoint_bub_ms &pos )

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -167,11 +167,16 @@ TEST_CASE( "starting_bicycle_damaged_pedal", "[vehicle]" )
     here.detach_vehicle( veh_ptr );
 }
 
+namespace
+{
 struct vehicle_preset {
     itype_id vehicle_itype_id; // folding vehicle to test
     std::vector<itype_id> tool_itype_ids; // tool to grant
 };
+} // namespace
 
+namespace
+{
 struct damage_preset {
     int damage;
     int degradation;
@@ -179,6 +184,7 @@ struct damage_preset {
     int expect_degradation;
     int expect_hp;
 };
+} // namespace
 
 static void complete_activity( Character &u, const activity_actor &act )
 {
@@ -332,6 +338,8 @@ TEST_CASE( "Unfolding_vehicle_parts_and_testing_degradation", "[item][degradatio
     clear_vehicles( &get_map() );
 }
 
+namespace
+{
 struct folded_item_damage_preset {
     itype_id folded_vehicle_item;
     int item_damage_first_fold;
@@ -339,6 +347,7 @@ struct folded_item_damage_preset {
     int part_damage_second_unfold; // sum of damage over all parts
     int part_damage_third_unfold;  // sum of damage over all parts
 };
+} // namespace
 
 static void check_folded_item_to_parts_damage_transfer( const folded_item_damage_preset &preset )
 {
@@ -583,6 +592,8 @@ TEST_CASE( "power_cable_stretch_disconnect" )
     }
 }
 
+namespace
+{
 struct rack_activation {
     int racking_vehicle_index; // vehicle with the rack
     tripoint_bub_ms rack_pos;  // rack to activate
@@ -601,6 +612,7 @@ struct rack_preset {
     std::vector<rack_activation> rack_orders;   // racking orders
     std::vector<rack_activation> unrack_orders; // unracking orders
 };
+} // namespace
 
 static void rack_check( const rack_preset &preset )
 {

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -131,6 +131,8 @@ static const tile_predicate set_up_tiles_common =
     ifchar( 'G', ter_set( ter_t_window_stained_green ) + ter_set_flat_roof_above ) ||
     fail;
 
+namespace
+{
 struct vision_test_flags {
     bool crouching = false;
     bool headlamp = false;
@@ -138,7 +140,10 @@ struct vision_test_flags {
     bool moncam = false;
     bool myopic = false;
 };
+} // namespace
 
+namespace
+{
 struct vision_test_case {
 
     std::vector<std::string> setup;
@@ -240,6 +245,7 @@ struct vision_test_case {
         }
     }
 };
+} // namespace
 
 static std::optional<units::angle> testcase_veh_dir( point const &def, vision_test_case const &t,
         map_test_case::tile &tile )

--- a/tests/visitable_zone_test.cpp
+++ b/tests/visitable_zone_test.cpp
@@ -21,6 +21,9 @@
 static const tripoint_bub_ms p1( 0, 0, -2 );
 static const tripoint_bub_ms p2( ( MAPSIZE *SEEX ) - 1, ( MAPSIZE *SEEY ) - 1, 1 );
 
+namespace
+{
+
 struct structure {
     structure( const tripoint_bub_ms &origin, const tripoint_rel_ms &dimensions,
                const std::string &name ) :
@@ -31,6 +34,8 @@ struct structure {
     inclusive_cuboid<tripoint_bub_ms> area;
     std::string name_;
 };
+
+} // namespace
 
 static void place_structures( const std::vector<structure> &spawn_areas,
                               std::vector<std::vector<tripoint_bub_ms>> &interior_areas,

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -173,6 +173,8 @@ TEST_CASE( "avatar_diving", "[diving]" )
     g->vertical_shift( 0 );
 }
 
+namespace
+{
 struct swimmer_stats {
     int strength = 0;
     int dexterity = 0;
@@ -230,6 +232,7 @@ struct swim_result {
     int move_cost = 0;
     int steps = 0;
 };
+} // namespace
 
 static const std::unordered_map<std::string, swimmer_stats> stats_map = {
     {"minimum", { 4, 4 }},
@@ -257,6 +260,8 @@ static const std::unordered_map<std::string, swimmer_traits> traits_map = {
     {"webbed hands and feet", {{"WEBBED", "WEBBED_FEET"}}},
 };
 
+namespace
+{
 struct swim_scenario {
     move_mode_id move_mode;
     swimmer_config config;
@@ -275,6 +280,7 @@ struct swim_scenario {
                               config.stats_name, config.skills_name, config.gear_name, config.traits_name );
     }
 };
+} // namespace
 
 static int swimming_steps( avatar &swimmer )
 {

--- a/tests/weakpoint_test.cpp
+++ b/tests/weakpoint_test.cpp
@@ -35,6 +35,8 @@ static const mtype_id mon_test_zombie_cop( "mon_test_zombie_cop" );
 static const mtype_id mon_zombie( "mon_zombie" );
 static const mtype_id pseudo_debug_mon( "pseudo_debug_mon" );
 
+namespace
+{
 struct weakpoint_report_item {
     std::string weakpoint;
     int totaldamage;
@@ -43,7 +45,10 @@ struct weakpoint_report_item {
         hits{ 1 } { }
     weakpoint_report_item() : weakpoint_report_item( "", 0 ) { }
 };
+} // namespace
 
+namespace
+{
 struct weakpoint_report {
     int hits;
     std::map<std::string, weakpoint_report_item> items;
@@ -79,6 +84,7 @@ struct weakpoint_report {
         items.clear();
     }
 };
+} // namespace
 
 static weakpoint_report damage_monster( const mtype_id &target_type, const damage_instance &dam,
                                         int attacks )
@@ -281,12 +287,15 @@ TEST_CASE( "Check_copy-from_inheritance_between_sets_and_inline_weakpoints",
     }
 }
 
+namespace
+{
 struct wp_test_values {
     mtype_id mon;
     itype_id weapon;
     float skill_lvl;
     float accuracy = 0.f;
 };
+} // namespace
 
 static std::unordered_map<std::string, int> weakpoint_hit_distribution_proj(
     wp_test_values test_values )

--- a/tests/weather_test.cpp
+++ b/tests/weather_test.cpp
@@ -50,6 +50,9 @@ static double proportion_gteq_x( std::vector<double> const &v, double x )
 static constexpr int n_hours = to_hours<int>( 1_days );
 static constexpr int n_minutes = to_minutes<int>( 1_days );
 
+namespace
+{
+
 struct year_of_weather_data {
     explicit year_of_weather_data( int n_days )
         : temperature( n_days, std::vector<double>( n_minutes, 0 ) )
@@ -63,6 +66,8 @@ struct year_of_weather_data {
     std::vector<double> highs;
     std::vector<double> lows;
 };
+
+} // namespace
 
 static year_of_weather_data collect_weather_data( unsigned seed )
 {

--- a/tests/zzip_test.cpp
+++ b/tests/zzip_test.cpp
@@ -36,7 +36,7 @@ std::vector<std::byte> make_bytes( size_t count )
     std::vector<std::byte> bytes;
     bytes.reserve( count );
     for( size_t i = 0; i < count; ++i ) {
-        // NOLINTNEXTLINE(cata-determinism,cert-msc30-c,cert-msc50-cpp)
+        // NOLINTNEXTLINE(cata-determinism,cert-msc30-c,cert-msc50-cpp,misc-predictable-rand)
         bytes.push_back( static_cast<std::byte>( rand() %
                          std::numeric_limits<std::underlying_type_t<std::byte>>::max() ) );
     }


### PR DESCRIPTION
#### Summary
Infrastructure "Address LLVM 22 clang-tidy findings"

#### Purpose of change
Followup to #86952. With cata-large-stack-object re-enabled, the biggest remaining clang-tidy 22 noise is misc-use-internal-linkage. Discussion landed on anonymous namespaces over `static`: it's a C++ codebase, anon-ns is the idiomatic move, and `static` doesn't even work for types.

Also folds in a handful of other clang-tidy 22 one-liners that were riding along: make_unique, emplace_back, redundant void returns in ncurses wrappers, point aggregation, SDL_SOUND-gating for already-static decls that only have SDL_SOUND consumers, and intentional NOLINTs for popen / sscanf / float-loop / etc.

#### Describe the solution
~290 TU-local struct/class/enum/variable definitions wrapped in `namespace { ... } // namespace` across 93 files.

A few cases needed extra surgery:

- Out-of-anon-ns `static operator<` etc. moved into the anon-ns alongside their type (item_info, shadowcasting, throwing_test, activity_handlers). Otherwise GCC errors on "defined but not used" since ADL no longer finds them.
- mission_ui / scores_ui Impl + member definitions folded into the existing anon-ns so `friend class Impl` still resolves to the same class.
- One extern template instantiation in npctalk can't move into anon-ns; NOLINT'd.
- flexbuffer_disk_cache stays in global ns because its forward decl in the header is used by a `unique_ptr` member.

#### Describe alternatives you've considered
`static` on the variables/functions (the only ones it could apply to). Splits the file into two idioms for what's conceptually one rule.

#### Testing
Verified with local clang-tidy 22; game builds and starts.

#### Additional context
N/A