### PR TITLE
Hot-swap MEMORY_MAP_MODE via SDL3 GPU shaders

### DIFF
--- a/data/shaders/memory_blue_dark.frag
+++ b/data/shaders/memory_blue_dark.frag
@@ -1,0 +1,31 @@
+// Per-pixel memory blue-dark variant. Float-domain port of
+// color_pixel_blue_dark (color_pixel_mixer with cool tints, gamma 1.0).
+
+#version 450
+
+layout(set = 2, binding = 0) uniform sampler2D u_atlas;
+
+layout(location = 0) in vec4 v_vertex_color;
+layout(location = 1) in vec2 v_uv;
+layout(location = 0) out vec4 out_color;
+
+const vec3 COLOR_DARK = vec3(19.0, 23.0, 39.0) / 255.0;
+const vec3 COLOR_LIGHT = vec3(60.0, 66.0, 70.0) / 255.0;
+const float GAMMA = 1.0;
+
+void main()
+{
+    vec4 sample_color = texture(u_atlas, v_uv);
+    vec3 rgb = sample_color.rgb;
+
+    // Preserve pure black: source short-circuits when r==g==b==0.
+    float black = step(rgb.r + rgb.g + rgb.b, 0.0);
+
+    float av = (rgb.r + rgb.g + rgb.b) / 3.0;
+    float p = clamp(pow(av, GAMMA) * 1.5, 0.0, 1.0);
+    vec3 mixed = mix(COLOR_DARK, COLOR_LIGHT, p);
+    vec3 result_rgb = mix(mixed, rgb, black);
+
+    out_color = vec4(result_rgb * v_vertex_color.rgb,
+                     sample_color.a * v_vertex_color.a);
+}

--- a/data/shaders/memory_darken.frag
+++ b/data/shaders/memory_darken.frag
@@ -1,0 +1,26 @@
+// Per-pixel memory darken variant. Float-domain port of color_pixel_darken
+// (multiplies RGB by 85/256 ~ 1/3).
+
+#version 450
+
+layout(set = 2, binding = 0) uniform sampler2D u_atlas;
+
+layout(location = 0) in vec4 v_vertex_color;
+layout(location = 1) in vec2 v_uv;
+layout(location = 0) out vec4 out_color;
+
+void main()
+{
+    vec4 sample_color = texture(u_atlas, v_uv);
+    vec3 rgb = sample_color.rgb;
+
+    // Preserve pure black: source short-circuits when r==g==b==0.
+    float black = step(rgb.r + rgb.g + rgb.b, 0.0);
+
+    // 85/256 dimming with a 1/255 floor on each channel.
+    vec3 dim = max(rgb * (85.0 / 256.0), vec3(1.0 / 255.0));
+    vec3 result_rgb = mix(dim, rgb, black);
+
+    out_color = vec4(result_rgb * v_vertex_color.rgb,
+                     sample_color.a * v_vertex_color.a);
+}

--- a/data/shaders/memory_sepia_dark.frag
+++ b/data/shaders/memory_sepia_dark.frag
@@ -1,0 +1,31 @@
+// Per-pixel memory sepia-dark variant. Float-domain port of
+// color_pixel_sepia_dark (color_pixel_mixer with dark sepia tints, gamma 1.0).
+
+#version 450
+
+layout(set = 2, binding = 0) uniform sampler2D u_atlas;
+
+layout(location = 0) in vec4 v_vertex_color;
+layout(location = 1) in vec2 v_uv;
+layout(location = 0) out vec4 out_color;
+
+const vec3 COLOR_DARK = vec3(39.0, 23.0, 19.0) / 255.0;
+const vec3 COLOR_LIGHT = vec3(70.0, 66.0, 60.0) / 255.0;
+const float GAMMA = 1.0;
+
+void main()
+{
+    vec4 sample_color = texture(u_atlas, v_uv);
+    vec3 rgb = sample_color.rgb;
+
+    // Preserve pure black: source short-circuits when r==g==b==0.
+    float black = step(rgb.r + rgb.g + rgb.b, 0.0);
+
+    float av = (rgb.r + rgb.g + rgb.b) / 3.0;
+    float p = clamp(pow(av, GAMMA) * 1.5, 0.0, 1.0);
+    vec3 mixed = mix(COLOR_DARK, COLOR_LIGHT, p);
+    vec3 result_rgb = mix(mixed, rgb, black);
+
+    out_color = vec4(result_rgb * v_vertex_color.rgb,
+                     sample_color.a * v_vertex_color.a);
+}

--- a/data/shaders/memory_sepia_light.frag
+++ b/data/shaders/memory_sepia_light.frag
@@ -1,0 +1,31 @@
+// Per-pixel memory sepia-light variant. Float-domain port of
+// color_pixel_sepia_light (color_pixel_mixer with sepia tints, gamma 1.6).
+
+#version 450
+
+layout(set = 2, binding = 0) uniform sampler2D u_atlas;
+
+layout(location = 0) in vec4 v_vertex_color;
+layout(location = 1) in vec2 v_uv;
+layout(location = 0) out vec4 out_color;
+
+const vec3 COLOR_DARK = vec3(39.0, 23.0, 19.0) / 255.0;
+const vec3 COLOR_LIGHT = vec3(241.0, 220.0, 163.0) / 255.0;
+const float GAMMA = 1.6;
+
+void main()
+{
+    vec4 sample_color = texture(u_atlas, v_uv);
+    vec3 rgb = sample_color.rgb;
+
+    // Preserve pure black: source short-circuits when r==g==b==0.
+    float black = step(rgb.r + rgb.g + rgb.b, 0.0);
+
+    float av = (rgb.r + rgb.g + rgb.b) / 3.0;
+    float p = clamp(pow(av, GAMMA) * 1.5, 0.0, 1.0);
+    vec3 mixed = mix(COLOR_DARK, COLOR_LIGHT, p);
+    vec3 result_rgb = mix(mixed, rgb, black);
+
+    out_color = vec4(result_rgb * v_vertex_color.rgb,
+                     sample_color.a * v_vertex_color.a);
+}

