### PR TITLE
Make character_creator_ui_impl draw_scenarios/draw_professions const

### DIFF
--- a/src/character_creator_ui.h
+++ b/src/character_creator_ui.h
@@ -157,8 +157,8 @@ class character_creator_ui_impl : public cataimgui::window
         explicit character_creator_ui_impl( character_creator_ui *parent );
 
         void draw_top_bar( const avatar &u ) const;
-        void draw_scenarios();
-        void draw_professions();
+        void draw_scenarios() const;
+        void draw_professions() const;
         void draw_backgrounds();
         // STR, DEX, etc...
         void draw_stats();

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2889,7 +2889,7 @@ bool character_creator_ui::display()
     return true;
 }
 
-void character_creator_ui_impl::draw_scenarios()
+void character_creator_ui_impl::draw_scenarios() const
 {
     const avatar &u = get_avatar();
     cc_uistate.recalc_scenario_list( u );
@@ -2914,7 +2914,7 @@ void character_creator_ui_impl::draw_scenarios()
     }
 }
 
-void character_creator_ui_impl::draw_professions()
+void character_creator_ui_impl::draw_professions() const
 {
     const avatar &u = get_avatar();
     cc_uistate.recalc_profession_list( u );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
clang-tidy `readability-make-member-function-const` flagged `draw_scenarios` and `draw_professions` in `src/newcharacter.cpp`, breaking the warnings-as-errors CI.

#### Describe the solution
Mark both methods `const`.

#### Describe alternatives you've considered
N/A

#### Testing
N/A

#### Additional context