### PR TITLE
Add tainted human blood to the any_blood requirement.

### DIFF
--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -1016,7 +1016,7 @@
     "id": "any_blood",
     "type": "requirement",
     "//": "Any type of blood.",
-    "components": [ [ [ "edible_blood", 1, "LIST" ], [ "blood_tainted", 1 ] ] ]
+    "components": [ [ [ "edible_blood", 1, "LIST" ], [ "blood_tainted", 1 ], [ "blood_tainted_human", 1 ] ] ]
   },
   {
     "id": "any_butter_or_oil",


### PR DESCRIPTION
#### Summary
Balance "Add tainted human blood to the any_blood requirement"

#### Purpose of change
Consistency. Recipes that could use 'any blood' can now use ANY blood. Except mi-go because that's from space and who knows what's in it?

#### Describe the solution
copy + paste + type "_human"

'Tainted blood' and 'human blood' were both allowed, but not 'tainted human blood'. I made it allow tainted human blood.

#### Describe alternatives you've considered
Leaving it broken I guess.
Also allow mi-go blood? I don't think this makes sense because it probably lacks crucial blood-like properties to actually be useful for the same things as the other blood types.

#### Testing
played game
it work.s
I can use tainted human blood in recipes now

#### Additional context
there is none