### PR TITLE
Crafting faults

### DIFF
--- a/data/json/faults/fault_groups_melee.json
+++ b/data/json/faults/fault_groups_melee.json
@@ -39,6 +39,11 @@
   },
   {
     "type": "fault_group",
+    "id": "bladed_weapon_craft_failures",
+    "group": [ { "fault": "interior_cracks", "weight": 100 }, { "fault": "limp_edge", "weight": 1 } ]
+  },
+  {
+    "type": "fault_group",
     "id": "blade_general",
     "//": "Mechanical damage of any blade, from a sword to a knife",
     "group": [

--- a/data/json/faults/faults_melee.json
+++ b/data/json/faults/faults_melee.json
@@ -17,6 +17,23 @@
   },
   {
     "type": "fault",
+    "id": "interior_cracks",
+    "fault_type": "crafting_defect",
+    "name": { "str": "Interior cracks" },
+    "description": "Although this weapon appears to have been constructed properly, there are voids and damage below the surface.",
+    "//COMMENT": "Later this should be a hidden fault and increase the likelihood of damage-type faults appearing.",
+    "melee_damage_mod": [ { "damage_id": "cut", "multiply": 0.9 } ]
+  },
+  {
+    "type": "fault",
+    "id": "limp_edge",
+    "fault_type": "crafting_defect",
+    "name": { "str": "Limp edge" },
+    "description": "You've made a curved sword.  Very curved.",
+    "melee_damage_mod": [ { "damage_id": "cut", "multiply": 0.1 } ]
+  },
+  {
+    "type": "fault",
     "id": "fault_blade_cracked",
     "fault_type": "mechanical_damage",
     "name": { "str": "Crack" },

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -993,6 +993,11 @@
     "inherit": false
   },
   {
+    "id": "FAULT_ON_COMPLETION",
+    "//COMMENT": "Hardcoded application/removal.",
+    "type": "json_flag"
+  },
+  {
     "id": "SUN_GLASSES",
     "type": "json_flag",
     "//": "Prevents glaring when in sunlight.",

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -2764,7 +2764,11 @@
     "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 9 ] ],
     "weapon_category": [ "LONG_SWORDS" ],
-    "faults": [ { "fault_group": "handle_short" }, { "fault_group": "blade_general", "weight_mult": 5 } ],
+    "faults": [
+      { "fault_group": "handle_short" },
+      { "fault_group": "blade_general", "weight_mult": 5 },
+      { "fault_group": "bladed_weapon_craft_failures" }
+    ],
     "melee_damage": { "bash": 5, "cut": 33 }
   },
   {

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -468,6 +468,17 @@ bool craft_command::safe_to_unload_comp( const item &it )
     return true;
 }
 
+static bool should_add_crafting_faults( Character *who, const recipe *rec )
+{
+    // Intentionally does not consider books helping.
+    // Because ~~lazy implementation~~ book learning is no substitute for experience.
+    if( rec->proficiency_skill_maluses( *who ) > 0.0f ) {
+        return true;
+    }
+    return false;
+}
+
+
 std::vector<std::vector<step_tool_alloc>> select_step_tool_allocs(
         Character &crafter, const recipe &rec, int batch, read_only_visitable &map_inv,
         bool &cancelled, int reselect_step )
@@ -590,7 +601,7 @@ item craft_command::create_in_progress_craft()
     item_components used;
     std::vector<item_comp> comps_used;
     if( crafter->has_trait( trait_DEBUG_HS ) ) {
-        return item( rec, batch_size, used, comps_used );
+        return item( rec, batch_size, used, comps_used, false );
     }
 
     if( empty() ) {
@@ -674,7 +685,7 @@ item craft_command::create_in_progress_craft()
         }
     }
 
-    item new_craft( rec, batch_size, used, comps_used );
+    item new_craft( rec, batch_size, used, comps_used, should_add_crafting_faults( crafter, rec ) );
 
     // Carry the probe's debited start buckets onto the real craft.
     new_craft.set_step_tool_allocs( start_allocs );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2330,6 +2330,12 @@ bool item::handle_craft_failure( Character &crafter )
         return false;
     }
 
+    // The completed result will have a crafting defect (if any are defined).
+    // TODO: Change this into either-fault-or-damage-and-progress-loss, instead of both. Once crafting defects have wider adoption.
+    if( !has_flag( flag_FAULT_ON_COMPLETION ) ) {
+        set_flag( flag_FAULT_ON_COMPLETION );
+    }
+
     const double success_roll = crafter.crafting_failure_roll( get_making() );
     const int starting_components = this->components.size();
     // Destroy at most 75% of the components, always a chance of losing 1 though
