### PR TITLE
Fix clang-tidy CI under LLVM 22

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -37,8 +37,15 @@ endif
 
 # clang 22 bug results in non-trivially supressable error about counter with -Wc2y-extensions
 # see https://github.com/llvm/llvm-project/issues/189645
-ifeq ($(CLANG), 1)
-  DEFINES += -DCATCH_CONFIG_NO_COUNTER
+# Root Makefile may set CLANG to the compiler name (e.g. "clang++-22") rather than "1",
+# so trigger on any clang and (when detectable) restrict to clang >= 22 to match CMake.
+ifneq ($(CLANG), 0)
+  CLANG_MAJOR := $(shell $(CXX) -dM -E -x c++ /dev/null 2>/dev/null | sed -n 's/^\#define __clang_major__ //p')
+  ifeq ($(CLANG_MAJOR),)
+    DEFINES += -DCATCH_CONFIG_NO_COUNTER
+  else ifeq ($(shell test $(CLANG_MAJOR) -ge 22 && echo yes),yes)
+    DEFINES += -DCATCH_CONFIG_NO_COUNTER
+  endif
 endif
 
 ifeq ($(PCH), 1)


### PR DESCRIPTION
#### Summary
Infrastructure "Fix clang-tidy CI under LLVM 22"

#### Purpose of change
clang-tidy CI broken.

#### Describe the solution
Fix.

#### Describe alternatives you've considered
N/A

#### Testing
CI.

#### Additional context
N/A