### PR TITLE
Improve view of single-step recipes in crafting menu

### DIFF
--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -1468,7 +1468,7 @@
     "components": [ [ [ "2x4", 1 ] ] ],
     "steps": [
       {
-        "name": "Sawing plank into sword shape.  Trying to convincing yourself it's a real sword",
+        "name": "Sawing plank into sword shape.  Trying to convince yourself it's a real sword",
         "time": "25 m",
         "activity_level": "LIGHT_EXERCISE",
         "qualities": [ { "id": "SAW_W", "level": 1 } ],

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1396,12 +1396,11 @@ void crafting_ui_impl::draw_recipe_info_panel()
 
                         // Per-step tools + qualities
                         const requirement_data &step_req = step.requirements;
+                        ImGui::Unindent( step_indent );
                         if( !step_req.get_tools().empty() || !step_req.get_qualities().empty() ) {
                             draw_requirement_tools( step_req, crafting_inv, batch_size,
                                                     tool_group_offset );
                         }
-
-                        ImGui::Unindent( step_indent );
                         tool_group_offset += step_req.get_tools().size();
                     }
                 } else {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1293,7 +1293,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
 
             // Single step recipes
             if( recp.has_steps() && ( recp.steps().size() <= 1 ) ) {
-                const recipe_step &step = recp.steps()[0];
+                const recipe_step &step = recp.steps().front();
                 ImGui::TextColored( cataimgui::imvec4_from_color( c_white ),
                                     "%s", step.name.translated().c_str() );
                 ImGui::NewLine();

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1405,11 +1405,12 @@ void crafting_ui_impl::draw_recipe_info_panel()
 
                         // Per-step tools + qualities
                         const requirement_data &step_req = step.requirements;
-                        ImGui::Unindent( step_indent );
-                        if( !step_req.get_tools().empty() || !step_req.get_qualities().empty() ) {
+                                                if( !step_req.get_tools().empty() || !step_req.get_qualities().empty() ) {
                             draw_requirement_tools( step_req, crafting_inv, batch_size,
                                                     tool_group_offset );
                         }
+
+                        ImGui::Unindent( step_indent );
                         tool_group_offset += step_req.get_tools().size();
                     }
                 } else {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1405,7 +1405,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
 
                         // Per-step tools + qualities
                         const requirement_data &step_req = step.requirements;
-                            if( !step_req.get_tools().empty() || !step_req.get_qualities().empty() ) {
+                        if( !step_req.get_tools().empty() || !step_req.get_qualities().empty() ) {
                             draw_requirement_tools( step_req, crafting_inv, batch_size,
                                                     tool_group_offset );
                         }

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1292,7 +1292,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
                                             ? *avail.inv_override : crafter->crafting_inventory();
 
             // Single step recipes
-            if ( recp.has_steps() && ( recp.steps().size() <= 1 ) ) {
+            if( recp.has_steps() && ( recp.steps().size() <= 1 ) ) {
                 const recipe_step &step = recp.steps()[0];
                 ImGui::TextColored( cataimgui::imvec4_from_color( c_white ),
                                     "%s", step.name.translated().c_str() );

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1291,6 +1291,14 @@ void crafting_ui_impl::draw_recipe_info_panel()
             const inventory &crafting_inv = avail.inv_override
                                             ? *avail.inv_override : crafter->crafting_inventory();
 
+            // Single step recipes
+            if ( recp.has_steps() && ( recp.steps().size() <= 1 ) ) {
+                const recipe_step &step = recp.steps()[0];
+                ImGui::TextColored( cataimgui::imvec4_from_color( c_white ),
+                                    "%s", step.name.translated().c_str() );
+                ImGui::NewLine();
+            }
+
             // Components (always recipe-level)
             draw_components( recp.simple_requirements(), crafting_inv,
                              recp.get_component_filter(), batch_size );
@@ -1310,7 +1318,8 @@ void crafting_ui_impl::draw_recipe_info_panel()
                 }
             }
 
-            if( recp.has_steps() ) {
+            // Multi step details
+            if( recp.has_steps() && ( recp.steps().size() > 1 ) ) {
                 // Step details are collapsible; collapsed shows flat merged view
                 {
                     const char *steps_label = uistate.crafting_expand_steps

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1405,7 +1405,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
 
                         // Per-step tools + qualities
                         const requirement_data &step_req = step.requirements;
-                                                if( !step_req.get_tools().empty() || !step_req.get_qualities().empty() ) {
+                            if( !step_req.get_tools().empty() || !step_req.get_qualities().empty() ) {
                             draw_requirement_tools( step_req, crafting_inv, batch_size,
                                                     tool_group_offset );
                         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Improve view of single-step recipes in crafting menu"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Single-step recipes could use some improvement in the crafting menu.  Currently they are showing repeat information and there is some alignment issues with regards to Tools.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change how single-step recipes are displayed.  I also fixed a grammar issue in the `wood_sword` that I found while doing this (not shown in screenshot).

Before:
<img width="897" height="498" alt="before" src="https://github.com/user-attachments/assets/7cd03977-1275-4e27-b43e-08f2def6409e" />

After:
<img width="896" height="432" alt="after" src="https://github.com/user-attachments/assets/367ce6f2-6d43-4794-9cef-f2336c596363" />

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled in Windows.
Loaded a game and verified single and multiple steps looked correct in crafting menu.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
