### PR TITLE
allow to limit amount of specific wounds received per bodypart

### DIFF
--- a/doc/JSON/WOUNDS.md
+++ b/doc/JSON/WOUNDS.md
@@ -11,6 +11,7 @@ Wound is a type, that affects specific bodyparts. It's similar in this to effect
     "name": { "str": "scratch", "str_pl": "scratches" },
     "description": "Foobar.",
     "weight": 10, // weight of a wound, determines the chance of this specific wound to be picked when limb takes damage. Default 1
+    "limit": 2, // limits amount of wounds of this type you can get per limb
     "damage_types": [ "cut", "bash" ], // only taking these type of damage can apply wound. Mandatory
     "damage_required": [ 1, 1000 ], // smallest and highest damage that is required for this wound to be applied. Mandatory
     "pain": [ 1, 10 ], // when wound is applied, it would give character this random amount of pain rolled between this two numbers. Default 0
@@ -38,6 +39,7 @@ Wound fix is a way for wounds to be treated
     "wounds_removed": [ "scratch" ], // wounds removed when this fix is applied
     "wounds_added": [ "scratch" ], // wounds added when fix is applied
     "success_msg": "Tada.",
+    "mod_hp": 10, // if used, the HP of bodypart will be healed by this amount when wound fix is used; negative number will damage the limb instead 
     "requirements": [ [ "gun_cleaning", 1 ] ], // requirements that dictate tools and materials needed to apply this fix
     "proficiencies": [
       {

--- a/src/character.h
+++ b/src/character.h
@@ -1283,6 +1283,9 @@ class Character : public Creature, public visitable
         /** Actually hurt the player, hurts a body_part directly, no armor reduction */
         void apply_damage( Creature *source, bodypart_id hurt, int dam,
                            bool bypass_med = false ) override;
+        // checks if amount of specific wounds on bodypart is not higher than `limit`
+        // return false if more than limit
+        bool is_within_wound_limit_for_bp( bodypart_id bp, wound_type_id wound_id ) const;
         void apply_random_wound( bodypart_id bp, const damage_instance &d );
         /** Calls Creature::deal_damage and handles damaged effects (waking up, etc.) */
         dealt_damage_instance deal_damage( Creature *source, bodypart_id bp,

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -2626,6 +2626,21 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam,
     }
 }
 
+bool Character::is_within_wound_limit_for_bp( const bodypart_id bp, wound_type_id wound_id ) const
+{
+    if( wound_id->get_limit() == 0 ) {
+        return true;
+    }
+
+    const std::vector present_wounds = get_part( bp )->get_wounds();
+    const int amount = std::count_if( present_wounds.begin(),
+    present_wounds.end(), [wound_id]( wound wd ) {
+        return wd.type == wound_id;
+    } );
+
+    return amount < wound_id->get_limit();
+}
+
 void Character::apply_random_wound( bodypart_id bp, const damage_instance &d )
 {
     if( x_in_y( 1.0f - get_option<float>( "WOUND_CHANCE" ), 1.0f ) ) {
@@ -2633,14 +2648,16 @@ void Character::apply_random_wound( bodypart_id bp, const damage_instance &d )
     }
 
     weighted_int_list<wound_type_id> possible_wounds;
-    for( const std::pair<bp_wounds, int> &wd : bp->potential_wounds ) {
+    for( const auto &[potential_wound, wound_weight] : bp->potential_wounds ) {
         for( const damage_unit &du : d.damage_units ) {
-            const bool damage_within_limits = du.amount >= wd.first.damage_required.first &&
-                                              du.amount <= wd.first.damage_required.second;
-            const bool damage_type_matches = std::find( wd.first.damage_type.begin(),
-                                             wd.first.damage_type.end(), du.type ) != wd.first.damage_type.end();
-            if( damage_within_limits && damage_type_matches ) {
-                possible_wounds.add( wd.first.id, wd.second );
+            const bool damage_within_limits = du.amount >= potential_wound.damage_required.first &&
+                                              du.amount <= potential_wound.damage_required.second;
+            const bool damage_type_matches = std::find( potential_wound.damage_type.begin(),
+                                             potential_wound.damage_type.end(), du.type ) != potential_wound.damage_type.end();
+            const bool iwwlfb = is_within_wound_limit_for_bp( bp, potential_wound.id );
+
+            if( damage_within_limits && damage_type_matches && iwwlfb ) {
+                possible_wounds.add( potential_wound.id, wound_weight );
             }
         }
     }

--- a/src/wound.cpp
+++ b/src/wound.cpp
@@ -24,6 +24,7 @@ void wound_type::load( const JsonObject &jo, const std::string_view & )
     mandatory( jo, was_loaded, "damage_types", damage_types );
     mandatory( jo, was_loaded, "damage_required", damage_required );
     optional( jo, was_loaded, "weight", weight, 1 );
+    optional( jo, was_loaded, "limit", limit, 0 );
 
     optional( jo, was_loaded, "whitelist_bp_with_flag", whitelist_bp_with_flag );
     optional( jo, was_loaded, "whitelist_body_part_types", whitelist_body_part_types );
@@ -283,6 +284,11 @@ int wound_type::evaluate_pain() const
 time_duration wound_type::evaluate_healing_time() const
 {
     return rng( healing_time_.first, healing_time_.second );
+}
+
+int wound_type::get_limit() const
+{
+    return limit;
 }
 
 std::string wound_type::get_name() const

--- a/src/wound.h
+++ b/src/wound.h
@@ -41,6 +41,7 @@ class wound_type
         std::string get_description() const;
         int evaluate_pain() const;
         time_duration evaluate_healing_time() const;
+        int get_limit() const;
 
 
         // what damage types can apply this wound
@@ -61,6 +62,10 @@ class wound_type
     private:
         translation name_;
         translation description_;
+
+        // how many of this specific wound character can receive
+        // 0 means any amount
+        unsigned int limit = 0;
 
         // if applied, how long it may take for it to heal
         std::pair<time_duration, time_duration> healing_time_;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Request from Tektolnes
#### Describe the solution
Allow to limit amount of wounds per bodypart you receive
Document previously omitted `mod_hp` field
#### Testing
Added debug wound with limit of 2, took 9000 attacks from zombies, did not saw any more than 2 wounds on the same bodypart