### PR TITLE
Remove dangerous pickups option

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -698,6 +698,17 @@
   },
   {
     "type": "effect_type",
+    "id": "overburdened",
+    "name": [ "Overburdened" ],
+    "desc": [ "You strain to move with all you're carrying." ],
+    "//COMMENT": "This has no apply message because there's an existing application message in Pickup::do_pickup().",
+    "//COMMENT2": "You're carrying too much and are overburdened!",
+    "rating": "bad",
+    "show_in_info": true,
+    "flags": [ "DISABLE_FLIGHT" ]
+  },
+  {
+    "type": "effect_type",
     "id": "assisted",
     "name": [ "Assisted" ],
     "max_intensity": 1000,

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -35,6 +35,7 @@
 #include "butchery_requirements.h"
 #include "cached_options.h"
 #include "calendar.h"
+#include "cata_assert.h"
 #include "cata_utility.h"
 #include "character.h"
 #include "character_id.h"
@@ -3086,6 +3087,8 @@ void pickup_activity_actor::do_turn( player_activity &, Character &who )
         return;
     }
 
+    // Pickup::do_pickup() actively assumes the player. Calling it with anyone else is a mistake.
+    cata_assert( &who == &get_player_character() );
     // False indicates that the player canceled pickup when met with some prompt
     const bool keep_going = Pickup::do_pickup( target_items, quantities, autopickup,
                             stash_successful, info );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -334,7 +334,7 @@ static std::vector<item_location> try_to_put_into_vehicle( Character &c, item_dr
             //~ %1$s is item name, %2$s is vehicle name, %3$s is vehicle part name
             add_msg( m_mixed, _( "Unable to fit %1$s in the %2$s's %3$s." ), it.tname(), veh.name, part_name );
             // Retain item in inventory if overflow not too large/heavy or wield if possible otherwise drop on the ground
-            if( c.can_pickVolume( it ) && c.can_pickWeight( it, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
+            if( c.can_pickVolume( it ) && c.can_pickWeight( it, false ) ) {
                 result.push_back( c.i_add( it ) );
             } else if( !c.has_wield_conflicts( it ) && c.can_wield( it ).success() ) {
                 c.wield( it );

--- a/src/character.h
+++ b/src/character.h
@@ -2343,7 +2343,7 @@ class Character : public Creature, public visitable
                                                 &locations ) const;
         units::mass weight_capacity() const override;
 
-        /* maximum you should ever be able to pick up ( i.e. with DANGEROUS_PICKUPS enabled) */
+        /* maximum you should ever be able to pick up */
         units::mass max_pickup_capacity() const;
         // total capacity of pockets in the player's top level of inventory.
         // bags-of-holding aside, this is the max volume the character can carry without changing what they're wearing/wielding.

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -59,7 +59,6 @@
 #include "monster.h"
 #include "morale.h"
 #include "mtype.h"
-#include "options.h"
 #include "overmapbuffer.h"
 #include "pickup.h"
 #include "pimpl.h"
@@ -579,7 +578,7 @@ bool Character::i_add_or_drop( item &it, int qty, const item *avoid,
     inv->assign_empty_invlet( it, *this );
     map &here = get_map();
     for( int i = 0; i < qty; ++i ) {
-        drop |= !can_pickWeight( it, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) || !can_pickVolume( it );
+        drop |= !can_pickWeight( it, false ) || !can_pickVolume( it );
         if( drop ) {
             retval &= !here.add_item_or_charges( pos_bub(), it ).is_null();
             if( !retval ) {
@@ -2403,7 +2402,7 @@ bool Character::add_or_drop_with_msg( item &it, const bool /*unloading*/, const 
     }
     if( !this->can_pickVolume( it, false, avoid ) ) {
         put_into_vehicle_or_drop( *this, item_drop_reason::too_large, { it } );
-    } else if( !this->can_pickWeight( it, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
+    } else if( !this->can_pickWeight( it, false ) ) {
         put_into_vehicle_or_drop( *this, item_drop_reason::too_heavy, { it } );
     } else {
         bool wielded_has_it = false;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -801,7 +801,7 @@ static item_location set_item_inventory( Character &p, item &newit )
         // We might not have space for the item
         if( !p.can_pickVolume( newit ) ) { //Accounts for result_mult
             put_into_vehicle_or_drop( p, item_drop_reason::too_large, { newit } );
-        } else if( !p.can_pickWeight( newit, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
+        } else if( !p.can_pickWeight( newit, false ) ) {
             put_into_vehicle_or_drop( p, item_drop_reason::too_heavy, { newit } );
         } else {
             ret_val = p.i_add( newit );
@@ -965,7 +965,7 @@ static item_location place_craft_or_disassembly(
                             '1', _( "Dispose of your wielded %s and start working." ), ch.get_wielded_item()->tname() );
             amenu.addentry( DROP_CRAFT, true, '2', _( "Put it down and start working." ) );
             const bool can_stash = ch.can_pickVolume( craft ) &&
-                                   ch.can_pickWeight( craft, !get_option<bool>( "DANGEROUS_PICKUPS" ) );
+                                   ch.can_pickWeight( craft, false );
             amenu.addentry( STASH, can_stash, '3', _( "Store it in your inventory." ) );
             amenu.addentry( DROP, true, '4', _( "Drop it on the ground." ) );
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -609,7 +609,7 @@ class pickup_inventory_preset : public inventory_selector_preset
                 } else if( !you.can_pickVolume_partial( *loc, false, nullptr, false, true ) &&
                            ( skip_wield_check || you.has_wield_conflicts( *loc ) ) ) {
                     return _( "Does not fit in any pocket!" );
-                } else if( !you.can_pickWeight_partial( *loc, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
+                } else if( !you.can_pickWeight_partial( *loc, false ) ) {
                     return _( "Too heavy to pick up!" );
                 }
             }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2317,7 +2317,7 @@ void iexamine_helper::handle_harvest( Character &you, const itype_id &itemid, bo
             }
         }
     } else if( !force_drop && you.can_pickVolume( harvest, true ) &&
-               you.can_pickWeight( harvest, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
+               you.can_pickWeight( harvest, false ) ) {
         you.i_add( harvest );
         you.add_msg_if_player( _( "You harvest: %s." ), harvest.tname() );
         you.add_msg_if_npc( _( "<npcname> harvests: %s." ), harvest.tname() );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1577,11 +1577,6 @@ void options_manager::add_options_general()
     add_option_group( "general", Group( "player_safe_opts", to_translation( "Player safety options" ),
                                         to_translation( "Options regarding player safety." ) ),
     [&]( const std::string & page_id ) {
-        add( "DANGEROUS_PICKUPS", page_id, to_translation( "Dangerous pickups" ),
-             to_translation( "If true, will allow player to pick new items, even if it causes them to exceed the weight limit." ),
-             false
-           );
-
         add( "DANGEROUS_TERRAIN_WARNING_PROMPT", page_id,
              to_translation( "Dangerous terrain warning prompt" ),
              to_translation( "Always: You will be prompted to move onto dangerous tiles.  Running: You will only be able to move onto dangerous tiles while running and will be prompted.  Crouching: You will only be able to move onto a dangerous tile while crouching and will be prompted.  Never:  You will not be able to move onto a dangerous tile unless running and will not be warned or prompted." ),

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -97,6 +97,7 @@ static const efftype_id effect_mending( "mending" );
 static const efftype_id effect_narcosis( "narcosis" );
 static const efftype_id effect_nausea( "nausea" );
 static const efftype_id effect_onfire( "onfire" );
+static const efftype_id effect_overburdened( "overburdened" );
 static const efftype_id effect_shakes( "shakes" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_sunscreen( "sunscreen" );
@@ -455,11 +456,18 @@ void suffer::from_addictions( Character &you )
 
 void suffer::while_awake( Character &you, const int current_stim )
 {
+    // The purpose of reapplying the effects for 2 turns is to prevent the application message from appearing every turn.
     if( you.weight_carried() > you.max_pickup_capacity() ) {
         if( you.has_effect( effect_downed ) ) {
             you.add_effect( effect_downed, 1_turns, false, 0, true );
         } else {
             you.add_effect( effect_downed, 2_turns, false, 0, true );
+        }
+    } else if( you.weight_carried() > you.weight_capacity() ) {
+        if( you.has_effect( effect_overburdened ) ) {
+            you.add_effect( effect_overburdened, 1_turns, false, 0, true );
+        } else {
+            you.add_effect( effect_overburdened, 2_turns, false, 0, true );
         }
     }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
This option bedevils new players... "How do I pick up something *I can carry*?". The answer is go to the options menu and turn this option *on*. Then to leave the option on forever and forget about it.

In some roguelikes, you can be harmed by carrying over your unburdened capacity. Not here.

Previously (at some point?) you would receive pain for carrying over your unburdened capacity. Not here.

#### Describe the solution
You can always go above your unburdened capacity. No need to mess with the options.

The game already warns you when picking up. I have added a `overburdened` status effect to better convey this to players looking at their status screen. There is also an existing weight display in most sidebars which turns red when overburdened.

I believe all of these are sufficient to warn a player that is loading themselves down with tons of crap.

#### Describe alternatives you've considered
The existing penalties for going past unburdened are quite minor - the significant one is extra stamina burn every turn of movement. The speed penalty is comical, I had a 8/8/8/8(pure average) character deadlifting 150kgs of metal ingots and still moving at 43 speed. These likely need to be revisited in the future, regardless of whether this option exists.

#### Testing
Loaded myself up with crap, walked around, checked to make sure everything was working. Found that overburdened was applied correctly, stamina burn and speed scaling were the same as before (as intended).

#### Additional context

