### PR TITLE
Aftershock: Small balance pass.

### DIFF
--- a/data/mods/aftershock_exoplanet/items/ammo/shot.json
+++ b/data/mods/aftershock_exoplanet/items/ammo/shot.json
@@ -1,5 +1,25 @@
 [
   {
+    "id": "shot_00",
+    "copy-from": "shotshell_abstract",
+    "type": "ITEM",
+    "subtypes": [ "AMMO" ],
+    "name": { "str_sp": "12 gauge buckshot" },
+    "weight": "43 g",
+    "description": "A 12 gauge shotgun shell, filled with 9 pellets of 00 buck.  A very common and versatile round, they're useful for both self defense and for hunting.  The spread of the shot doesn't just increase your chances to have a projectile hit, it also causes a much larger wound, greatly increasing lethality.  It does struggle with range, and against body armor.",
+    "ascii_picture": "shot_00",
+    "price": "5 USD",
+    "price_postapoc": "8 USD",
+    "range": 18,
+    "damage": { "damage_type": "bullet", "amount": 60 },
+    "shot_damage": { "damage_type": "bullet", "amount": 15, "armor_penetration": 4 },
+    "projectile_count": 9,
+    "shot_spread": 300,
+    "recoil": 2500,
+    "loudness": 160,
+    "effects": [ "COOKOFF", "SHOT" ]
+  },
+  {
     "id": "afs_shot_he",
     "copy-from": "shot_slug",
     "type": "ITEM",

--- a/data/mods/aftershock_exoplanet/maps/mapgen/aeolian_plains/aeolian_plains.json
+++ b/data/mods/aftershock_exoplanet/maps/mapgen/aeolian_plains/aeolian_plains.json
@@ -13,12 +13,12 @@
       "predecessor_mapgen": "field",
       "place_nested": [ { "chunks": [ "aeolian_base_tile" ], "x": 0, "y": 0 } ],
       "place_monsters": [
-        { "monster": "AFS_GROUP_FAUNA_HERBIVORE", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 2, "density": 0.1 },
+        { "monster": "AFS_GROUP_FAUNA_HERBIVORE", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 3, "density": 0.1 },
         {
           "monster": "AFS_GROUP_FAUNA_PREDATORS_LOW_RISK",
           "x": [ 0, 23 ],
           "y": [ 0, 23 ],
-          "chance": 1,
+          "chance": 10,
           "density": 0.1
         }
       ]

--- a/data/mods/aftershock_exoplanet/monsters/monster_groups/robot_monster_groups.json
+++ b/data/mods/aftershock_exoplanet/monsters/monster_groups/robot_monster_groups.json
@@ -58,7 +58,7 @@
     "id": "GROUP_ROBOT_FARM_HOSTILE",
     "default": "mon_manhack",
     "monsters": [
-      { "monster": "mon_utilibot_hostile", "weight": 500, "cost_multiplier": 70 },
+      { "monster": "mon_utilibot_hostile", "weight": 100, "cost_multiplier": 70 },
       { "monster": "mon_fumigator", "weight": 200, "cost_multiplier": 4, "pack_size": [ 1, 2 ] },
       { "monster": "mon_skitterbot", "weight": 200, "cost_multiplier": 20 },
       { "monster": "mon_scavbot_needle", "weight": 3, "cost_multiplier": 70 }

--- a/data/mods/aftershock_exoplanet/monsters/zombies.json
+++ b/data/mods/aftershock_exoplanet/monsters/zombies.json
@@ -199,7 +199,7 @@
     "melee_skill": 6,
     "melee_dice": 2,
     "melee_dice_sides": 3,
-    "melee_damage": [ { "damage_type": "bash", "amount": 2 } ],
+    "melee_damage": [ { "damage_type": "bash", "amount": 3 } ],
     "dodge": 4,
     "vision_day": 25,
     "regenerates": 10,


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Improves on some stuff I noticed while playing.

#### Describe the solution
By number of commit:

1. While moxphore scavengers could bypass the 8 bash treshold of light armor, this didnt happen very often, which made light combat robots to effective as distractions. A single extra point of bash damage improves this noticeably.

2. Shotgun pellets all do exactly 15 ballistic damage, the same as light armor, so they get completely blocked. This is not intended, a some amount of damage is meant to go through.

3. Rampant udarniks are way to dangerous for their frequency, same as some of the predators that could spawn in the Aeolian flats biome. Made both less common.

#### Testing
Loaded,
