### PR TITLE
Greatly reduce vehicle mirror visibility

### DIFF
--- a/data/json/vehicleparts/mirrors.json
+++ b/data/json/vehicleparts/mirrors.json
@@ -11,6 +11,7 @@
     "description": "A small mirror, mounted outside the vehicle.  If you see the mirror, your vision is expanded as though you were standing where the mirror is.",
     "folded_volume": "500 ml",
     "item": "mirror",
+    "bonus": -50,
     "location": "structure",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "100 s", "using": [ [ "vehicle_screw", 1 ] ] },
@@ -36,6 +37,7 @@
     "description": "A small mirror, mounted inside the vehicle.  If you see the mirror, your vision is expanded as though you were standing where the mirror is.",
     "folded_volume": "250 ml",
     "item": "mirror",
+    "bonus": -50,
     "location": "on_windshield",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "100 s", "using": [ [ "vehicle_screw", 1 ] ] },

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -1327,7 +1327,7 @@ void map::build_seen_cache( const tripoint_bub_ms &origin, const int target_z, i
         int offsetDistance;
         mdarray *mocache = &out_cache;
         if( !is_camera ) {
-            offsetDistance = penalty + rl_dist( origin, mirror_pos );
+            offsetDistance = penalty + rl_dist( origin, mirror_pos ) - vpi_mirror.bonus;
         } else {
             offsetDistance = MAX_VIEW_DISTANCE - vpi_mirror.bonus * vp_mirror.hp() / vpi_mirror.durability;
             mocache = &camera_cache;

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -824,13 +824,13 @@ TEST_CASE( "vision_vehicle_mirrors", "[shadowcasting][vision][vehicle]" )
             "66666666",
 } :
         std::vector<std::string> {
-            "44444444",
-            "44444444",
+            "64444444",
+            "64444444",
             "66666644",
             "66666644",
             "66666644",
-            "44444444",
-            "44444444",
+            "64444444",
+            "64444444",
         },
         day_time
     };
@@ -1093,7 +1093,7 @@ TEST_CASE( "vision_inside_meth_lab", "[shadowcasting][vision][moncam]" )
         std::vector<std::string> {
             "4444444",
             "4444444",
-            "4444444",
+            "6444446",
             "6444446",
             "6444446",
             "6144416",
@@ -1106,8 +1106,8 @@ TEST_CASE( "vision_inside_meth_lab", "[shadowcasting][vision][moncam]" )
             // active moncam can see through mirrors
             "4444444",
             "4444444",
-            "4411144",
             "6411146",
+            "6111116",
             "6111116",
             "6111116",
             "6111116",


### PR DESCRIPTION
#### Summary
Balance "Greatly reduce vehicle mirror visibility"

#### Purpose of change
Reducing perfect visibility in vehicles

#### Describe the solution
Greatly reduce the range at which mirrors can see.

I have driven a U-haul truck on a few occasions and it is frankly very scary for someone used to a small civilian car! I certainly did not have perfect 360 vision no matter how many mirrors were stuck on!

#### Describe alternatives you've considered
Apparently you can bounce mirror vision off of mirror vision and that is pretty crazy, but the lightmap handling is pretty complicated so I couldn't see an easy way to stop that.

#### Testing
Before:
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/68d8ca3c-0ba4-48e5-bd84-22416e23dfad" />


After:
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/35a6db9b-5205-4a61-9bde-bfe508f148f4" />

Notice that visibility to the far front and sides was reduced as well. Because of the limited range they are no longer omnidirectional god's eyes, but situationally useful to extend vision to the blind spots of a vehicle. Like, you know, actual mirrors.

#### Additional context
I would also like to nerf camera vision (limit max amount, narrow FOV) but that can wait for another PR.
