### PR TITLE
Sort itemgroups (2): Food

### DIFF
--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
@@ -444,6 +444,13 @@
   },
   {
     "type": "item_group",
+    "id": "adderall_bottle_plastic_pill_prescription_1",
+    "subtype": "collection",
+    "container-item": "bottle_plastic_pill_prescription",
+    "entries": [ { "item": "adderall", "container-item": "null" } ]
+  },
+  {
+    "type": "item_group",
     "id": "antibiotics_dr_group",
     "subtype": "collection",
     "container-item": "bottle_plastic_pill_prescription",
@@ -500,10 +507,24 @@
   },
   {
     "type": "item_group",
+    "id": "weak_antibiotic_bottle_plastic_pill_prescription_1",
+    "subtype": "collection",
+    "container-item": "bottle_plastic_pill_prescription",
+    "entries": [ { "item": "weak_antibiotic", "container-item": "null" } ]
+  },
+  {
+    "type": "item_group",
     "id": "antifungal_dr_group",
     "subtype": "collection",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "antifungal", "container-item": "null", "count": [ 15, 60 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "antifungal_bottle_plastic_pill_prescription_1_10",
+    "subtype": "collection",
+    "container-item": "bottle_plastic_pill_prescription",
+    "entries": [ { "item": "antifungal", "container-item": "null", "count": [ 1, 10 ] } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Food/bread.json
+++ b/data/json/itemgroups/Food/bread.json
@@ -1,0 +1,101 @@
+[
+  {
+    "type": "item_group",
+    "id": "sourdough_bread_in_bag",
+    "subtype": "collection",
+    "entries": [ { "item": "sourdough_bread", "entry-wrapper": "bag_plastic", "count": [ 1, 14 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "sourdough_bread_in_bag_full",
+    "subtype": "collection",
+    "entries": [ { "item": "sourdough_bread", "entry-wrapper": "bag_plastic", "count": 14 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "bread_in_bag",
+    "subtype": "collection",
+    "entries": [ { "item": "bread", "entry-wrapper": "bag_plastic", "count": [ 1, 14 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "bread_in_bag_full",
+    "subtype": "collection",
+    "entries": [ { "item": "bread", "entry-wrapper": "bag_plastic", "count": 14 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "garlic_bread_in_bag",
+    "subtype": "collection",
+    "entries": [ { "item": "bread_garlic", "entry-wrapper": "bag_plastic_small", "count": [ 1, 8 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "garlic_bread_in_bag_full",
+    "subtype": "collection",
+    "entries": [ { "item": "bread_garlic", "entry-wrapper": "bag_plastic_small", "count": 8 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "frybread_in_bag",
+    "subtype": "collection",
+    "entries": [ { "item": "frybread", "entry-wrapper": "bag_plastic_small", "count": [ 1, 8 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "frybread_in_bag_full",
+    "subtype": "collection",
+    "entries": [ { "item": "frybread", "entry-wrapper": "bag_plastic_small", "count": 8 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "cornbread_in_bag",
+    "subtype": "collection",
+    "entries": [ { "item": "cornbread", "entry-wrapper": "bag_plastic_small", "count": [ 1, 8 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "cornbread_in_bag_full",
+    "subtype": "collection",
+    "entries": [ { "item": "cornbread", "entry-wrapper": "bag_plastic_small", "count": 8 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "flatbread_in_bag",
+    "subtype": "collection",
+    "entries": [ { "item": "flatbread", "entry-wrapper": "bag_plastic_small", "count": [ 1, 8 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "flatbread_in_bag_full",
+    "subtype": "collection",
+    "entries": [ { "item": "flatbread", "entry-wrapper": "bag_plastic_small", "count": 8 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "bread_wheat_free_bag_plastic_14",
+    "subtype": "collection",
+    "container-item": "bag_plastic",
+    "entries": [ { "item": "bread_wheat_free", "container-item": "null", "components": [ "flour_wheat_free" ], "count": 14 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "brown_bread_in_bag_full",
+    "subtype": "collection",
+    "entries": [ { "item": "brown_bread", "entry-wrapper": "bag_plastic", "count": 10 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "brown_bread_in_bag",
+    "subtype": "collection",
+    "entries": [ { "item": "brown_bread", "entry-wrapper": "bag_plastic", "count": [ 0, 10 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "brown_bread_can_medium_14",
+    "subtype": "collection",
+    "on_overflow": "discard",
+    "container-item": "can_medium",
+    "entries": [ { "item": "brown_bread", "container-item": "null", "count": 14 } ]
+  }
+]

--- a/data/json/itemgroups/Food/bread.json
+++ b/data/json/itemgroups/Food/bread.json
@@ -76,7 +76,7 @@
     "id": "bread_wheat_free_bag_plastic_14",
     "subtype": "collection",
     "container-item": "bag_plastic",
-    "entries": [ { "item": "bread_wheat_free", "container-item": "null", "components": [ "flour_wheat_free" ], "count": 14 } ]
+    "entries": [ { "item": "bread", "container-item": "null", "components": [ "flour_wheat_free" ], "count": 14 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Food/food.json
+++ b/data/json/itemgroups/Food/food.json
@@ -64,150 +64,6 @@
     ]
   },
   {
-    "id": "dog_food_six_pack_box",
-    "type": "item_group",
-    "subtype": "distribution",
-    "container-item": "box_medium",
-    "items": [ { "prob": 1, "item": "dogfood", "container-item": "can_medium", "count": [ 1, 6 ] } ]
-  },
-  {
-    "id": "dog_food_six_pack_box_full",
-    "type": "item_group",
-    "subtype": "distribution",
-    "container-item": "box_medium",
-    "items": [ { "prob": 1, "item": "dogfood", "container-item": "can_medium", "count": 6 } ]
-  },
-  {
-    "id": "dog_food_six_pack_bag",
-    "type": "item_group",
-    "subtype": "distribution",
-    "container-item": "bag_plastic",
-    "items": [ { "prob": 1, "item": "dogfood", "container-item": "can_medium", "count": [ 1, 6 ] } ]
-  },
-  {
-    "id": "dog_food_six_pack_bag_full",
-    "type": "item_group",
-    "subtype": "distribution",
-    "container-item": "bag_plastic",
-    "items": [ { "prob": 1, "item": "dogfood", "container-item": "can_medium", "count": 6 } ]
-  },
-  {
-    "id": "dog_food_six_pack",
-    "type": "item_group",
-    "subtype": "distribution",
-    "items": [ { "prob": 1, "group": "dog_food_six_pack_box" }, { "prob": 1, "group": "dog_food_six_pack_bag" } ]
-  },
-  {
-    "id": "dog_food_six_pack_full",
-    "type": "item_group",
-    "subtype": "distribution",
-    "items": [ { "prob": 1, "group": "dog_food_six_pack_box_full" }, { "prob": 1, "group": "dog_food_six_pack_bag_full" } ]
-  },
-  {
-    "id": "dog_food_in_container",
-    "type": "item_group",
-    "subtype": "distribution",
-    "entries": [
-      { "prob": 1, "group": "dog_food_six_pack" },
-      { "prob": 1, "item": "dogfood_dry", "count": [ 1, 100 ], "entry-wrapper": "bag_garbage" },
-      { "prob": 1, "item": "dogfood_dry", "count": [ 1, 50 ], "entry-wrapper": "bag_garbage" },
-      { "prob": 1, "item": "dogfood_dry", "count": [ 1, 20 ], "entry-wrapper": "bag_plastic" }
-    ]
-  },
-  {
-    "id": "dog_food_in_container_full",
-    "type": "item_group",
-    "subtype": "distribution",
-    "entries": [
-      { "prob": 1, "group": "dog_food_six_pack_full" },
-      { "prob": 1, "item": "dogfood_dry", "count": 100, "entry-wrapper": "bag_garbage" },
-      { "prob": 1, "item": "dogfood_dry", "count": 50, "entry-wrapper": "bag_garbage" },
-      { "prob": 1, "item": "dogfood_dry", "count": 20, "entry-wrapper": "bag_plastic" }
-    ]
-  },
-  {
-    "id": "cat_food_six_pack_box",
-    "type": "item_group",
-    "subtype": "distribution",
-    "container-item": "box_medium",
-    "items": [ { "prob": 1, "item": "catfood", "container-item": "can_medium", "count": [ 1, 6 ] } ]
-  },
-  {
-    "id": "cat_food_six_pack_box_full",
-    "type": "item_group",
-    "subtype": "distribution",
-    "container-item": "box_medium",
-    "items": [ { "prob": 1, "item": "catfood", "container-item": "can_medium", "count": 6 } ]
-  },
-  {
-    "id": "cat_food_six_pack_bag",
-    "type": "item_group",
-    "subtype": "distribution",
-    "container-item": "bag_plastic",
-    "items": [ { "prob": 1, "item": "catfood", "container-item": "can_food", "count": [ 1, 6 ] } ]
-  },
-  {
-    "id": "cat_food_six_pack_bag_full",
-    "type": "item_group",
-    "subtype": "distribution",
-    "container-item": "bag_plastic",
-    "items": [ { "prob": 1, "item": "catfood", "container-item": "can_food", "count": 6 } ]
-  },
-  {
-    "id": "cat_food_six_pack",
-    "type": "item_group",
-    "subtype": "distribution",
-    "items": [ { "prob": 1, "group": "cat_food_six_pack_box" }, { "prob": 1, "group": "cat_food_six_pack_bag" } ]
-  },
-  {
-    "id": "cat_food_six_pack_full",
-    "type": "item_group",
-    "subtype": "distribution",
-    "items": [ { "prob": 1, "group": "cat_food_six_pack_box_full" }, { "prob": 1, "group": "cat_food_six_pack_bag_full" } ]
-  },
-  {
-    "id": "cat_food_in_container",
-    "type": "item_group",
-    "subtype": "distribution",
-    "entries": [
-      { "prob": 1, "group": "cat_food_six_pack" },
-      { "prob": 1, "item": "catfood_dry", "count": [ 1, 100 ], "entry-wrapper": "bag_garbage" },
-      { "prob": 1, "item": "catfood_dry", "count": [ 1, 50 ], "entry-wrapper": "bag_garbage" },
-      { "prob": 1, "item": "catfood_dry", "count": [ 1, 20 ], "entry-wrapper": "bag_plastic" }
-    ]
-  },
-  {
-    "id": "cat_food_in_container_full",
-    "type": "item_group",
-    "subtype": "distribution",
-    "entries": [
-      { "prob": 1, "group": "cat_food_six_pack_full" },
-      { "prob": 1, "item": "catfood_dry", "count": 100, "entry-wrapper": "bag_garbage" },
-      { "prob": 1, "item": "catfood_dry", "count": 50, "entry-wrapper": "bag_garbage" },
-      { "prob": 1, "item": "catfood_dry", "count": 20, "entry-wrapper": "bag_plastic" }
-    ]
-  },
-  {
-    "id": "pet_food_in_container",
-    "type": "item_group",
-    "subtype": "distribution",
-    "entries": [
-      { "prob": 1, "item": "birdfood", "container-item": "bag_plastic", "count": -1 },
-      { "prob": 4, "group": "dog_food_in_container" },
-      { "prob": 4, "group": "cat_food_in_container" }
-    ]
-  },
-  {
-    "id": "pet_food_in_container_full",
-    "type": "item_group",
-    "subtype": "distribution",
-    "entries": [
-      { "prob": 1, "item": "birdfood", "container-item": "bag_plastic", "count": -1 },
-      { "prob": 4, "group": "dog_food_in_container_full" },
-      { "prob": 4, "group": "cat_food_in_container_full" }
-    ]
-  },
-  {
     "type": "item_group",
     "id": "ketchup_sealed_rng",
     "subtype": "distribution",
@@ -1255,13 +1111,6 @@
   },
   {
     "type": "item_group",
-    "id": "confit_meat_jar_3l_glass_sealed_12",
-    "subtype": "collection",
-    "container-item": "jar_3l_glass_sealed",
-    "entries": [ { "item": "confit_meat", "container-item": "null", "count": 12 } ]
-  },
-  {
-    "type": "item_group",
     "id": "fruit_leather_bag_plastic_full",
     "subtype": "collection",
     "container-item": "bag_plastic_small",
@@ -1287,14 +1136,6 @@
     "subtype": "collection",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "chem_agar", "container-item": "null", "count": 50 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "brown_bread_can_medium_14",
-    "subtype": "collection",
-    "on_overflow": "discard",
-    "container-item": "can_medium",
-    "entries": [ { "item": "brown_bread", "container-item": "null", "count": 14 } ]
   },
   {
     "type": "item_group",
@@ -1427,13 +1268,6 @@
         ]
       }
     ]
-  },
-  {
-    "type": "item_group",
-    "id": "bread_wheat_free_bag_plastic_14",
-    "subtype": "collection",
-    "container-item": "bag_plastic",
-    "entries": [ { "item": "bread_wheat_free", "container-item": "null", "components": [ "flour_wheat_free" ], "count": 14 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Food/irradiated.json
+++ b/data/json/itemgroups/Food/irradiated.json
@@ -100,5 +100,33 @@
       { "item": "rhubarb", "prob": 50, "custom-flags": [ "IRRADIATED" ] },
       { "item": "eggplant", "prob": 5, "custom-flags": [ "IRRADIATED" ] }
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "irradiated_lettuce_bag_plastic_5",
+    "subtype": "collection",
+    "container-item": "bag_plastic",
+    "entries": [ { "item": "lettuce", "container-item": "null", "count": 5, "custom-flags": [ "IRRADIATED" ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "irradiated_cabbage_bag_plastic_8",
+    "subtype": "collection",
+    "container-item": "bag_plastic",
+    "entries": [ { "item": "cabbage", "container-item": "null", "count": 8, "custom-flags": [ "IRRADIATED" ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "irradiated_carrot_bag_plastic_6",
+    "subtype": "collection",
+    "container-item": "bag_plastic",
+    "entries": [ { "item": "carrot", "container-item": "null", "count": 6, "custom-flags": [ "IRRADIATED" ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "irradiated_cranberries_bag_plastic_3",
+    "subtype": "collection",
+    "container-item": "bag_plastic",
+    "entries": [ { "item": "cranberries", "container-item": "null", "count": 3, "custom-flags": [ "IRRADIATED" ] } ]
   }
 ]

--- a/data/json/itemgroups/Food/pet_food.json
+++ b/data/json/itemgroups/Food/pet_food.json
@@ -1,0 +1,146 @@
+[
+  {
+    "id": "dog_food_six_pack_box",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "box_medium",
+    "items": [ { "prob": 1, "item": "dogfood", "container-item": "can_medium", "count": [ 1, 6 ] } ]
+  },
+  {
+    "id": "dog_food_six_pack_box_full",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "box_medium",
+    "items": [ { "prob": 1, "item": "dogfood", "container-item": "can_medium", "count": 6 } ]
+  },
+  {
+    "id": "dog_food_six_pack_bag",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "bag_plastic",
+    "items": [ { "prob": 1, "item": "dogfood", "container-item": "can_medium", "count": [ 1, 6 ] } ]
+  },
+  {
+    "id": "dog_food_six_pack_bag_full",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "bag_plastic",
+    "items": [ { "prob": 1, "item": "dogfood", "container-item": "can_medium", "count": 6 } ]
+  },
+  {
+    "id": "dog_food_six_pack",
+    "type": "item_group",
+    "subtype": "distribution",
+    "items": [ { "prob": 1, "group": "dog_food_six_pack_box" }, { "prob": 1, "group": "dog_food_six_pack_bag" } ]
+  },
+  {
+    "id": "dog_food_six_pack_full",
+    "type": "item_group",
+    "subtype": "distribution",
+    "items": [ { "prob": 1, "group": "dog_food_six_pack_box_full" }, { "prob": 1, "group": "dog_food_six_pack_bag_full" } ]
+  },
+  {
+    "id": "dog_food_in_container",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "prob": 1, "group": "dog_food_six_pack" },
+      { "prob": 1, "item": "dogfood_dry", "count": [ 1, 100 ], "entry-wrapper": "bag_garbage" },
+      { "prob": 1, "item": "dogfood_dry", "count": [ 1, 50 ], "entry-wrapper": "bag_garbage" },
+      { "prob": 1, "item": "dogfood_dry", "count": [ 1, 20 ], "entry-wrapper": "bag_plastic" }
+    ]
+  },
+  {
+    "id": "dog_food_in_container_full",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "prob": 1, "group": "dog_food_six_pack_full" },
+      { "prob": 1, "item": "dogfood_dry", "count": 100, "entry-wrapper": "bag_garbage" },
+      { "prob": 1, "item": "dogfood_dry", "count": 50, "entry-wrapper": "bag_garbage" },
+      { "prob": 1, "item": "dogfood_dry", "count": 20, "entry-wrapper": "bag_plastic" }
+    ]
+  },
+  {
+    "id": "cat_food_six_pack_box",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "box_medium",
+    "items": [ { "prob": 1, "item": "catfood", "container-item": "can_medium", "count": [ 1, 6 ] } ]
+  },
+  {
+    "id": "cat_food_six_pack_box_full",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "box_medium",
+    "items": [ { "prob": 1, "item": "catfood", "container-item": "can_medium", "count": 6 } ]
+  },
+  {
+    "id": "cat_food_six_pack_bag",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "bag_plastic",
+    "items": [ { "prob": 1, "item": "catfood", "container-item": "can_food", "count": [ 1, 6 ] } ]
+  },
+  {
+    "id": "cat_food_six_pack_bag_full",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "bag_plastic",
+    "items": [ { "prob": 1, "item": "catfood", "container-item": "can_food", "count": 6 } ]
+  },
+  {
+    "id": "cat_food_six_pack",
+    "type": "item_group",
+    "subtype": "distribution",
+    "items": [ { "prob": 1, "group": "cat_food_six_pack_box" }, { "prob": 1, "group": "cat_food_six_pack_bag" } ]
+  },
+  {
+    "id": "cat_food_six_pack_full",
+    "type": "item_group",
+    "subtype": "distribution",
+    "items": [ { "prob": 1, "group": "cat_food_six_pack_box_full" }, { "prob": 1, "group": "cat_food_six_pack_bag_full" } ]
+  },
+  {
+    "id": "cat_food_in_container",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "prob": 1, "group": "cat_food_six_pack" },
+      { "prob": 1, "item": "catfood_dry", "count": [ 1, 100 ], "entry-wrapper": "bag_garbage" },
+      { "prob": 1, "item": "catfood_dry", "count": [ 1, 50 ], "entry-wrapper": "bag_garbage" },
+      { "prob": 1, "item": "catfood_dry", "count": [ 1, 20 ], "entry-wrapper": "bag_plastic" }
+    ]
+  },
+  {
+    "id": "cat_food_in_container_full",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "prob": 1, "group": "cat_food_six_pack_full" },
+      { "prob": 1, "item": "catfood_dry", "count": 100, "entry-wrapper": "bag_garbage" },
+      { "prob": 1, "item": "catfood_dry", "count": 50, "entry-wrapper": "bag_garbage" },
+      { "prob": 1, "item": "catfood_dry", "count": 20, "entry-wrapper": "bag_plastic" }
+    ]
+  },
+  {
+    "id": "pet_food_in_container",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "prob": 1, "item": "birdfood", "container-item": "bag_plastic", "count": -1 },
+      { "prob": 4, "group": "dog_food_in_container" },
+      { "prob": 4, "group": "cat_food_in_container" }
+    ]
+  },
+  {
+    "id": "pet_food_in_container_full",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "prob": 1, "item": "birdfood", "container-item": "bag_plastic", "count": -1 },
+      { "prob": 4, "group": "dog_food_in_container_full" },
+      { "prob": 4, "group": "cat_food_in_container_full" }
+    ]
+  }
+]

--- a/data/json/itemgroups/Food/preserved.json
+++ b/data/json/itemgroups/Food/preserved.json
@@ -1,0 +1,256 @@
+[
+  {
+    "type": "item_group",
+    "id": "clams_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "can_clams", "entry-wrapper": "can_food", "count": 1 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "salmon_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "can_salmon", "entry-wrapper": "can_food", "count": 1 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "tuna_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "can_tuna", "entry-wrapper": "can_food", "count": 1 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "sardine_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "can_sardine", "entry-wrapper": "can_food", "count": 1 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "lobster_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "lobster_canned", "entry-wrapper": "can_food", "count": 1 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "fish_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "fish_canned", "entry-wrapper": "can_food", "count": 1 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "fruits_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "apple_canned", "entry-wrapper": "can_food", "count": 1 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "chili_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "chili", "entry-wrapper": "can_medium", "count": 2 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "beans_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "can_beans", "entry-wrapper": "can_medium", "count": 2 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "tomatoes_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "can_tomato", "entry-wrapper": "can_medium", "count": 4 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "pork_beans_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "pork_beans", "entry-wrapper": "can_medium", "count": 2 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "chicken_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "can_chicken", "entry-wrapper": "can_medium", "count": 2 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "corn_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "can_corn", "entry-wrapper": "can_medium", "count": 2 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "spam_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "can_spam", "entry-wrapper": "can_medium", "count": 6 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "pineapple_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "can_pineapple", "entry-wrapper": "can_medium", "count": 2 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "coconut_milk_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "can_coconut", "entry-wrapper": "can_medium" } ]
+  },
+  {
+    "type": "item_group",
+    "id": "chowder_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "can_chowder", "entry-wrapper": "can_medium", "count": 2 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "ravioli_in_can",
+    "subtype": "distribution",
+    "entries": [ { "item": "ravioli", "entry-wrapper": "can_medium", "count": 2 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "salsa_jar_glass_sealed_1_inf",
+    "subtype": "collection",
+    "container-item": "jar_glass_sealed",
+    "entries": [ { "item": "salsa", "container-item": "null", "count": [ 1, -1 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "veggy_pickled_jar_glass_sealed_1_inf",
+    "subtype": "collection",
+    "container-item": "jar_glass_sealed",
+    "entries": [ { "item": "veggy_pickled", "container-item": "null", "count": [ 1, -1 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "veggy_pickled_jar_glass_sealed_2",
+    "subtype": "collection",
+    "container-item": "jar_glass_sealed",
+    "entries": [ { "item": "veggy_pickled", "container-item": "null", "count": 2 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "sauerkraut_jar_glass_sealed_1_inf",
+    "subtype": "collection",
+    "container-item": "jar_glass_sealed",
+    "entries": [ { "item": "sauerkraut", "container-item": "null", "count": [ 1, -1 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "sauerkraut_jar_glass_sealed_2",
+    "subtype": "collection",
+    "container-item": "jar_glass_sealed",
+    "entries": [ { "item": "sauerkraut", "container-item": "null", "count": 2 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "meat_pickled_jar_glass_sealed_1_inf",
+    "subtype": "collection",
+    "container-item": "jar_glass_sealed",
+    "entries": [ { "item": "meat_pickled", "container-item": "null", "count": [ 1, -1 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "meat_pickled_jar_glass_sealed_2",
+    "subtype": "collection",
+    "container-item": "jar_glass_sealed",
+    "entries": [ { "item": "meat_pickled", "container-item": "null", "count": 2 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "offal_pickled_jar_glass_sealed_2",
+    "subtype": "collection",
+    "container-item": "jar_glass_sealed",
+    "entries": [ { "item": "offal_pickled", "container-item": "null", "count": 2 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "fish_pickled_jar_glass_sealed_1_inf",
+    "subtype": "collection",
+    "container-item": "jar_glass_sealed",
+    "entries": [ { "item": "fish_pickled", "container-item": "null", "count": [ 1, -1 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "fish_pickled_jar_glass_sealed_2",
+    "subtype": "collection",
+    "container-item": "jar_glass_sealed",
+    "entries": [ { "item": "fish_pickled", "container-item": "null", "count": 2 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "can_herring_jar_glass_sealed_2",
+    "subtype": "collection",
+    "container-item": "jar_glass_sealed",
+    "entries": [ { "item": "can_herring", "container-item": "null", "count": 2 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "pickle_jar_glass_sealed_1_inf",
+    "subtype": "collection",
+    "container-item": "jar_glass_sealed",
+    "entries": [ { "item": "pickle", "count": [ 1, -1 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "pickle_jar_glass_sealed_2",
+    "subtype": "collection",
+    "container-item": "jar_glass_sealed",
+    "entries": [ { "item": "pickle", "count": 2 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "meat_canned_jar_3l_glass_sealed_12",
+    "subtype": "collection",
+    "container-item": "jar_3l_glass_sealed",
+    "entries": [ { "item": "meat_canned", "container-item": "null", "count": 12 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "confit_meat_jar_3l_glass_sealed_12",
+    "subtype": "collection",
+    "container-item": "jar_3l_glass_sealed",
+    "entries": [ { "item": "confit_meat", "container-item": "null", "count": 12 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "veggy_canned_jar_3l_glass_sealed_12",
+    "subtype": "collection",
+    "container-item": "jar_3l_glass_sealed",
+    "entries": [ { "item": "veggy_canned", "container-item": "null", "count": 12 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "fruits_in_3l_jar",
+    "subtype": "distribution",
+    "entries": [ { "item": "apple_canned", "entry-wrapper": "jar_3l_glass_sealed", "count": 24 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "can_tomato_jar_3l_glass_sealed_24",
+    "subtype": "collection",
+    "container-item": "jar_3l_glass_sealed",
+    "entries": [ { "item": "can_tomato", "container-item": "null", "count": 24 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "fish_pickled_jar_3l_glass_sealed_12",
+    "subtype": "collection",
+    "container-item": "jar_3l_glass_sealed",
+    "entries": [ { "item": "fish_pickled", "container-item": "null", "count": 12 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "meat_pickled_jar_3l_glass_sealed_12",
+    "subtype": "collection",
+    "container-item": "jar_3l_glass_sealed",
+    "entries": [ { "item": "meat_pickled", "container-item": "null", "count": 12 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "veggy_pickled_jar_3l_glass_sealed_12",
+    "subtype": "collection",
+    "container-item": "jar_3l_glass_sealed",
+    "entries": [ { "item": "veggy_pickled", "container-item": "null", "count": 12 } ]
+  }
+]

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -2130,13 +2130,6 @@
   },
   {
     "type": "item_group",
-    "id": "antifungal_bottle_plastic_pill_prescription_1_10",
-    "subtype": "collection",
-    "container-item": "bottle_plastic_pill_prescription",
-    "entries": [ { "item": "antifungal", "container-item": "null", "count": [ 1, 10 ] } ]
-  },
-  {
-    "type": "item_group",
     "id": "cattlefodder_bag_canvas_50",
     "subtype": "collection",
     "container-item": "bag_canvas",

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -1220,20 +1220,6 @@
   },
   {
     "type": "item_group",
-    "id": "adderall_bottle_plastic_pill_prescription_1",
-    "subtype": "collection",
-    "container-item": "bottle_plastic_pill_prescription",
-    "entries": [ { "item": "adderall", "container-item": "null" } ]
-  },
-  {
-    "type": "item_group",
-    "id": "weak_antibiotic_bottle_plastic_pill_prescription_1",
-    "subtype": "collection",
-    "container-item": "bottle_plastic_pill_prescription",
-    "entries": [ { "item": "weak_antibiotic", "container-item": "null" } ]
-  },
-  {
-    "type": "item_group",
     "id": "garlic_powder_various",
     "subtype": "distribution",
     "entries": [

--- a/data/json/itemgroups/SUS/fridges.json
+++ b/data/json/itemgroups/SUS/fridges.json
@@ -1066,52 +1066,10 @@
   },
   {
     "type": "item_group",
-    "id": "salsa_jar_glass_sealed_1_inf",
-    "subtype": "collection",
-    "container-item": "jar_glass_sealed",
-    "entries": [ { "item": "salsa", "container-item": "null", "count": [ 1, -1 ] } ]
-  },
-  {
-    "type": "item_group",
     "id": "butter_wrapper_32",
     "subtype": "collection",
     "container-item": "wrapper",
     "entries": [ { "item": "butter", "container-item": "null", "count": 32 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "sauerkraut_jar_glass_sealed_1_inf",
-    "subtype": "collection",
-    "container-item": "jar_glass_sealed",
-    "entries": [ { "item": "sauerkraut", "container-item": "null", "count": [ 1, -1 ] } ]
-  },
-  {
-    "type": "item_group",
-    "id": "pickle_jar_glass_sealed_1_inf",
-    "subtype": "collection",
-    "container-item": "jar_glass_sealed",
-    "entries": [ { "item": "pickle", "count": [ 1, -1 ] } ]
-  },
-  {
-    "type": "item_group",
-    "id": "meat_pickled_jar_glass_sealed_1_inf",
-    "subtype": "collection",
-    "container-item": "jar_glass_sealed",
-    "entries": [ { "item": "meat_pickled", "container-item": "null", "count": [ 1, -1 ] } ]
-  },
-  {
-    "type": "item_group",
-    "id": "fish_pickled_jar_glass_sealed_1_inf",
-    "subtype": "collection",
-    "container-item": "jar_glass_sealed",
-    "entries": [ { "item": "fish_pickled", "container-item": "null", "count": [ 1, -1 ] } ]
-  },
-  {
-    "type": "item_group",
-    "id": "veggy_pickled_jar_glass_sealed_1_inf",
-    "subtype": "collection",
-    "container-item": "jar_glass_sealed",
-    "entries": [ { "item": "veggy_pickled", "container-item": "null", "count": [ 1, -1 ] } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -1634,67 +1634,6 @@
   },
   {
     "type": "item_group",
-    "id": "beans_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "can_beans", "entry-wrapper": "can_medium", "count": 2 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "tomatoes_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "can_tomato", "entry-wrapper": "can_medium", "count": 4 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "pork_beans_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "pork_beans", "entry-wrapper": "can_medium", "count": 2 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "chicken_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "can_chicken", "entry-wrapper": "can_medium", "count": 2 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "corn_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "can_corn", "entry-wrapper": "can_medium", "count": 2 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "spam_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "can_spam", "entry-wrapper": "can_medium", "count": 6 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "pineapple_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "can_pineapple", "entry-wrapper": "can_medium", "count": 2 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "coconut_milk_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "can_coconut", "entry-wrapper": "can_medium" } ]
-  },
-  {
-    "type": "item_group",
-    "id": "chowder_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "can_chowder", "entry-wrapper": "can_medium", "count": 2 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "can_herring_jar_glass_sealed_2",
-    "subtype": "collection",
-    "container-item": "jar_glass_sealed",
-    "entries": [ { "item": "can_herring", "container-item": "null", "count": 2 } ]
-  },
-  {
-    "type": "item_group",
     "id": "curry_powder_various",
     "subtype": "distribution",
     "entries": [
@@ -1852,84 +1791,6 @@
   },
   {
     "type": "item_group",
-    "id": "ravioli_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "ravioli", "entry-wrapper": "can_medium", "count": 2 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "sourdough_bread_in_bag",
-    "subtype": "collection",
-    "entries": [ { "item": "sourdough_bread", "entry-wrapper": "bag_plastic", "count": [ 1, 14 ] } ]
-  },
-  {
-    "type": "item_group",
-    "id": "sourdough_bread_in_bag_full",
-    "subtype": "collection",
-    "entries": [ { "item": "sourdough_bread", "entry-wrapper": "bag_plastic", "count": 14 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "bread_in_bag",
-    "subtype": "collection",
-    "entries": [ { "item": "bread", "entry-wrapper": "bag_plastic", "count": [ 1, 14 ] } ]
-  },
-  {
-    "type": "item_group",
-    "id": "bread_in_bag_full",
-    "subtype": "collection",
-    "entries": [ { "item": "bread", "entry-wrapper": "bag_plastic", "count": 14 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "garlic_bread_in_bag",
-    "subtype": "collection",
-    "entries": [ { "item": "bread_garlic", "entry-wrapper": "bag_plastic_small", "count": [ 1, 8 ] } ]
-  },
-  {
-    "type": "item_group",
-    "id": "garlic_bread_in_bag_full",
-    "subtype": "collection",
-    "entries": [ { "item": "bread_garlic", "entry-wrapper": "bag_plastic_small", "count": 8 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "frybread_in_bag",
-    "subtype": "collection",
-    "entries": [ { "item": "frybread", "entry-wrapper": "bag_plastic_small", "count": [ 1, 8 ] } ]
-  },
-  {
-    "type": "item_group",
-    "id": "frybread_in_bag_full",
-    "subtype": "collection",
-    "entries": [ { "item": "frybread", "entry-wrapper": "bag_plastic_small", "count": 8 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "cornbread_in_bag",
-    "subtype": "collection",
-    "entries": [ { "item": "cornbread", "entry-wrapper": "bag_plastic_small", "count": [ 1, 8 ] } ]
-  },
-  {
-    "type": "item_group",
-    "id": "cornbread_in_bag_full",
-    "subtype": "collection",
-    "entries": [ { "item": "cornbread", "entry-wrapper": "bag_plastic_small", "count": 8 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "flatbread_in_bag",
-    "subtype": "collection",
-    "entries": [ { "item": "flatbread", "entry-wrapper": "bag_plastic_small", "count": [ 1, 8 ] } ]
-  },
-  {
-    "type": "item_group",
-    "id": "flatbread_in_bag_full",
-    "subtype": "collection",
-    "entries": [ { "item": "flatbread", "entry-wrapper": "bag_plastic_small", "count": 8 } ]
-  },
-  {
-    "type": "item_group",
     "id": "crackers_box_small_full",
     "subtype": "collection",
     "container-item": "box_small",
@@ -1961,82 +1822,6 @@
     "id": "cheese_in_can",
     "subtype": "distribution",
     "entries": [ { "item": "can_cheese", "entry-wrapper": "can_food", "count": 8 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "veggy_pickled_jar_glass_sealed_2",
-    "subtype": "collection",
-    "container-item": "jar_glass_sealed",
-    "entries": [ { "item": "veggy_pickled", "container-item": "null", "count": 2 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "sauerkraut_jar_glass_sealed_2",
-    "subtype": "collection",
-    "container-item": "jar_glass_sealed",
-    "entries": [ { "item": "sauerkraut", "container-item": "null", "count": 2 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "meat_pickled_jar_glass_sealed_2",
-    "subtype": "collection",
-    "container-item": "jar_glass_sealed",
-    "entries": [ { "item": "meat_pickled", "container-item": "null", "count": 2 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "fish_pickled_jar_glass_sealed_2",
-    "subtype": "collection",
-    "container-item": "jar_glass_sealed",
-    "entries": [ { "item": "fish_pickled", "container-item": "null", "count": 2 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "meat_canned_jar_3l_glass_sealed_12",
-    "subtype": "collection",
-    "container-item": "jar_3l_glass_sealed",
-    "entries": [ { "item": "meat_canned", "container-item": "null", "count": 12 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "veggy_canned_jar_3l_glass_sealed_12",
-    "subtype": "collection",
-    "container-item": "jar_3l_glass_sealed",
-    "entries": [ { "item": "veggy_canned", "container-item": "null", "count": 12 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "fruits_in_3l_jar",
-    "subtype": "distribution",
-    "entries": [ { "item": "apple_canned", "entry-wrapper": "jar_3l_glass_sealed", "count": 24 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "can_tomato_jar_3l_glass_sealed_24",
-    "subtype": "collection",
-    "container-item": "jar_3l_glass_sealed",
-    "entries": [ { "item": "can_tomato", "container-item": "null", "count": 24 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "fish_pickled_jar_3l_glass_sealed_12",
-    "subtype": "collection",
-    "container-item": "jar_3l_glass_sealed",
-    "entries": [ { "item": "fish_pickled", "container-item": "null", "count": 12 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "meat_pickled_jar_3l_glass_sealed_12",
-    "subtype": "collection",
-    "container-item": "jar_3l_glass_sealed",
-    "entries": [ { "item": "meat_pickled", "container-item": "null", "count": 12 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "veggy_pickled_jar_3l_glass_sealed_12",
-    "subtype": "collection",
-    "container-item": "jar_3l_glass_sealed",
-    "entries": [ { "item": "veggy_pickled", "container-item": "null", "count": 12 } ]
   },
   {
     "type": "item_group",
@@ -2072,27 +1857,6 @@
   },
   {
     "type": "item_group",
-    "id": "irradiated_lettuce_bag_plastic_5",
-    "subtype": "collection",
-    "container-item": "bag_plastic",
-    "entries": [ { "item": "lettuce", "container-item": "null", "count": 5, "custom-flags": [ "IRRADIATED" ] } ]
-  },
-  {
-    "type": "item_group",
-    "id": "irradiated_cabbage_bag_plastic_8",
-    "subtype": "collection",
-    "container-item": "bag_plastic",
-    "entries": [ { "item": "cabbage", "container-item": "null", "count": 8, "custom-flags": [ "IRRADIATED" ] } ]
-  },
-  {
-    "type": "item_group",
-    "id": "irradiated_carrot_bag_plastic_6",
-    "subtype": "collection",
-    "container-item": "bag_plastic",
-    "entries": [ { "item": "carrot", "container-item": "null", "count": 6, "custom-flags": [ "IRRADIATED" ] } ]
-  },
-  {
-    "type": "item_group",
     "id": "frozen_dinner_box_small_2",
     "subtype": "collection",
     "container-item": "box_small",
@@ -2100,30 +1864,10 @@
   },
   {
     "type": "item_group",
-    "id": "chili_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "chili", "entry-wrapper": "can_medium", "count": 2 } ]
-  },
-  {
-    "type": "item_group",
     "id": "blt_wrapper_2",
     "subtype": "collection",
     "container-item": "wrapper",
     "entries": [ { "item": "blt", "container-item": "null", "count": 2 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "irradiated_cranberries_bag_plastic_3",
-    "subtype": "collection",
-    "container-item": "bag_plastic",
-    "entries": [ { "item": "cranberries", "container-item": "null", "count": 3, "custom-flags": [ "IRRADIATED" ] } ]
-  },
-  {
-    "type": "item_group",
-    "id": "pickle_jar_glass_sealed_2",
-    "subtype": "collection",
-    "container-item": "jar_glass_sealed",
-    "entries": [ { "item": "pickle", "count": 2 } ]
   },
   {
     "type": "item_group",
@@ -2160,47 +1904,5 @@
         ]
       }
     ]
-  },
-  {
-    "type": "item_group",
-    "id": "clams_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "can_clams", "entry-wrapper": "can_food", "count": 1 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "salmon_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "can_salmon", "entry-wrapper": "can_food", "count": 1 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "tuna_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "can_tuna", "entry-wrapper": "can_food", "count": 1 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "sardine_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "can_sardine", "entry-wrapper": "can_food", "count": 1 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "lobster_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "lobster_canned", "entry-wrapper": "can_food", "count": 1 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "fish_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "fish_canned", "entry-wrapper": "can_food", "count": 1 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "fruits_in_can",
-    "subtype": "distribution",
-    "entries": [ { "item": "apple_canned", "entry-wrapper": "can_food", "count": 1 } ]
   }
 ]

--- a/data/json/itemgroups/food_service.json
+++ b/data/json/itemgroups/food_service.json
@@ -2469,18 +2469,6 @@
   },
   {
     "type": "item_group",
-    "id": "brown_bread_in_bag",
-    "subtype": "collection",
-    "entries": [ { "item": "brown_bread", "entry-wrapper": "bag_plastic", "count": [ 0, 10 ] } ]
-  },
-  {
-    "type": "item_group",
-    "id": "brown_bread_in_bag_full",
-    "subtype": "collection",
-    "entries": [ { "item": "brown_bread", "entry-wrapper": "bag_plastic", "count": 10 } ]
-  },
-  {
-    "type": "item_group",
     "id": "brioche_box_small_6",
     "subtype": "collection",
     "container-item": "box_small",
@@ -2844,13 +2832,6 @@
     "subtype": "collection",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "PBJ_Toast", "container-item": "null", "count": 2 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "offal_pickled_jar_glass_sealed_2",
-    "subtype": "collection",
-    "container-item": "jar_glass_sealed",
-    "entries": [ { "item": "offal_pickled", "container-item": "null", "count": 2 } ]
   },
   {
     "type": "item_group",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Continuation of #87033
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Drug sorting is now completed.
2. There are a lot of itemgroups for food, so they've been split into `bread.json`, `preserved.json`, and `pet_food.json` for now.
3. One itemgroup referenced an obsolete item `bread_wheat_free`, which was being silently migrated to `bread` with a different component. I replaced it with `bread`.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Using a script, I verified that the itemgroups match their state before the changes. The game loads without errors. The modified itemgroup correctly spawns bread made with wheat-free flour.
<img width="955" height="655" alt="bread" src="https://github.com/user-attachments/assets/6603a8d8-576e-41f3-b39d-e7636fa15b47" />
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
