### PR TITLE
Modernize engine faults with fault groups

### DIFF
--- a/data/json/faults/faults_vehicles.json
+++ b/data/json/faults/faults_vehicles.json
@@ -1,8 +1,43 @@
 [
   {
+    "type": "fault_group",
+    "id": "any_ICE_engine_maintenance",
+    "group": [
+      { "fault": "fault_engine_belt_drive", "weight": 100 },
+      { "fault": "fault_engine_filter_air", "weight": 100 },
+      { "fault": "fault_engine_filter_fuel", "weight": 100 },
+      { "fault": "fault_engine_starter", "weight": 100 }
+    ]
+  },
+  {
+    "type": "fault_group",
+    "id": "diesel_engine_maintenance",
+    "group": [ { "fault": "fault_engine_glow_plug", "weight": 100 }, { "fault": "fault_engine_pump_diesel", "weight": 100 } ]
+  },
+  {
+    "type": "fault_group",
+    "id": "gasoline_engine_maintenance",
+    "group": [ { "fault": "fault_engine_pump_fuel", "weight": 100 } ]
+  },
+  {
+    "type": "fault_group",
+    "id": "any_ICE_defect",
+    "group": [ { "fault": "fault_engine_immobiliser", "weight": 20 } ]
+  },
+  {
+    "type": "fault_group",
+    "id": "steam_engine_maintenance",
+    "group": [
+      { "fault": "fault_engine_belt_drive", "weight": 100 },
+      { "fault": "fault_engine_filter_air", "weight": 100 },
+      { "fault": "fault_engine_starter", "weight": 100 }
+    ]
+  },
+  {
     "id": "fault_engine_belt_drive",
     "type": "fault",
     "name": { "str": "Worn drive belt" },
+    "fault_type": "engine_maintenance",
     "description": "Required for operation of an attached alternator.",
     "item_prefix": "faulty",
     "price_modifier": 0.7,
@@ -12,6 +47,7 @@
     "id": "fault_engine_glow_plug",
     "type": "fault",
     "name": { "str": "Faulty glow plugs" },
+    "fault_type": "engine_maintenance",
     "description": "Help when starting an engine in low ambient temperatures.",
     "item_prefix": "faulty",
     "price_modifier": 0.7,
@@ -21,6 +57,7 @@
     "id": "fault_engine_immobiliser",
     "type": "fault",
     "name": { "str": "Active immobilizer" },
+    "//COMMENT": "This INTENTIONALLY does not have a fault_type.",
     "description": "An immobilizer device prevents starting of the vehicle without the appropriate key.",
     "item_prefix": "faulty",
     "price_modifier": 0.25,
@@ -30,6 +67,7 @@
     "id": "fault_engine_pump_diesel",
     "type": "fault",
     "name": { "str": "Faulty diesel pump" },
+    "fault_type": "engine_maintenance",
     "description": "Required to pump and pressurize diesel from a vehicle's tank.",
     "item_prefix": "faulty",
     "price_modifier": 0.7,
@@ -39,6 +77,7 @@
     "id": "fault_engine_filter_air",
     "type": "fault",
     "name": { "str": "Expired air filter" },
+    "fault_type": "engine_maintenance",
     "description": "An expired filter reduces fuel efficiency and increases smoke production.",
     "item_prefix": "faulty",
     "price_modifier": 0.9,
@@ -48,6 +87,7 @@
     "id": "fault_engine_filter_fuel",
     "type": "fault",
     "name": { "str": "Expired fuel filter" },
+    "fault_type": "engine_maintenance",
     "description": "An expired filter reduces performance and increases the chance of backfires.",
     "item_prefix": "faulty",
     "price_modifier": 0.7,
@@ -57,6 +97,7 @@
     "id": "fault_engine_pump_fuel",
     "type": "fault",
     "name": { "str": "Faulty fuel pump" },
+    "fault_type": "engine_maintenance",
     "description": "Required to pump gasoline from a vehicle's tank.",
     "item_prefix": "faulty",
     "price_modifier": 0.7,
@@ -66,6 +107,7 @@
     "id": "fault_engine_starter",
     "type": "fault",
     "name": { "str": "Faulty starter motor" },
+    "fault_type": "engine_maintenance",
     "description": "Required to initially start the engine.",
     "item_prefix": "faulty",
     "price_modifier": 0.5,

--- a/data/json/items/vehicle/engine.json
+++ b/data/json/items/vehicle/engine.json
@@ -16,13 +16,9 @@
     "subtypes": [ "ENGINE" ],
     "name": { "str": "base diesel engine", "//~": "NO_I18N" },
     "faults": [
-      { "fault": "fault_engine_belt_drive" },
-      { "fault": "fault_engine_filter_air" },
-      { "fault": "fault_engine_filter_fuel" },
-      { "fault": "fault_engine_glow_plug" },
-      { "fault": "fault_engine_immobiliser" },
-      { "fault": "fault_engine_pump_diesel" },
-      { "fault": "fault_engine_starter" }
+      { "fault_group": "any_ICE_engine_maintenance" },
+      { "fault_group": "diesel_engine_maintenance" },
+      { "fault_group": "any_ICE_defect" }
     ]
   },
   {
@@ -32,12 +28,9 @@
     "subtypes": [ "ENGINE" ],
     "name": { "str": "base gasoline engine", "//~": "NO_I18N" },
     "faults": [
-      { "fault": "fault_engine_belt_drive" },
-      { "fault": "fault_engine_filter_air" },
-      { "fault": "fault_engine_filter_fuel" },
-      { "fault": "fault_engine_immobiliser" },
-      { "fault": "fault_engine_pump_fuel" },
-      { "fault": "fault_engine_starter" }
+      { "fault_group": "any_ICE_engine_maintenance" },
+      { "fault_group": "gasoline_engine_maintenance" },
+      { "fault_group": "any_ICE_defect" }
     ]
   },
   {
@@ -47,7 +40,7 @@
     "subtypes": [ "ENGINE" ],
     "name": { "str": "base steam engine", "//~": "NO_I18N" },
     "looks_like": "v12_diesel",
-    "faults": [ { "fault": "fault_engine_belt_drive" }, { "fault": "fault_engine_filter_air" }, { "fault": "fault_engine_starter" } ]
+    "faults": [ { "fault_group": "steam_engine_maintenance" } ]
   },
   {
     "id": "1cyl_combustion",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -11784,7 +11784,8 @@ bool vehicle_unfolding_activity_actor::unfold_vehicle( Character &p, bool check_
         return false;
     }
     map &here = get_map();
-    vehicle *veh = here.add_vehicle( vehicle_prototype_none, p.pos_bub(), 0_degrees, 0, 0, false );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_none, p.pos_bub(), 0_degrees, 0,
+                                     veh_spawn_status::UNDAMAGED, false );
     if( veh == nullptr ) {
         p.add_msg_if_player( m_info, _( "There's no room to unfold the %s." ), it.tname() );
         return false;

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1854,7 +1854,8 @@ void construct::done_vehicle( const tripoint_bub_ms &p, Character & )
         return;
     }
 
-    vehicle *veh = here.add_vehicle( vehicle_prototype_none, p, 270_degrees, 0, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_none, p, 270_degrees, 0,
+                                     veh_spawn_status::UNDAMAGED );
 
     if( !veh ) {
         debugmsg( "constructing failed: add_vehicle returned null" );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3267,6 +3267,7 @@ static void debug_menu_spawn_vehicle()
             tripoint_bub_ms dest = player_character.pos_bub();
             uilist veh_cond_menu;
             veh_cond_menu.text = _( "Vehicle condition" );
+            // Manual assignment of weird retvals because -1 is a sentinel value for uilist, but a valid int value of veh_spawn_status enum
             veh_cond_menu.addentry( 3, true, MENU_AUTOASSIGN, _( "Undamaged" ) );
             veh_cond_menu.addentry( 0, true, MENU_AUTOASSIGN, _( "Light damage" ) );
             veh_cond_menu.addentry( 2, true, MENU_AUTOASSIGN, _( "Disabled (tires or engine)" ) );
@@ -3275,7 +3276,8 @@ static void debug_menu_spawn_vehicle()
             if( veh_cond_menu.ret >= 0 && veh_cond_menu.ret < 4 ) {
                 // TODO: Allow picking this when add_vehicle has 3d argument
                 vehicle *veh = here.add_vehicle(
-                                   selected_opt, dest, -90_degrees, 100, veh_cond_menu.ret - 1, true, true );
+                                   selected_opt, dest, -90_degrees, 100, static_cast<veh_spawn_status>( veh_cond_menu.ret - 1 ),
+                                   true, true );
                 if( veh != nullptr ) {
                     here.board_vehicle( dest, &player_character );
                 }

--- a/src/enums.h
+++ b/src/enums.h
@@ -74,6 +74,14 @@ struct enum_traits<bionic_ui_sort_mode> {
     static constexpr bionic_ui_sort_mode last = bionic_ui_sort_mode::nsort;
 };
 
+enum class veh_spawn_status : int {
+    DEFAULT_LIGHT_DMG = -1, // light damage (DEFAULT)
+    UNDAMAGED = 0, // Undamaged
+    DISABLED = 1, // disabled: destroyed seats, controls, tanks, tires, OR engine
+    PRISTINE = 2, // undamaged with no faults or security
+    LAST = 3
+};
+
 // default is sorting by distance
 enum class surroundings_menu_sort_flags : int {
     DEFAULT       = 0,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1093,7 +1093,7 @@ vehicle *game::place_vehicle_nearby(
                 }
             };
             vehicle *veh = target_map.add_vehicle( id, tinymap_center, random_entry( angles ),
-                                                   rng( 50, 80 ), 0, false );
+                                                   rng( 50, 80 ), veh_spawn_status::UNDAMAGED, false );
             if( veh ) {
                 const tripoint_abs_ms abs_local = target_map.get_abs( tinymap_center );
                 tripoint_abs_sm quotient;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1402,7 +1402,7 @@ void spell_effect::spawn_summoned_vehicle( const spell &sp, Creature &caster,
         return;
     }
     if( vehicle *veh = here.add_vehicle( sp.summon_vehicle_id(), target, -90_degrees,
-                                         100, 2, false, true ) ) {
+                                         100, veh_spawn_status::PRISTINE, false, true ) ) {
         veh->unlock();
         veh->magic = true;
         if( !sp.has_flag( spell_flag::PERMANENT ) ) {

--- a/src/map.h
+++ b/src/map.h
@@ -1834,7 +1834,8 @@ class map
         // @param merge_wrecks      if true and vehicle overlaps another then both turn into wrecks
         //                          if false and vehicle will overlap aborts and returns nullptr
         vehicle *add_vehicle( const vproto_id &type, const tripoint_bub_ms &p, const units::angle &dir,
-                              int init_veh_fuel = -1, int init_veh_status = -1, bool merge_wrecks = true,
+                              int init_veh_fuel = -1, veh_spawn_status init_veh_status = veh_spawn_status::DEFAULT_LIGHT_DMG,
+                              bool merge_wrecks = true,
                               bool force_status = false );
 
         // Light/transparency
@@ -2615,7 +2616,9 @@ class tinymap : private map
             return map::veh_at( rebase_bub( p ) );
         }
         vehicle *add_vehicle( const vproto_id &type, const tripoint_omt_ms &p, const units::angle &dir,
-                              int init_veh_fuel = -1, int init_veh_status = -1, bool merge_wrecks = true,
+                              int init_veh_fuel = -1,
+                              veh_spawn_status init_veh_status = veh_spawn_status::DEFAULT_LIGHT_DMG,
+                              bool merge_wrecks = true,
                               bool force_status = false ) {
             return map::add_vehicle( type, rebase_bub( p ), dir, init_veh_fuel, init_veh_status,
                                      merge_wrecks, force_status );

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -363,7 +363,8 @@ static bool mx_helicopter( map &m, const tripoint_abs_sm &abs_sub )
                        };
     }
 
-    vehicle *wreckage = m.add_vehicle( crashed_hull, wreckage_pos, dir1, rng( 1, 33 ), 1 );
+    vehicle *wreckage = m.add_vehicle( crashed_hull, wreckage_pos, dir1, rng( 1, 33 ),
+                                       veh_spawn_status::DISABLED );
 
     const auto controls_at = [&m]( vehicle * wreckage, const tripoint_bub_ms & pos ) {
         return !wreckage->get_parts_at( &m, pos, "CONTROLS", part_status_flag::any ).empty() ||

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2723,6 +2723,7 @@ class jmapgen_vehicle : public jmapgen_piece_with_has_vehicle_collision
             //, rotation( jsi.get_int( "rotation", 0 ) ) // unless there is a way for the json parser to
             // return a single int as a list, we have to manually check this in the constructor below
             , fuel( jsi.get_int( "fuel", -1 ) )
+            // Default -1 status is veh_spawn_status::DEFAULT_LIGHT_DMG
             , status( jsi.get_int( "status", -1 ) ) {
             if( jsi.has_array( "rotation" ) ) {
                 for( const JsonValue elt : jsi.get_array( "rotation" ) ) {
@@ -2747,7 +2748,7 @@ class jmapgen_vehicle : public jmapgen_piece_with_has_vehicle_collision
             }
             tripoint_bub_ms const dst( x.get(), y.get(), dat.zlevel() + z.get() );
             vehicle *veh = dat.m.add_vehicle( chosen_id->pick(), dst, random_entry( rotation ),
-                                              fuel, status );
+                                              fuel, static_cast<veh_spawn_status>( status ) );
             if( veh && !faction.empty() ) {
                 veh->set_owner( faction_id( faction ) );
             }
@@ -6854,7 +6855,7 @@ void map::add_spawn(
 
 vehicle *map::add_vehicle( const vproto_id &type, const tripoint_bub_ms &p,
                            const units::angle &dir,
-                           const int veh_fuel, const int veh_status, const bool merge_wrecks,
+                           const int veh_fuel, veh_spawn_status init_veh_status, const bool merge_wrecks,
                            const bool force_status/* = false*/ )
 {
     if( !type.is_valid() ) {
@@ -6874,7 +6875,7 @@ vehicle *map::add_vehicle( const vproto_id &type, const tripoint_bub_ms &p,
     std::tie( quotient, remainder ) = coords::project_remain<coords::sm>( p_ms );
     veh->sm_pos = abs_sub.xy() + rebase_rel( quotient );
     veh->pos = remainder;
-    veh->init_state( *this, veh_fuel, veh_status, force_status );
+    veh->init_state( *this, veh_fuel, init_veh_status, force_status );
     veh->place_spawn_items( *this );
     veh->face.init( dir );
     veh->turn_dir = dir;

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -88,7 +88,8 @@ bool place_appliance( map &here, const tripoint_bub_ms &p, const vpart_id &vpart
 {
 
     const vpart_info &vpinfo = vpart.obj();
-    vehicle *veh = here.add_vehicle( vehicle_prototype_none, p, 0_degrees, 0, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_none, p, 0_degrees, 0,
+                                     veh_spawn_status::UNDAMAGED );
 
     if( !veh ) {
         debugmsg( "error constructing appliance" );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -331,7 +331,7 @@ bool vehicle::remote_controlled( const Character &p ) const
     return false;
 }
 
-void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status,
+void vehicle::init_state( map &placed_on, int init_veh_fuel, veh_spawn_status init_veh_status,
                           const bool force_status/* = false*/ )
 {
     // vehicle parts excluding engines in non-owned vehicles are by default turned off
@@ -354,7 +354,7 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
 
     if( get_option<bool>( "OVERRIDE_VEHICLE_INIT_STATE" ) ) {
         if( !force_status ) {
-            init_veh_status = get_option<int>( "VEHICLE_STATUS_AT_SPAWN" );
+            init_veh_status = static_cast<veh_spawn_status>( get_option<int>( "VEHICLE_STATUS_AT_SPAWN" ) );
         }
         init_veh_fuel = get_option<int>( "VEHICLE_FUEL_AT_SPAWN" );
     }
@@ -379,17 +379,13 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
             vp.ammo_set( fuel, max );
         }
     };
-    // veh_status is initial vehicle damage
-    // -1 = light damage (DEFAULT)
-    //  0 = undamaged
-    //  1 = disabled: destroyed seats, controls, tanks, tires, OR engine
-    //  2 = undamaged with no faults or security
-    int veh_status = -1;
-    if( init_veh_status == 0 ) {
-        veh_status = 0;
+
+    veh_spawn_status veh_status = veh_spawn_status::DEFAULT_LIGHT_DMG;
+    if( init_veh_status == veh_spawn_status::UNDAMAGED ) {
+        veh_status = veh_spawn_status::UNDAMAGED;
     }
-    if( init_veh_status == 1 ) {
-        veh_status = 1;
+    if( init_veh_status == veh_spawn_status::DISABLED ) {
+        veh_status = veh_spawn_status::DISABLED;
 
         const int rand = rng( 1, 5 );
         switch( rand ) {
@@ -423,15 +419,15 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
     // Make engine faults more likely
     destroyEngine = destroyEngine || one_in( 3 );
 
-    if( init_veh_status == 2 ) {
-        veh_status = 0;
+    if( init_veh_status == veh_spawn_status::PRISTINE ) {
+        veh_status = veh_spawn_status::UNDAMAGED;
         has_no_key = false;
         destroyAlarm = false;
         destroyEngine = false;
     }
 
     //Provide some variety to non-mint vehicles
-    if( veh_status != 0 ) {
+    if( veh_status != veh_spawn_status::UNDAMAGED ) {
         //Leave engine running in some vehicles, if the engine has not been destroyed
         //chance decays from 1 in 4 vehicles on day 0 to 1 in (day + 4) in the future.
         int current_day = std::max( to_days<int>( calendar::turn - calendar::turn_zero ), 0 );
@@ -516,7 +512,7 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
         }
 
         // initial vehicle damage
-        if( veh_status == 0 ) {
+        if( veh_status == veh_spawn_status::UNDAMAGED ) {
             // Completely mint condition vehicle
             set_hp( pt, vp.info().durability, false );
         } else {
@@ -560,7 +556,8 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
             }
 
             //Solar panels have 25% of being destroyed
-            if( vp.has_feature( "SOLAR_PANEL" ) && one_in( 4 ) && init_veh_status != 2 ) {
+            if( vp.has_feature( "SOLAR_PANEL" ) && one_in( 4 ) &&
+                init_veh_status != veh_spawn_status::PRISTINE ) {
                 set_hp( pt, 0, false );
             }
 
@@ -614,7 +611,7 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
     }
 
     // Additional 50% chance for heavy damage to disabled vehicles
-    if( veh_status == 1 && one_in( 2 ) ) {
+    if( veh_status == veh_spawn_status::DISABLED && one_in( 2 ) ) {
         damage_all_parts( 0.5 );
     }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -539,7 +539,7 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, veh_spawn_status in
                     set_hp( pt, 0, false );
                 } else if( destroyEngine ) {
                     do {
-                        pt.fault_set( random_entry( pt.faults_potential() ) );
+                        pt.base.set_random_fault_of_type( "engine_maintenance" );
                     } while( one_in( 3 ) );
                 }
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1029,7 +1029,7 @@ class vehicle
         bool remote_controlled( const Character &p ) const;
 
         // initializes parts and fuel state for randomly generated vehicle and calls refresh()
-        void init_state( map &placed_on, int init_veh_fuel, int init_veh_status,
+        void init_state( map &placed_on, int init_veh_fuel, veh_spawn_status init_veh_status,
                          bool force_status = false );
 
         // damages all parts of a vehicle by a random amount

--- a/src/vehicle_group.cpp
+++ b/src/vehicle_group.cpp
@@ -8,6 +8,7 @@
 
 #include "coordinates.h"
 #include "debug.h"
+#include "enums.h"
 #include "flexbuffer_json.h"
 #include "map.h"
 #include "memory_fast.h"
@@ -154,10 +155,12 @@ void VehicleFunction_json::apply( map &m, const std::string &terrain_name ) cons
                 return;
             }
             const tripoint_bub_ms pos{ loc->pick_point(), m.get_abs_sub().z() };
-            m.add_vehicle( vehicle->pick(), pos, loc->pick_facing(), fuel, status );
+            m.add_vehicle( vehicle->pick(), pos, loc->pick_facing(), fuel,
+                           static_cast<veh_spawn_status>( status ) );
         } else {
             const tripoint_bub_ms pos{ location->pick_point(), m.get_abs_sub().z()};
-            m.add_vehicle( vehicle->pick(), pos, location->pick_facing(), fuel, status );
+            m.add_vehicle( vehicle->pick(), pos, location->pick_facing(), fuel,
+                           static_cast<veh_spawn_status>( status ) );
         }
     }
 }
@@ -241,7 +244,8 @@ static void builtin_parkinglot( map &m, std::string_view )
             } else {
                 facing = one_in( 2 ) ? 0_degrees : 180_degrees;
             }
-            m.add_vehicle( VehicleGroup_parkinglot->pick(), pos_p, facing, -1, -1 );
+            m.add_vehicle( VehicleGroup_parkinglot->pick(), pos_p, facing, -1,
+                           veh_spawn_status::DEFAULT_LIGHT_DMG );
         }
     }
 }

--- a/tests/active_item_test.cpp
+++ b/tests/active_item_test.cpp
@@ -8,6 +8,7 @@
 #include "calendar.h"
 #include "cata_catch.h"
 #include "coordinates.h"
+#include "enums.h"
 #include "item.h"
 #include "item_location.h"
 #include "itype.h"
@@ -54,7 +55,8 @@ TEST_CASE( "active_items_processed_regularly", "[active_item]" )
     here.add_item( player_character.pos_bub(), active_item );
 
     tripoint_bub_ms vehicle_pos = player_character.pos_bub() + tripoint::east;
-    REQUIRE( here.add_vehicle( vehicle_prototype_test_shopping_cart, vehicle_pos, 0_degrees, 0, 0 ) );
+    REQUIRE( here.add_vehicle( vehicle_prototype_test_shopping_cart, vehicle_pos, 0_degrees, 0,
+                               veh_spawn_status::UNDAMAGED ) );
     std::optional<vpart_reference> cargo = here.veh_at( here.get_abs( vehicle_pos ) ).cargo();
     REQUIRE( cargo );
     item vehicle_active_item( itype_chainsaw_on );

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -123,7 +123,7 @@ TEST_CASE( "zone_unloading_ammo_belts", "[zones][items][ammo_belt][activities][u
 
     if( in_vehicle ) {
         REQUIRE( here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                   tripoint_bub_ms::zero + tripoint::east, 0_degrees, 0, 0 ) );
+                                   tripoint_bub_ms::zero + tripoint::east, 0_degrees, 0, veh_spawn_status::UNDAMAGED ) );
         vp = here.veh_at( start ).cargo();
         REQUIRE( vp );
         vp->vehicle().set_owner( dummy );
@@ -445,7 +445,7 @@ TEST_CASE( "zone_sorting_skips_source_when_all_destinations_count_full",
 
     SECTION( "vehicle cargo destination at MAX_ITEM_IN_VEHICLE_STORAGE" ) {
         vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                          dest_pos, 0_degrees, 0, 0 );
+                                          dest_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
         REQUIRE( cart != nullptr );
         cart->set_owner( dummy );
         dest_vp = here.veh_at( dest_pos ).cargo();
@@ -527,7 +527,7 @@ TEST_CASE( "zone_sorting_activity_terminates_with_count_full_vehicle_destination
     here.ter_set( dest_pos, ter_t_floor );
 
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      dest_pos, 0_degrees, 0, 0 );
+                                      dest_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     std::optional<vpart_reference> vp = here.veh_at( dest_pos ).cargo();
@@ -590,7 +590,7 @@ TEST_CASE( "zone_sorting_with_grabbed_single_tile_vehicle",
     // Spawn shopping cart adjacent to player (east) and grab it
     const tripoint_bub_ms cart_pos = start_pos + tripoint::east;
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      cart_pos, 0_degrees, 0, 0 );
+                                      cart_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::east );
@@ -648,7 +648,7 @@ TEST_CASE( "zone_sorting_with_grabbed_multi_tile_vehicle",
     // Spawn multi-tile vehicle (test_turret_rig) adjacent to player and grab it
     const tripoint_bub_ms veh_pos = start_pos + tripoint::east;
     vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig,
-                                     veh_pos, 0_degrees, 0, 0 );
+                                     veh_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
     REQUIRE( veh->get_points().size() > 1 );
     veh->set_owner( dummy );
@@ -707,7 +707,7 @@ TEST_CASE( "zone_sorting_cart_on_source_full_inventory",
 
     // Spawn shopping cart at the source tile and grab it
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      src_pos, 0_degrees, 0, 0 );
+                                      src_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::south );
@@ -774,7 +774,7 @@ TEST_CASE( "zone_sorting_virtual_pickup_from_cart",
     here.ter_set( src_pos, ter_t_floor );
 
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      src_pos, 0_degrees, 0, 0 );
+                                      src_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::south );
@@ -832,7 +832,7 @@ TEST_CASE( "zone_sorting_virtual_pickup_full_inventory",
     here.ter_set( src_pos, ter_t_floor );
 
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      src_pos, 0_degrees, 0, 0 );
+                                      src_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::south );
@@ -902,7 +902,7 @@ TEST_CASE( "zone_sorting_direct_delivery_to_cart",
     here.ter_set( cart_pos, ter_t_floor );
 
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      cart_pos, 0_degrees, 0, 0 );
+                                      cart_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::east );
@@ -954,7 +954,7 @@ TEST_CASE( "zone_sorting_cart_source_with_dest_zone",
     here.ter_set( src_pos, ter_t_floor );
 
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      src_pos, 0_degrees, 0, 0 );
+                                      src_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::south );
@@ -1008,7 +1008,7 @@ TEST_CASE( "zone_sorting_direct_delivery_cart_full",
     here.ter_set( cart_pos, ter_t_floor );
 
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      cart_pos, 0_degrees, 0, 0 );
+                                      cart_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::east );
@@ -1066,7 +1066,7 @@ TEST_CASE( "zone_sorting_virtual_pickup_adjacent_dest",
     here.ter_set( src_pos, ter_t_floor );
 
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      src_pos, 0_degrees, 0, 0 );
+                                      src_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::south );
@@ -1121,7 +1121,7 @@ TEST_CASE( "zone_sorting_virtual_pickup_unreachable_dest",
     here.ter_set( src_pos, ter_t_floor );
 
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      src_pos, 0_degrees, 0, 0 );
+                                      src_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::south );
@@ -1234,7 +1234,7 @@ TEST_CASE( "zone_sorting_vehicle_on_terrain_unsorted_both_items",
 
     // Spawn cart at source
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      src_pos, 0_degrees, 0, 0 );
+                                      src_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::south );
@@ -1295,7 +1295,7 @@ TEST_CASE( "zone_sorting_vehicle_unsorted_zone_ground_items_ignored",
 
     // Spawn cart at source, set owner
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      src_pos, 0_degrees, 0, 0 );
+                                      src_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::south );
@@ -1361,7 +1361,7 @@ TEST_CASE( "zone_sorting_both_zones_at_same_position",
 
     // Spawn cart, set owner
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      src_pos, 0_degrees, 0, 0 );
+                                      src_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::south );
@@ -1425,7 +1425,7 @@ TEST_CASE( "zone_sorting_terrain_zone_sorts_non_grabbed_vehicle_cargo",
 
     // Spawn a vehicle at source but do NOT grab it (simulates a parked van)
     vehicle *van = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                     src_pos, 0_degrees, 0, 0 );
