### PR TITLE
Fix crash on shutdown

### DIFF
--- a/src/third-party/imgui/imgui.h
+++ b/src/third-party/imgui/imgui.h
@@ -3536,7 +3536,7 @@ struct ImFont
 
     // Methods
     IMGUI_API ImFont();
-    virtual IMGUI_API ~ImFont();
+    IMGUI_API ~ImFont();
     IMGUI_API ImFontGlyph*      FindGlyph(ImWchar c);
     IMGUI_API ImFontGlyph*      FindGlyphNoFallback(ImWchar c);
     float                       GetCharAdvance(ImWchar c) const;


### PR DESCRIPTION
This `virtual` is incompatible with the `memset` in `ImFont::ImFont()`.

#### Summary
Bugfixes "Fix crash on shutdown"

#### Purpose of change

Fix crash during shutdown.

#### Describe the solution

`ImFont::ImFont()` constructor runs `memset(this, 0, sizeof(*this));`. This clears the vptr (pointer from object to its class-specific list of methods). When deallocating an `ImFont`, the destructor tries to run - but because it's a _virtual_ destructor (allowing subclassing and chained destructors), we need to look up the particular destructor via vtable, which is behind vptr, which is zeroed out with `memset`, leading to a segfault.

#### Describe alternatives you've considered

Another way to fix this would be to change the `memset` in constructor into something else - NSDMI `= 0`, for example.

#### Testing

None :)

#### Additional context

Also none