--- a/src/cata_shader.cpp
+++ b/src/cata_shader.cpp
@@ -2,6 +2,31 @@
 
 #include "cata_shader.h"
 
+namespace cata_shader
+{
+
+namespace
+{
+bool g_reprobe_requested = false;
+} // namespace
+
+void request_reprobe()
+{
+    g_reprobe_requested = true;
+}
+
+bool reprobe_requested()
+{
+    return g_reprobe_requested;
+}
+
+void clear_reprobe()
+{
+    g_reprobe_requested = false;
+}
+
+} // namespace cata_shader
+
 #if SDL_MAJOR_VERSION >= 3
 
 #include <array>
@@ -456,6 +481,22 @@ bool load_and_probe( SDL_GPUDevice *device, SDL_Renderer *renderer,
 
 } // namespace
 
+void variant_pass::reset()
+{
+    flush();
+    for( size_t i = 0; i < shaders_.size(); ++i ) {
+        states_[i] = render_state{};
+        shaders_[i] = shader{};
+    }
+    for( size_t i = 0; i < memory_shaders_.size(); ++i ) {
+        memory_states_[i] = render_state{};
+        memory_shaders_[i] = shader{};
+    }
+    probe_attempted_ = false;
+    probed_ok_ = false;
+    session_disabled_ = false;
+}
+
 void variant_pass::probe()
 {
     probe_attempted_ = true;
@@ -507,6 +548,10 @@ SDL_GPURenderState *variant_pass::state_for( variant_kind v ) const
 
 bool variant_pass::try_begin( variant_kind v )
 {
+    if( reprobe_requested() ) {
+        reset();
+        clear_reprobe();
+    }
     if( session_disabled_ ) {
         // Drop any held bind so the disabled session does not leave shader
         // state on subsequent draws.

--- a/src/cata_shader.cpp
+++ b/src/cata_shader.cpp
@@ -350,9 +350,7 @@ variant_pass::variant_pass( SDL_Renderer *renderer )
 
 variant_pass::~variant_pass()
 {
-    if( active_ ) {
-        ( void )SDL_SetGPURenderState( renderer_, nullptr );
-    }
+    flush();
 }
 
 namespace
@@ -496,9 +494,23 @@ void variant_pass::probe()
     probed_ok_ = true;
 }
 
+SDL_GPURenderState *variant_pass::state_for( variant_kind v ) const
+{
+    if( v == variant_kind::MEMORY ) {
+        if( !active_memory_preset_ ) {
+            return nullptr;
+        }
+        return memory_states_[static_cast<size_t>( *active_memory_preset_ )].get();
+    }
+    return states_[static_cast<size_t>( v )].get();
+}
+
 bool variant_pass::try_begin( variant_kind v )
 {
     if( session_disabled_ ) {
+        // Drop any held bind so the disabled session does not leave shader
+        // state on subsequent draws.
+        flush();
         return false;
     }
     if( !probe_attempted_ ) {
@@ -507,54 +519,46 @@ bool variant_pass::try_begin( variant_kind v )
     if( !probed_ok_ ) {
         return false;
     }
-    if( active_ ) {
-        // try_begin called without preceding end(); programming error.
-        DebugLog( D_ERROR, DC_ALL )
-                << "cata_shader::variant_pass: try_begin while bind active; "
-                "session disabled to prevent state bleed";
-        session_disabled_ = true;
-        ( void )SDL_SetGPURenderState( renderer_, nullptr );
-        active_ = false;
-        return false;
+    SDL_GPURenderState *target = state_for( v );
+    SDL_GPURenderState *current = currently_bound_
+                                  ? state_for( *currently_bound_ )
+                                  : nullptr;
+    if( target == current ) {
+        return target != nullptr;
     }
-    SDL_GPURenderState *state = nullptr;
-    if( v == variant_kind::MEMORY ) {
-        if( active_memory_preset_ ) {
-            state = memory_states_[static_cast<size_t>(
-                                       *active_memory_preset_ )].get();
-        }
-    } else {
-        state = states_[static_cast<size_t>( v )].get();
-    }
-    if( !state ) {
-        // NORMAL/unselected MEMORY preset: no shader path for this variant.
-        return false;
-    }
-    if( !SDL_SetGPURenderState( renderer_, state ) ) {
+    if( !SDL_SetGPURenderState( renderer_, target ) ) {
         DebugLog( D_ERROR, DC_ALL )
                 << "cata_shader::variant_pass: SDL_SetGPURenderState failed: "
                 << SDL_GetError();
         session_disabled_ = true;
+        currently_bound_.reset();
         return false;
     }
-    active_ = true;
-    return true;
+    if( target ) {
+        currently_bound_ = v;
+    } else {
+        currently_bound_.reset();
+    }
+    return target != nullptr;
 }
 
 bool variant_pass::end()
 {
-    if( !active_ ) {
-        return true;
+    return true;
+}
+
+void variant_pass::flush()
+{
+    if( !currently_bound_ ) {
+        return;
     }
-    active_ = false;
+    currently_bound_.reset();
     if( !SDL_SetGPURenderState( renderer_, nullptr ) ) {
         DebugLog( D_ERROR, DC_ALL )
                 << "cata_shader::variant_pass: SDL_SetGPURenderState(NULL) failed: "
                 << SDL_GetError();
         session_disabled_ = true;
-        return false;
     }
-    return true;
 }
 
 void variant_pass::select_memory_preset( std::optional<memory_preset> preset )

--- a/src/cata_shader.cpp
+++ b/src/cata_shader.cpp
@@ -239,7 +239,109 @@ const char *shader_basename_for( variant_kind v )
     return nullptr;
 }
 
+const char *shader_basename_for( memory_preset p )
+{
+    switch( p ) {
+        case memory_preset::DARKEN:
+            return "memory_darken.frag";
+        case memory_preset::SEPIA_LIGHT:
+            return "memory_sepia_light.frag";
+        case memory_preset::SEPIA_DARK:
+            return "memory_sepia_dark.frag";
+        case memory_preset::BLUE_DARK:
+            return "memory_blue_dark.frag";
+        case memory_preset::count:
+            return nullptr;
+    }
+    return nullptr;
+}
+
+using probe_predicate = bool ( * )( int r, int g, int b );
+
+bool grayscale_predicate( int r, int g, int b )
+{
+    // Gray-toned (R~=G~=B within 8 LSB) AND strictly darker than the
+    // mid-gray (128) input.
+    return std::abs( r - g ) < 8 && std::abs( g - b ) < 8 && r < 120;
+}
+
+bool nightvision_predicate( int r, int g, int b )
+{
+    // Green-tinted: G clearly greater than R and B. Margin 20 covers driver
+    // rounding without false-positiving the unmodulated gray (R==G==B).
+    return g > r + 20 && g > b + 20;
+}
+
+bool darken_predicate( int r, int g, int b )
+{
+    // Memory darken multiplies by 85/256 (~1/3) of input mid-gray, so the
+    // expected output is ~42 on each channel. Allow some driver slack.
+    return std::abs( r - g ) < 8 && std::abs( g - b ) < 8 && r < 80;
+}
+
+bool warm_predicate( int r, int /*g*/, int b )
+{
+    // Sepia variants emit warm-tinted output: R clearly greater than B.
+    return r > b + 5;
+}
+
+bool cool_predicate( int r, int /*g*/, int b )
+{
+    // Blue dark emits cool-tinted output: B clearly greater than R.
+    return b > r + 5;
+}
+
+probe_predicate predicate_for( variant_kind v )
+{
+    switch( v ) {
+        case variant_kind::SHADOW:
+            return grayscale_predicate;
+        case variant_kind::NIGHT:
+        case variant_kind::OVEREXPOSED:
+            return nightvision_predicate;
+        case variant_kind::NORMAL:
+        case variant_kind::MEMORY:
+        case variant_kind::count:
+            return nullptr;
+    }
+    return nullptr;
+}
+
+probe_predicate predicate_for( memory_preset p )
+{
+    switch( p ) {
+        case memory_preset::DARKEN:
+            return darken_predicate;
+        case memory_preset::SEPIA_LIGHT:
+        case memory_preset::SEPIA_DARK:
+            return warm_predicate;
+        case memory_preset::BLUE_DARK:
+            return cool_predicate;
+        case memory_preset::count:
+            return nullptr;
+    }
+    return nullptr;
+}
+
 } // namespace
+
+std::optional<memory_preset> memory_preset_from_option_value(
+    const std::string &mode )
+{
+    if( mode == "color_pixel_darken" ) {
+        return memory_preset::DARKEN;
+    }
+    if( mode == "color_pixel_sepia_light" ) {
+        return memory_preset::SEPIA_LIGHT;
+    }
+    if( mode == "color_pixel_sepia_dark" ) {
+        return memory_preset::SEPIA_DARK;
+    }
+    if( mode == "color_pixel_blue_dark" ) {
+        return memory_preset::BLUE_DARK;
+    }
+    return std::nullopt;
+}
 
 variant_pass::variant_pass( SDL_Renderer *renderer )
     : renderer_( renderer )
@@ -256,14 +358,11 @@ variant_pass::~variant_pass()
 namespace
 {
 
-// Renders a single 1x1 mid-gray sprite via `state` to a 1x1 offscreen RT
-// and reads the result back. Mid-gray (128,128,128,255) is chosen because
-// every variant transform produces a distinctive output for it: grayscale
-// stays gray-but-dimmer, nightvision/overexposed produce a green tint
-// (G > R+20 and G > B+20). That distinguishes "shader ran" from "shader
-// bind was silently ignored" (the latter returns the unmodulated gray).
-bool variant_draw_probe( SDL_Renderer *renderer, SDL_GPURenderState *state,
-                         variant_kind v )
+// Renders a 1x1 mid-gray sprite via state and checks readback via pred.
+// Mid-gray (128,128,128,255) gives each variant a distinctive output, so a
+// passing predicate distinguishes "shader ran" from "bind silently ignored".
+bool draw_probe( SDL_Renderer *renderer, SDL_GPURenderState *state,
+                 probe_predicate pred )
 {
     SDL_Surface *src_surf = SDL_CreateSurface( 1, 1, SDL_PIXELFORMAT_RGBA32 );
     if( !src_surf ) {
@@ -306,30 +405,7 @@ bool variant_draw_probe( SDL_Renderer *renderer, SDL_GPURenderState *state,
                         const int g = p[1];
                         const int b = p[2];
                         const int a = p[3];
-                        if( a < 250 ) {
-                            ok = false;
-                        } else {
-                            switch( v ) {
-                                case variant_kind::SHADOW:
-                                    // Grayscale: gray-toned (R~=G~=B within 8 LSB) AND
-                                    // strictly darker than input mid-gray (128).
-                                    ok = std::abs( r - g ) < 8 && std::abs( g - b ) < 8
-                                         && r < 120;
-                                    break;
-                                case variant_kind::NIGHT:
-                                case variant_kind::OVEREXPOSED:
-                                    // Both variants emit green-tinted output: G clearly
-                                    // greater than R and B. Margin 20 covers driver
-                                    // rounding without false-positiving the unmodulated
-                                    // gray (R==G==B).
-                                    ok = g > r + 20 && g > b + 20;
-                                    break;
-                                default:
-                                    // NORMAL/MEMORY are not probed (no shader path).
-                                    ok = false;
-                                    break;
-                            }
-                        }
+                        ok = a >= 250 && pred && pred( r, g, b );
                         SDL_DestroySurface( rgba );
                     }
                 }
@@ -342,6 +418,42 @@ bool variant_draw_probe( SDL_Renderer *renderer, SDL_GPURenderState *state,
     SDL_DestroyTexture( rt );
     SDL_DestroyTexture( src );
     return ok;
+}
+
+} // namespace
+
+namespace
+{
+
+// Loads shader + render_state for basename and validates via draw_probe.
+bool load_and_probe( SDL_GPUDevice *device, SDL_Renderer *renderer,
+                     const char *basename, probe_predicate pred,
+                     shader &out_shader, render_state &out_state )
+{
+    shader frag = shader::load_fragment( device, basename, 1, 0 );
+    if( !frag.is_valid() ) {
+        DebugLog( D_ERROR, DC_ALL )
+                << "cata_shader::variant_pass: shader load failed for "
+                << basename << "; shader variant path disabled";
+        return false;
+    }
+    render_state state = render_state::create( renderer, frag );
+    if( !state.is_valid() ) {
+        DebugLog( D_ERROR, DC_ALL )
+                << "cata_shader::variant_pass: render_state::create failed for "
+                << basename << "; shader variant path disabled";
+        return false;
+    }
+    if( !draw_probe( renderer, state.get(), pred ) ) {
+        DebugLog( D_ERROR, DC_ALL )
+                << "cata_shader::variant_pass: textured-draw probe failed for "
+                << basename << " (silent miswire? readback did not match "
+                "expected variant transform); shader variant path disabled";
+        return false;
+    }
+    out_shader = std::move( frag );
+    out_state = std::move( state );
+    return true;
 }
 
 } // namespace
@@ -365,29 +477,21 @@ void variant_pass::probe()
         if( !basename ) {
             continue;
         }
-        shader frag = shader::load_fragment( device, basename, 1, 0 );
-        if( !frag.is_valid() ) {
-            DebugLog( D_ERROR, DC_ALL )
-                    << "cata_shader::variant_pass: shader load failed for "
-                    << basename << "; shader variant path disabled";
+        if( !load_and_probe( device, renderer_, basename, predicate_for( v ),
+                             shaders_[i], states_[i] ) ) {
             return;
         }
-        render_state state = render_state::create( renderer_, frag );
-        if( !state.is_valid() ) {
-            DebugLog( D_ERROR, DC_ALL )
-                    << "cata_shader::variant_pass: render_state::create failed for "
-                    << basename << "; shader variant path disabled";
+    }
+    for( int i = 0; i < static_cast<int>( memory_preset::count ); ++i ) {
+        const memory_preset p = static_cast<memory_preset>( i );
+        const char *basename = shader_basename_for( p );
+        if( !basename ) {
+            continue;
+        }
+        if( !load_and_probe( device, renderer_, basename, predicate_for( p ),
+                             memory_shaders_[i], memory_states_[i] ) ) {
             return;
         }
-        if( !variant_draw_probe( renderer_, state.get(), v ) ) {
-            DebugLog( D_ERROR, DC_ALL )
-                    << "cata_shader::variant_pass: textured-draw probe failed for "
-                    << basename << " (silent miswire? readback did not match "
-                    "expected variant transform); shader variant path disabled";
-            return;
-        }
-        shaders_[i] = std::move( frag );
-        states_[i] = std::move( state );
     }
     probed_ok_ = true;
 }
@@ -413,9 +517,17 @@ bool variant_pass::try_begin( variant_kind v )
         active_ = false;
         return false;
     }
-    SDL_GPURenderState *state = states_[static_cast<size_t>( v )].get();
+    SDL_GPURenderState *state = nullptr;
+    if( v == variant_kind::MEMORY ) {
+        if( active_memory_preset_ ) {
+            state = memory_states_[static_cast<size_t>(
+                                       *active_memory_preset_ )].get();
+        }
+    } else {
+        state = states_[static_cast<size_t>( v )].get();
+    }
     if( !state ) {
-        // NORMAL/MEMORY/unhandled: no shader path for this variant.
+        // NORMAL/unselected MEMORY preset: no shader path for this variant.
         return false;
     }
     if( !SDL_SetGPURenderState( renderer_, state ) ) {
@@ -443,6 +555,11 @@ bool variant_pass::end()
         return false;
     }
     return true;
+}
+
+void variant_pass::select_memory_preset( std::optional<memory_preset> preset )
+{
+    active_memory_preset_ = preset;
 }
 
 } // namespace cata_shader

--- a/src/cata_shader.h
+++ b/src/cata_shader.h
@@ -162,6 +162,10 @@ class gpu_state_scope
 // without recycling, so each variant gets its own state and the dispatch
 // is a state switch rather than a uniform mutation.
 //
+// try_begin holds the bound state across same-variant runs of sprites and
+// only calls SDL_SetGPURenderState when the variant changes. flush() at the
+// end of the frame clears the held state.
+//
 // Lifecycle:
 //   - construct with renderer (no work).
 //   - probe() lazily on first use; loads shaders and creates states for
@@ -171,12 +175,13 @@ class gpu_state_scope
 //   - select_memory_preset(p) picks which memory shader try_begin(MEMORY)
 //     binds. Nullopt disables the MEMORY shader path so callers fall back
 //     to the memory atlas (used for the custom MEMORY_MAP_MODE preset).
-//   - try_begin(v) returns true iff v has an active shader path AND bind
-//     succeeded. Caller must call end() iff try_begin returned true.
-//   - end() returns true on clean unbind. False sets session_disabled
-//     (one-way) so subsequent try_begin returns false; recovers on
-//     restart.
-//   - destruction releases held shader/state slots.
+//   - try_begin(v) returns true iff v has an active shader path AND the
+//     state is bound. NORMAL or unsupported MEMORY preset returns false and
+//     ensures no shader stays bound from a previous draw.
+//   - end() is a no-op; bind persists for the next sprite.
+//   - flush() unbinds any held state. Call once per frame after the last
+//     sprite draw so ImGui or the next-frame draws see no leaked bind.
+//   - destruction unbinds and releases held shader/state slots.
 class variant_pass
 {
     public:
@@ -197,10 +202,13 @@ class variant_pass
         bool try_begin( variant_kind v );
         bool end();
 
+        void flush();
+
         void select_memory_preset( std::optional<memory_preset> preset );
 
     private:
         void probe();
+        SDL_GPURenderState *state_for( variant_kind v ) const;
 
         SDL_Renderer *renderer_ = nullptr;
         std::array<shader, static_cast<size_t>( variant_kind::count )> shaders_;
@@ -209,10 +217,10 @@ class variant_pass
         std::array<render_state, static_cast<size_t>( memory_preset::count )>
         memory_states_;
         std::optional<memory_preset> active_memory_preset_;
+        std::optional<variant_kind> currently_bound_;
         bool probe_attempted_ = false;
         bool probed_ok_ = false;
         bool session_disabled_ = false;
-        bool active_ = false;
 };
 
 } // namespace cata_shader

--- a/src/cata_shader.h
+++ b/src/cata_shader.h
@@ -6,6 +6,18 @@
 
 #include "sdl_wrappers.h"
 
+namespace cata_shader
+{
+
+// Forces the next variant_pass::try_begin to drop cached shader artifacts
+// and re-run the activation probe. Used to pick up freshly rebuilt
+// .spv/.dxil/.msl without restarting. No-op on SDL2 / non-GPU renderer.
+void request_reprobe();
+bool reprobe_requested();
+void clear_reprobe();
+
+} // namespace cata_shader
+
 // SDL_SetGPURenderState and the SDL_GPU* surface this header wraps were added
 // in SDL 3.4.0 and have no SDL2 counterpart. The class types below are
 // SDL3-only.
@@ -208,6 +220,7 @@ class variant_pass
 
     private:
         void probe();
+        void reset();
         SDL_GPURenderState *state_for( variant_kind v ) const;
 
         SDL_Renderer *renderer_ = nullptr;

--- a/src/cata_shader.h
+++ b/src/cata_shader.h
@@ -13,14 +13,16 @@
 
 #include <array>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace cata_shader
 {
 
 // Sprite-variant kinds for the GPU shader path. NORMAL has no shader and
-// uses the atlas directly. MEMORY has no shader either; the memory atlas
-// drives MEMORIZED draws.
+// uses the atlas directly. MEMORY dispatches by the selected memory_preset
+// (see select_memory_preset); the custom MEMORY_MAP_MODE preset has no shader
+// and falls back to the memory atlas.
 enum class variant_kind : int {
     NORMAL = 0,
     SHADOW,       // lit_level::LOW without nightvision
@@ -29,6 +31,22 @@ enum class variant_kind : int {
     MEMORY,       // lit_level::MEMORIZED
     count
 };
+
+// Memory map overlay presets that have a baked shader. Mirrors the four
+// named MEMORY_MAP_MODE values; the custom preset has no shader here and
+// falls back to the memory atlas.
+enum class memory_preset : int {
+    DARKEN = 0,
+    SEPIA_LIGHT,
+    SEPIA_DARK,
+    BLUE_DARK,
+    count
+};
+
+// Maps a MEMORY_MAP_MODE option value to its memory_preset. Returns nullopt
+// for color_pixel_custom or any unknown value.
+std::optional<memory_preset> memory_preset_from_option_value(
+    const std::string &mode );
 
 // RAII over SDL_GPUShader *. Lifetime is tied to the SDL_GPUDevice that
 // created the shader (device-scoped).
@@ -146,10 +164,13 @@ class gpu_state_scope
 //
 // Lifecycle:
 //   - construct with renderer (no work).
-//   - probe() lazily on first use; loads shaders, creates states for
-//     SHADOW/NIGHT/OVEREXPOSED. Either every variant succeeds or every
-//     variant is marked unavailable (single decision, no per-variant
-//     gating). NORMAL and MEMORY are never probed: neither has a shader.
+//   - probe() lazily on first use; loads shaders and creates states for
+//     SHADOW/NIGHT/OVEREXPOSED plus one per named memory_preset. Either
+//     every variant succeeds or every variant is marked unavailable
+//     (single decision, no per-variant gating). NORMAL has no shader.
+//   - select_memory_preset(p) picks which memory shader try_begin(MEMORY)
+//     binds. Nullopt disables the MEMORY shader path so callers fall back
+//     to the memory atlas (used for the custom MEMORY_MAP_MODE preset).
 //   - try_begin(v) returns true iff v has an active shader path AND bind
 //     succeeded. Caller must call end() iff try_begin returned true.
 //   - end() returns true on clean unbind. False sets session_disabled
@@ -176,12 +197,18 @@ class variant_pass
         bool try_begin( variant_kind v );
         bool end();
 
+        void select_memory_preset( std::optional<memory_preset> preset );
+
     private:
         void probe();
 
         SDL_Renderer *renderer_ = nullptr;
         std::array<shader, static_cast<size_t>( variant_kind::count )> shaders_;
         std::array<render_state, static_cast<size_t>( variant_kind::count )> states_;
+        std::array<shader, static_cast<size_t>( memory_preset::count )> memory_shaders_;
+        std::array<render_state, static_cast<size_t>( memory_preset::count )>
+        memory_states_;
+        std::optional<memory_preset> active_memory_preset_;
         bool probe_attempted_ = false;
         bool probed_ok_ = false;
         bool session_disabled_ = false;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1365,6 +1365,13 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
     }
 
     RenderSetClipRect( renderer, nullptr );
+#if SDL_MAJOR_VERSION >= 3
+    // Unbind any GPU render state held across sprite batches so ImGui or the
+    // next-frame draws see a clean state.
+    if( m_variant_pass ) {
+        m_variant_pass->flush();
+    }
+#endif
 }
 
 void cata_tiles::set_draw_cache_dirty()
@@ -2462,9 +2469,10 @@ bool cata_tiles::draw_sprite_at(
     if( m_variant_pass ) {
         const cata_shader::variant_kind v =
             compute_variant_kind( rp.ll, rp.use_night_vision_tiles );
-        if( v != cata_shader::variant_kind::NORMAL ) {
-            shader_bound = m_variant_pass->try_begin( v );
-        }
+        // Call try_begin for every variant including NORMAL. State-cached
+        // bind stays put across same-variant runs; NORMAL clears any prior
+        // shader state so it doesn't leak onto the next sprite.
+        shader_bound = m_variant_pass->try_begin( v );
     }
 #endif
 
@@ -2649,9 +2657,8 @@ bool cata_tiles::draw_sprite_at(
 
     printErrorIf( ret != 0, "SDL_RenderCopyEx() failed" );
 #if SDL_MAJOR_VERSION >= 3
-    if( shader_bound ) {
-        ( void )m_variant_pass->end();
-    }
+    // variant_pass unbinds on frame-end flush; nothing to do per-sprite.
+    ( void )shader_bound;
 #endif
     // this reference passes all the way back up the call chain back to
     // cata_tiles::draw() here.draw_points_cache[z][row][col].com.height_3d

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -278,6 +278,13 @@ void cata_tiles::on_options_changed()
 {
     memory_map_mode = get_option <std::string>( "MEMORY_MAP_MODE" );
 
+#if SDL_MAJOR_VERSION >= 3
+    if( m_variant_pass ) {
+        m_variant_pass->select_memory_preset(
+            cata_shader::memory_preset_from_option_value( memory_map_mode ) );
+    }
+#endif
+
     pixel_minimap_settings settings;
 
     settings.mode =
@@ -381,7 +388,8 @@ void cata_tiles::load_tileset( const std::string &tileset_id, const bool prechec
     // reset the overlay ordering from the previous loaded tileset
     tileset_mutation_overlay_ordering.clear();
 
-    tileset_ptr = cache.load_tileset( tileset_id, renderer, precheck, force, pump_events, terrain );
+    tileset_ptr = cache.load_tileset( tileset_id, renderer, precheck, force, pump_events, terrain,
+                                      memory_map_mode );
 
     set_draw_scale( 16 );
 
@@ -2448,14 +2456,13 @@ bool cata_tiles::draw_sprite_at(
 #if SDL_MAJOR_VERSION >= 3
     // Try the GPU shader variant first. On success the main atlas drives
     // the render and the variant transform happens per-pixel in the
-    // fragment shader. On failure or unsupported variant
-    // (NORMAL/MEMORY/late session-disable) the fallthrough below picks the
-    // matching pre-baked variant atlas.
+    // fragment shader. On unsupported variant (NORMAL, custom MEMORY
+    // preset, late session-disable) try_begin returns false and the
+    // fallthrough below picks the matching pre-baked variant atlas.
     if( m_variant_pass ) {
         const cata_shader::variant_kind v =
             compute_variant_kind( rp.ll, rp.use_night_vision_tiles );
-        if( v != cata_shader::variant_kind::NORMAL
-            && v != cata_shader::variant_kind::MEMORY ) {
+        if( v != cata_shader::variant_kind::NORMAL ) {
             shader_bound = m_variant_pass->try_begin( v );
         }
     }
@@ -3913,13 +3920,13 @@ bool cata_tiles::draw_item_highlight( const tripoint_bub_ms &pos, int &height_3d
 
 std::shared_ptr<const tileset> tileset_cache::load_tileset( const std::string &tileset_id,
         const SDL_Renderer_Ptr &renderer, const bool precheck, const bool force, const bool pump_events,
-        const bool terrain )
+        const bool terrain, const std::string &memory_map_mode )
 {
     const auto get_or_create_tileset = [&]() {
         const auto it = tilesets_.find( tileset_id );
         if( it == tilesets_.end() || it->second.expired() ) {
             std::shared_ptr<tileset> new_ts = std::make_shared<tileset>();
-            loader loader( *new_ts, renderer );
+            loader loader( *new_ts, renderer, memory_map_mode );
             loader.load( tileset_id, precheck, pump_events, terrain );
             tilesets_.emplace( tileset_id, new_ts );
             return new_ts;
@@ -3930,7 +3937,7 @@ std::shared_ptr<const tileset> tileset_cache::load_tileset( const std::string &t
     std::shared_ptr<tileset> ts = get_or_create_tileset();
 
     if( force || ( ts->get_tileset_id().empty() && !precheck ) ) {
-        loader loader( *ts, renderer );
+        loader loader( *ts, renderer, memory_map_mode );
         loader.load( tileset_id, precheck, pump_events, terrain );
     }
     return ts;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -343,7 +343,8 @@ class tileset_cache
     public:
         std::shared_ptr<const tileset> load_tileset( const std::string &tileset_id,
                 const SDL_Renderer_Ptr &renderer, bool precheck,
-                bool force, bool pump_events, bool terrain );
+                bool force, bool pump_events, bool terrain,
+                const std::string &memory_map_mode );
     private:
         class loader;
 

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -35,6 +35,9 @@
 #include "calendar.h"
 #include "calendar_ui.h"
 #include "cata_path.h"
+#if defined(TILES) && defined(USE_SDL3)
+#include "cata_shader.h"
+#endif
 #include "cata_utility.h"
 #include "catacharset.h"
 #include "character.h"
@@ -296,6 +299,7 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
         case debug_menu::debug_menu_index::TALK_TOPIC: return "TALK_TOPIC";
         case debug_menu::debug_menu_index::IMGUI_DEMO: return "IMGUI_DEMO";
         case debug_menu::debug_menu_index::VEHICLE_EFFECTS: return "VEHICLE_EFFECTS";
+        case debug_menu::debug_menu_index::RELOAD_GPU_SHADERS: return "RELOAD_GPU_SHADERS";
         // *INDENT-ON*
         case debug_menu::debug_menu_index::last:
             break;
@@ -991,6 +995,9 @@ static int info_uilist()
         { uilist_entry( debug_menu_index::GENERATE_EFFECT_LIST, true, 'L', _( "Generate effect list" ) ) },
         { uilist_entry( debug_menu_index::WRITE_CITY_LIST, true, 'C', _( "Write city list to cities.output" ) ) },
         { uilist_entry( debug_menu_index::IMGUI_DEMO, true, 'u', _( "Open ImGui demo screen" ) ) },
+#if defined(TILES) && defined(USE_SDL3)
+        { uilist_entry( debug_menu_index::RELOAD_GPU_SHADERS, true, 'P', _( "Reload GPU shaders" ) ) },
+#endif
     };
 
     return uilist( _( "Info…" ), uilist_initializer );
@@ -4613,6 +4620,13 @@ void debug()
 
         case debug_menu_index::IMGUI_DEMO:
             run_imgui_demo();
+            break;
+
+        case debug_menu_index::RELOAD_GPU_SHADERS:
+#if defined(TILES) && defined(USE_SDL3)
+            cata_shader::request_reprobe();
+            add_msg( _( "GPU shaders will reload on next frame." ) );
+#endif
             break;
 
         case debug_menu_index::TALK_TOPIC:

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -121,6 +121,7 @@ enum class debug_menu_index : int {
     TALK_TOPIC,
     IMGUI_DEMO,
     VEHICLE_EFFECTS,
+    RELOAD_GPU_SHADERS,
     last
 };
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2525,7 +2525,7 @@ void options_manager::add_options_graphics()
            );
 
         add( "MEMORY_MAP_MODE", page_id, to_translation( "Memory map overlay preset" ),
-        to_translation( "Specify the overlay in which the memory map is drawn.  Requires restart.  For custom overlay, define RGB values for dark and bright colors as well as gamma." ), {
+        to_translation( "Specify the overlay in which the memory map is drawn.  The custom overlay needs a restart to take effect; for it, define RGB values for dark and bright colors as well as gamma." ), {
             { "color_pixel_darken", to_translation( "Darkened" ) },
             { "color_pixel_sepia_light", to_translation( "Sepia" ) },
             { "color_pixel_sepia_dark", to_translation( "Sepia Dark" ) },

--- a/src/tileset_loader.cpp
+++ b/src/tileset_loader.cpp
@@ -247,9 +247,7 @@ void tileset_cache::loader::create_textures_from_tile_atlas( const SDL_Surface_P
             { std::make_tuple( &ts.shadow_tile_values, "color_pixel_grayscale" ) },
             { std::make_tuple( &ts.night_tile_values, "color_pixel_nightvision" ) },
             { std::make_tuple( &ts.overexposed_tile_values, "color_pixel_overexposed" ) },
-            // TODO: drop tilecontext->memory_map_mode reach; loader pulls a live cata_tiles
-            // option here, blocking runtime mode swaps and clean loader/renderer separation.
-            { std::make_tuple( &ts.memory_tile_values, tilecontext->memory_map_mode ) },
+            { std::make_tuple( &ts.memory_tile_values, memory_map_mode ) },
             { std::make_tuple( &ts.silhouette_tile_values, "color_pixel_silhouette" ) }
         }
     };

--- a/src/tileset_loader.h
+++ b/src/tileset_loader.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "cata_tiles.h"
@@ -19,6 +20,7 @@ class tileset_cache::loader
     private:
         tileset &ts;
         const SDL_Renderer_Ptr &renderer;
+        std::string memory_map_mode;
 
         point sprite_offset;
         point sprite_offset_retracted;
@@ -76,7 +78,8 @@ class tileset_cache::loader
         void load_layers( const JsonObject &config );
 
     public:
-        loader( tileset &ts, const SDL_Renderer_Ptr &r ) : ts( ts ), renderer( r ) {
+        loader( tileset &ts, const SDL_Renderer_Ptr &r, std::string memory_map_mode )
+            : ts( ts ), renderer( r ), memory_map_mode( std::move( memory_map_mode ) ) {
         }
         // tileset_id matches the option string. precheck only loads metadata
         // (tile dimensions). pump_events same caveat as load_tileset. terrain

--- a/tests/gpu_variant_dispatch_test.cpp
+++ b/tests/gpu_variant_dispatch_test.cpp
@@ -34,5 +34,28 @@ TEST_CASE( "compute_variant_kind_dispatch_table", "[tiles][gpu]" )
         CHECK( compute_variant_kind( lit_level::BLANK, false ) == variant_kind::NORMAL );
     }
 }
+
+TEST_CASE( "memory_preset_from_option_value_mapping", "[tiles][gpu]" )
+{
+    using cata_shader::memory_preset;
+    using cata_shader::memory_preset_from_option_value;
+
+    SECTION( "named MEMORY_MAP_MODE values map to their preset" ) {
+        CHECK( memory_preset_from_option_value( "color_pixel_darken" )
+               == memory_preset::DARKEN );
+        CHECK( memory_preset_from_option_value( "color_pixel_sepia_light" )
+               == memory_preset::SEPIA_LIGHT );
+        CHECK( memory_preset_from_option_value( "color_pixel_sepia_dark" )
+               == memory_preset::SEPIA_DARK );
+        CHECK( memory_preset_from_option_value( "color_pixel_blue_dark" )
+               == memory_preset::BLUE_DARK );
+    }
+
+    SECTION( "custom and unknown values map to nullopt" ) {
+        CHECK_FALSE( memory_preset_from_option_value( "color_pixel_custom" ).has_value() );
+        CHECK_FALSE( memory_preset_from_option_value( "" ).has_value() );
+        CHECK_FALSE( memory_preset_from_option_value( "garbage" ).has_value() );
+    }
+}
 #endif // SDL_MAJOR_VERSION >= 3
 #endif // TILES


### PR DESCRIPTION
#### Summary
Interface "Hot-swap MEMORY_MAP_MODE on SDL3 GPU renderer without restart"

#### Purpose of change

Builds on #87003. MEMORY_MAP_MODE used to need a restart because the loader pre-baked the memory atlas with whatever filter the option named. On the SDL3 GPU lane the per-pixel transform lives in a fragment shader, so the preset can be picked at draw time and a mode change applies immediately.

#### Describe the solution

One fragment shader per named preset (darken, sepia_light, sepia_dark, blue_dark). `variant_pass` loads them alongside the existing shadow/night/overexposed shaders and `select_memory_preset` is called from `on_options_changed` to swap which one binds for the MEMORY variant. The custom preset still falls back to the pre-baked memory atlas and keeps the restart-required flag. As cleanup, the loader takes the mode as a parameter instead of reaching into the live `cata_tiles`.

Two follow-on changes ride along:
- `variant_pass::try_begin` holds the bound state across same-variant sprite runs and only calls `SDL_SetGPURenderState` on variant change; `flush()` clears it at frame end. Cuts per-frame state binds from one-per-sprite to one-per-variant-transition, mitigating the unbounded GPU memory growth the SDL3 GPU backend exhibits at sprite-rate transitions.
- Debug-menu entry to reload GPU shaders. Run `tools/build_shaders.py`, hit the menu, probe re-runs on the next sprite draw.

#### Describe alternatives you've considered

Uniforms instead of one shader per preset: SDL3's runtime fragment-uniform setter allocates per call without recycling on the GPU renderer. Per-frame pushes leak. One shader per preset has no upload churn.

Dropping the pre-baked memory/shadow/night/overexposed atlases entirely. Deferred. Want soak time on the shader path before removing the fallback, and the SDL_GPU per-bind leak still needs characterising on newer SDL.

#### Testing

Built with SDL3=1 and ran the tile test suite. Switched MEMORY_MAP_MODE between the four named presets in-game; verified the overlay updates immediately and that the custom preset still uses the pre-baked atlas.

#### Additional context

Pre-baked atlases remain as fallback for SDL2, custom preset, and GPU probe failure.