+                                     src_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( van != nullptr );
     van->set_owner( dummy );
     // No grab - this is a parked vehicle
@@ -1488,7 +1488,7 @@ TEST_CASE( "zone_sorting_has_terrain_has_vehicle_helpers",
     avatar &dummy = get_avatar();
     clear_avatar();
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      pos_a_bub, 0_degrees, 0, 0 );
+                                      pos_a_bub, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     create_tile_zone( "Food Vehicle A", zone_type_LOOT_FOOD, pos_a, true );
@@ -1605,7 +1605,7 @@ TEST_CASE( "zone_sorting_batches_into_grabbed_vehicle",
     const tripoint_bub_ms cart_pos = s1_pos + tripoint::south;
     here.ter_set( cart_pos, ter_t_floor );
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      cart_pos, 0_degrees, 0, 0 );
+                                      cart_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::south );
@@ -1689,7 +1689,7 @@ TEST_CASE( "zone_sorting_adjacent_dest_both_full",
     here.ter_set( dest_pos, ter_t_floor );
 
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      dest_pos, 0_degrees, 0, 0 );
+                                      dest_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::east );
@@ -1833,7 +1833,7 @@ TEST_CASE( "zone_sorting_vehicle_dest_cargo_full_ground_fallback",
     here.ter_set( cart_pos, ter_t_floor );
 
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      cart_pos, 0_degrees, 0, 0 );
+                                      cart_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::east );
@@ -1893,7 +1893,7 @@ TEST_CASE( "zone_sorting_terrain_zone_vehicle_cargo_no_loop",
     here.ter_set( src_pos, ter_t_floor );
 
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      src_pos, 0_degrees, 0, 0 );
+                                      src_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::south );
@@ -2131,7 +2131,7 @@ TEST_CASE( "zone_sorting_drag_weight_gate",
     // Leave terrain as grass (default from clear_map) -- no ROAD/FLAT flags,
     // so traction is poor and drag becomes harder.
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      cart_pos, 0_degrees, 0, 0 );
+                                      cart_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, tripoint_rel_ms::south );
@@ -2259,7 +2259,7 @@ static vehicle *setup_grabbed_cart( avatar &dummy, map &here,
 
     const tripoint_bub_ms cart_pos = player_pos + grab_dir;
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      cart_pos, 0_degrees, 0, 0 );
+                                      cart_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, grab_dir );
@@ -2548,7 +2548,7 @@ TEST_CASE( "multi_zone_vehicle_repair_large_zone_no_hang",
     const tripoint_bub_ms veh_pos = start_pos + tripoint( 2, 0, 0 );
     here.ter_set( veh_pos, ter_t_floor );
     vehicle *veh = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                     veh_pos, 0_degrees, 0, 0 );
