### PR TITLE
Move `do_turn()` to `game`, documentation for `Creature::moves`

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -1230,7 +1230,9 @@ class Creature : public viewer
 
         void migrate_effects();
     protected:
-        // How many moves do we have to work with
+        /*
+        * moves are spent and replenished during game::do_turn()
+        */
         int moves;
         Creature *killer; // whoever killed us. this should be NULL unless we are dead
         void set_killer( Creature *killer );
@@ -1262,7 +1264,12 @@ class Creature : public viewer
         int num_dodges_bonus = 0;
 
         std::map<damage_type_id, float> armor_bonus;
-        int speed_base = 0; // only speed needs a base, the rest are assumed at 0 and calculated off skills
+
+        /*
+        * speed is measured in moves and replenishes Creature::moves in game::do_turn()
+        * only speed needs a base, the other bonuses are assumed at 0 and calculated off skills
+        */
+        int speed_base = 0;
 
         int speed_bonus = 0;
         float dodge_bonus = 0.0f;

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -483,14 +483,7 @@ bool do_turn()
     // Increment game turn
     if( g->new_game ) {
         g->new_game = false;
-        if( get_option<std::string>( "ETERNAL_WEATHER" ) != "normal" ) {
-            weather.weather_override = static_cast<weather_type_id>
-                                       ( get_option<std::string>( "ETERNAL_WEATHER" ) );
-            weather.set_nextweather( calendar::turn );
-        } else {
-            weather.weather_override = WEATHER_NULL;
-            weather.set_nextweather( calendar::turn );
-        }
+        weather.on_game_start();
     } else {
         g->gamemode->per_turn();
         calendar::turn += 1_turns;

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -463,8 +463,15 @@ void overmap_npc_move()
 
 } // namespace
 
-// MAIN GAME LOOP
-// Returns true if game is over (death, saved, quit, etc)
+/*
+* MAIN GAME LOOP
+*
+* Process a `turn`, equal to one in-game second, by doing two things:
+* 1. spend and replenish Creature::moves -- for `avatar`, `npc`, `monster`
+* 2. handle game systems (weather, missions, fields, see below)
+*
+* @return true if game is over (death, saved, quit, etc)
+*/
 bool do_turn()
 {
     if( g->is_game_over() ) {
@@ -472,7 +479,8 @@ bool do_turn()
     }
 
     weather_manager &weather = get_weather();
-    // Actual stuff
+
+    // Increment game turn
     if( g->new_game ) {
         g->new_game = false;
         if( get_option<std::string>( "ETERNAL_WEATHER" ) != "normal" ) {
@@ -548,12 +556,15 @@ bool do_turn()
     }
 
     weather.update_weather();
+
     g->reset_light_level();
     for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
         m.set_lightmap_cache_dirty( z );
     }
 
     g->perhaps_add_random_npc( /* ignore_spawn_timers_and_rates = */ false );
+
+    // process avatar activities (ignoring user input)
     while( u.get_moves() > 0 && u.activity ) {
         u.activity.do_turn( u );
     }
@@ -574,11 +585,15 @@ bool do_turn()
         sfx::do_hearing_loss();
     }
 
