### PR TITLE
Fix bronze bill axe recipe

### DIFF
--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -1469,7 +1469,7 @@
     ],
     "using": [ [ "forging_standard", 2 ], [ "bronzesmithing_tools", 1 ] ],
     "tools": [ [ [ "casting_mold", -1 ] ] ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fur", 2 ], [ "leather", 2 ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fur", 2 ], [ "leather", 2 ] ], [ [ "scrap_bronze", 10 ] ] ]
   },
   {
     "result": "bronze_brush_pole",


### PR DESCRIPTION
#### Summary

Balance "Add missing bronze scrap requirement to bronze brush axe recipe"

#### Purpose of change

The **bronze_brush_axe** recipe was missing the component requirement for bronze.

#### Describe the solution

Added **[ "scrap_bronze", 10 ]** to the components list of the **bronze_brush_axe** recipe.

#### Describe alternatives you've considered

None.

#### Testing

1. Checked the recipe in-game to ensure it now requires 10 bronze scrap.

2. Successfully completed the craft.

#### Additional context

None.