+                                     veh_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
     for( const vpart_reference &vpr : veh->get_all_parts() ) {
         veh->set_hp( vpr.part(), vpr.part().info().durability / 2, false );
@@ -3339,7 +3339,7 @@ TEST_CASE( "vehicle_zone_refresh_preserves_personal_zone_positions",
     const tripoint_bub_ms veh_pos = start_pos + tripoint( 0, -3, 0 );
     here.ter_set( veh_pos, ter_t_floor );
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      veh_pos, 0_degrees, 0, 0 );
+                                      veh_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     const tripoint_abs_ms veh_abs = here.get_abs( veh_pos );

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -2448,7 +2448,8 @@ TEST_CASE( "pseudo_tools_in_crafting_inventory", "[crafting][tools]" )
     const itype_id pseudo_tool = furn_f_smoking_rack.obj().crafting_pseudo_item;
 
     GIVEN( "a vehicle with a liquid tank" ) {
-        vehicle *veh = here.add_vehicle( vehicle_prototype_test_rv, veh_pos, 0_degrees, 0, 0 );
+        vehicle *veh = here.add_vehicle( vehicle_prototype_test_rv, veh_pos, 0_degrees, 0,
+                                         veh_spawn_status::UNDAMAGED );
         REQUIRE( veh != nullptr );
         for( const vpart_reference &door : veh->get_avail_parts( VPFLAG_OPENABLE ) ) {
             door.part().open = true;

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -15,6 +15,7 @@
 #include "coordinates.h"
 #include "creature.h"
 #include "damage.h"
+#include "enums.h"
 #include "explosion.h"
 #include "fragment_cloud.h"
 #include "game.h"
@@ -195,7 +196,7 @@ static void check_vehicle_damage( const itype_id &explosive_id, const std::strin
     tripoint_bub_ms origin( 30, 30, 0 );
 
     vehicle *target_vehicle = get_map().add_vehicle( vproto_id( vehicle_id ), origin, 0_degrees,
-                              -1, 0 );
+                              -1, veh_spawn_status::UNDAMAGED );
     std::vector<int> before_hp = get_part_hp( target_vehicle );
 
     while( get_map().veh_at( origin ) ) {

--- a/tests/item_location_test.cpp
+++ b/tests/item_location_test.cpp
@@ -11,6 +11,7 @@
 #include "character.h"
 #include "coordinates.h"
 #include "debug.h"
+#include "enums.h"
 #include "flexbuffer_json.h"
 #include "inventory.h"
 #include "item.h"
@@ -447,7 +448,8 @@ TEST_CASE( "item_location_on_vehicle_base_item", "[item][item_location][item_uid
 
     // Place a simple vehicle
     tripoint_bub_ms veh_pos( 60, 60, 0 );
-    vehicle *veh = m.add_vehicle( vehicle_prototype_bicycle, veh_pos, 0_degrees, -1, 100 );
+    vehicle *veh = m.add_vehicle( vehicle_prototype_bicycle, veh_pos, 0_degrees, -1,
+                                  veh_spawn_status::PRISTINE );
     REQUIRE( veh != nullptr );
 
     // Get a vehicle part and create item_location for its base item
@@ -485,7 +487,8 @@ TEST_CASE( "item_location_on_vehicle_cargo_survives_removal",
     // Place a vehicle with cargo -- use a car which has trunk/cargo
     // Status 0 = fully intact (no random damage that could break the cargo part)
     tripoint_bub_ms veh_pos( 60, 60, 0 );
-    vehicle *veh = m.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, 0, 0 );
+    vehicle *veh = m.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, 0,
+                                  veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
 
     // Find the largest cargo part (trunk)
@@ -566,7 +569,8 @@ TEST_CASE( "expired_vehicle_cargo_item_location_serializes_as_nowhere",
     clear_vehicles();
 
     tripoint_bub_ms veh_pos( 60, 60, 0 );
-    vehicle *veh = m.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, 0, 0 );
+    vehicle *veh = m.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, 0,
+                                  veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
 
     // Find the largest cargo part

--- a/tests/item_spawn_test.cpp
+++ b/tests/item_spawn_test.cpp
@@ -7,6 +7,7 @@
 
 #include "cata_catch.h"
 #include "coordinates.h"
+#include "enums.h"
 #include "item.h"
 #include "item_group.h"
 #include "map.h"
@@ -64,7 +65,8 @@ TEST_CASE( "correct_amounts_of_an_item_spawn_inside_a_container", "[item_spawn]"
                             clear_map_without_vision();
                             map &here = get_map();
                             const tripoint_bub_ms vehpos( 0, 0, here.get_abs_sub().z() );
-                            vehicle *veh = here.add_vehicle( cs_data.vehicle, vehpos, 0_degrees, 0, 0 );
+                            vehicle *veh = here.add_vehicle( cs_data.vehicle, vehpos, 0_degrees, 0,
+                                                             veh_spawn_status::UNDAMAGED );
                             REQUIRE( veh );
                             REQUIRE( here.get_vehicles().size() == 1 );
                             const tripoint_bub_ms pos( point_bub_ms::zero, veh->sm_pos.z() );

--- a/tests/item_wakeup_test.cpp
+++ b/tests/item_wakeup_test.cpp
@@ -14,6 +14,7 @@
 #include "character_id.h"
 #include "coordinates.h"
 #include "debug.h"
+#include "enums.h"
 #include "flexbuffer_json.h"
 #include "item.h"
 #include "item_location.h"
@@ -719,7 +720,8 @@ TEST_CASE( "item_wakeup_resolve_on_vehicle_cargo", "[item_wakeup][resolve][vehic
     u.setpos( here, origin );
 
     const tripoint_bub_ms veh_pos( 65, 65, 0 );
-    vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, veh_pos, 0_degrees, -1, 2 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, veh_pos, 0_degrees, -1,
+                                     veh_spawn_status::PRISTINE );
     REQUIRE( veh != nullptr );
 
     int cargo_part_idx = -1;
@@ -761,7 +763,8 @@ TEST_CASE( "item_wakeup_resolve_vehicle_stale_part_index_uses_mount",
     u.setpos( here, origin );
 
     const tripoint_bub_ms veh_pos( 65, 65, 0 );
-    vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, veh_pos, 0_degrees, -1, 2 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, veh_pos, 0_degrees, -1,
+                                     veh_spawn_status::PRISTINE );
     REQUIRE( veh != nullptr );
 
     int cargo_part_idx = -1;
@@ -806,7 +809,7 @@ TEST_CASE( "item_wakeup_resolve_vehicle_moved_uses_loaded_scan",
 
     const tripoint_bub_ms initial_pos( 65, 65, 0 );
     vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, initial_pos,
-                                     0_degrees, -1, 2 );
+                                     0_degrees, -1, veh_spawn_status::PRISTINE );
     REQUIRE( veh != nullptr );
 
     int cargo_part_idx = -1;

--- a/tests/light_color_test.cpp
+++ b/tests/light_color_test.cpp
@@ -336,7 +336,8 @@ TEST_CASE( "vehicle_cone_light_carries_color", "[light_color]" )
         }
     }
 
-    vehicle *veh = here.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, 100, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, 100,
+                                     veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
 
     // Replace one stock headlight with our red test headlight
@@ -537,7 +538,8 @@ TEST_CASE( "capture_golden_values_for_arc_light", "[.][golden_arc_capture]" )
         }
     }
 
-    vehicle *veh = here.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, 100, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, 100,
+                                     veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
 
     std::vector<point_rel_ms> hl_mounts;
@@ -637,7 +639,8 @@ TEST_CASE( "colored_vehicle_cone_sets_has_colored_lights", "[light_color]" )
         }
     }
 
