### PR TITLE
Bulk inventory load and grouped craft result placement

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -831,6 +831,27 @@ static item_location set_item_map( const tripoint_bub_ms &loc, item &newit )
 }
 
 /**
+ * Place `copies` identical instances of `exemplar` near `loc`. Emits a debugmsg
+ * if any copies cannot fit after exhausting the target tile and its overflow
+ * neighborhood, matching the bounded-failure contract of per-item set_item_map.
+ */
+static void set_item_map_copies( const tripoint_bub_ms &loc, item &exemplar, int copies )
+{
+    int remaining = copies;
+    item &first_added = get_map().add_item_or_charges( loc, exemplar, remaining, true );
+    const bool total_failure = &first_added == &null_item_reference();
+    if( total_failure ) {
+        debugmsg( "Could not place %d %s on map near (%d, %d, %d)", copies, exemplar.tname(),
+                  loc.x(), loc.y(), loc.z() );
+        return;
+    }
+    if( remaining > 0 ) {
+        debugmsg( "Could not place %d of %d %s on map near (%d, %d, %d); overflow neighborhood full",
+                  remaining, copies, exemplar.tname(), loc.x(), loc.y(), loc.z() );
+    }
+}
+
+/**
  * Set an item on the map or in a vehicle and return the new location
  */
 static item_location set_item_map_or_vehicle( const Character &p, const tripoint_bub_ms &loc,
@@ -2269,26 +2290,78 @@ static void spawn_items( Character &guy, std::vector<item> &results,
                          const std::optional<tripoint_bub_ms> &loc, const double relative_rot, const bool should_heat,
                          bool allow_wield = false )
 {
-    for( item &newit : results ) {
+    auto prepare = [&]( item & it ) {
         // todo: set this up recursively, who knows what kinda crafts will need it
-        if( !newit.empty() ) {
-            for( item *new_content : newit.all_items_top() ) {
+        if( !it.empty() ) {
+            for( item *new_content : it.all_items_top() ) {
                 set_temp_rot( *new_content, relative_rot, should_heat );
             }
         }
-        set_temp_rot( newit, relative_rot, should_heat );
+        set_temp_rot( it, relative_rot, should_heat );
+        it.set_owner( guy.get_faction()->id );
+    };
 
-        newit.set_owner( guy.get_faction()->id );
+    map &here = get_map();
+    for( size_t i = 0; i < results.size(); ) {
+        item &newit = results[i];
+        prepare( newit );
+
         if( newit.made_of( phase_id::LIQUID ) ) {
             liquid_handler::handle_all_or_npc_liquid( guy, newit, PICKUP_RANGE );
-        } else if( !loc && allow_wield && !guy.has_wield_conflicts( newit ) &&
-                   guy.can_wield( newit ).success() ) {
-            wield_craft( guy, newit );
-        } else if( !loc ) {
-            set_item_inventory( guy, newit );
-        } else {
-            set_item_map_or_vehicle( guy, loc.value_or( guy.pos_bub() ), newit );
+            ++i;
+            continue;
         }
+        if( !loc && allow_wield && !guy.has_wield_conflicts( newit ) &&
+            guy.can_wield( newit ).success() ) {
+            wield_craft( guy, newit );
+            ++i;
+            continue;
+        }
+        if( !loc ) {
+            set_item_inventory( guy, newit );
+            ++i;
+            continue;
+        }
+
+        // Map placement. Group consecutive identical non-charge results so a
+        // single multi-copy add_item_or_charges call handles overflow and
+        // per-tile cap once per group, instead of per-item closest_points_first
+        // fanout. Skip grouping when the target tile is a vehicle cargo part
+        // because veh add_item lacks a multi-copy entry point.
+        const tripoint_bub_ms target = loc.value_or( guy.pos_bub() );
+        const bool target_is_vehicle = here.veh_at( target ).cargo().has_value();
+        if( !target_is_vehicle && !newit.count_by_charges() ) {
+            size_t group_end = i + 1;
+            while( group_end < results.size() &&
+                   !results[group_end].made_of( phase_id::LIQUID ) &&
+                   !results[group_end].count_by_charges() &&
+                   static_cast<bool>( newit.stacks_with( results[group_end] ) ) ) {
+                prepare( results[group_end] );
+                ++group_end;
+            }
+            const int copies = static_cast<int>( group_end - i );
+            if( copies > 1 ) {
+                if( here.has_furn( target ) ) {
+                    const furn_t &workbench = here.furn( target ).obj();
+                    guy.add_msg_player_or_npc(
+                        //~ %1$s: name of item being placed, %2$s: vehicle part name
+                        pgettext( "item, furniture", "You put the %1$s on the %2$s." ),
+                        pgettext( "item, furniture", "<npcname> puts the %1$s on the %2$s." ),
+                        newit.tname( copies ), workbench.name() );
+                } else {
+                    guy.add_msg_player_or_npc(
+                        pgettext( "item", "You put the %s on the ground." ),
+                        pgettext( "item", "<npcname> puts the %s on the ground." ),
+                        newit.tname( copies ) );
+                }
+                set_item_map_copies( target, newit, copies );
+                i = group_end;
+                continue;
+            }
+        }
+
+        set_item_map_or_vehicle( guy, target, newit );
+        ++i;
     }
 }
 

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <iterator>
 #include <memory>
 #include <optional>
 #include <string>
@@ -338,6 +339,79 @@ item &inventory::add_item( item newit, bool keep_invlet, bool assign_invlet, boo
 
     items.emplace_back( std::list<item> { std::move( newit ) } );
     return items.back().back();
+}
+
+void inventory::add_items_bulk( std::vector<item> items_in, bool keep_invlet,
+                                bool assign_invlet, bool should_stack )
+{
+    // assign_invlet=true needs the per-item invlet collision resolution
+    // that bulk grouping cannot reproduce cheaply; fall back to add_item.
+    if( assign_invlet ) {
+        for( item &it : items_in ) {
+            add_item( std::move( it ), keep_invlet, assign_invlet, should_stack );
+        }
+        return;
+    }
+
+    binned = false;
+
+    if( !should_stack ) {
+        for( item &it : items_in ) {
+            if( !keep_invlet ) {
+                update_invlet( it, assign_invlet );
+            }
+            update_cache_with_item( it );
+            items.emplace_back( std::list<item> { std::move( it ) } );
+        }
+        return;
+    }
+
+    // Index existing stacks by the front item's typeId so each new entry skips
+    // the linear stacks_with sweep over unrelated stacks. Multiple stacks of
+    // the same typeId can coexist with different variant/damage/etc., so the
+    // bucket holds every match and the deep stacks_with check filters within.
+    std::unordered_map<itype_id, std::vector<invstack::iterator>> by_type;
+    for( auto it = items.begin(); it != items.end(); ++it ) {
+        by_type[it->front().typeId()].push_back( it );
+    }
+
+    for( item &newit : items_in ) {
+        bool merged = false;
+        auto bucket_it = by_type.find( newit.typeId() );
+        if( bucket_it != by_type.end() ) {
+            for( invstack::iterator stack_it : bucket_it->second ) {
+                std::list<item>::iterator front_it = stack_it->begin();
+                if( !front_it->stacks_with( newit ) ) {
+                    continue;
+                }
+                if( front_it->merge_charges( newit ) ) {
+                    merged = true;
+                    break;
+                }
+                if( front_it->invlet == '\0' ) {
+                    if( !keep_invlet ) {
+                        update_invlet( newit, assign_invlet );
+                    }
+                    update_cache_with_item( newit );
+                    front_it->invlet = newit.invlet;
+                } else {
+                    newit.invlet = front_it->invlet;
+                }
+                stack_it->emplace_back( std::move( newit ) );
+                merged = true;
+                break;
+            }
+        }
+        if( merged ) {
+            continue;
+        }
+        if( !keep_invlet ) {
+            update_invlet( newit, assign_invlet );
+        }
+        update_cache_with_item( newit );
+        items.emplace_back( std::list<item> { std::move( newit ) } );
+        by_type[items.back().front().typeId()].push_back( std::prev( items.end() ) );
+    }
 }
 
 void inventory::add_item_keep_invlet( const item &newit )

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -650,7 +650,16 @@ void inventory::form_from_map( map &m, std::vector<tripoint_bub_ms> pts, const C
             }
         }
         if( m.accessible_items( p ) ) {
-            for( item &i : m.i_at( p ) ) {
+            // assign_invlet=false has no per-item invlet collision pass, so a
+            // single bulk add per tile reproduces serial output while skipping
+            // the O(stacks) stacks_with sweep that add_item does per call.
+            map_stack items_here = m.i_at( p );
+            const bool bulk_eligible = !assign_invlet && items_here.size() > 1;
+            std::vector<item> bulk_batch;
+            if( bulk_eligible ) {
+                bulk_batch.reserve( items_here.size() );
+            }
+            for( item &i : items_here ) {
                 // if it's *the* player requesting this from from map inventory
                 // then don't allow items owned by another faction to be factored into recipe components etc.
                 if( pl && !i.is_owned_by( *pl, true ) ) {
@@ -661,8 +670,15 @@ void inventory::form_from_map( map &m, std::vector<tripoint_bub_ms> pts, const C
                         const int count = i.count_by_charges() ? i.charges : 1;
                         update_liq_container_count( i.typeId(), count );
                     }
-                    add_item( i, false, assign_invlet );
+                    if( bulk_eligible ) {
+                        bulk_batch.emplace_back( i );
+                    } else {
+                        add_item( i, false, assign_invlet );
+                    }
                 }
+            }
+            if( bulk_eligible && !bulk_batch.empty() ) {
+                add_items_bulk( std::move( bulk_batch ), false, false );
             }
         }
         // Kludges for now!

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -145,6 +145,14 @@ class inventory : public visitable
         // returns a reference to the added item
         item &add_item( item newit, bool keep_invlet = false, bool assign_invlet = true,
                         bool should_stack = true );
+        // Bulk variant of add_item for callers ingesting many items at once
+        // (json save load, form_from_map). Preserves source order within each
+        // typeId bucket to match add_item's per-item invlet inheritance.
+        // Supports keep_invlet=true,assign_invlet=false and
+        // keep_invlet=false,assign_invlet=false; other combinations fall
+        // through to repeated add_item calls.
+        void add_items_bulk( std::vector<item> items_in, bool keep_invlet = false,
+                             bool assign_invlet = true, bool should_stack = true );
         void add_item_keep_invlet( const item &newit );
         void push_back( const item &newit );
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2462,11 +2462,14 @@ void inventory::json_save_items( JsonOut &json ) const
 
 void inventory::json_load_items( const JsonArray &ja )
 {
+    std::vector<item> batch;
+    batch.reserve( ja.size() );
     for( JsonObject jo : ja ) {
         item tmp;
         tmp.deserialize( jo );
-        add_item( tmp, true, false );
+        batch.emplace_back( std::move( tmp ) );
     }
+    add_items_bulk( std::move( batch ), true, false );
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
#### Summary
Performance "Bulk inventory load and grouped craft result placement"

#### Purpose of change

Two hot paths that get worse as charges keep coming out of items (PR #87000 and ongoing). Both show clear wins in a local benchmark, same-binary A/B against the master shape:

- `inventory::json_load_items` for 10000 items across 1000 typeIds: 28.9 ms vs 10.4 ms.
- `spawn_items` placing 10000 rocks on a tile: 39.4 ms vs 20.7 ms.

Same-shape pain pops up in #84604 and #85287 as decharged items become discrete stacks.

#### Describe the solution

Three commits:

1. New `inventory::add_items_bulk` that hash-buckets by `typeId`, so each add is O(1) instead of master's O(stacks) scan. Adopted in `json_load_items`. Source order preserved inside each bucket.

2. Same helper adopted in the `form_from_map` ground-item loop when `assign_invlet=false` and the tile has more than one item. That's the crafting cache build and `veh_utils::repair_part`. Other `form_from_map` branches and `assign_invlet=true` callers stay serial.

3. `spawn_items` groups identical non-charge craft results and calls `map::add_item_or_charges` multi-copy once per group. The 25-tile `closest_points_first` fanout runs once per group, not per item. Vehicle cargo stays per-item.

#### Describe alternatives you've considered

N/A.

#### Testing

`[item]`, `[pocket]`, `[invlet]`, `[crafting]`, `[pickup]` pass. clang-tidy and IWYU clean.

#### Additional context

Two more commits were on the branch and got reviewed out (skip pocket restack on non-charge; one-pass invlet snapshot in `inventory::restack`). Neither moved any benchmark I could write, since master already short-circuits the worst case in practice.