### PR TITLE
Fix typo in Hard Target book description

### DIFF
--- a/data/json/items/book/dodge.json
+++ b/data/json/items/book/dodge.json
@@ -145,7 +145,7 @@
       {
         "id": "book_nonf_hard_dodge_tlwd_1",
         "name": { "str": "A Guide To Making Yourself A Hard Target", "str_pl": "copies of A Guide To Making Yourself A Hard Target" },
-        "description": "Written by self-defense instructor Neal Martin, this book describe techniques and movesets you need to train to avoid being a victim, as well as avoid trouble with the law in the aftermath.",
+        "description": "Written by self-defense instructor Neal Martin, this book describes techniques and movesets you need to train to avoid being a victim, as well as avoid trouble with the law in the aftermath.",
         "//": "979-8620742561"
       },
       {


### PR DESCRIPTION

#### Summary
Bugfixes "Fix typo in Hard Target book description"

#### Purpose of change
Fixes #87068 which describes this minor grammatical error.

#### Describe the solution
Changed “describe” to “describes” in the book description text.

#### Describe alternatives you've considered
None

#### Testing
Loaded up a Debug character and verified the item description changed in the item spawning menu.

#### Additional context
None