-    vehicle *veh = here.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, 100, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, 100,
+                                     veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
 
     // Replace one stock headlight with our red test headlight
@@ -712,7 +715,8 @@ TEST_CASE( "fused_arc_color_output_matches_golden_values", "[light_color]" )
         }
     }
 
-    vehicle *veh = here.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, 100, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, 100,
+                                     veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
 
     std::vector<point_rel_ms> hl_mounts;

--- a/tests/mapgen_remove_vehicles_test.cpp
+++ b/tests/mapgen_remove_vehicles_test.cpp
@@ -3,6 +3,7 @@
 #include "avatar.h"
 #include "cata_catch.h"
 #include "coordinates.h"
+#include "enums.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "map_scale_constants.h"
@@ -43,7 +44,8 @@ void check_vehicle_still_works( vehicle &veh )
 
 vehicle *add_test_vehicle( map &m, tripoint_bub_ms loc )
 {
-    return m.add_vehicle( vehicle_prototype_shopping_cart, loc, -90_degrees, 100, 0 );
+    return m.add_vehicle( vehicle_prototype_shopping_cart, loc, -90_degrees, 100,
+                          veh_spawn_status::UNDAMAGED );
 }
 
 void remote_add_test_vehicle( map &m )
@@ -102,7 +104,8 @@ TEST_CASE( "mapgen_remove_vehicles" )
     REQUIRE( here.get_vehicles().empty() );
 
     vehicle *const veh =
-        here.add_vehicle( vehicle_prototype_motorcycle_cross, start_loc, -90_degrees, 100, 0 );
+        here.add_vehicle( vehicle_prototype_motorcycle_cross, start_loc, -90_degrees, 100,
+                          veh_spawn_status::UNDAMAGED );
     veh->set_owner( get_avatar() );
     REQUIRE( here.get_vehicles().size() == 1 );
     here.board_vehicle( start_loc, &get_avatar() );

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -6,6 +6,7 @@
 #include "cata_catch.h"
 #include "character.h"
 #include "coordinates.h"
+#include "enums.h"
 #include "game.h"
 #include "gates.h"
 #include "map.h"
