### PR TITLE
Allow some items to be displayed by length

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -417,6 +417,7 @@
     "price": "3 cent",
     "price_postapoc": "1 cent",
     "name": { "str_sp": "duct tape" },
+    "display_type": "BY_LENGTH",
     "symbol": "=",
     "color": "light_gray",
     "description": "A roll of incredibly strong tape.  Its uses are innumerable.",

--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -109,7 +109,7 @@ These fields can be read by any ITEM regardless of subtypes:
     "condition": "leather",       // The condition to check for.
     "name": { "str": "pair of leather socks", "str_pl": "pairs of leather socks" } // Name field, same rules as above.
 } ],
-"display_type": "BY_WEIGHT",      // (Optional) Whether this item should be displayed by weight or volume instead of count. Valid entries are `DEFAULT`(no need to put anything), `BY_VOLUME`, and `BY_WEIGHT`.
+"display_type": "BY_WEIGHT",      // (Optional) Whether this item should be displayed by weight or volume instead of count. Valid entries are `DEFAULT`(no need to put anything), `BY_LENGTH`, `BY_VOLUME`, and `BY_WEIGHT`.
 "container": "null",             // What container (if any) this item should spawn within
 "repairs_like": "scarf",          // If this item does not have recipe, what item to look for a recipe for when repairing it.
 "color": "blue",                 // Color of the item symbol.

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4221,6 +4221,8 @@ std::string enum_to_string<item_display_type>( item_display_type data )
             return "BY_WEIGHT";
         case item_display_type::BY_VOLUME:
             return "BY_VOLUME";
+        case item_display_type::BY_LENGTH:
+            return "BY_LENGTH";
         case item_display_type::LAST:
             break;
     }

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -142,6 +142,9 @@ std::string itype::count_or_volume_or_weight_prefix( unsigned int quantity ) con
             volume_per_charge = volume / stack_size;
         }
         return string_format( _( "%1$s" ), vol_to_string( volume_per_charge * quantity, true, true ) );
+    } else if( display_type == item_display_type::BY_LENGTH ) {
+        // Note: item::length() has some special cases where this might not work well!
+        return string_format( _( "%1$s" ), length_to_string( longest_side * quantity, true ) );
     }
     return std::to_string( quantity );
 }

--- a/src/itype.h
+++ b/src/itype.h
@@ -352,6 +352,7 @@ enum class item_display_type {
     DEFAULT, // count, charges, etc.
     BY_WEIGHT, // e.g. "12lbs of salt"
     BY_VOLUME, // e.g. "4 liters of water"
+    BY_LENGTH, // e.g. "12ft of duct tape"
     LAST
 };
 


### PR DESCRIPTION
#### Summary
Interface "Allow some items to be displayed by length"

#### Purpose of change
How much is `40 duct tape`?

#### Describe the solution
Display it by length 😎 

(Only added to duct tape for now, but things like medical tape or welding rods would also make sense)

#### Describe alternatives you've considered


#### Testing
<img width="428" height="60" alt="image" src="https://github.com/user-attachments/assets/811d5820-2bf8-467e-b1ca-2237a06da844" />


#### Additional context
