### PR TITLE
Hub 01 doesn't work with Exodii cyborgs

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/robofac_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/robofac_npc_eocs.json
@@ -65,6 +65,24 @@
     ]
   },
   {
+    "type": "effect_on_condition",
+    "id": "EOC_ROBOFAC_HATES_EXODII_CYBORGS",
+    "global": true,
+    "effect": [
+      { "mapgen_update": "remove_robofac_intercom", "om_terrain": "robofachq_surface_entrance" },
+      { "math": [ "hub01_intercom_locked = 1" ] },
+      { "math": [ "faction_like('robofac') = -100" ] },
+      { "math": [ "faction_respect('robofac') = -100" ] },
+      { "math": [ "faction_trust('robofac') = -100" ] },
+      { "math": [ "faction_like('robofac_auxiliaries_chop_shop') = -100" ] },
+      { "math": [ "faction_respect('robofac_auxiliaries_chop_shop') = -100" ] },
+      { "math": [ "faction_trust('robofac_auxiliaries_chop_shop') = -100" ] },
+      { "math": [ "faction_like('robofac_auxiliaries') = -100" ] },
+      { "math": [ "faction_respect('robofac_auxiliaries') = -100" ] },
+      { "math": [ "faction_trust('robofac_auxiliaries') = -100" ] }
+    ]
+  },
+  {
     "type": "mapgen",
     "update_mapgen_id": "remove_robofac_mercs",
     "object": {

--- a/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
@@ -474,7 +474,8 @@
           { "u_add_effect": "sleep", "duration": "12 hours" },
           { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "12 hours" },
           { "u_add_trait": "EXODII_BODY_1" },
-          { "run_eocs": "EOC_EXODII_MERCHANT_Exodize_Cyberframe_done", "time_in_future": "12 hours" }
+          { "run_eocs": "EOC_EXODII_MERCHANT_Exodize_Cyberframe_done", "time_in_future": "12 hours" },
+          { "run_eocs": "EOC_ROBOFAC_HATES_EXODII_CYBORGS" }
         ],
         "topic": "TALK_DONE"
       }
@@ -492,7 +493,8 @@
           { "u_add_effect": "sleep", "duration": "12 hours" },
           { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "12 hours" },
           { "u_add_trait": "EXODII_BODY_1b" },
-          { "run_eocs": "EOC_EXODII_MERCHANT_Exodize_Cyberframe_done", "time_in_future": "12 hours" }
+          { "run_eocs": "EOC_EXODII_MERCHANT_Exodize_Cyberframe_done", "time_in_future": "12 hours" },
+          { "run_eocs": "EOC_ROBOFAC_HATES_EXODII_CYBORGS" }
         ],
         "topic": "TALK_DONE"
       }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Getting an Exodii Cyberframe locks you out of Hub 01 content"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Hub 01 would be more likely to try and capture or kill an Exodii-looking cyborg rather than work with them.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Getting an Exodii Cyberframe now locks down the intercom, and makes the core robofac, ancilla, and ancilla chop shop kill on sight.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Perhaps there are other factions that should run/attack you on sight.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Got cyborgified.  Went to Hub 01.  Got shot by Cranberry.  Couldn't use the intercom.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Pat will required a more nuanced approach.  Working on them separately.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