@@ -213,7 +214,7 @@ TEST_CASE( "NPC-rules-avoid-locks", "[npc_rules]" )
 
 
     vehicle *test_vehicle = here.add_vehicle( vehicle_prototype_locked_as_hell_car,
-                            car_center_pos, 0_degrees, 0, 0 );
+                            car_center_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
 
     // vehicle is a 5x5 grid, car_door_pos is the only door/exit
     std::vector<vehicle_part *> door_parts_at_target = test_vehicle->get_parts_at(

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -32,6 +32,7 @@
 #include "creature_tracker.h"
 #include "damage.h"
 #include "debug.h"
+#include "enums.h"
 #include "faction.h"
 #include "field.h"
 #include "field_type.h"
@@ -478,7 +479,8 @@ TEST_CASE( "npc-board-player-vehicle" )
             map &here = get_map();
             Character &pc = get_player_character();
 
-            vehicle *veh = here.add_vehicle( data.veh_prototype, data.player_pos, 0_degrees, 100, 2 );
+            vehicle *veh = here.add_vehicle( data.veh_prototype, data.player_pos, 0_degrees, 100,
+                                             veh_spawn_status::PRISTINE );
             REQUIRE( veh != nullptr );
             here.board_vehicle( data.player_pos, &pc );
             REQUIRE( pc.in_vehicle );
@@ -596,7 +598,8 @@ TEST_CASE( "npc-movement" )
             }
             // create vehicles
             if( type == 'V' || type == 'W' || type == 'M' ) {
-                vehicle *veh = here.add_vehicle( vehicle_prototype_none, p, 270_degrees, 0, 0 );
+                vehicle *veh = here.add_vehicle( vehicle_prototype_none, p, 270_degrees, 0,
+                                                 veh_spawn_status::UNDAMAGED );
                 REQUIRE( veh != nullptr );
                 veh->install_part( here, point_rel_ms::zero, vpart_frame );
                 veh->install_part( here, point_rel_ms::zero, vpart_seat );
@@ -2359,7 +2362,7 @@ TEST_CASE( "npc_find_food_vehicle_cargo", "[npc][needs]" )
 
     SECTION( "finds food in cargo-only tile (no ground items)" ) {
         vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                          adj, 0_degrees, 0, 0 );
+                                          adj, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
         REQUIRE( cart != nullptr );
         const std::optional<vpart_reference> cargo = here.veh_at( adj ).cargo();
         REQUIRE( cargo.has_value() );
@@ -2375,7 +2378,7 @@ TEST_CASE( "npc_find_food_vehicle_cargo", "[npc][needs]" )
     SECTION( "adjacent cargo food consumed via address_needs (end-to-end)" ) {
         guy.set_stored_kcal( 2000 );
         vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                          adj, 0_degrees, 0, 0 );
+                                          adj, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
         REQUIRE( cart != nullptr );
         const std::optional<vpart_reference> cargo = here.veh_at( adj ).cargo();
         REQUIRE( cargo.has_value() );
@@ -2392,7 +2395,8 @@ TEST_CASE( "npc_find_food_vehicle_cargo", "[npc][needs]" )
 
     SECTION( "cargo-locking blocks food discovery" ) {
         // Build from empty prototype: frame + trunk_floor (LOCKABLE_CARGO) + cargo_lock.
-        vehicle *veh = here.add_vehicle( vehicle_prototype_none, adj, 0_degrees, 0, 0 );
+        vehicle *veh = here.add_vehicle( vehicle_prototype_none, adj, 0_degrees, 0,
+                                         veh_spawn_status::UNDAMAGED );
         REQUIRE( veh != nullptr );
         const point_rel_ms origin( 0, 0 );
         veh->install_part( here, origin, vpart_frame );
@@ -2425,7 +2429,7 @@ TEST_CASE( "npc_find_clothing_vehicle_cargo", "[npc][needs]" )
 
     SECTION( "finds warm clothing in cargo-only tile" ) {
         vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                          adj, 0_degrees, 0, 0 );
+                                          adj, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
         REQUIRE( cart != nullptr );
         const std::optional<vpart_reference> cargo = here.veh_at( adj ).cargo();
         REQUIRE( cargo.has_value() );
@@ -2441,7 +2445,7 @@ TEST_CASE( "npc_find_clothing_vehicle_cargo", "[npc][needs]" )
     SECTION( "adjacent cargo sweater worn via address_needs (end-to-end)" ) {
         guy.set_all_parts_temp_conv( BODYTEMP_VERY_COLD );
         vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                          adj, 0_degrees, 0, 0 );
+                                          adj, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
         REQUIRE( cart != nullptr );
         const std::optional<vpart_reference> cargo = here.veh_at( adj ).cargo();
         REQUIRE( cargo.has_value() );
@@ -2453,7 +2457,8 @@ TEST_CASE( "npc_find_clothing_vehicle_cargo", "[npc][needs]" )
     }
 
     SECTION( "cargo-locking blocks clothing discovery" ) {
-        vehicle *veh = here.add_vehicle( vehicle_prototype_none, adj, 0_degrees, 0, 0 );
+        vehicle *veh = here.add_vehicle( vehicle_prototype_none, adj, 0_degrees, 0,
+                                         veh_spawn_status::UNDAMAGED );
         REQUIRE( veh != nullptr );
         const point_rel_ms origin( 0, 0 );
         veh->install_part( here, origin, vpart_frame );
@@ -2622,7 +2627,7 @@ TEST_CASE( "npc_harvest_scavenging", "[npc][needs]" )
         guy.set_stored_kcal( 2000 );
         guy.set_thirst( 0 );
         vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                          adj, 0_degrees, 0, 0 );
+                                          adj, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
         REQUIRE( cart != nullptr );
         const std::optional<vpart_reference> cargo = here.veh_at( adj ).cargo();
         REQUIRE( cargo.has_value() );
@@ -4073,7 +4078,7 @@ TEST_CASE( "player_embarks_clears_follow_commitment", "[npc][behavior]" )
 
     // Player boards a vehicle.
     vehicle *veh = here.add_vehicle( vehicle_prototype_test_rv, pc.pos_bub(),
-                                     0_degrees, 100, 0 );
+                                     0_degrees, 100, veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
     here.board_vehicle( pc.pos_bub(), &pc );
     REQUIRE( pc.in_vehicle );
@@ -4105,7 +4110,7 @@ TEST_CASE( "follower_yields_to_moving_player_vehicle", "[npc][behavior][vehicle]
     guy.clear_ai_guard_pos();
 
     vehicle *veh = here.add_vehicle( vehicle_prototype_test_rv, pc.pos_bub(),
-                                     0_degrees, 100, 0 );
+                                     0_degrees, 100, veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
     here.board_vehicle( pc.pos_bub(), &pc );
     REQUIRE( pc.in_vehicle );

--- a/tests/pathfinding_test.cpp
+++ b/tests/pathfinding_test.cpp
@@ -62,7 +62,7 @@ static vehicle *setup_grabbed_cart( avatar &dummy, map &here,
 
     const tripoint_bub_ms cart_pos = player_pos + grab_dir;
     vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
-                                      cart_pos, 0_degrees, 0, 0 );
+                                      cart_pos, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( cart != nullptr );
     cart->set_owner( dummy );
     dummy.grab( object_type::VEHICLE, grab_dir );

--- a/tests/unseal_and_spill_test.cpp
+++ b/tests/unseal_and_spill_test.cpp
@@ -16,6 +16,7 @@
 #include "character_attire.h"
 #include "contents_change_handler.h"
 #include "coordinates.h"
+#include "enums.h"
 #include "item.h"
 #include "item_location.h"
 #include "item_pocket.h"
@@ -409,7 +410,7 @@ item_location prepare_item( avatar &guy, map &here, item &it,
         }
         case container_location::vehicle: {
             vehicle *veh = here.add_vehicle( vehicle_prototype_test_cargo_space, guy.pos_bub(),
-                                             -90_degrees, 0, 0 );
+                                             -90_degrees, 0, veh_spawn_status::UNDAMAGED );
             REQUIRE( veh );
             here.board_vehicle( guy.pos_bub(), &guy );
             std::optional<vpart_reference> vp =

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -8,6 +8,7 @@
 #include "cata_catch.h"
 #include "character.h"
 #include "coordinates.h"
+#include "enums.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "point.h"
@@ -53,7 +54,8 @@ static vehicle *setup_drag_test( const vproto_id &veh_id )
     map &here = get_map();
     clear_vehicles();
     const tripoint_bub_ms map_starting_point( 60, 60, 0 );
-    vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, -90_degrees, 0, 0 );
+    vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, -90_degrees, 0,
+                                         veh_spawn_status::UNDAMAGED );
 
     REQUIRE( veh_ptr != nullptr );
     if( veh_ptr == nullptr ) {

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -176,7 +176,8 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
 
     const tripoint_bub_ms map_starting_point( 60, 60, 0 );
     map &here = get_map();
-    vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, -90_degrees, 0, 0 );
+    vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, -90_degrees, 0,
+                                         veh_spawn_status::UNDAMAGED );
 
     REQUIRE( veh_ptr != nullptr );
     if( veh_ptr == nullptr ) {

--- a/tests/vehicle_export_test.cpp
+++ b/tests/vehicle_export_test.cpp
@@ -6,6 +6,7 @@
 #include "cata_catch.h"
 #include "character.h"
 #include "coordinates.h"
+#include "enums.h"
 #include "flexbuffer_json.h"
 #include "json.h"
 #include "json_loader.h"
@@ -33,7 +34,7 @@ TEST_CASE( "export_vehicle_test" )
     map &here = get_map();
     // Spawn the vehicle with fuel.
     vehicle *veh_ptr = get_map().add_vehicle( vehicle_prototype_veh_export_test, tripoint_bub_ms::zero,
-                       0_degrees, -1, 0 );
+                       0_degrees, -1, veh_spawn_status::UNDAMAGED );
     REQUIRE( veh_ptr != nullptr );
 
     // To ensure the zones get placed.

--- a/tests/vehicle_fake_part_test.cpp
+++ b/tests/vehicle_fake_part_test.cpp
@@ -9,6 +9,7 @@
 #include "cata_catch.h"
 #include "character.h"
 #include "coordinates.h"
+#include "enums.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "pathfinding.h"
@@ -83,7 +84,8 @@ TEST_CASE( "ensure_fake_parts_enable_on_place", "[vehicle] [vehicle_fake]" )
                 really_clear_map_without_vision();
                 map &here = get_map();
 
