### PR TITLE
Fix some minor issues with my recent PRs

### DIFF
--- a/data/json/faults/faults_vehicles.json
+++ b/data/json/faults/faults_vehicles.json
@@ -75,6 +75,7 @@
     "id": "fault_punctured_tires",
     "type": "fault",
     "name": { "str": "Punctured tire" },
+    "fault_type": "mechanical_damage",
     "description": "Something made a hole in the tire, and it is now as flat as the ground it drives onto.",
     "price_modifier": 0.0,
     "//COMMENT": "Reduced contact area, but not 0. Making the contact area lower actually reduces the effect of low traction and high rolling resistance.",

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1120,10 +1120,11 @@ void crafting_ui_impl::draw_recipe_info_panel()
                 if( total_yield > 1 ) {
                     //~ %1$s: success chance, %2$s: yield count, %3$s: time, %4$s: activity level
                     const std::string fmt = _( "%1$s chance to yield %2$s in %3$s of %4$s" );
-                    plain = string_format( fmt, chance_str, std::to_string( total_yield ), time_str, activity_str );
+                    const std::string yield_as_string = recp.result()->count_or_volume_or_weight_prefix( total_yield );
+                    plain = string_format( fmt, chance_str, yield_as_string, time_str, activity_str );
                     colored = string_format( fmt,
                                              colorize( chance_str, success_col ),
-                                             colorize( std::to_string( total_yield ), c_light_blue ),
+                                             colorize( yield_as_string, c_light_blue ),
                                              colorize( time_str, c_cyan ),
                                              colorize( activity_str, activity_col ) );
                 } else {

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -341,7 +341,7 @@ void Single_item_creator::check_consistency( bool actually_spawn ) const
             if( !modifier->ammo && !content_final->can_have_charges() && !content_final->tool &&
                 !content_final->gun && !content_final->magazine ) {
                 debugmsg( "itemgroup entry in \"%s\" for spawning item %s defined charges but can't have any",
-                          context_, id );
+                          context(), id );
             }
         }
     } else if( type == S_ITEM_GROUP ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -677,7 +677,8 @@ void monster::plan()
 
     if( !mon_plan.target ) {
         // No other valid targets found, maybe there's a vehicle!
-        std::set<tripoint_bub_ms> target_vehicles = here.get_moving_vehicle_targets( *this, 60 );
+        std::set<tripoint_bub_ms> target_vehicles =
+            here.get_moving_vehicle_targets( *this, MAX_VIEW_DISTANCE );
         const bool will_throw_self_at_vehicle = !get_pathfinding_settings().avoid_dangerous_fields;
         if( !target_vehicles.empty() && will_throw_self_at_vehicle ) {
             tripoint_bub_ms target_pt = random_entry( target_vehicles );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I've managed to accumulate a bunch of minor problems with my recent PRs. I was filing them away mentally for fixes, better actually fix them before I forget.

#### Describe the solution
-Replace a magic 60 with MAX_VIEW_DISTANCE
-Use getter instead of direct access to private member
-Tire punctures can come from regular damage, not just running stuff over. (e.g. shooting or stabbing or even bashing a tire, as long as it is *actually damaged*)
-Crafting GUI shows count OR weight/volume/length instead of always just count

#### Describe alternatives you've considered
This is somewhat of an "omnibus" PR, which I know we discourage. But they're so minor I think it's probably fine to put them together.

#### Testing
Crafting GUI:
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/8b06399d-76ee-42a1-b9c0-a1f9d1a49528" />


#### Additional context
