### PR TITLE
Refresh inventory cache when stowing into a worn container

### DIFF
--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -2974,9 +2974,9 @@ void Character::store( item &container, item &put, bool penalties, int base_cost
         container.get_container_pockets().size() > 1 ) {
         // Bypass pocket settings (assuming the item is manually stored)
         int charges = put.count_by_charges() ? put.charges : 1;
-        container.fill_with( i_rem( &put ), charges, false, false, true );
+        container.fill_with( i_rem( &put ), charges, false, false, true, false, true, this );
     } else {
-        container.put_in( i_rem( &put ), pk_type );
+        container.put_in( i_rem( &put ), pk_type, false, this );
     }
     calc_encumbrance();
 }

--- a/tests/wield_test.cpp
+++ b/tests/wield_test.cpp
@@ -7,6 +7,7 @@
 #include "avatar.h"
 #include "calendar.h"
 #include "cata_catch.h"
+#include "character.h"
 #include "character_attire.h"
 #include "coordinates.h"
 #include "game.h"
@@ -25,7 +26,9 @@
 
 static const itype_id itype_aspirin( "aspirin" );
 static const itype_id itype_backpack( "backpack" );
+static const itype_id itype_backpack_hiking( "backpack_hiking" );
 static const itype_id itype_bag_plastic( "bag_plastic" );
+static const itype_id itype_halligan( "halligan" );
 static const itype_id itype_knife_combat( "knife_combat" );
 static const itype_id itype_knife_hunting( "knife_hunting" );
 static const itype_id itype_metal_tank( "metal_tank" );
@@ -419,4 +422,42 @@ TEST_CASE( "Wield_time_test", "[wield]" )
         wield_check_from_ground( guy, itype_metal_tank, 300 );
         clear_character( guy );
     }
+}
+
+// Storing the wielded weapon into a worn container via dispose_item's
+// "Store in <bag>" path must refresh inv_search_caches; otherwise cached
+// lookups miss the item.
+TEST_CASE( "unwield_to_pocket_preserves_inventory_cache",
+           "[wield][inventory_cache]" )
+{
+    clear_map_without_vision();
+    Character &they = get_avatar();
+    clear_character( they );
+
+    item backpack( itype_backpack_hiking );
+    auto iter = they.worn.wear_item( they, backpack, false, false );
+    REQUIRE( iter.has_value() );
+    item_location backpack_loc( they, & **iter );
+    REQUIRE( backpack_loc );
+
+    item halligan( itype_halligan );
+    REQUIRE( backpack_loc->can_contain( halligan ).success() );
+    REQUIRE( they.wield( halligan ) );
+    REQUIRE( they.is_armed() );
+
+    // Prime "HAS TYPE halligan" cache while wielded. The cache stores an
+    // item_location pointing into the wield slot; that reference dies once
+    // the item is moved out.
+    REQUIRE( they.cache_has_item_with( itype_halligan ) );
+
+    // Mimic the exact call dispose_item makes for "Store in <worn bag>".
+    item &wielded_ref = *they.get_wielded_item();
+    they.store( *backpack_loc, wielded_ref, false,
+                backpack_loc->insert_cost( wielded_ref ),
+                pocket_type::CONTAINER, true );
+
+    REQUIRE_FALSE( they.is_armed() );
+    REQUIRE( backpack_loc->num_item_stacks() == 1 );
+
+    CHECK( they.cache_has_item_with( itype_halligan ) );
 }


### PR DESCRIPTION
#### Summary

Bugfixes "Unwielding into a worn pocket leaves the item out of inventory lookups"

#### Purpose of change

Fixes #85052. Unwielding via "Store in <bag>" left the item out of `inv_search_caches`, so cached lookups missed it until the cache was rebuilt. "Store in inventory" was fine.

#### Describe the solution

`Character::store(item &container, ...)` now passes `this` as the carrier to `put_in` / `fill_with`. Both fire `on_pickup` on the inserted item when given a carrier, which refreshes the cache. The pocket-overload of `store` already did this.

#### Describe alternatives you've considered

Calling `on_item_acquire` directly in `store`. Works, but patches the symptom.

#### Testing

Added a wield_test regression. Fails on master, passes with the fix.

#### Additional context

`holster_actor::store` goes through the same overload, so holsters are covered too.