-                vehicle *veh = here.add_vehicle( vehicle_prototype_test_van, test_origin, angle, 100, 0 );
+                vehicle *veh = here.add_vehicle( vehicle_prototype_test_van, test_origin, angle, 100,
+                                                 veh_spawn_status::UNDAMAGED );
                 REQUIRE( veh != nullptr );
 
                 /* since we want all the doors closed anyway, go ahead and test that opening
@@ -113,7 +115,8 @@ TEST_CASE( "ensure_fake_parts_enable_on_turn", "[vehicle] [vehicle_fake]" )
         really_clear_map_without_vision();
         map &here = get_map();
         const tripoint_bub_ms test_origin( 30, 30, 0 );
-        vehicle *veh = here.add_vehicle( vehicle_prototype_test_van, test_origin, 0_degrees, 100, 0 );
+        vehicle *veh = here.add_vehicle( vehicle_prototype_test_van, test_origin, 0_degrees, 100,
+                                         veh_spawn_status::UNDAMAGED );
         REQUIRE( veh != nullptr );
 
         /* since we want all the doors closed anyway, go ahead and test that opening
@@ -171,7 +174,8 @@ TEST_CASE( "ensure_vehicle_weight_is_constant", "[vehicle] [vehicle_fake]" )
     really_clear_map_without_vision();
     const tripoint_bub_ms test_origin( 30, 30, 0 );
     map &here = get_map();
-    vehicle *veh = here.add_vehicle( vehicle_prototype_suv, test_origin, 0_degrees, 0, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_suv, test_origin, 0_degrees, 0,
+                                     veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
 
     veh->tags.insert( "IN_CONTROL_OVERRIDE" );
@@ -200,7 +204,8 @@ TEST_CASE( "vehicle_collision_applies_damage_to_fake_parent", "[vehicle] [vehicl
     map &here = get_map();
     GIVEN( "A moving vehicle traveling at a 45 degree angle to the X axis" ) {
         const tripoint_bub_ms test_origin( 30, 30, 0 );
-        vehicle *veh = here.add_vehicle( vehicle_prototype_suv, test_origin, 0_degrees, 100, 0 );
+        vehicle *veh = here.add_vehicle( vehicle_prototype_suv, test_origin, 0_degrees, 100,
+                                         veh_spawn_status::UNDAMAGED );
         REQUIRE( veh != nullptr );
 
         veh->tags.insert( "IN_CONTROL_OVERRIDE" );
@@ -259,7 +264,8 @@ TEST_CASE( "vehicle_to_vehicle_collision", "[vehicle] [vehicle_fake]" )
     map &here = get_map();
     GIVEN( "A moving vehicle traveling at a 30 degree angle to the X axis" ) {
         const tripoint_bub_ms test_origin( 30, 30, 0 );
-        vehicle *veh = here.add_vehicle( vehicle_prototype_test_van, test_origin, 30_degrees, 100, 0 );
+        vehicle *veh = here.add_vehicle( vehicle_prototype_test_van, test_origin, 30_degrees, 100,
+                                         veh_spawn_status::UNDAMAGED );
         REQUIRE( veh != nullptr );
         const tripoint_bub_ms global_origin = veh->pos_bub( here );
 
@@ -271,7 +277,8 @@ TEST_CASE( "vehicle_to_vehicle_collision", "[vehicle] [vehicle_fake]" )
         here.vehmove();
         const tripoint_bub_ms global_move = veh->pos_bub( here );
         const tripoint_bub_ms obstacle_point = test_origin + 2 * ( global_move - global_origin );
-        vehicle *trg = here.add_vehicle( vehicle_prototype_schoolbus, obstacle_point, 90_degrees, 100, 0 );
+        vehicle *trg = here.add_vehicle( vehicle_prototype_schoolbus, obstacle_point, 90_degrees, 100,
+                                         veh_spawn_status::UNDAMAGED );
         REQUIRE( trg != nullptr );
         trg->name = "crash bus";
         WHEN( "A vehicle is placed in the vehicle's path such that it will hit a true part" ) {
@@ -316,7 +323,8 @@ TEST_CASE( "ensure_vehicle_with_no_obstacles_has_no_fake_parts", "[vehicle] [veh
     map &here = get_map();
     GIVEN( "A vehicle with no parts that block movement" ) {
         const tripoint_bub_ms test_origin( 30, 30, 0 );
-        vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, test_origin, 45_degrees, 100, 0 );
+        vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, test_origin, 45_degrees, 100,
+                                         veh_spawn_status::UNDAMAGED );
         REQUIRE( veh != nullptr );
         WHEN( "The vehicle is placed in the world" ) {
             THEN( "There are no fake parts added" ) {
@@ -334,7 +342,7 @@ TEST_CASE( "vehicle_with_fake_obstacle_parts_block_movement", "[vehicle][vehicle
     Character &you = get_player_character();
     const tripoint_bub_ms test_origin( 30, 30, 0 );
     vehicle *veh = here.add_vehicle( vehicle_prototype_obstacle_test,
-                                     test_origin, 315_degrees, 100, 0 );
+                                     test_origin, 315_degrees, 100, veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
     veh->refresh( );
     here.set_seen_cache_dirty( 0 );
@@ -360,7 +368,8 @@ TEST_CASE( "fake_parts_are_opaque", "[vehicle][vehicle_fake]" )
     set_time_to_day();
 
     REQUIRE( you.sees( here, you.pos_bub( here ) + point( 10, 10 ) ) );
-    vehicle *veh = here.add_vehicle( vehicle_prototype_test_van, test_origin, 315_degrees, 100, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_test_van, test_origin, 315_degrees, 100,
+                                     veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
     here.set_seen_cache_dirty( 0 );
     here.build_map_cache( 0 );
@@ -375,7 +384,8 @@ TEST_CASE( "open_and_close_fake_doors", "[vehicle][vehicle_fake]" )
     const tripoint_bub_ms test_origin = you.pos_bub() + point( 3, 0 );
     map &here = get_map();
 
-    vehicle *veh = here.add_vehicle( vehicle_prototype_test_van, test_origin, 315_degrees, 100, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_test_van, test_origin, 315_degrees, 100,
+                                     veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
 
     // First get the doors to a known good state.

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -70,7 +70,7 @@ static void test_repair( const std::vector<item> &tools, bool plug_in_tools, boo
 
     const tripoint_bub_ms vehicle_origin = test_origin + tripoint::south_east;
     vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_car, vehicle_origin, -90_degrees, 0,
-                                         0 );
+                                         veh_spawn_status::UNDAMAGED );
 
     REQUIRE( veh_ptr != nullptr );
     // Find the frame at the origin.

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -14,6 +14,7 @@
 #include "cata_catch.h"
 #include "character.h"
 #include "coordinates.h"
+#include "enums.h"
 #include "inventory.h"
 #include "item.h"
 #include "item_location.h"
@@ -160,7 +161,8 @@ static void test_craft_via_rig( const std::vector<item> &items, int give_battery
     }
     character.learn_recipe( &recipe );
 
-    here.add_vehicle( vehicle_prototype_test_rv, test_origin, -90_degrees, 0, 0 );
+    here.add_vehicle( vehicle_prototype_test_rv, test_origin, -90_degrees, 0,
+                      veh_spawn_status::UNDAMAGED );
     const optional_vpart_position ovp = here.veh_at( test_origin );
     REQUIRE( ovp.has_value() );
     vehicle &veh = ovp->vehicle();
@@ -222,7 +224,8 @@ TEST_CASE( "vehicle_prepare_tool_multimag", "[vehicle][multimag]" )
 
     const tripoint_bub_ms test_origin( 60, 60, 0 );
     REQUIRE_FALSE( here.veh_at( test_origin ).has_value() );
-    vehicle *veh = here.add_vehicle( vehicle_prototype_none, test_origin, 0_degrees, 0, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_none, test_origin, 0_degrees, 0,
+                                     veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
     REQUIRE( veh->install_part( here, point_rel_ms::zero, vpart_frame ) != -1 );
     REQUIRE( veh->install_part( here, point_rel_ms::zero, vpart_small_storage_battery ) != -1 );
@@ -398,7 +401,8 @@ TEST_CASE( "vehicle_run_legacy_charge_tool_uses_water_purifier",
 
     const tripoint_bub_ms test_origin( 60, 60, 0 );
     REQUIRE_FALSE( here.veh_at( test_origin ).has_value() );
-    vehicle *veh = here.add_vehicle( vehicle_prototype_none, test_origin, 0_degrees, 0, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_none, test_origin, 0_degrees, 0,
+                                     veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
     REQUIRE( veh->install_part( here, point_rel_ms::zero, vpart_frame ) != -1 );
     REQUIRE( veh->install_part( here, point_rel_ms::zero, vpart_small_storage_battery ) != -1 );
@@ -457,7 +461,8 @@ TEST_CASE( "faucet_offers_cold_water", "[vehicle][vehicle_parts]" )
     Character &character = get_player_character();
     const item backpack( itype_backpack );
     character.wear_item( backpack );
-    here.add_vehicle( vehicle_prototype_test_rv, test_origin, -90_degrees, 0, 0 );
+    here.add_vehicle( vehicle_prototype_test_rv, test_origin, -90_degrees, 0,
+                      veh_spawn_status::UNDAMAGED );
     const optional_vpart_position ovp = here.veh_at( test_origin );
     REQUIRE( ovp.has_value() );
     vehicle &veh = ovp->vehicle();

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -127,7 +127,8 @@ TEST_CASE( "power_loss_to_cables", "[vehicle][power]" )
     std::vector<vpart_reference> batteries;
     for( const tripoint_bub_ms &p : placements ) {
         REQUIRE( !here.veh_at( p ).has_value() );
-        vehicle *veh = here.add_vehicle( vehicle_prototype_none, p, 0_degrees, 0, 0 );
+        vehicle *veh = here.add_vehicle( vehicle_prototype_none, p, 0_degrees, 0,
+                                         veh_spawn_status::UNDAMAGED );
         REQUIRE( veh != nullptr );
         const int frame_part_idx = veh->install_part( here, point_rel_ms::zero, vpart_frame );
         REQUIRE( frame_part_idx != -1 );
@@ -179,7 +180,7 @@ TEST_CASE( "Solar_power", "[vehicle][power]" )
 
     const tripoint_bub_ms solar_origin{ 5, 5, 0 };
     vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_solar_panel_test, solar_origin, 0_degrees, 0,
-                                         0 );
+                                         veh_spawn_status::UNDAMAGED );
     REQUIRE( veh_ptr != nullptr );
     REQUIRE_FALSE( veh_ptr->solar_panels.empty() );
     scoped_weather_override clear_weather( WEATHER_CLEAR );
@@ -225,7 +226,7 @@ TEST_CASE( "Solar_power", "[vehicle][power]" )
         const tripoint_bub_ms solar_origin_2{ 10, 10, 0 };
         vehicle *veh_2_ptr = here.add_vehicle( vehicle_prototype_solar_panel_test, solar_origin_2,
                                                0_degrees, 0,
-                                               0 );
+                                               veh_spawn_status::UNDAMAGED );
         REQUIRE( veh_ptr != nullptr );
         REQUIRE( veh_2_ptr != nullptr );
 
@@ -258,7 +259,7 @@ TEST_CASE( "Daily_solar_power", "[vehicle][power]" )
 
     const tripoint_bub_ms solar_origin{ 5, 5, 0 };
     vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_solar_panel_test, solar_origin, 0_degrees, 0,
-                                         0 );
+                                         veh_spawn_status::UNDAMAGED );
     REQUIRE( veh_ptr != nullptr );
     scoped_weather_override clear_weather( WEATHER_CLEAR );
 
@@ -321,7 +322,8 @@ TEST_CASE( "maximum_reverse_velocity", "[vehicle][power][reverse]" )
 
     GIVEN( "a scooter with combustion engine and charged battery" ) {
         const tripoint_bub_ms origin{ 10, 0, 0 };
-        vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_scooter_test, origin, 0_degrees, 0, 0 );
+        vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_scooter_test, origin, 0_degrees, 0,
+                                             veh_spawn_status::UNDAMAGED );
         REQUIRE( veh_ptr != nullptr );
         veh_ptr->charge_battery( here, 450 );
         REQUIRE( veh_ptr->fuel_left( here, fuel_type_battery ) == 450 );
@@ -347,7 +349,7 @@ TEST_CASE( "maximum_reverse_velocity", "[vehicle][power][reverse]" )
     GIVEN( "a scooter with an electric motor and charged battery" ) {
         const tripoint_bub_ms origin{ 15, 0, 0 };
         vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_scooter_electric_test, origin,
-                                             0_degrees, 0, 0 );
+                                             0_degrees, 0, veh_spawn_status::UNDAMAGED );
         REQUIRE( veh_ptr != nullptr );
         veh_ptr->charge_battery( here, 5000 );
         REQUIRE( veh_ptr->fuel_left( here, fuel_type_battery ) == 5000 );
@@ -557,7 +559,8 @@ TEST_CASE( "non_appliance_vehicle_not_auto_recovered", "[vehicle][power][grid]" 
 
     // build a regular (non-appliance) vehicle with a frame, battery, and a consumer part
     const tripoint_bub_ms veh_pos( HALF_MAPSIZE_X + 2, HALF_MAPSIZE_Y + 2, 0 );
-    vehicle *veh = here.add_vehicle( vehicle_prototype_none, veh_pos, 0_degrees, 0, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_none, veh_pos, 0_degrees, 0,
+                                     veh_spawn_status::UNDAMAGED );
     REQUIRE( veh != nullptr );
     const int frame_idx = veh->install_part( here, point_rel_ms::zero, vpart_frame );
     REQUIRE( frame_idx != -1 );
@@ -722,7 +725,7 @@ TEST_CASE( "off_map_solar_catchup_generates_energy", "[vehicle][power][grid]" )
 
     const tripoint_bub_ms solar_origin{ 5, 5, 0 };
     vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_solar_panel_test, solar_origin,
-                                         0_degrees, 0, 0 );
+                                         0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( veh_ptr != nullptr );
     REQUIRE_FALSE( veh_ptr->solar_panels.empty() );
     scoped_weather_override clear_weather( WEATHER_CLEAR );
@@ -759,7 +762,7 @@ TEST_CASE( "off_map_solar_catchup_generates_energy", "[vehicle][power][grid]" )
         clear_vehicles();
         build_test_map( ter_id( "t_thconc_floor" ) );
         vehicle *indoor_veh = here.add_vehicle( vehicle_prototype_solar_panel_test,
-                                                solar_origin, 0_degrees, 0, 0 );
+                                                solar_origin, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
         REQUIRE( indoor_veh != nullptr );
         REQUIRE_FALSE( indoor_veh->solar_panels.empty() );
 
@@ -781,7 +784,7 @@ TEST_CASE( "off_map_catchup_prevents_double_charge", "[vehicle][power][grid]" )
 
     const tripoint_bub_ms solar_origin{ 5, 5, 0 };
     vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_solar_panel_test, solar_origin,
-                                         0_degrees, 0, 0 );
+                                         0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( veh_ptr != nullptr );
     scoped_weather_override clear_weather( WEATHER_CLEAR );
 
@@ -811,7 +814,7 @@ TEST_CASE( "off_map_catchup_skips_short_intervals", "[vehicle][power][grid]" )
 
     const tripoint_bub_ms solar_origin{ 5, 5, 0 };
     vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_solar_panel_test, solar_origin,
-                                         0_degrees, 0, 0 );
+                                         0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( veh_ptr != nullptr );
     scoped_weather_override clear_weather( WEATHER_CLEAR );
 
@@ -1081,7 +1084,7 @@ TEST_CASE( "power_network_rated_values_populated", "[vehicle][power][grid]" )
 
     const tripoint_bub_ms solar_origin{ 5, 5, 0 };
     vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_solar_panel_test, solar_origin,
-                                         0_degrees, 0, 0 );
+                                         0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( veh_ptr != nullptr );
     REQUIRE_FALSE( veh_ptr->solar_panels.empty() );
 
@@ -1185,7 +1188,7 @@ TEST_CASE( "off_map_solar_charges_remote_battery_through_cable", "[vehicle][powe
         time_point future = calendar::turn;
         vehicle *fresh_solar = here.add_vehicle( vehicle_prototype_solar_panel_test,
                                tripoint_bub_ms( HALF_MAPSIZE_X + 10, HALF_MAPSIZE_Y + 10, 0 ),
-                               0_degrees, 0, 0 );
+                               0_degrees, 0, veh_spawn_status::UNDAMAGED );
         REQUIRE( fresh_solar != nullptr );
         fresh_solar->update_time( here, calendar::turn - 30_minutes );
         int raw_energy = fresh_solar->catchup_off_map_renewables( future );
@@ -1212,7 +1215,7 @@ TEST_CASE( "off_map_wind_turbine_catchup", "[vehicle][power][grid]" )
 
     const tripoint_bub_ms origin{ 5, 5, 0 };
     vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_wind_turbine_test, origin,
-                                         0_degrees, 0, 0 );
+                                         0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( veh_ptr != nullptr );
     REQUIRE_FALSE( veh_ptr->wind_turbines.empty() );
 
@@ -1241,7 +1244,7 @@ TEST_CASE( "off_map_water_wheel_catchup", "[vehicle][power][grid]" )
 
     const tripoint_bub_ms origin{ 5, 5, 0 };
     vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_water_wheel_test, origin,
-                                         0_degrees, 0, 0 );
+                                         0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( veh_ptr != nullptr );
     REQUIRE_FALSE( veh_ptr->water_wheels.empty() );
 

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -11,6 +11,7 @@
 #include "coordinates.h"
 #include "creature.h"
 #include "creature_tracker.h"
+#include "enums.h"
 #include "game.h"
 #include "map.h"
 #include "map_helpers.h"
@@ -100,7 +101,8 @@ static void ramp_transition_angled( const vproto_id &veh_id, const units::angle 
     if( here.ter( map_starting_point ) != ter_id( "t_pavement" ) ) {
         return;
     }
-    vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, angle, 1, 0 );
+    vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, angle, 1,
+                                         veh_spawn_status::UNDAMAGED );
 
     REQUIRE( veh_ptr != nullptr );
     if( veh_ptr == nullptr ) {
@@ -252,7 +254,8 @@ static void level_out( const vproto_id &veh_id, const bool drop_pos )
     // Make sure the avatar is out of the way
     Character &player_character = get_player_character();
     player_character.setpos( here, map_starting_point + point( 5, 5 ) );
-    vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, 180_degrees, 1, 0 );
+    vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, 180_degrees, 1,
+                                         veh_spawn_status::UNDAMAGED );
 
     REQUIRE( veh_ptr != nullptr );
     if( veh_ptr == nullptr ) {

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -5,6 +5,7 @@
 #include "cata_catch.h"
 #include "character.h"
 #include "coordinates.h"
+#include "enums.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "point.h"
@@ -31,7 +32,7 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
         clear_vehicles();
         REQUIRE( here.get_vehicles().empty() );
         vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_cross_split_test,
-                                             vehicle_origin, dir, 0, 0 );
+                                             vehicle_origin, dir, 0, veh_spawn_status::UNDAMAGED );
         REQUIRE( veh_ptr != nullptr );
         std::set<tripoint_abs_ms> original_points = veh_ptr->get_points( true );
 
@@ -73,7 +74,8 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
         }
         REQUIRE( here.get_vehicles().empty() );
         vehicle_origin = { 20, 20, 0 };
-        veh_ptr = here.add_vehicle( vehicle_prototype_circle_split_test, vehicle_origin, dir, 0, 0 );
+        veh_ptr = here.add_vehicle( vehicle_prototype_circle_split_test, vehicle_origin, dir, 0,
+                                    veh_spawn_status::UNDAMAGED );
         REQUIRE( veh_ptr != nullptr );
         here.destroy_vehicle( vehicle_origin );
         veh_ptr->part_removal_cleanup( here );
@@ -124,7 +126,7 @@ TEST_CASE( "split_vehicle_during_mapgen", "[vehicle]" )
     REQUIRE( tm.get_vehicles().empty() );
     tripoint_omt_ms vehicle_origin{ 14, 14, 0 };
     vehicle *veh_ptr = tm.add_vehicle( vehicle_prototype_cross_split_test,
-                                       vehicle_origin, 0_degrees, 0, 0 );
+                                       vehicle_origin, 0_degrees, 0, veh_spawn_status::UNDAMAGED );
     REQUIRE( veh_ptr != nullptr );
     REQUIRE( !tm.get_vehicles().empty() );
     tm.destroy( vehicle_origin );

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -78,7 +78,7 @@ TEST_CASE( "detaching_vehicle_unboards_passengers", "[vehicle]" )
     map &here = get_map();
     Character &player_character = get_player_character();
     vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_bicycle, vehicle_origin, -90_degrees, 0,
-                                         0 );
+                                         veh_spawn_status::UNDAMAGED );
     here.board_vehicle( test_origin, &player_character );
     REQUIRE( player_character.in_vehicle );
     here.detach_vehicle( veh_ptr );
@@ -94,7 +94,7 @@ TEST_CASE( "destroy_grabbed_vehicle_section", "[vehicle]" )
         player_character.setpos( here, test_origin );
         const tripoint_bub_ms vehicle_origin = test_origin + tripoint::south_east;
         vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_bicycle, vehicle_origin, -90_degrees,
-                                             0, 0 );
+                                             0, veh_spawn_status::UNDAMAGED );
         REQUIRE( veh_ptr != nullptr );
         tripoint_bub_ms grab_point = test_origin + tripoint::east;
         player_character.grab( object_type::VEHICLE, tripoint_rel_ms::east );
@@ -118,7 +118,7 @@ TEST_CASE( "add_item_to_broken_vehicle_part", "[vehicle]" )
     const tripoint_bub_ms test_origin( 60, 60, 0 );
     const tripoint_bub_ms vehicle_origin = test_origin;
     vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_bicycle, vehicle_origin, 0_degrees,
-                                         0, 0 );
+                                         0, veh_spawn_status::UNDAMAGED );
     REQUIRE( veh_ptr != nullptr );
 
     const tripoint_bub_ms pos = vehicle_origin + tripoint::west;
@@ -143,7 +143,7 @@ TEST_CASE( "starting_bicycle_damaged_pedal", "[vehicle]" )
     map &here = get_map();
     Character &player_character = get_player_character();
     vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_bicycle, vehicle_origin, -90_degrees, 0,
-                                         0 );
+                                         veh_spawn_status::UNDAMAGED );
     here.board_vehicle( test_origin, &player_character );
     REQUIRE( player_character.in_vehicle );
     REQUIRE( veh_ptr->engines.size() == 1 );
@@ -632,7 +632,7 @@ static void rack_check( const rack_preset &preset )
     for( size_t i = 0; i < preset.vehicles.size(); i++ ) {
         CAPTURE( preset.vehicles[i], preset.positions[i], preset.facings[i] );
         vehicle *veh_ptr = m.add_vehicle( preset.vehicles[i], preset.positions[i],
-                                          preset.facings[i], 0, 0 );
+                                          preset.facings[i], 0, veh_spawn_status::UNDAMAGED );
         REQUIRE( veh_ptr != nullptr );
         veh_ptr->refresh( );
         vehs.push_back( veh_ptr );
@@ -793,7 +793,8 @@ static int test_autopilot_moving( const vproto_id &veh_id, const vpart_id &extra
     player_character.setpos( here, tripoint_bub_ms::zero );
 
     const tripoint_bub_ms map_starting_point( 60, 60, 0 );
-    vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, -90_degrees, 100, 0, false );
+    vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, -90_degrees, 100,
+                                         veh_spawn_status::UNDAMAGED, false );
 
     REQUIRE( veh_ptr != nullptr );
 
@@ -845,7 +846,8 @@ TEST_CASE( "vehicle_enchantments", "[vehicle][enchantments]" )
     player_character.setpos( here, tripoint_bub_ms::zero );
 
     const tripoint_bub_ms map_starting_point( 60, 60, 0 );
-    vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_car, map_starting_point, -90_degrees, 100, 0,
+    vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_car, map_starting_point, -90_degrees, 100,
+                                         veh_spawn_status::UNDAMAGED,
                                          false );
 
     REQUIRE( veh_ptr != nullptr );
@@ -881,7 +883,8 @@ TEST_CASE( "vehicle_effects", "[vehicle][effects]" )
     player_character.setpos( here, tripoint_bub_ms::zero );
 
     const tripoint_bub_ms map_starting_point( 60, 60, 0 );
-    vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_car, map_starting_point, -90_degrees, 100, 0,
+    vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_car, map_starting_point, -90_degrees, 100,
+                                         veh_spawn_status::UNDAMAGED,
                                          false );
 
     REQUIRE( veh_ptr != nullptr );
@@ -958,7 +961,7 @@ TEST_CASE( "vehicle_wheels_damaged_by_running_over_items", "[vehicle]" )
 
     SECTION( "Bicycle wheel vs variety of test items" ) {
         vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_unicycle_bike_wheel,
-                                             test_point, 0_degrees, 100, 0, false );
+                                             test_point, 0_degrees, 100, veh_spawn_status::UNDAMAGED, false );
         vehicle_part *vp_wheel = setup_squish_test_return_wheel( here, test_point, veh_ptr );
 
         const std::map<itype_id, double> test_items = {
@@ -981,7 +984,7 @@ TEST_CASE( "vehicle_wheels_damaged_by_running_over_items", "[vehicle]" )
 
     SECTION( "Normal wheel vs variety of test items" ) {
         vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_unicycle_normal_wheel,
-                                             test_point, 0_degrees, 100, 0, false );
+                                             test_point, 0_degrees, 100, veh_spawn_status::UNDAMAGED, false );
         vehicle_part *vp_wheel = setup_squish_test_return_wheel( here, test_point, veh_ptr );
 
         const std::map<itype_id, double> test_items = {
@@ -998,7 +1001,7 @@ TEST_CASE( "vehicle_wheels_damaged_by_running_over_items", "[vehicle]" )
 
     SECTION( "Armored wheel vs variety of test items" ) {
         vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_unicycle_armored_wheel,
-                                             test_point, 0_degrees, 100, 0, false );
+                                             test_point, 0_degrees, 100, veh_spawn_status::UNDAMAGED, false );
         vehicle_part *vp_wheel = setup_squish_test_return_wheel( here, test_point, veh_ptr );
 
         const std::map<itype_id, double> test_items = {

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -9,6 +9,7 @@
 #include "character.h"
 #include "character_attire.h"
 #include "coordinates.h"
+#include "enums.h"
 #include "explosion.h"
 #include "item.h"
 #include "itype.h"
@@ -85,7 +86,8 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
             continue;
         }
         SECTION( turret_vpi->name() ) {
-            vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos, 270_degrees, 0, 2,
+            vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos, 270_degrees, 0,
+                                             veh_spawn_status::PRISTINE,
                                              false, true );
             REQUIRE( veh );
 
@@ -180,7 +182,7 @@ TEST_CASE( "vehicle_turret_multimag", "[vehicle][turret][multimag]" )
 
     SECTION( "install + query + fire happy path" ) {
         vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos,
-                                         270_degrees, 0, 2, false, true );
+                                         270_degrees, 0, veh_spawn_status::PRISTINE, false, true );
         REQUIRE( veh );
 
         const int turr_idx = veh->install_part( here, point_rel_ms::zero,
@@ -229,7 +231,7 @@ TEST_CASE( "vehicle_turret_multimag", "[vehicle][turret][multimag]" )
 
     SECTION( "post_fire clears bound power well, leaves player ammo well intact" ) {
         vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos,
-                                         270_degrees, 0, 2, false, true );
+                                         270_degrees, 0, veh_spawn_status::PRISTINE, false, true );
         REQUIRE( veh );
         const int turr_idx = veh->install_part( here, point_rel_ms::zero,
                                                 vpart_turret_test_multimag_turret_gun );
@@ -271,7 +273,7 @@ TEST_CASE( "vehicle_turret_multimag", "[vehicle][turret][multimag]" )
 
     SECTION( "USE_UPS multimag turret leaves player UPS untouched" ) {
         vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos,
-                                         270_degrees, 0, 2, false, true );
+                                         270_degrees, 0, veh_spawn_status::PRISTINE, false, true );
         REQUIRE( veh );
         const int turr_idx = veh->install_part( here, point_rel_ms::zero,
                                                 vpart_turret_test_multimag_turret_gun_ups );
@@ -324,7 +326,7 @@ TEST_CASE( "vehicle_turret_multimag", "[vehicle][turret][multimag]" )
 
     SECTION( "tank picker skips insufficient tank in favour of sufficient sibling" ) {
         vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos,
-                                         270_degrees, 0, 2, false, true );
+                                         270_degrees, 0, veh_spawn_status::PRISTINE, false, true );
         REQUIRE( veh );
         // test_turret_rig already has a tank at (1,0); install a second frame
         // + tank at (1,1) so the picker has to choose between two siblings.
@@ -382,7 +384,7 @@ TEST_CASE( "vehicle_turret_multimag", "[vehicle][turret][multimag]" )
 
     SECTION( "BURST mode drains per_use_battery * mode.qty per shot" ) {
         vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos,
-                                         270_degrees, 0, 2, false, true );
+                                         270_degrees, 0, veh_spawn_status::PRISTINE, false, true );
         REQUIRE( veh );
         const int turr_idx = veh->install_part( here, point_rel_ms::zero,
                                                 vpart_turret_test_multimag_turret_gun );
@@ -429,7 +431,7 @@ TEST_CASE( "vehicle_turret_multimag", "[vehicle][turret][multimag]" )
 
     SECTION( "BURST stops mid-sequence when vehicle battery cannot cover next burst" ) {
         vehicle *veh = here.add_vehicle( vehicle_prototype_test_turret_rig, veh_pos,
-                                         270_degrees, 0, 2, false, true );
+                                         270_degrees, 0, veh_spawn_status::PRISTINE, false, true );
         REQUIRE( veh );
         const int turr_idx = veh->install_part( here, point_rel_ms::zero,
                                                 vpart_turret_test_multimag_turret_gun );

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -13,6 +13,7 @@
 #include "character.h"
 #include "coordinates.h"
 #include "creature.h"
+#include "enums.h"
 #include "game.h"
 #include "map.h"
 #include "map_helpers.h"
@@ -837,7 +838,8 @@ TEST_CASE( "vision_vehicle_mirrors", "[shadowcasting][vision][vehicle]" )
     tile_predicate spawn_veh = [&]( map_test_case::tile tile ) {
         std::optional<units::angle> dir = testcase_veh_dir( {7, 2}, t, tile );
         if( dir ) {
-            vehicle *v = here.add_vehicle( vehicle_prototype_meth_lab, tile.p, *dir, 0, 0 );
+            vehicle *v = here.add_vehicle( vehicle_prototype_meth_lab, tile.p, *dir, 0,
+                                           veh_spawn_status::UNDAMAGED );
             for( const vpart_reference &vp : v->get_avail_parts( "OPENABLE" ) ) {
                 v->close( here, vp.part_index() );
             }
@@ -884,7 +886,8 @@ TEST_CASE( "vision_vehicle_camera", "[shadowcasting][vision][vehicle]" )
         std::optional<units::angle> const dir = testcase_veh_dir( { 1, 0 }, t, tile );
         if( dir ) {
             vehicle *v =
-                get_map().add_vehicle( vehicle_prototype_vehicle_camera_test, tile.p, *dir, 0, 0 );
+                get_map().add_vehicle( vehicle_prototype_vehicle_camera_test, tile.p, *dir, 0,
+                                       veh_spawn_status::UNDAMAGED );
             v->camera_on = true;
         }
         return true;
@@ -939,7 +942,7 @@ TEST_CASE( "vision_vehicle_camera_skew", "[shadowcasting][vision][vehicle][vehic
         if( dir ) {
             units::angle const skew = *dir + 45_degrees;
             v = here.add_vehicle( vehicle_prototype_vehicle_camera_test, tile.p, skew, 0,
-                                  0 );
+                                  veh_spawn_status::UNDAMAGED );
             v->camera_on = camera_on;
         }
         return true;
@@ -999,7 +1002,8 @@ TEST_CASE( "vision_moncam_invalidation", "[shadowcasting][vision][moncam]" )
         std::optional<units::angle> const dir = testcase_veh_dir( { 1, 1 }, t, tile );
         if( dir ) {
             vehicle *v =
-                get_map().add_vehicle( vehicle_prototype_vehicle_camera_test, tile.p, *dir, 0, 0 );
+                get_map().add_vehicle( vehicle_prototype_vehicle_camera_test, tile.p, *dir, 0,
+                                       veh_spawn_status::UNDAMAGED );
             v->camera_on = true;
         }
         return true;
@@ -1161,7 +1165,7 @@ TEST_CASE( "vision_inside_meth_lab", "[shadowcasting][vision][moncam]" )
             dir = 0_degrees;
         }
         if( dir ) {
-            v = here.add_vehicle( vehicle_prototype_meth_lab, tile.p, *dir, 0, 0 );
+            v = here.add_vehicle( vehicle_prototype_meth_lab, tile.p, *dir, 0, veh_spawn_status::UNDAMAGED );
             for( const vpart_reference &vp : v->get_avail_parts( "OPENABLE" ) ) {
                 v -> close( here, vp.part_index() );
             }

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -10,6 +10,7 @@
 #include "character.h"
 #include "character_attire.h"
 #include "coordinates.h"
+#include "enums.h"
 #include "inventory.h"
 #include "item.h"
 #include "item_location.h"
@@ -428,7 +429,8 @@ TEST_CASE( "visitable_remove", "[visitable]" )
         std::vector<tripoint_bub_ms> tiles = closest_points_first( p.pos_bub(), 1 );
         tiles.erase( tiles.begin() ); // player tile
         tripoint_bub_ms veh = tripoint_bub_ms( random_entry( tiles ) );
-        REQUIRE( here.add_vehicle( vehicle_prototype_shopping_cart, veh, 0_degrees, 0, 0 ) );
+        REQUIRE( here.add_vehicle( vehicle_prototype_shopping_cart, veh, 0_degrees, 0,
+                                   veh_spawn_status::UNDAMAGED ) );
 
         REQUIRE( std::count_if( tiles.begin(), tiles.end(), [&here]( const tripoint_bub_ms & e ) {
             return static_cast<bool>( here.veh_at( e ) );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
While doing some recent vehicle fault stuff I noticed that engine faults were doing their own implementation of picking randomly. That's not great.

#### Describe the solution
Use the existing item::set_random_fault_of_type() function so that it weighs and picks faults. Also, add the faults to a fault group so they can be weighted.

Along the way I replaced magic number ints for vehicle status with an enum. It makes the function calls much clearer to see that you're adding a vehicle in "pristine" state rather than `2` state. (You would have to go step into the function and look up what the hell 2 was supposed to be). It also makes the juggling clearer in vehicle::init_state() itself.

**ONLY FUNCTIONAL CHANGE**: Immobilizers will no longer be picked randomly for faults to be set, they are intentionally not `engine_maintenance` type. The immobilizer fault will still be set for vehicles with security systems, at the same (50%) chance as before.

#### Describe alternatives you've considered


#### Testing


#### Additional context
