### PR TITLE
Cap recipes that make more than 4096 items

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -2578,11 +2578,16 @@ void crafting_ui_impl::process_action( const std::string &action_in,
             nested_toggle( current[line]->ident(), recalc, keepline );
         } else {
             const int bs = get_batch_size();
+            const recipe crafting_rec = *current[line];
             craft_confirm_result confirm = can_start_craft(
-                                               *current[line], available[line], *crafter );
+                                               crafting_rec, available[line], *crafter, bs );
             switch( confirm ) {
                 case craft_confirm_result::cannot_craft:
                     popup( _( "Crafter can't craft that!" ) );
+                    break;
+                case craft_confirm_result::too_many_results:
+                    popup( string_format( _( "Batch would create too many items (%1$d).  The limit is %2$d." ),
+                                          crafting_rec.makes_amount() * bs, MAX_ITEM_IN_SQUARE ) );
                     break;
                 case craft_confirm_result::too_dark:
                     popup( _( "Crafter can't see!" ) );

--- a/src/crafting_gui_helpers.cpp
+++ b/src/crafting_gui_helpers.cpp
@@ -198,10 +198,14 @@ bool availability::check_can_craft_nested( Character &_crafter, const recipe &r 
 craft_confirm_result can_start_craft(
     const recipe &rec,
     const availability &avail,
-    const Character &crafter )
+    const Character &crafter,
+    int batch_size )
 {
     if( !avail.can_craft || !avail.crafter_has_primary_skill ) {
         return craft_confirm_result::cannot_craft;
+    }
+    if( rec.makes_amount() * batch_size > MAX_ITEM_IN_SQUARE ) {
+        return craft_confirm_result::too_many_results;
     }
     if( crafter.lighting_craft_speed_multiplier( rec ) <= 0.0f ) {
         return craft_confirm_result::too_dark;

--- a/src/crafting_gui_helpers.h
+++ b/src/crafting_gui_helpers.h
@@ -69,6 +69,7 @@ struct availability {
 enum class craft_confirm_result {
     ok,
     cannot_craft,
+    too_many_results,
     too_dark
 };
 
@@ -77,7 +78,8 @@ enum class craft_confirm_result {
 craft_confirm_result can_start_craft(
     const recipe &rec,
     const availability &avail,
-    const Character &crafter );
+    const Character &crafter,
+    int batch_size = 1 );
 
 // Recipe sort comparator for the crafting menu recipe list.
 // Comparison order:


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #85287

Certain users were convinced that just because you could make **100,000** caffeine pills, it was "illogical" not to.

#### Describe the solution
The game expressly stops you from making an insane amount of anything. This is a token attempt at preventing people from shooting themselves in the foot.

#### Describe alternatives you've considered


#### Testing
<img width="1282" height="1372" alt="image" src="https://github.com/user-attachments/assets/feb7bc84-3f94-4e75-8b70-195b13931368" />


#### Additional context
