### PR TITLE
Fix fallback fonts not being rendered in ImGui

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -477,14 +477,12 @@ void cataimgui::client::load_fonts( UNUSED const Font_Ptr &gui_font,
             load_font( io, gui_typefaces, ranges.begin(),
                        static_cast<float>( lroundf( fontheight * 1.5f ) ) );
         }
-        for( int i = 0; i < io.Fonts->Fonts.Size; i++ ) {
-            io.Fonts->Fonts[i]->SetFallbackStrSizeCallback( GetFallbackStrWidth );
-            io.Fonts->Fonts[i]->SetFallbackCharSizeCallback( GetFallbackCharWidth );
-            io.Fonts->Fonts[i]->SetRenderFallbackCharCallback( CanRenderFallbackChar );
-        }
         io.Fonts->Build();
         for( int i = 0; i < io.Fonts->Fonts.Size; i++ ) {
             check_font( io.Fonts->Fonts[i] );
+            io.Fonts->Fonts[i]->SetFallbackStrSizeCallback( GetFallbackStrWidth );
+            io.Fonts->Fonts[i]->SetFallbackCharSizeCallback( GetFallbackCharWidth );
+            io.Fonts->Fonts[i]->SetRenderFallbackCharCallback( CanRenderFallbackChar );
         }
         ImGui::SetCurrentFont( ImGui::GetDefaultFont() );
 #if SDL_MAJOR_VERSION >= 3


### PR DESCRIPTION
#### Summary
Bugfixes "Fix fallback fonts not being rendered in ImGui"


#### Purpose of change
#86637 introduced clearing the fallback glyph callbacks in `ClearOutputData()` that is called when building the fonts. The fallback glyph callbacks are being set before building, so `ClearOutputData()` is nulling them causing a '?' to appear for all fallback glyphs.

#### Describe the solution
Move registration of the fallback glyph callbacks to after building the fonts so they are not nulled out.

Resolves #86976

#### Describe alternatives you've considered
None

#### Testing
Compiled in Windows.
Started a game with MoM and powers.
Verified special symbol for powers was correct and not a `?`

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
