### PR TITLE
Fix unattended-crafting env loss and resume timer offset

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6344,6 +6344,11 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
             }
 
             if( plan.choice == step_choice::do_wait ) {
+                // Per-turn env check fast-path.  do_something / set_timer
+                // rely on the periodic env_check wakeup at 1-minute cadence
+                // since no actor runs for those modes.
+                craft_actualize_scheduled( craft, item_wakeup_kind::env_check,
+                                           calendar::turn, craft_item );
                 crafter.set_moves( 0 );
                 return;
             }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1007,9 +1007,26 @@ void fire_step_complete_distraction( const std::string &interrupt_msg,
     }
 }
 
+inflight_alarm_choices compute_inflight_alarm_choices(
+    time_point passive_started_at, time_point live_ready_at, time_point now )
+{
+    inflight_alarm_choices result;
+    result.remaining = live_ready_at - now;
+    if( result.remaining <= 0_seconds ) {
+        return result;
+    }
+    result.finish_enabled = true;
+    result.finish_offset = live_ready_at - passive_started_at;
+    if( result.remaining > 5_minutes ) {
+        result.five_before_enabled = true;
+        result.five_before_offset = live_ready_at - passive_started_at - 5_minutes;
+    }
+    return result;
+}
+
 std::optional<std::vector<attention_plan>> show_craft_planning_modal(
         const recipe &rec, const Character &crafter, int batch, int from_step,
-        const std::vector<attention_plan> &existing )
+        const std::vector<attention_plan> &existing, const item *current_craft )
 {
     const std::vector<recipe_step> &steps = rec.steps();
     std::vector<attention_plan> plans( steps.size() );
@@ -1028,9 +1045,34 @@ std::optional<std::vector<attention_plan>> show_craft_planning_modal(
             continue;
         }
 
-        const time_duration step_dur = time_duration::from_moves(
-                                           rec.step_budget_moves( crafter, i, batch, ctx,
-                                                   recipe_time_flag::ignore_proficiencies ) );
+        const bool is_inflight = current_craft != nullptr
+                                 && current_craft->get_passive_started_at() != calendar::before_time_starts
+                                 && current_craft->get_current_step() == static_cast<int>( i );
+        inflight_alarm_choices inflight;
+        time_duration step_dur;
+        if( is_inflight ) {
+            const bool paused =
+                current_craft->get_saved_ready_at() != calendar::before_time_starts;
+            const time_point live_ready_at = paused
+                                             ? current_craft->get_saved_ready_at()
+                                             : current_craft->get_ready_at();
+            // Paused deadlines slide on unpause; evaluate at pause snapshot.
+            const time_point eval_now = paused
+                                        ? current_craft->get_pause_started_at()
+                                        : calendar::turn;
+            inflight = compute_inflight_alarm_choices(
+                           current_craft->get_passive_started_at(), live_ready_at,
+                           eval_now );
+            // Past completion: overdue resolver will pick it up; skip here.
+            if( inflight.remaining <= 0_seconds ) {
+                continue;
+            }
+            step_dur = inflight.remaining;
+        } else {
+            step_dur = time_duration::from_moves(
+                           rec.step_budget_moves( crafter, i, batch, ctx,
+                                                  recipe_time_flag::ignore_proficiencies ) );
+        }
 
         uilist menu;
         menu.text = string_format(
@@ -1057,10 +1099,14 @@ std::optional<std::vector<attention_plan>> show_craft_planning_modal(
         } else if( menu.ret == 2 ) {
             uilist alarm;
             alarm.text = _( "Set an alarm for when?" );
-            alarm.addentry( 1, true, '1',
+            const bool finish_enabled = is_inflight ? inflight.finish_enabled : true;
+            const bool five_before_enabled = is_inflight
+                                             ? inflight.five_before_enabled
+                                             : step_dur > 5_minutes;
+            alarm.addentry( 1, finish_enabled, '1',
                             string_format( _( "When the step finishes (%s)" ),
                                            to_string( step_dur ) ) );
-            alarm.addentry( 2, step_dur > 5_minutes, '2',
+            alarm.addentry( 2, five_before_enabled, '2',
                             string_format( _( "5 minutes before (%s in)" ),
                                            to_string( step_dur - 5_minutes ) ) );
             alarm.query();
@@ -1068,7 +1114,10 @@ std::optional<std::vector<attention_plan>> show_craft_planning_modal(
                 return std::nullopt;
             }
             plans[i].choice = step_choice::set_timer;
-            if( alarm.ret == 2 ) {
+            if( is_inflight ) {
+                plans[i].alarm_offset = alarm.ret == 2 ? inflight.five_before_offset
+                                        : inflight.finish_offset;
+            } else if( alarm.ret == 2 ) {
                 plans[i].alarm_offset = step_dur - 5_minutes;
             } else {
                 plans[i].alarm_offset = step_dur;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1089,6 +1089,7 @@ std::vector<desired_wakeup> craft_enumerate_scheduled_wakeups(
     const time_point ready_at = craft.get_ready_at();
     const time_point alarm_at = craft.get_alarm_at();
     const time_point fail_at = craft.get_fail_at();
+    const time_point env_check_at = craft.get_env_check_at();
     if( ready_at != calendar::before_time_starts ) {
         result.push_back( desired_wakeup{ item_wakeup_kind::ready_check, ready_at } );
     }
@@ -1097,6 +1098,9 @@ std::vector<desired_wakeup> craft_enumerate_scheduled_wakeups(
     }
     if( fail_at != calendar::before_time_starts ) {
         result.push_back( desired_wakeup{ item_wakeup_kind::fail_check, fail_at } );
+    }
+    if( env_check_at != calendar::before_time_starts ) {
+        result.push_back( desired_wakeup{ item_wakeup_kind::env_check, env_check_at } );
     }
     return result;
 }
@@ -1168,6 +1172,7 @@ static void advance_passive_step( item &craft )
     craft.set_saved_ready_at( calendar::before_time_starts );
     craft.set_saved_alarm_at( calendar::before_time_starts );
     craft.set_saved_fail_at( calendar::before_time_starts );
+    craft.set_env_check_at( calendar::before_time_starts );
     craft.set_passive_start_counter( 0 );
     craft.set_passive_end_counter( 0 );
     craft.set_current_step( craft.get_current_step() + 1 );
@@ -1272,6 +1277,111 @@ static void finalize_passive_craft( item &craft, const item_location &loc )
     crafter->complete_craft( craft_copy, finalize_loc );
 }
 
+// Result of an env-check pass.
+enum class env_check_result {
+    // Pause was entered or continues.
+    paused,
+    // Pause restored; deadlines slid.  Ready-advance must recheck
+    // ready_at before continuing.
+    restored,
+    // No pause.
+    ok,
+};
+
+// Shared env-pause / env-restore helper.  Owns env_check_at re-arm
+// cadence and rebuilds wakeups in all paths.
+static env_check_result craft_check_env_step( item &craft, time_point now,
+        const item_location &loc )
+{
+    const recipe &rec = craft.get_making();
+    const int step_idx = craft.get_current_step();
+    if( step_idx < 0 || step_idx >= static_cast<int>( rec.steps().size() ) ) {
+        return env_check_result::ok;
+    }
+    const recipe_step &step = rec.steps()[step_idx];
+
+    if( !env_satisfied_for_step( step, craft, loc ) ) {
+        if( craft.get_pause_started_at() == calendar::before_time_starts ) {
+            craft.set_pause_started_at( now );
+            craft.set_saved_ready_at( craft.get_ready_at() );
+            craft.set_saved_alarm_at( craft.get_alarm_at() );
+            craft.set_saved_fail_at( craft.get_fail_at() );
+            craft.set_alarm_at( calendar::before_time_starts );
+            craft.set_fail_at( calendar::before_time_starts );
+        }
+        craft.set_ready_at( now + 1_minutes );
+        // While paused, ready_at is the 1-minute polling cursor; clear
+        // env_check_at to avoid double-arming the queue.
+        craft.set_env_check_at( calendar::before_time_starts );
+        get_item_wakeups().rebuild_for_item( loc );
+        return env_check_result::paused;
+    }
+
+    if( craft.get_pause_started_at() != calendar::before_time_starts ) {
+        const time_duration paused_for = now - craft.get_pause_started_at();
+        // Restored fail_at is always in the future: pause entry is gated by
+        // the top-of-handler fail guard, so saved_fail_at > pause_started_at.
+        craft.set_ready_at( craft.get_saved_ready_at() + paused_for );
+        if( craft.get_saved_alarm_at() != calendar::before_time_starts ) {
+            craft.set_alarm_at( craft.get_saved_alarm_at() + paused_for );
+        }
+        if( craft.get_saved_fail_at() != calendar::before_time_starts ) {
+            craft.set_fail_at( craft.get_saved_fail_at() + paused_for );
+        }
+        craft.set_pause_started_at( calendar::before_time_starts );
+        craft.set_saved_ready_at( calendar::before_time_starts );
+        craft.set_saved_alarm_at( calendar::before_time_starts );
+        craft.set_saved_fail_at( calendar::before_time_starts );
+        // Already-due alarm fires inline, not one queue tick late.
+        if( craft.get_alarm_at() != calendar::before_time_starts &&
+            now >= craft.get_alarm_at() ) {
+            craft_actualize_alarm( craft, now, loc );
+        }
+        // Re-arm env_check cursor, clamped to ready_at so a near-end-of-step
+        // restore does not arm a poll past completion.
+        if( step_has_env_requirements( step ) ) {
+            const time_point next = now + 1_minutes;
+            craft.set_env_check_at( std::min( next, craft.get_ready_at() ) );
+        } else {
+            craft.set_env_check_at( calendar::before_time_starts );
+        }
+        get_item_wakeups().rebuild_for_item( loc );
+        return env_check_result::restored;
+    }
+
+    // Normal mid-step env check (no pause entered or exited).  Re-arm the
+    // cursor for the next minute; clamp to ready_at so a poll never fires
+    // after step completion.
+    if( step_has_env_requirements( step ) ) {
+        const time_point next = now + 1_minutes;
+        craft.set_env_check_at( std::min( next, craft.get_ready_at() ) );
+    } else {
+        craft.set_env_check_at( calendar::before_time_starts );
+    }
+    get_item_wakeups().rebuild_for_item( loc );
+    return env_check_result::ok;
+}
+
+static void craft_actualize_env( item &craft, time_point now, const item_location &loc )
+{
+    if( !craft.is_craft() ) {
+        return;
+    }
+    if( craft.get_passive_started_at() == calendar::before_time_starts ) {
+        // No unattended step in flight; clear the cursor and bail.
+        craft.set_env_check_at( calendar::before_time_starts );
+        get_item_wakeups().rebuild_for_item( loc );
+        return;
+    }
+    // Overdue for failure: fail_check will handle it on its tick; do not
+    // pause a craft that is past its grace period.
+    if( craft.get_fail_at() != calendar::before_time_starts &&
+        now >= craft.get_fail_at() ) {
+        return;
+    }
+    ( void ) craft_check_env_step( craft, now, loc );
+}
+
 static void craft_actualize_ready( item &craft, time_point now, const item_location &loc )
 {
     if( craft.get_ready_at() == calendar::before_time_starts ) {
@@ -1297,6 +1407,7 @@ static void craft_actualize_ready( item &craft, time_point now, const item_locat
         craft.set_saved_ready_at( calendar::before_time_starts );
         craft.set_saved_alarm_at( calendar::before_time_starts );
         craft.set_saved_fail_at( calendar::before_time_starts );
+        craft.set_env_check_at( calendar::before_time_starts );
         craft.set_passive_start_counter( 0 );
         craft.set_passive_end_counter( 0 );
         get_item_wakeups().rebuild_for_item( loc );
@@ -1311,44 +1422,12 @@ static void craft_actualize_ready( item &craft, time_point now, const item_locat
         return;
     }
 
-    if( !env_satisfied_for_step( step, craft, loc ) ) {
-        if( craft.get_pause_started_at() == calendar::before_time_starts ) {
-            craft.set_pause_started_at( now );
-            craft.set_saved_ready_at( craft.get_ready_at() );
-            craft.set_saved_alarm_at( craft.get_alarm_at() );
-            craft.set_saved_fail_at( craft.get_fail_at() );
-            craft.set_alarm_at( calendar::before_time_starts );
-            craft.set_fail_at( calendar::before_time_starts );
-        }
-        craft.set_ready_at( now + 1_minutes );
-        get_item_wakeups().rebuild_for_item( loc );
+    const env_check_result env_result = craft_check_env_step( craft, now, loc );
+    if( env_result == env_check_result::paused ) {
         return;
     }
-
-    if( craft.get_pause_started_at() != calendar::before_time_starts ) {
-        const time_duration paused_for = now - craft.get_pause_started_at();
-        // Restored fail_at is always in the future: pause entry is gated by
-        // the top-of-handler fail guard, so saved_fail_at > pause_started_at.
-        craft.set_ready_at( craft.get_saved_ready_at() + paused_for );
-        if( craft.get_saved_alarm_at() != calendar::before_time_starts ) {
-            craft.set_alarm_at( craft.get_saved_alarm_at() + paused_for );
-        }
-        if( craft.get_saved_fail_at() != calendar::before_time_starts ) {
-            craft.set_fail_at( craft.get_saved_fail_at() + paused_for );
-        }
-        craft.set_pause_started_at( calendar::before_time_starts );
-        craft.set_saved_ready_at( calendar::before_time_starts );
-        craft.set_saved_alarm_at( calendar::before_time_starts );
-        craft.set_saved_fail_at( calendar::before_time_starts );
-        // Already-due alarm fires inline, not one queue tick late.
-        if( craft.get_alarm_at() != calendar::before_time_starts &&
-            now >= craft.get_alarm_at() ) {
-            craft_actualize_alarm( craft, now, loc );
-        }
-        if( now < craft.get_ready_at() ) {
-            get_item_wakeups().rebuild_for_item( loc );
-            return;
-        }
+    if( env_result == env_check_result::restored && now < craft.get_ready_at() ) {
+        return;
     }
 
     const std::string completion_msg = compose_unattend_message( craft, step );
@@ -1467,6 +1546,15 @@ void craft_stamp_passive_entry( item &craft, const Character &crafter, time_poin
     if( plan.choice == step_choice::set_timer && plan.alarm_offset.has_value() ) {
         craft.set_alarm_at( entry_time + *plan.alarm_offset );
     }
+    // Periodic env-check cursor: arm only when the step actually has env
+    // requirements.  Clamp to ready_at so a short step never schedules a
+    // poll past completion.
+    if( step_has_env_requirements( cur_step ) ) {
+        const time_point next = now + 1_minutes;
+        craft.set_env_check_at( std::min( next, craft.get_ready_at() ) );
+    } else {
+        craft.set_env_check_at( calendar::before_time_starts );
+    }
     // Counter bounds derive from prior steps' budgets (default flags) so any
     // active-step overshoot in item_counter does not carry into this passive
     // step.  Matches the active accumulator's batch_time(default) basis.
@@ -1544,6 +1632,9 @@ void craft_actualize_scheduled( item &craft, item_wakeup_kind kind, time_point n
     switch( kind ) {
         case item_wakeup_kind::alarm:
             craft_actualize_alarm( craft, now, loc );
+            return;
+        case item_wakeup_kind::env_check:
+            craft_actualize_env( craft, now, loc );
             return;
         case item_wakeup_kind::ready_check:
             craft_actualize_ready( craft, now, loc );

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -7,13 +7,13 @@
 #include <string>
 #include <vector>
 
+#include "calendar.h"
 #include "item_wakeup.h"
 
 class Character;
 class item;
 class item_location;
 class recipe;
-class time_point;
 struct attention_plan;
 template <typename E> struct enum_traits;
 
@@ -35,12 +35,38 @@ void remove_ammo( std::list<item> &dis_items, Character &p );
 
 void drop_or_handle( const item &newit, Character &p );
 
+// Per-choice data for the timer sub-menu when the modal is shown on an
+// in-flight unattended step.  All offsets are step-start anchored
+// (`alarm_at = passive_started_at + offset`), so the resulting
+// `attention_plan::alarm_offset` field is wire-compatible with the
+// pre-flight branch.
+struct inflight_alarm_choices {
+    time_duration remaining;
+    bool finish_enabled = false;
+    bool five_before_enabled = false;
+    std::optional<time_duration> finish_offset;
+    std::optional<time_duration> five_before_offset;
+};
+
+// Pure helper.  Returns the timer choice set for an in-flight unattended
+// step given its `passive_started_at`, the live deadline (`saved_ready_at`
+// when env-paused, otherwise `ready_at`), and the current calendar turn.
+// "5 minutes before" is disabled when remaining time is at most 5 minutes.
+inflight_alarm_choices compute_inflight_alarm_choices(
+    time_point passive_started_at, time_point live_ready_at,
+    time_point now );
+
 // Asks the avatar what to do at each remaining unattended step (skipping
 // any step before `from_step`).  Returns nullopt if the avatar cancelled.
-// `existing` pre-fills choices on resume.
+// `existing` pre-fills choices on resume.  When `current_craft` is non-null
+// AND the iterated step matches `current_craft->get_current_step()` AND
+// the step is mid-flight, the timer sub-menu offers choices relative to
+// the remaining runtime so resume timers do not anchor to a stale step
+// start.
 std::optional<std::vector<attention_plan>> show_craft_planning_modal(
         const recipe &rec, const Character &crafter, int batch, int from_step,
-        const std::vector<attention_plan> &existing );
+        const std::vector<attention_plan> &existing,
+        const item *current_craft = nullptr );
 
 // Interrupts the avatar's current activity with a craft_step_complete
 // distraction when the avatar can read time; falls back to a vague flavor

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -7446,7 +7446,8 @@ void iexamine::workbench_internal( Character &you, const tripoint_bub_ms &examp,
                     chosen = show_craft_planning_modal( rec, you,
                                                         selected_craft->get_making_batch_size(),
                                                         selected_craft->get_current_step(),
-                                                        selected_craft->get_step_plans() );
+                                                        selected_craft->get_step_plans(),
+                                                        selected_craft );
                     if( !chosen ) {
                         break;
                     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5313,6 +5313,18 @@ void item::set_saved_fail_at( time_point t )
     craft_data_->saved_fail_at = t;
 }
 
+time_point item::get_env_check_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->env_check_at;
+}
+
+void item::set_env_check_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->env_check_at = t;
+}
+
 character_id item::get_crafter_id() const
 {
     cata_assert( craft_data_ );

--- a/src/item.h
+++ b/src/item.h
@@ -3264,6 +3264,8 @@ class item : public visitable
         void set_saved_alarm_at( time_point t );
         time_point get_saved_fail_at() const;
         void set_saved_fail_at( time_point t );
+        time_point get_env_check_at() const;
+        void set_env_check_at( time_point t );
 
         character_id get_crafter_id() const;
         void set_crafter_id( character_id id );
@@ -3565,6 +3567,10 @@ class item : public visitable
                 time_point saved_ready_at = calendar::before_time_starts;
                 time_point saved_alarm_at = calendar::before_time_starts;
                 time_point saved_fail_at  = calendar::before_time_starts;
+                // Periodic env-check cursor while step is live, has env
+                // reqs, and is not env-paused.  before_time_starts otherwise
+                // (during pause, ready_at is the 1-minute polling cursor).
+                time_point env_check_at = calendar::before_time_starts;
 
                 // Counter bounds snapshotted at passive-step entry; item_tname
                 // projects linearly between them without mutation.

--- a/src/item_wakeup.cpp
+++ b/src/item_wakeup.cpp
@@ -34,6 +34,8 @@ const char *kind_to_string( item_wakeup_kind k )
     switch( k ) {
         case item_wakeup_kind::alarm:
             return "alarm";
+        case item_wakeup_kind::env_check:
+            return "env_check";
         case item_wakeup_kind::ready_check:
             return "ready_check";
         case item_wakeup_kind::fail_check:
@@ -48,6 +50,10 @@ bool string_to_kind( const std::string &s, item_wakeup_kind &out )
 {
     if( s == "alarm" ) {
         out = item_wakeup_kind::alarm;
+        return true;
+    }
+    if( s == "env_check" ) {
+        out = item_wakeup_kind::env_check;
         return true;
     }
     if( s == "ready_check" ) {

--- a/src/item_wakeup.h
+++ b/src/item_wakeup.h
@@ -24,6 +24,7 @@ class item_location;
 // Distinct kinds coexist per item.
 enum class item_wakeup_kind : uint8_t {
     alarm = 0,
+    env_check,
     ready_check,
     fail_check,
     last

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8844,7 +8844,7 @@ std::optional<int> iuse::craft( Character *p, item *it, const tripoint_bub_ms & 
     if( rec.has_remaining_attention_steps( it->get_current_step() ) && p->is_avatar() ) {
         chosen = show_craft_planning_modal( rec, *p, it->get_making_batch_size(),
                                             it->get_current_step(),
-                                            it->get_step_plans() );
+                                            it->get_step_plans(), it );
         if( !chosen ) {
             return std::nullopt;
         }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2874,6 +2874,9 @@ void item::craft_data::serialize( JsonOut &jsout ) const
     if( saved_fail_at != calendar::before_time_starts ) {
         jsout.member( "saved_fail_at", saved_fail_at );
     }
+    if( env_check_at != calendar::before_time_starts ) {
+        jsout.member( "env_check_at", env_check_at );
+    }
     if( crafter_id.is_valid() ) {
         jsout.member( "crafter_id", crafter_id );
     }
@@ -2955,6 +2958,9 @@ void item::craft_data::deserialize( const JsonObject &obj )
     if( obj.has_member( "saved_fail_at" ) ) {
         obj.read( "saved_fail_at", saved_fail_at );
     }
+    if( obj.has_member( "env_check_at" ) ) {
+        obj.read( "env_check_at", env_check_at );
+    }
     if( obj.has_member( "crafter_id" ) ) {
         obj.read( "crafter_id", crafter_id );
     }
@@ -2988,6 +2994,7 @@ void item::craft_data::deserialize( const JsonObject &obj )
         saved_ready_at = calendar::before_time_starts;
         saved_alarm_at = calendar::before_time_starts;
         saved_fail_at = calendar::before_time_starts;
+        env_check_at = calendar::before_time_starts;
         passive_start_counter = 0;
         passive_end_counter = 0;
     }

--- a/tests/craft_attention_test.cpp
+++ b/tests/craft_attention_test.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "activity_actor_definitions.h"
 #include "avatar.h"
 #include "calendar.h"
 #include "cata_catch.h"
@@ -22,12 +23,15 @@
 #include "map.h"
 #include "map_helpers.h"
 #include "map_selector.h"
+#include "player_activity.h"
+#include "player_helpers.h"
 #include "point.h"
 #include "recipe.h"
 #include "requirements.h"
 #include "type_id.h"
 
 static const itype_id itype_2x4( "2x4" );
+static const itype_id itype_microwave( "microwave" );
 
 static const recipe_id recipe_cudgel_test_consecutive_unattended(
     "cudgel_test_consecutive_unattended" );
@@ -683,5 +687,279 @@ TEST_CASE( "craft_env_unpause_alarm_clears_when_already_due",
 
     CHECK( on_map.get_alarm_at() == calendar::before_time_starts );
     CHECK( on_map.get_pause_started_at() == calendar::before_time_starts );
+}
+
+TEST_CASE( "craft_stamp_arms_env_check_when_step_has_env_requirements",
+           "[craft][attention][env_check]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    u.i_add( item( itype_microwave, calendar::turn ) );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_with_qual.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+    on_map.set_current_step( 1 );
+    on_map.set_crafter_id( u.getID() );
+    on_map.set_step_plans( std::vector<attention_plan>( 2 ) );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+    craft_stamp_passive_entry( on_map, u, calendar::turn, loc );
+
+    // Step has OVEN quality requirement -> env_check_at armed at now+1min,
+    // clamped under ready_at.
+    REQUIRE( on_map.get_passive_started_at() == calendar::turn );
+    CHECK( on_map.get_env_check_at() != calendar::before_time_starts );
+    CHECK( on_map.get_env_check_at() <= on_map.get_ready_at() );
+    CHECK( get_item_wakeups().is_scheduled( on_map.uid().get_value(),
+                                            item_wakeup_kind::env_check ) );
+}
+
+TEST_CASE( "craft_stamp_skips_env_check_when_step_has_no_env_requirements",
+           "[craft][attention][env_check]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+    on_map.set_current_step( 1 );
+    on_map.set_crafter_id( u.getID() );
+    on_map.set_step_plans( std::vector<attention_plan>( 2 ) );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+    craft_stamp_passive_entry( on_map, u, calendar::turn, loc );
+
+    REQUIRE( on_map.get_passive_started_at() == calendar::turn );
+    CHECK( on_map.get_env_check_at() == calendar::before_time_starts );
+    CHECK_FALSE( get_item_wakeups().is_scheduled( on_map.uid().get_value(),
+                 item_wakeup_kind::env_check ) );
+}
+
+TEST_CASE( "craft_env_check_dispatch_pauses_when_quality_missing",
+           "[craft][attention][env_check]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    // No OVEN tool: env_satisfied_for_step returns false.
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_with_qual.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+    on_map.set_current_step( 1 );
+    on_map.set_crafter_id( u.getID() );
+    on_map.set_step_plans( std::vector<attention_plan>( 2 ) );
+
+    const time_point t0 = calendar::turn;
+    on_map.set_passive_started_at( t0 );
+    on_map.set_ready_at( t0 + 10_minutes );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+
+    const time_point fire_time = t0 + 1_minutes;
+    craft_actualize_scheduled( on_map, item_wakeup_kind::env_check,
+                               fire_time, loc );
+
+    CHECK( on_map.get_pause_started_at() == fire_time );
+    CHECK( on_map.get_saved_ready_at() == t0 + 10_minutes );
+    CHECK( on_map.get_ready_at() == fire_time + 1_minutes );
+    CHECK( on_map.get_env_check_at() == calendar::before_time_starts );
+}
+
+TEST_CASE( "craft_env_check_dispatch_restores_when_quality_returns",
+           "[craft][attention][env_check]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_with_qual.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+    on_map.set_current_step( 1 );
+    on_map.set_crafter_id( u.getID() );
+    on_map.set_step_plans( std::vector<attention_plan>( 2 ) );
+
+    // Manually install a pause state, then satisfy env and dispatch env_check.
+    const time_point t0 = calendar::turn;
+    on_map.set_passive_started_at( t0 - 2_minutes );
+    on_map.set_ready_at( t0 + 1_minutes ); // pause polling cursor
+    on_map.set_saved_ready_at( t0 + 8_minutes );
+    on_map.set_pause_started_at( t0 - 1_minutes );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+
+    // Restore environment.
+    u.i_add( item( itype_microwave, calendar::turn ) );
+    craft_actualize_scheduled( on_map, item_wakeup_kind::env_check, t0, loc );
+
+    CHECK( on_map.get_pause_started_at() == calendar::before_time_starts );
+    CHECK( on_map.get_ready_at() == t0 + 8_minutes + 1_minutes );
+    CHECK( on_map.get_saved_ready_at() == calendar::before_time_starts );
+    CHECK( on_map.get_env_check_at() != calendar::before_time_starts );
+    CHECK( on_map.get_env_check_at() <= on_map.get_ready_at() );
+}
+
+TEST_CASE( "craft_env_check_dispatch_clamps_cursor_under_ready_at",
+           "[craft][attention][env_check]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    u.i_add( item( itype_microwave, calendar::turn ) );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_with_qual.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+    on_map.set_current_step( 1 );
+    on_map.set_crafter_id( u.getID() );
+    on_map.set_step_plans( std::vector<attention_plan>( 2 ) );
+
+    // Short remaining: ready_at is 30s away.  Cursor must clamp to ready_at,
+    // not now+1min which would poll past completion.
+    const time_point t0 = calendar::turn;
+    on_map.set_passive_started_at( t0 - 9_minutes - 30_seconds );
+    on_map.set_ready_at( t0 + 30_seconds );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+    craft_actualize_scheduled( on_map, item_wakeup_kind::env_check, t0, loc );
+
+    CHECK( on_map.get_env_check_at() == t0 + 30_seconds );
+}
+
+TEST_CASE( "craft_actualize_ready_via_helper_still_pauses_on_env_loss",
+           "[craft][attention][env_check][regression]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_with_qual.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+    on_map.set_current_step( 1 );
+    on_map.set_crafter_id( u.getID() );
+    on_map.set_step_plans( std::vector<attention_plan>( 2 ) );
+
+    const time_point t0 = calendar::turn;
+    on_map.set_passive_started_at( t0 );
+    on_map.set_ready_at( t0 + 10_minutes );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+
+    // ready_check at ready_at with no OVEN tool must pause the craft.
+    craft_actualize_scheduled( on_map, item_wakeup_kind::ready_check,
+                               t0 + 10_minutes, loc );
+
+    CHECK( on_map.get_pause_started_at() == t0 + 10_minutes );
+    CHECK( on_map.get_saved_ready_at() == t0 + 10_minutes );
+    CHECK( on_map.get_ready_at() == t0 + 11_minutes );
+    CHECK( on_map.get_env_check_at() == calendar::before_time_starts );
+}
+
+TEST_CASE( "craft_activity_do_wait_env_check_fires_per_turn",
+           "[craft][attention][env_check][actor]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    // No OVEN: per-turn env_check inside do_wait branch must trip pause.
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_with_qual.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+    on_map.set_current_step( 1 );
+    on_map.set_crafter_id( u.getID() );
+    std::vector<attention_plan> plans( 2 );
+    plans[1].choice = step_choice::do_wait;
+    on_map.set_step_plans( plans );
+
+    const time_point t0 = calendar::turn;
+    on_map.set_passive_started_at( t0 );
+    on_map.set_ready_at( t0 + 10_minutes );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+    REQUIRE( on_map.get_pause_started_at() == calendar::before_time_starts );
+
+    craft_activity_actor craft_actor( loc, /*is_long=*/false );
+    u.activity = player_activity( craft_actor );
+    u.activity.targets.push_back( loc );
+
+    u.activity.do_turn( u );
+
+    CHECK( on_map.get_pause_started_at() != calendar::before_time_starts );
+    CHECK( on_map.get_saved_ready_at() == t0 + 10_minutes );
+}
+
+TEST_CASE( "reconcile_walks_avatar_inventory_for_env_check",
+           "[craft][attention][env_check][reconcile]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    u.setpos( get_map(), tripoint_bub_ms( 60, 60, 0 ) );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item carried( &recipe_cudgel_test_unattended_with_qual.obj(), 1, ingredient );
+    carried.set_current_step( 1 );
+    carried.set_crafter_id( u.getID() );
+    carried.set_step_plans( std::vector<attention_plan>( 2 ) );
+
+    const time_point t0 = calendar::turn;
+    carried.set_passive_started_at( t0 );
+    carried.set_ready_at( t0 + 10_minutes );
+    carried.set_env_check_at( t0 + 1_minutes );
+
+    item_location placed = u.i_add( carried );
+    REQUIRE( placed );
+    REQUIRE( placed->is_craft() );
+    const int64_t uid = placed->uid().get_value();
+
+    // Clear any schedule that i_add may have triggered, then exercise the
+    // same iteration map::reconcile_item_wakeups uses for character inventory
+    // (Character::all_items_loc() + rebuild_for_item per location).
+    get_item_wakeups().cancel_all( uid );
+    REQUIRE_FALSE( get_item_wakeups().is_scheduled( uid, item_wakeup_kind::env_check ) );
+
+    for( item_location &loc : u.all_items_loc() ) {
+        if( loc && loc.get_item() != nullptr ) {
+            get_item_wakeups().rebuild_for_item( loc );
+        }
+    }
+
+    CHECK( get_item_wakeups().is_scheduled( uid, item_wakeup_kind::env_check ) );
+    CHECK( get_item_wakeups().is_scheduled( uid, item_wakeup_kind::ready_check ) );
 }
 

--- a/tests/craft_attention_test.cpp
+++ b/tests/craft_attention_test.cpp
@@ -963,3 +963,91 @@ TEST_CASE( "reconcile_walks_avatar_inventory_for_env_check",
     CHECK( get_item_wakeups().is_scheduled( uid, item_wakeup_kind::ready_check ) );
 }
 
+TEST_CASE( "compute_inflight_alarm_choices_for_resume_timer_modal",
+           "[craft][attention][modal]" )
+{
+    const time_point started = calendar::turn_zero;
+
+    GIVEN( "a 10-minute step with ready_at at started+10min" ) {
+        const time_point ready = started + 10_minutes;
+
+        WHEN( "8 minutes have passed (2 minutes remaining)" ) {
+            const inflight_alarm_choices c = compute_inflight_alarm_choices(
+                                                 started, ready, started + 8_minutes );
+            THEN( "finish is offered but five-before is disabled" ) {
+                CHECK( c.remaining == 2_minutes );
+                CHECK( c.finish_enabled );
+                CHECK_FALSE( c.five_before_enabled );
+            }
+            THEN( "finish offset resolves to ready_at when added to step start" ) {
+                REQUIRE( c.finish_offset.has_value() );
+                CHECK( started + *c.finish_offset == ready );
+                CHECK_FALSE( c.five_before_offset.has_value() );
+            }
+        }
+
+        WHEN( "3 minutes have passed (7 minutes remaining)" ) {
+            const inflight_alarm_choices c = compute_inflight_alarm_choices(
+                                                 started, ready, started + 3_minutes );
+            THEN( "both finish and five-before choices are enabled" ) {
+                CHECK( c.remaining == 7_minutes );
+                CHECK( c.finish_enabled );
+                CHECK( c.five_before_enabled );
+            }
+            THEN( "both offsets are step-start-anchored and resolve to ready_at and ready_at - 5min" ) {
+                REQUIRE( c.finish_offset.has_value() );
+                REQUIRE( c.five_before_offset.has_value() );
+                CHECK( started + *c.finish_offset == ready );
+                CHECK( started + *c.five_before_offset == ready - 5_minutes );
+            }
+        }
+
+        WHEN( "12 minutes have passed (step is overdue)" ) {
+            const inflight_alarm_choices c = compute_inflight_alarm_choices(
+                                                 started, ready, started + 12_minutes );
+            THEN( "no timer choices are offered" ) {
+                CHECK( c.remaining == -2_minutes );
+                CHECK_FALSE( c.finish_enabled );
+                CHECK_FALSE( c.five_before_enabled );
+                CHECK_FALSE( c.finish_offset.has_value() );
+                CHECK_FALSE( c.five_before_offset.has_value() );
+            }
+        }
+    }
+
+    GIVEN( "a paused step whose live_ready_at has been slid forward" ) {
+        // live_ready_at = passive_started_at + slid duration via env pause.
+        const time_point ready = started + 15_minutes;
+
+        WHEN( "evaluated 6 minutes after step start" ) {
+            const inflight_alarm_choices c = compute_inflight_alarm_choices(
+                                                 started, ready, started + 6_minutes );
+            THEN( "finish offset stays step-start-anchored, not slid-ready-anchored" ) {
+                REQUIRE( c.finish_offset.has_value() );
+                CHECK( *c.finish_offset == 15_minutes );
+                CHECK( started + *c.finish_offset == ready );
+            }
+        }
+    }
+
+    GIVEN( "a step env-paused at minute 4 of an originally 10-minute deadline" ) {
+        const time_point saved_ready_at = started + 10_minutes;
+        const time_point pause_started = started + 4_minutes;
+
+        WHEN( "helper is called with eval_now = pause_started" ) {
+            const inflight_alarm_choices c = compute_inflight_alarm_choices(
+                                                 started, saved_ready_at, pause_started );
+            THEN( "remaining reflects the time left at the moment of pause" ) {
+                CHECK( c.remaining == 6_minutes );
+                CHECK( c.finish_enabled );
+                CHECK( c.five_before_enabled );
+            }
+            THEN( "offsets stay step-start-anchored against saved_ready_at" ) {
+                REQUIRE( c.finish_offset.has_value() );
+                REQUIRE( c.five_before_offset.has_value() );
+                CHECK( started + *c.finish_offset == saved_ready_at );
+                CHECK( started + *c.five_before_offset == saved_ready_at - 5_minutes );
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Summary
Bugfixes "Pause unattended crafts when tools go missing mid-step, and fix resume timer offset"

#### Purpose of change

Two leftover bugs in current unattended steps impl.

If a tool or quality vanishes partway through an unattended step and comes back before the step ends, the craft never notices. Currently the env check only runs when ready_at fires.

And resume timers anchor to step start, not to remaining time. Resume eight minutes into a ten-minute step, pick "5 minutes before", and the alarm tries to fire three minutes ago.

#### Describe the solution

For env loss: new `env_check` wakeup polls once a minute while an unattended step is live and has env reqs. The existing pause/slide branch in `craft_actualize_ready` moved into a shared helper, so the ready handler and the new dispatcher behave identically. do_wait fires the same dispatch per turn for faster reaction.

For the timer: the modal takes an optional in-flight craft pointer. When the iterated step matches the live step, it asks a small helper for the choices against remaining time instead of full step duration. Paused steps measure remaining at `pause_started_at` since the deadline slides on unpause. Stored offsets stay step-start-anchored, no save migration.

#### Describe alternatives you've considered

For env loss, a per-turn check inside the actor alone would only help do_wait. The wakeup covers do_something and set_timer too.

For the timer, storing offsets as remaining-from-now would have been simpler in the modal but would change the persisted shape.

#### Testing

New tests cover env pause/restore via dispatch, the do_wait per-turn path, avatar-inventory reconcile, and the modal helper across short/long remaining, overdue, and paused cases. Existing `[craft][attention]` tests still pass.

#### Additional context

Sub-minute env loss is still invisible to do_something / set_timer (one-minute cadence). Documented limitation.