### PR TITLE
Bump clang-tidy CI to LLVM 22

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,4 +1,4 @@
-name: Clang-tidy 21
+name: Clang-tidy 22
 
 on:
   push:
@@ -37,8 +37,8 @@ jobs:
         fail-fast: true
     runs-on: ubuntu-24.04
     env:
-        COMPILER: clang++-21
-        LLVM_VERSION: '21'
+        COMPILER: clang++-22
+        LLVM_VERSION: '22'
     steps:
     - name: checkout repository
       if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
@@ -51,13 +51,13 @@ jobs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so
-        key: clang-tidy-plugin-llvm21-ubuntu2404-${{ hashFiles('tools/clang-tidy-plugin/**', 'build-scripts/clang-tidy-build.sh', 'CMakeLists.txt', 'CMakeModules/**') }}
-    - name: install LLVM 21
+        key: clang-tidy-plugin-llvm22-ubuntu2404-${{ hashFiles('tools/clang-tidy-plugin/**', 'build-scripts/clang-tidy-build.sh', 'CMakeLists.txt', 'CMakeModules/**') }}
+    - name: install LLVM 22
       if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && steps.plugin-cache.outputs.cache-hit != 'true' }}
       run: |
           wget -O llvm.sh https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 21 all
+          sudo ./llvm.sh 22 all
           sudo apt-get install -y python3-pip ninja-build cmake
           pip3 install --user lit
     - uses: ammaraskar/gcc-problem-matcher@0f9c86f9e693db67dacf53986e1674de5f2e5f28 # master
@@ -89,9 +89,9 @@ jobs:
 
     runs-on: ubuntu-24.04
     env:
-        COMPILER: clang++-21
-        CATA_CLANG_TIDY: clang-tidy-21
-        LLVM_VERSION: '21'
+        COMPILER: clang++-22
+        CATA_CLANG_TIDY: clang-tidy-22
+        LLVM_VERSION: '22'
         CATA_CLANG_TIDY_SUBSET: ${{ matrix.subset }}
         TILES: 1
         SOUND: 1
@@ -102,8 +102,8 @@ jobs:
       run: |
           wget -O llvm.sh https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 21
-          sudo apt-get install -y clang-tidy-21 cmake ccache jq
+          sudo ./llvm.sh 22
+          sudo apt-get install -y clang-tidy-22 cmake ccache jq
           sudo apt-get install -y libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev gettext
     - name: checkout repository
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
#### Summary
Infrastructure "Bump clang-tidy CI baseline from LLVM 21 to LLVM 22"

#### Purpose of change
Plugin compat (#86917, #86952) and lint cleanup (#86977) for LLVM 22 are merged. Switching 21 to 22 in CI.

#### Describe the solution
Workflow installs LLVM 22 via `llvm.sh`. `COMPILER`, `CATA_CLANG_TIDY`, `LLVM_VERSION`, cache key bumped.

#### Describe alternatives you've considered
N/A.

#### Testing
N/A, CI is the test.

#### Additional context
Follows #86977.