+    // avatar processes human input through handle_action()
     if( !u.has_effect( effect_sleep ) || g->uquit == QUIT_WATCH ) {
         if( u.get_moves() > 0 || g->uquit == QUIT_WATCH ) {
             while( u.get_moves() > 0 || g->uquit == QUIT_WATCH ) {
+
+                // handle_action() may cause map updates, creatures to die
                 m.process_falling();
                 g->cleanup_dead();
+
                 g->mon_info_update();
                 // Process any new sounds the player caused during their turn.
                 for( npc &guy : g->all_npcs() ) {
@@ -611,6 +626,8 @@ bool do_turn()
                 if( g->uquit == QUIT_WATCH ) {
                     break;
                 }
+
+                // avatar processes moves for activities started by handle_action()
                 while( u.get_moves() > 0 && u.activity ) {
                     u.activity.do_turn( u );
                 }
@@ -677,7 +694,10 @@ bool do_turn()
     // Update vision caches for monsters. If this turns out to be expensive,
     // consider a stripped down cache just for monsters.
     m.build_map_cache( levz, true );
+
+    // process monster and npc turn
     monmove();
+
     if( calendar::once_every( time_between_npc_OM_moves ) ) {
         overmap_npc_move();
     }
@@ -695,8 +715,12 @@ bool do_turn()
             }
         }
     }
+    // required after monsters move and fields emit
     g->mon_info_update();
+
+    // replenish avatar moves
     u.process_turn();
+
     if( u.get_moves() < 0 && get_option<bool>( "FORCE_REDRAW" ) ) {
         ui_manager::redraw();
         refresh_display();
@@ -706,6 +730,7 @@ bool do_turn()
         handle_weather_effects( weather.weather_id );
     }
 
+    // handle activity/progress/waiting UI
     const bool player_is_sleeping = u.has_effect( effect_sleep );
     bool wait_redraw = false;
     std::string wait_message;

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -11,7 +11,6 @@
 #include <optional>
 #include <ostream>
 #include <ratio>
-#include <set>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -57,7 +56,6 @@
 #include "npc.h"
 #include "options.h"
 #include "output.h"
-#include "overmap_ui.h"
 #include "overmapbuffer.h"
 #include "pimpl.h"
 #include "player_activity.h"
@@ -79,7 +77,6 @@
 #include "vehicle.h"
 #include "vpart_position.h"
 #include "weather.h"
-#include "weather_type.h"
 #include "worldfactory.h"
 
 static const activity_id ACT_AUTODRIVE( "ACT_AUTODRIVE" );
@@ -463,42 +460,91 @@ void overmap_npc_move()
 
 } // namespace
 
