### PR TITLE
Clamp overmap sidebar to actual screen

### DIFF
--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -465,9 +465,10 @@ cataimgui::bounds overmap_sidebar::get_bounds()
     // old-school terminal emulation, even though the overmap tiles
     // are a different size entirely.
     float width = static_cast<float>( OVERMAP_LEGEND_WIDTH ) * character_cell_width;
-    return { viewport.x - width,
+    float window_x_position = viewport.x - width;
+    return { window_x_position,
              0,
-             viewport.x,
+             viewport.x - window_x_position,
              viewport.y
            };
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #86963

#### Describe the solution
The overmap sidebar was drawing a screen-sized window, starting 80% of the way across the screen. This resulted in 80% of its window being off-screen, always.

Clamped it, so that the window never goes off-screen.

#### Describe alternatives you've considered
We don't have any windows that want to go off-screen right now so maybe we should do this clamping in cataimgui::window::draw().

#### Testing
I replaced the string `"Press %s to preview direct route."` with `"Press %s to preview direct route. aaaaa aaaaa aaaaa aaaaa aaaaa aaaaa aaaaa aaaaa aaaaa aaaaa "`. This causes it to be wider than the available width even on my 1440p monitor. This image shows it properly breaking in the middle of the `aaaaa`s.
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/6ad8855c-a646-4daf-a507-2378e9e00837" />


#### Additional context