@@ -2536,6 +2542,7 @@ void Character::complete_craft( item &craft, const std::optional<tripoint_bub_ms
     item_components &used = craft.components;
     const double relative_rot = craft.get_relative_rot();
     const bool should_heat = making.hot_result();
+    const bool add_faults_to_results = craft.has_flag( flag_FAULT_ON_COMPLETION );
     std::vector<item> newits;
 
     if( making.is_practice() ) {
@@ -2543,6 +2550,11 @@ void Character::complete_craft( item &craft, const std::optional<tripoint_bub_ms
         // practice recipes don't produce a result item
     } else if( !making.result().is_null() ) {
         newits = making.create_results( batch_size, &used );
+        if( add_faults_to_results ) {
+            for( item &craft_result : newits ) {
+                craft_result.set_random_fault_of_type( "crafting_defect" );
+            }
+        }
         // only wield crafted items if there's only one
         bool allow_wield = newits.size() == 1;
         spawn_items( *this, newits, loc, relative_rot, should_heat, allow_wield );

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -124,6 +124,7 @@ const flag_id flag_E_STORABLE( "E_STORABLE" );
 const flag_id flag_E_STORABLE_EXCLUSIVE( "E_STORABLE_EXCLUSIVE" );
 const flag_id flag_FAKE_MILL( "FAKE_MILL" );
 const flag_id flag_FAKE_SMOKE( "FAKE_SMOKE" );
+const flag_id flag_FAULT_ON_COMPLETION( "FAULT_ON_COMPLETION" );
 const flag_id flag_FELINE( "FELINE" );
 const flag_id flag_FERTILIZER( "FERTILIZER" );
 const flag_id flag_FIELD_DRESS( "FIELD_DRESS" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -170,6 +170,7 @@ extern const flag_id flag_EXO_TORSO_PLATE;
 extern const flag_id flag_EXO_UNDERLAYER;
 extern const flag_id flag_FAKE_MILL;
 extern const flag_id flag_FAKE_SMOKE;
+extern const flag_id flag_FAULT_ON_COMPLETION;
 extern const flag_id flag_FELINE;
 extern const flag_id flag_FERTILIZER;
 extern const flag_id flag_FIELD_DRESS;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -310,7 +310,8 @@ safe_reference<item> item::get_safe_reference()
     return anchor->reference_to( this );
 }
 
-item::item( const recipe *rec, int qty, item_components items, std::vector<item_comp> selections )
+item::item( const recipe *rec, int qty, item_components items, std::vector<item_comp> selections,
+            bool should_add_faults )
     : item( itype_craft, calendar::turn )
 {
     craft_data_ = cata::make_value<craft_data>();
@@ -326,6 +327,10 @@ item::item( const recipe *rec, int qty, item_components items, std::vector<item_
         if( goes_bad() ) {
             inherit_rot_from_components( *this );
         }
+    }
+
+    if( should_add_faults ) {
+        set_flag( flag_FAULT_ON_COMPLETION );
     }
 
     for( item_components::type_vector_pair &tvp : components ) {

--- a/src/item.h
+++ b/src/item.h
@@ -228,7 +228,8 @@ class item : public visitable
         item( const itype *type, time_point turn, solitary_tag );
 
         /** For constructing in-progress crafts */
-        item( const recipe *rec, int qty, item_components items, std::vector<item_comp> selections );
+        item( const recipe *rec, int qty, item_components items, std::vector<item_comp> selections,
+              bool should_add_faults = false );
 
         /** For constructing in-progress disassemblies */
         item( const recipe *rec, int qty, item &component );

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -310,13 +310,13 @@ class recipe
         // The time malus due to proficiencies lacking.
         // book_bonuses: nearby book proficiency bonuses (avoids inventory scan).
         float proficiency_time_maluses( const Character &crafter,
-                                        const book_proficiency_bonuses &books ) const;
+                                        const book_proficiency_bonuses &books = {} ) const;
         // The time malus if all the proficiencies were lacking
         float max_proficiency_time_maluses( const Character &crafter ) const;
         // The skill malus due to proficiencies lacking.
         // book_bonuses: nearby book proficiency bonuses (avoids inventory scan).
         float proficiency_skill_maluses( const Character &crafter,
-                                         const book_proficiency_bonuses &books ) const;
+                                         const book_proficiency_bonuses &books = {} ) const;
         // The max skill malus due to proficiencies lacking
         float max_proficiency_skill_maluses( const Character &crafter ) const;
 


### PR DESCRIPTION
#### Summary
Features "Crafting faults"

#### Purpose of change
It's a bit strange that characters can only craft perfect items. Many imperfections can lie beneath the surface of metalworked objects or other crafts, degrading the performance of an item even if it *looks* right.

#### Describe the solution
Add support for crafting faults.

Crafting faults have the fault type `crafting_defect` and are weighted and applied like `mechanical_damage` faults.

Crafting faults will generally only be applied if some proficiencies are missing. ~~(This is a simple implementation, and can be expanded in the future). This means a fully proficient crafter will never apply a crafting fault.~~ Crafting faults will also be applied if any crafting failures happen during the craft.

The flag is applied at the start of the craft, and the flag itself is hidden from view. Mistakes can be made very early on, and not realized! Resolution of which fault to apply is handled when the craft finishes. (This also means you can't start working on a katana, "become proficient" in metalworking halfway through, and come out with a perfect product. The first part is where you fucked up!)

A single example group has been added to the katana and graded versions.

#### Describe alternatives you've considered


#### Testing
Craft a katana without any proficiencies -->
<img width="625" height="83" alt="image" src="https://github.com/user-attachments/assets/3cc9e650-762a-4f0f-828c-296921dfdea4" />


#### Additional context

