### PR TITLE
Fix uncraftable machete recipe

### DIFF
--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -1058,7 +1058,7 @@
         "name": "Forge welding & cutting steel",
         "time": "30 m",
         "activity_level": "MODERATE_EXERCISE",
-        "using": [ [ "hotcut_any", -1 ] ],
+        "tools": [ [ [ "hotcut", -1 ], [ "hotcut_bronze", -1 ] ] ],
         "proficiencies": [ { "proficiency": "prof_metalworking" } ]
       },
       {


### PR DESCRIPTION
#### Summary

Bugfixes "Fix uncraftable machete recipe by correcting tool requirement"


#### Purpose of change

The "Forge welding & cutting steel" step in the machete recipe used a **using** requirement that incorrectly demanded a charge from the hotcut tool. Since hotcut tools don't have charges, the recipe was impossible to complete.

#### Describe the solution

Replaced the **using** block with a direct **tools** requirement for **hotcut** or **hotcut_bronze**. This ensures the game checks for the presence of the tool without looking for non-existent charges.

#### Describe alternatives you've considered

None.

#### Testing

1. Started the game with the changes.

2. Verified that the machete recipe now correctly recognizes a standard hotcut chisel in the inventory/surroundings.

3. Successfully completed the craft.

#### Additional context

None.