### PR TITLE
Zombies are attracted to moving vehicles

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -674,6 +674,22 @@ void monster::plan()
             }
         } );
     }
+
+    if( !mon_plan.target ) {
+        // No other valid targets found, maybe there's a vehicle!
+        std::set<tripoint_bub_ms> target_vehicles = here.get_moving_vehicle_targets( *this, 60 );
+        const bool will_throw_self_at_vehicle = !get_pathfinding_settings().avoid_dangerous_fields;
+        if( !target_vehicles.empty() && will_throw_self_at_vehicle ) {
+            tripoint_bub_ms target_pt = random_entry( target_vehicles );
+            Character *driver = here.veh_at( target_pt )->vehicle().get_driver( here );
+            // NOTE: no hostility check here, we already filtered for that when deciding vehicle targets.
+            if( driver ) {
+                mon_plan.target = driver;
+                mon_plan.dist = rate_target( *driver, mon_plan.dist, mon_plan.smart_planning );
+            }
+        }
+    }
+
     if( mon_plan.target == nullptr ) {
         // Just avoiding overflow.
         turns_since_target = std::min( turns_since_target + 1, max_turns_for_rate_limiting );


### PR DESCRIPTION
#### Summary
Balance "Zombies are attracted to moving vehicles"

#### Purpose of change
Our enemies hide in **metal boxes**, the cowards! The fools! We should take away their... metal boxes.

#### Describe the solution
"Dumb" enemies (anything without `avoid_dangerous_fields` will consider a moving vehicle a valid target if they have found no other target. Even if they can't see the driver.

(Note: Metal boxes are not being taken away.)

#### Describe alternatives you've considered


#### Testing
[THROW_SELF_AT_VEHICLE.zip](https://github.com/user-attachments/files/27707061/THROW_SELF_AT_VEHICLE.zip)

Without this patch --> Invisible bike driver and magically moving bicycle are ignored

With this patch --> Zombies actively chase bike despite invisible driver

#### Additional context

