### PR TITLE
Wrap crafting.cpp env_check_result enum in anonymous namespace

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1326,6 +1326,8 @@ static void finalize_passive_craft( item &craft, const item_location &loc )
     crafter->complete_craft( craft_copy, finalize_loc );
 }
 
+namespace
+{
 // Result of an env-check pass.
 enum class env_check_result {
     // Pause was entered or continues.
@@ -1336,6 +1338,7 @@ enum class env_check_result {
     // No pause.
     ok,
 };
+} // namespace
 
 // Shared env-pause / env-restore helper.  Owns env_check_at re-arm
 // cadence and rebuilds wakeups in all paths.


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
clang-tidy `misc-use-internal-linkage` flagged `env_check_result` in `src/crafting.cpp` as eligible for internal linkage, breaking the warnings-as-errors CI.

#### Describe the solution
Wrap the enum in an anonymous namespace.

#### Describe alternatives you've considered
N/A

#### Testing
N/A

#### Additional context