-/*
-* MAIN GAME LOOP
-*
-* Process a `turn`, equal to one in-game second, by doing two things:
-* 1. spend and replenish Creature::moves -- for `avatar`, `npc`, `monster`
-* 2. handle game systems (weather, missions, fields, see below)
-*
-* @return true if game is over (death, saved, quit, etc)
-*/
-bool do_turn()
+void game::handle_progress_ui()
 {
-    if( g->is_game_over() ) {
+    avatar &u = get_avatar();
+
+    // handle activity/progress/waiting UI
+    const bool player_is_sleeping = u.has_effect( effect_sleep );
+    bool wait_redraw = false;
+    std::string wait_message;
+    time_duration wait_refresh_rate;
+    if( player_is_sleeping ) {
+        wait_redraw = true;
+        wait_message = _( "Wait till you wake up…" );
+        wait_refresh_rate = 30_minutes;
+    } else if( const std::optional<std::string> progress = u.activity.get_progress_message( u ) ) {
+        wait_redraw = true;
+        wait_message = *progress;
+        if( u.activity.is_interruptible() && u.activity.interruptable_with_kb ) {
+            wait_message += string_format( _( "\n%s to interrupt" ), press_x( ACTION_PAUSE ) );
+        }
+        if( u.activity.id() == ACT_AUTODRIVE ) {
+            wait_refresh_rate = 1_turns;
+        } else if( u.activity.id() == ACT_FIRSTAID ) {
+            wait_refresh_rate = 5_turns;
+        } else {
+            wait_refresh_rate = 5_minutes;
+        }
+    }
+    if( wait_redraw ) {
+        if( first_redraw_since_waiting_started ||
+            calendar::once_every( std::min( 1_minutes, wait_refresh_rate ) ) ) {
+            if( first_redraw_since_waiting_started || calendar::once_every( wait_refresh_rate ) ) {
+                ui_manager::redraw();
+            }
+
+            // Avoid redrawing the main UI every time due to invalidation
+#ifdef TILES
+            // If an ImGui window just closed and cleared the buffer, do a full
+            // redraw now before blocking UIs below.
+            if( cataimgui::clear_pending() ) {
+                ui_manager::redraw();
+            }
+#endif
+            ui_adaptor dummy( ui_adaptor::disable_uis_below {} );
+            if( !wait_popup ) {
+                wait_popup = std::make_unique<static_popup>();
+            }
+            wait_popup->on_top( true ).wait_message( "%s", wait_message );
+            ui_manager::redraw();
+            refresh_display();
+            first_redraw_since_waiting_started = false;
+        }
+    } else {
+        // Nothing to wait for now
+        wait_popup_reset();
+        first_redraw_since_waiting_started = true;
+    }
+}
+
+bool game::do_turn()
+{
+    if( is_game_over() ) {
         return turn_handler::cleanup_at_end();
     }
 
     weather_manager &weather = get_weather();
 
     // Increment game turn
-    if( g->new_game ) {
-        g->new_game = false;
+    if( new_game ) {
+        new_game = false;
         weather.on_game_start();
     } else {
-        g->gamemode->per_turn();
+        gamemode->per_turn();
         calendar::turn += 1_turns;
     }
     //used for dimension swapping
-    if( g->swapping_dimensions ) {
-        g->swapping_dimensions = false;
+    if( swapping_dimensions ) {
+        swapping_dimensions = false;
     }
     play_music( music::get_music_id_string() );
 
     // starting a new turn, clear out temperature cache
     weather.temperature_cache.clear();
 
-    if( g->npcs_dirty ) {
-        g->load_npcs();
+    if( npcs_dirty ) {
+        load_npcs();
     }
 
     timed_event_manager &timed_events = get_timed_events();
@@ -537,7 +583,7 @@ bool do_turn()
         }
     }
 
-    g->debug_hour_timer.print_time();
+    debug_hour_timer.print_time();
 
     u.update_body();
 
@@ -545,17 +591,17 @@ bool do_turn()
     if( get_option<bool>( "AUTOSAVE" ) &&
         calendar::once_every( 1_turns * get_option<int>( "AUTOSAVE_TURNS" ) ) &&
         !u.is_dead_state() ) {
-        g->autosave();
+        autosave();
     }
 
     weather.update_weather();
 
-    g->reset_light_level();
+    reset_light_level();
     for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
         m.set_lightmap_cache_dirty( z );
     }
 
-    g->perhaps_add_random_npc( /* ignore_spawn_timers_and_rates = */ false );
+    perhaps_add_random_npc( /* ignore_spawn_timers_and_rates = */ false );
 
     // process avatar activities (ignoring user input)
     while( u.get_moves() > 0 && u.activity ) {
@@ -563,7 +609,7 @@ bool do_turn()
     }
 
     // Process NPC sound events before they move or they hear themselves talking
-    for( npc &guy : g->all_npcs() ) {
+    for( npc &guy : all_npcs() ) {
         if( rl_dist( guy.pos_bub(), u.pos_bub() ) < MAX_VIEW_DISTANCE ) {
             sounds::process_sound_markers( &guy );
         }
@@ -579,44 +625,44 @@ bool do_turn()
     }
 
     // avatar processes human input through handle_action()
-    if( !u.has_effect( effect_sleep ) || g->uquit == QUIT_WATCH ) {
-        if( u.get_moves() > 0 || g->uquit == QUIT_WATCH ) {
-            while( u.get_moves() > 0 || g->uquit == QUIT_WATCH ) {
+    if( !u.has_effect( effect_sleep ) || uquit == QUIT_WATCH ) {
+        if( u.get_moves() > 0 || uquit == QUIT_WATCH ) {
+            while( u.get_moves() > 0 || uquit == QUIT_WATCH ) {
 
                 // handle_action() may cause map updates, creatures to die
                 m.process_falling();
-                g->cleanup_dead();
+                cleanup_dead();
 
-                g->mon_info_update();
+                mon_info_update();
                 // Process any new sounds the player caused during their turn.
-                for( npc &guy : g->all_npcs() ) {
+                for( npc &guy : all_npcs() ) {
                     if( rl_dist( guy.pos_bub(), u.pos_bub() ) < MAX_VIEW_DISTANCE ) {
                         sounds::process_sound_markers( &guy );
                     }
                 }
                 explosion_handler::process_explosions();
                 sounds::process_sound_markers( &u );
-                if( !u.activity && g->uquit != QUIT_WATCH
+                if( !u.activity && uquit != QUIT_WATCH
                     && ( !u.has_distant_destination() || calendar::once_every( 10_seconds ) ) ) {
-                    g->wait_popup_reset();
+                    wait_popup_reset();
                     ui_manager::redraw();
                 }
 
-                if( g->queue_screenshot ) {
-                    g->take_screenshot();
-                    g->queue_screenshot = false;
+                if( queue_screenshot ) {
+                    take_screenshot();
+                    queue_screenshot = false;
                 }
 
-                if( g->handle_action() ) {
-                    ++g->moves_since_last_save;
+                if( handle_action() ) {
+                    ++moves_since_last_save;
                     u.action_taken();
                 }
 
-                if( g->is_game_over() ) {
+                if( is_game_over() ) {
                     return turn_handler::cleanup_at_end();
                 }
 
-                if( g->uquit == QUIT_WATCH ) {
+                if( uquit == QUIT_WATCH ) {
                     break;
                 }
 
@@ -639,14 +685,14 @@ bool do_turn()
                 start = now;
             }
 
-            g->mon_info_update();
+            mon_info_update();
 
             // If player is performing a task, a monster is dangerously close,
             // and monster can reach to the player or it has some sort of a ranged attack,
             // warn them regardless of previous safemode warnings
             if( u.activity ) {
                 for( std::pair<const distraction_type, std::string> &dist : u.activity.get_distractions() ) {
-                    if( g->cancel_activity_or_ignore_query( dist.first, dist.second ) ) {
+                    if( cancel_activity_or_ignore_query( dist.first, dist.second ) ) {
                         break;
                     }
                 }
@@ -654,13 +700,13 @@ bool do_turn()
         }
     }
 
-    if( g->driving_view_offset.x() != 0 || g->driving_view_offset.y() != 0 ) {
+    if( driving_view_offset.x() != 0 || driving_view_offset.y() != 0 ) {
         // Still have a view offset, but might not be driving anymore,
         // or the option has been deactivated,
         // might also happen when someone dives from a moving car.
         // or when using the handbrake.
         vehicle *veh = veh_pointer_or_null( m.veh_at( u.pos_bub() ) );
-        g->calc_driving_offset( veh );
+        calc_driving_offset( veh );
     }
 
     scent_map &scent = get_scent();
@@ -696,7 +742,7 @@ bool do_turn()
     }
     m.furniture_terrain_emit_fields();
     // required after monsters move and fields emit
-    g->mon_info_update();
+    mon_info_update();
 
     // replenish avatar moves
     u.process_turn();
@@ -710,58 +756,7 @@ bool do_turn()
         handle_weather_effects( weather.weather_id );
     }
 
-    // handle activity/progress/waiting UI
-    const bool player_is_sleeping = u.has_effect( effect_sleep );
-    bool wait_redraw = false;
-    std::string wait_message;
-    time_duration wait_refresh_rate;
-    if( player_is_sleeping ) {
-        wait_redraw = true;
-        wait_message = _( "Wait till you wake up…" );
-        wait_refresh_rate = 30_minutes;
-    } else if( const std::optional<std::string> progress = u.activity.get_progress_message( u ) ) {
-        wait_redraw = true;
-        wait_message = *progress;
-        if( u.activity.is_interruptible() && u.activity.interruptable_with_kb ) {
-            wait_message += string_format( _( "\n%s to interrupt" ), press_x( ACTION_PAUSE ) );
-        }
-        if( u.activity.id() == ACT_AUTODRIVE ) {
-            wait_refresh_rate = 1_turns;
-        } else if( u.activity.id() == ACT_FIRSTAID ) {
-            wait_refresh_rate = 5_turns;
-        } else {
-            wait_refresh_rate = 5_minutes;
-        }
-    }
-    if( wait_redraw ) {
-        if( g->first_redraw_since_waiting_started ||
-            calendar::once_every( std::min( 1_minutes, wait_refresh_rate ) ) ) {
-            if( g->first_redraw_since_waiting_started || calendar::once_every( wait_refresh_rate ) ) {
-                ui_manager::redraw();
-            }
-
-            // Avoid redrawing the main UI every time due to invalidation
-#ifdef TILES
-            // If an ImGui window just closed and cleared the buffer, do a full
-            // redraw now before blocking UIs below.
-            if( cataimgui::clear_pending() ) {
-                ui_manager::redraw();
-            }
-#endif
-            ui_adaptor dummy( ui_adaptor::disable_uis_below {} );
-            if( !g->wait_popup ) {
-                g->wait_popup = std::make_unique<static_popup>();
-            }
-            g->wait_popup->on_top( true ).wait_message( "%s", wait_message );
-            ui_manager::redraw();
-            refresh_display();
-            g->first_redraw_since_waiting_started = false;
-        }
-    } else {
-        // Nothing to wait for now
-        g->wait_popup_reset();
-        g->first_redraw_since_waiting_started = true;
-    }
+    handle_progress_ui();
 
     m.invalidate_visibility_cache();
 
@@ -771,7 +766,7 @@ bool do_turn()
 
     if( calendar::once_every( 1_minutes ) ) {
         u.update_morale();
-        for( npc &guy : g->all_npcs() ) {
+        for( npc &guy : all_npcs() ) {
             guy.update_morale();
             guy.check_and_recover_morale();
         }

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -694,20 +694,7 @@ bool do_turn()
     if( calendar::once_every( time_between_npc_OM_moves ) ) {
         overmap_npc_move();
     }
-    if( calendar::once_every( 10_seconds ) ) {
-        for( const tripoint_bub_ms &elem : m.get_furn_field_locations() ) {
-            const furn_t &furn = *m.furn( elem );
-            for( const emit_id &e : furn.emissions ) {
-                m.emit_field( elem, e );
-            }
-        }
-        for( const tripoint_bub_ms &elem : m.get_ter_field_locations() ) {
-            const ter_t &ter = *m.ter( elem );
-            for( const emit_id &e : ter.emissions ) {
-                m.emit_field( elem, e );
-            }
-        }
-    }
+    m.furniture_terrain_emit_fields();
     // required after monsters move and fields emit
     g->mon_info_update();
 

--- a/src/do_turn.h
+++ b/src/do_turn.h
@@ -2,8 +2,6 @@
 #ifndef CATA_SRC_DO_TURN_H
 #define CATA_SRC_DO_TURN_H
 
-/** MAIN GAME LOOP. Returns true if game is over (death, saved, quit, etc.). */
-bool do_turn();
 void handle_key_blocking_activity();
 
 #endif // CATA_SRC_DO_TURN_H

--- a/src/game.h
+++ b/src/game.h
@@ -193,12 +193,22 @@ class game
         friend timed_event_manager &get_timed_events();
         friend item_wakeup_manager &get_item_wakeups();
         friend memorial_logger &get_memorial();
-        friend bool do_turn();
         friend bool turn_handler::cleanup_at_end();
         friend global_variables &get_globals();
     public:
         game();
         ~game();
+
+        /*
+        * MAIN GAME LOOP
+        *
+        * Process a `turn`, equal to one in-game second, by doing two things:
+        * 1. spend and replenish Creature::moves -- for `avatar`, `npc`, `monster`
+        * 2. handle game systems (weather, missions, fields, see below)
+        *
+        * @return true if game is over (death, saved, quit, etc)
+        */
+        bool do_turn();
 
         /** Loads static data that does not depend on mods or similar. */
         void load_static_data();
@@ -798,6 +808,7 @@ class game
         int get_zoom() const;
         int get_moves_since_last_save() const;
         int get_user_action_counter() const;
+        void handle_progress_ui();
 
         /** Saves a screenshot of the current viewport, as a PNG file, to the given location.
         * @param file_path: A full path to the file where the screenshot should be saved.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -865,7 +865,7 @@ int main( int argc, const char *argv[] )
 
         shared_ptr_fast<ui_adaptor> ui = g->create_or_get_main_ui_adaptor();
         get_event_bus().send<event_type::game_begin>( getVersionString() );
-        while( !do_turn() ) {}
+        while( !g->do_turn() ) {}
     }
 
     exit_handler( -999 );

--- a/src/map.h
+++ b/src/map.h
@@ -988,6 +988,8 @@ class map
             return ter( tripoint_bub_ms( p, abs_sub.z() ) );
         }
 
+        void furniture_terrain_emit_fields();
+
         int get_map_damage( const tripoint_bub_ms &p ) const;
         void set_map_damage( const tripoint_bub_ms &p, int dmg );
 

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -370,6 +370,24 @@ void map::spread_gas( field_entry &cur, const tripoint_bub_ms &p, int percent_sp
     }
 }
 
+void map::furniture_terrain_emit_fields()
+{
+    if( calendar::once_every( 10_seconds ) ) {
+        for( const tripoint_bub_ms &elem : get_furn_field_locations() ) {
+            const furn_t &furn_to_emit = *furn( elem );
+            for( const emit_id &e : furn_to_emit.emissions ) {
+                emit_field( elem, e );
+            }
+        }
+        for( const tripoint_bub_ms &elem : get_ter_field_locations() ) {
+            const ter_t &ter_to_emit = *ter( elem );
+            for( const emit_id &e : ter_to_emit.emissions ) {
+                emit_field( elem, e );
+            }
+        }
+    }
+}
+
 /*
 Helper function that encapsulates the logic involved in creating hot air.
 */

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -1020,6 +1020,18 @@ const weather_generator &weather_manager::get_cur_weather_gen() const
     return om.get_settings().get_settings_weather();
 }
 
+void weather_manager::on_game_start()
+{
+    if( get_option<std::string>( "ETERNAL_WEATHER" ) != "normal" ) {
+        weather_override = static_cast<weather_type_id>
+                           ( get_option<std::string>( "ETERNAL_WEATHER" ) );
+        set_nextweather( calendar::turn );
+    } else {
+        weather_override = WEATHER_NULL;
+        set_nextweather( calendar::turn );
+    }
+}
+
 void weather_manager::update_weather()
 {
     Character &player_character = get_player_character();

--- a/src/weather.h
+++ b/src/weather.h
@@ -204,6 +204,8 @@ class weather_manager
 {
     public:
         weather_manager();
+        // sets weather_override
+        void on_game_start();
         const weather_generator &get_cur_weather_gen() const;
         // Updates the temperature and weather patten
         void update_weather();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Trying to clean up and clarify the main game loop's functions.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- In the abstract, I think it makes sense for `do_turn()` to be a member function of `game`. The game is processing turns. `do_turn()` also already uses `g` for a lot of its calls. 
- Split up large functions from `do_turn()`: `map::furniture_terrain_emit_fields()`, `weather_manager::on_game_start()`, `game::handle_progress_ui()`
- Document `Creature::moves`, `Creature::speed_base`, and `do_turn()` more accurately.


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered



<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded game, walked around a little, did a practice activity. This PR should not have any functional changes.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

If there's something this would break horribly, let me know, and suggest changes if you'd like.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
