### PR TITLE
`replaced_bodyparts` field for bionics and infrastructure for automatically removing dependent bionics when removing a bionic limb

### DIFF
--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -1323,6 +1323,7 @@ mod = min( max, ( limb_score / denominator ) - subtract );
 | `known_ma_styles`            | (_optional_) A list of martial art styles that are known to the wearer when the bionic is activated
 | `canceled_mutations`         | (_optional_) A list of mutations/traits that are removed when this bionic is installed (e.g. because it replaces the fault biological part).
 | `mutation_conflicts`         | (_optional_) A list of mutations that prevent this bionic from being installed.
+| `bionics_conflicts`          | (_optional_) A list of bionics that prevent this bionic from being installed.
 | `included_bionics`           | (_optional_) Additional bionics that are installed automatically when this bionic is installed. This can be used to install several bionics from one CBM item, which is useful as each of those can be activated independently.
 | `included`                   | (_optional_) Whether this bionic is included with another. If true this bionic does not require a CBM item to be defined. (default: `false`)
 | `env_protec`                 | (_optional_) How much environmental protection does this bionic provide on the specified body parts.

--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -1328,7 +1328,7 @@ mod = min( max, ( limb_score / denominator ) - subtract );
 | `env_protec`                 | (_optional_) How much environmental protection does this bionic provide on the specified body parts.
 | `protec`                     | (_optional_) An array of resistance values that determines the types of protection this bionic provides on the specified body parts.
 | `occupied_bodyparts`         | (_optional_) A list of body parts occupied by this bionic, and the number of bionic slots it take on those parts.
-| `replaced_bodyparts`         | (_optional_) A list of body parts completely replaced by this bionic. Accepts an array of bodyparts like occupied_bodyparts.
+| `replaced_bodyparts`         | (_optional_) A list of body parts completely replaced by this bionic. Accepts an array of bodypart ids.  When removing a bionic, any dependent bionic with an occupied_bodyparts entry matching a replaced_bodyparts entry will also be removed.
 | `capacity`                   | (_optional_) Amount of power storage added by this bionic.  Strings can be used "1 kJ"/"1000 J"/"1000000 mJ" (default: `0`)
 | `fuel_options`               | (_optional_) A list of materials that this bionic can use to produce bionic power.
 | `is_remote_fueled`           | (_optional_) If true this bionic allows you to plug your power banks to an external power source (solar backpack, UPS, vehicle etc) via a cable. (default: `false`)

--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -1323,12 +1323,12 @@ mod = min( max, ( limb_score / denominator ) - subtract );
 | `known_ma_styles`            | (_optional_) A list of martial art styles that are known to the wearer when the bionic is activated
 | `canceled_mutations`         | (_optional_) A list of mutations/traits that are removed when this bionic is installed (e.g. because it replaces the fault biological part).
 | `mutation_conflicts`         | (_optional_) A list of mutations that prevent this bionic from being installed.
-| `bionics_conflicts`          | (_optional_) A list of bionics that prevent this bionic from being installed.
 | `included_bionics`           | (_optional_) Additional bionics that are installed automatically when this bionic is installed. This can be used to install several bionics from one CBM item, which is useful as each of those can be activated independently.
 | `included`                   | (_optional_) Whether this bionic is included with another. If true this bionic does not require a CBM item to be defined. (default: `false`)
 | `env_protec`                 | (_optional_) How much environmental protection does this bionic provide on the specified body parts.
 | `protec`                     | (_optional_) An array of resistance values that determines the types of protection this bionic provides on the specified body parts.
 | `occupied_bodyparts`         | (_optional_) A list of body parts occupied by this bionic, and the number of bionic slots it take on those parts.
+| `replaced_bodyparts`         | (_optional_) A list of body parts completely replaced by this bionic. Accepts an array of bodyparts like occupied_bodyparts.
 | `capacity`                   | (_optional_) Amount of power storage added by this bionic.  Strings can be used "1 kJ"/"1000 J"/"1000000 mJ" (default: `0`)
 | `fuel_options`               | (_optional_) A list of materials that this bionic can use to produce bionic power.
 | `is_remote_fueled`           | (_optional_) If true this bionic allows you to plug your power banks to an external power source (solar backpack, UPS, vehicle etc) via a cable. (default: `false`)

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2261,8 +2261,17 @@ void Character::perform_uninstall( const bionic &bio, int difficulty, int succes
         }
         
         for( const bionic &dependent : dependent_bionics ) {
+            if (!find_bionic_by_uid( dependent.get_uid() ) ) {
+                continue;
+            }
             add_msg( m_neutral, _( "%s removed with %s." ), dependent.id->name.translated(), bio_id->name.translated() );
+            get_event_bus().send<event_type::removes_cbm>( getID(), dependent.id );
             remove_bionic( dependent );
+            for( const trait_id &mid : dependent.id->give_mut_on_removal ) {
+                if( !has_trait( mid ) ) {
+                    set_mutation( mid );
+                }
+            }
             item dependent_cbm( itype_burnt_out_bionic );
             if( item::type_is_defined( dependent.id->itype() ) ) {
                 dependent_cbm = item( dependent.id->itype() );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2351,11 +2351,11 @@ ret_val<void> Character::is_installable( const item *it, const bool by_autodoc )
                 bionics.push_back( b->name.translated() );
             }
         }
-        
-        if ( !bionics.empty() ) {
+
+        if( !bionics.empty() ) {
             return ret_val<void>::make_failure( _( "CBM conflicts with: %s." ), string_join( bionics, ", " ) );
         }
-        
+
     } else if( bid->upgraded_bionic &&
                !has_bionic( bid->upgraded_bionic ) &&
                it->is_upgrade() ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -344,7 +344,7 @@ void bionic_data::load( const JsonObject &jsobj, std::string_view src )
     optional( jsobj, was_loaded, "learned_spells", learned_spells );
     optional( jsobj, was_loaded, "learned_proficiencies", proficiencies );
     optional( jsobj, was_loaded, "canceled_mutations", canceled_mutations );
-    optional( jsobj, was_loaded, "bionics_conflicts", bionics_conflicts );
+    optional( jsobj, was_loaded, "replaced_bodyparts", replaced_bodyparts );
     optional( jsobj, was_loaded, "mutation_conflicts", mutation_conflicts );
     optional( jsobj, was_loaded, "give_mut_on_removal", give_mut_on_removal );
     optional( jsobj, was_loaded, "included_bionics", included_bionics );
@@ -2344,16 +2344,20 @@ ret_val<void> Character::is_installable( const item *it, const bool by_autodoc )
     } else if( std::any_of( bid->mutation_conflicts.begin(), bid->mutation_conflicts.end(),
                             has_trait_lambda ) ) {
         return ret_val<void>::make_failure( _( "CBM not compatible with patient's body." ) );
-    } else if( !bid->bionics_conflicts.empty() ) {
-        std::vector<std::string> bionics;
-        for( const bionic_id &b : bid->bionics_conflicts ) {
-            if( has_bionic( b ) ) {
-                bionics.push_back( b->name.translated() );
+    } else if( !bid->replaced_bodyparts.empty() ) {
+        std::vector<std::string> conflicts;
+        
+        for( const bionic_id &installed : get_bionics() ) {
+            for( const bodypart_str_id &bp : bid->replaced_bodyparts ) {
+                if( installed->replaced_bodyparts.count( bp ) > 0 ) {
+                    conflicts.push_back( installed->name.translated() );
+                    break;
+                }
             }
         }
 
-        if( !bionics.empty() ) {
-            return ret_val<void>::make_failure( _( "CBM conflicts with: %s." ), string_join( bionics, ", " ) );
+        if( !conflicts.empty() ) {
+            return ret_val<void>::make_failure( _( "CBM conflicts with: %s." ), string_join( conflicts, ", " ) );
         }
 
     } else if( bid->upgraded_bionic &&

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2346,7 +2346,6 @@ ret_val<void> Character::is_installable( const item *it, const bool by_autodoc )
         return ret_val<void>::make_failure( _( "CBM not compatible with patient's body." ) );
     } else if( !bid->replaced_bodyparts.empty() ) {
         std::vector<std::string> conflicts;
-        
         for( const bionic_id &installed : get_bionics() ) {
             for( const bodypart_str_id &bp : bid->replaced_bodyparts ) {
                 if( installed->replaced_bodyparts.count( bp ) > 0 ) {
@@ -2357,7 +2356,8 @@ ret_val<void> Character::is_installable( const item *it, const bool by_autodoc )
         }
 
         if( !conflicts.empty() ) {
-            return ret_val<void>::make_failure( _( "CBM conflicts with: %s." ), string_join( conflicts, ", " ) );
+            return ret_val<void>::make_failure( _( "CBM conflicts with: %s." ), string_join( conflicts,
+                                                ", " ) );
         }
 
     } else if( bid->upgraded_bionic &&

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2144,7 +2144,6 @@ bool Character::can_uninstall_bionic( const bionic &bio, Character &installer, b
             if( installed == bio.id ) {
                 continue;
             }
-            
             for( const bodypart_str_id &bp : bio.id->replaced_bodyparts ) {
                 if( installed->occupied_bodyparts.count( bp ) > 0 ) {
                     dependent_bionics.push_back( installed->name.translated() );
@@ -2153,10 +2152,11 @@ bool Character::can_uninstall_bionic( const bionic &bio, Character &installer, b
             }
         }
     }
-    
+
     if( !dependent_bionics.empty() ) {
         if( !player_character.query_yn(
-                _( "Removing %s will also remove: %s" ), bio.id->name.translated(), string_join( dependent_bionics, ", " ) ) ) {
+                _( "Removing %s will also remove: %s" ), bio.id->name.translated(), string_join( dependent_bionics,
+                        ", " ) ) ) {
             return false;
         }
     }
@@ -2238,33 +2238,32 @@ void Character::perform_uninstall( const bionic &bio, int difficulty, int succes
         add_msg( m_good, _( "Successfully removed %s." ), bio.id.obj().name );
         const bionic_id bio_id = bio.id;
         remove_bionic( bio );
-        
         // remove dependent bionics
         std::vector<bionic> dependent_bionics;
         for( const bionic &installed : *my_bionics ) {
             if( installed.id == bio_id ) {
                 continue;
             }
-            
+
             bool conflicts = false;
-            
+
             for( const bodypart_str_id &bp : bio_id->replaced_bodyparts ) {
                 if( installed.id->occupied_bodyparts.count( bp ) > 0 ) {
                     conflicts = true;
                     break;
                 }
             }
-            
             if( conflicts ) {
                 dependent_bionics.push_back( installed );
             }
         }
-        
+
         for( const bionic &dependent : dependent_bionics ) {
-            if (!find_bionic_by_uid( dependent.get_uid() ) ) {
+            if( !find_bionic_by_uid( dependent.get_uid() ) ) {
                 continue;
             }
-            add_msg( m_neutral, _( "%s removed with %s." ), dependent.id->name.translated(), bio_id->name.translated() );
+            add_msg( m_neutral, _( "%s removed with %s." ), dependent.id->name.translated(),
+                     bio_id->name.translated() );
             get_event_bus().send<event_type::removes_cbm>( getID(), dependent.id );
             remove_bionic( dependent );
             for( const trait_id &mid : dependent.id->give_mut_on_removal ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -344,6 +344,7 @@ void bionic_data::load( const JsonObject &jsobj, std::string_view src )
     optional( jsobj, was_loaded, "learned_spells", learned_spells );
     optional( jsobj, was_loaded, "learned_proficiencies", proficiencies );
     optional( jsobj, was_loaded, "canceled_mutations", canceled_mutations );
+    optional( jsobj, was_loaded, "bionics_conflicts", bionics_conflicts );
     optional( jsobj, was_loaded, "mutation_conflicts", mutation_conflicts );
     optional( jsobj, was_loaded, "give_mut_on_removal", give_mut_on_removal );
     optional( jsobj, was_loaded, "included_bionics", included_bionics );
@@ -2343,6 +2344,18 @@ ret_val<void> Character::is_installable( const item *it, const bool by_autodoc )
     } else if( std::any_of( bid->mutation_conflicts.begin(), bid->mutation_conflicts.end(),
                             has_trait_lambda ) ) {
         return ret_val<void>::make_failure( _( "CBM not compatible with patient's body." ) );
+    } else if( !bid->bionics_conflicts.empty() ) {
+        std::vector<std::string> bionics;
+        for( const bionic_id &b : bid->bionics_conflicts ) {
+            if( has_bionic( b ) ) {
+                bionics.push_back( b->name.translated() );
+            }
+        }
+        
+        if ( !bionics.empty() ) {
+            return ret_val<void>::make_failure( _( "CBM conflicts with: %s." ), string_join( bionics, ", " ) );
+        }
+        
     } else if( bid->upgraded_bionic &&
                !has_bionic( bid->upgraded_bionic ) &&
                it->is_upgrade() ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2137,6 +2137,30 @@ bool Character::can_uninstall_bionic( const bionic &bio, Character &installer, b
         return false;
     }
 
+    // warn a player that removing a limb removes CBMs that touch that limb
+    std::vector<std::string> dependent_bionics;
+    if( !bio.id->replaced_bodyparts.empty() ) {
+        for( const bionic_id &installed : get_bionics() ) {
+            if( installed == bio.id ) {
+                continue;
+            }
+            
+            for( const bodypart_str_id &bp : bio.id->replaced_bodyparts ) {
+                if( installed->occupied_bodyparts.count( bp ) > 0 ) {
+                    dependent_bionics.push_back( installed->name.translated() );
+                    break;
+                }
+            }
+        }
+    }
+    
+    if( !dependent_bionics.empty() ) {
+        if( !player_character.query_yn(
+                _( "Removing %s will also remove: %s" ), bio.id->name.translated(), string_join( dependent_bionics, ", " ) ) ) {
+            return false;
+        }
+    }
+
     // removal of bionics adds +2 difficulty over installation
     int chance_of_success = bionic_success_chance( autodoc, skill_level, difficulty + 2,
                             installer );
@@ -2214,6 +2238,41 @@ void Character::perform_uninstall( const bionic &bio, int difficulty, int succes
         add_msg( m_good, _( "Successfully removed %s." ), bio.id.obj().name );
         const bionic_id bio_id = bio.id;
         remove_bionic( bio );
+        
+        // remove dependent bionics
+        std::vector<bionic> dependent_bionics;
+        for( const bionic &installed : *my_bionics ) {
+            if( installed.id == bio_id ) {
+                continue;
+            }
+            
+            bool conflicts = false;
+            
+            for( const bodypart_str_id &bp : bio_id->replaced_bodyparts ) {
+                if( installed.id->occupied_bodyparts.count( bp ) > 0 ) {
+                    conflicts = true;
+                    break;
+                }
+            }
+            
+            if( conflicts ) {
+                dependent_bionics.push_back( installed );
+            }
+        }
+        
+        for( const bionic &dependent : dependent_bionics ) {
+            add_msg( m_neutral, _( "%s removed with %s." ), dependent.id->name.translated(), bio_id->name.translated() );
+            remove_bionic( dependent );
+            item dependent_cbm( itype_burnt_out_bionic );
+            if( item::type_is_defined( dependent.id->itype() ) ) {
+                dependent_cbm = item( dependent.id->itype() );
+            }
+            dependent_cbm.set_flag( flag_FILTHY );
+            dependent_cbm.set_flag( flag_NO_STERILE );
+            dependent_cbm.set_flag( flag_NO_PACKED );
+            dependent_cbm.set_fault( fault_bionic_salvaged );
+            here.add_item( pos_bub(), dependent_cbm );
+        }
 
         // give us any muts it's supposed to (silently) if removed
         for( const trait_id &mid : bio_id->give_mut_on_removal ) {
@@ -2344,22 +2403,6 @@ ret_val<void> Character::is_installable( const item *it, const bool by_autodoc )
     } else if( std::any_of( bid->mutation_conflicts.begin(), bid->mutation_conflicts.end(),
                             has_trait_lambda ) ) {
         return ret_val<void>::make_failure( _( "CBM not compatible with patient's body." ) );
-    } else if( !bid->replaced_bodyparts.empty() ) {
-        std::vector<std::string> conflicts;
-        for( const bionic_id &installed : get_bionics() ) {
-            for( const bodypart_str_id &bp : bid->replaced_bodyparts ) {
-                if( installed->replaced_bodyparts.count( bp ) > 0 ) {
-                    conflicts.push_back( installed->name.translated() );
-                    break;
-                }
-            }
-        }
-
-        if( !conflicts.empty() ) {
-            return ret_val<void>::make_failure( _( "CBM conflicts with: %s." ), string_join( conflicts,
-                                                ", " ) );
-        }
-
     } else if( bid->upgraded_bionic &&
                !has_bionic( bid->upgraded_bionic ) &&
                it->is_upgrade() ) {
@@ -2374,6 +2417,23 @@ ret_val<void> Character::is_installable( const item *it, const bool by_autodoc )
     return has_bionic( b );
     } ) ) {
         return ret_val<void>::make_failure( _( "Superior version installed." ) );
+    }
+
+    if( !bid->replaced_bodyparts.empty() ) {
+        std::vector<std::string> conflicts;
+        for( const bionic_id &installed : get_bionics() ) {
+            for( const bodypart_str_id &bp : bid->replaced_bodyparts ) {
+                if( installed->replaced_bodyparts.count( bp ) > 0 ) {
+                    conflicts.push_back( installed->name.translated() );
+                    break;
+                }
+            }
+        }
+
+        if( !conflicts.empty() ) {
+            return ret_val<void>::make_failure( _( "CBM conflicts with: %s." ), string_join( conflicts,
+                                                ", " ) );
+        }
     }
 
     return ret_val<void>::make_success( std::string() );

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -117,9 +117,9 @@ struct bionic_data {
     std::set<json_character_flag> installable_weapon_flags;
 
     /**
-     * CBMs that prevent installing this CBM
+     * Body parts that are completely replaced by this CBM
      */
-    std::set<bionic_id> bionics_conflicts;
+    std::set<bodypart_str_id> replaced_bodyparts;
     /**
      * Mutations/traits that prevent installing this CBM
      */

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -117,6 +117,10 @@ struct bionic_data {
     std::set<json_character_flag> installable_weapon_flags;
 
     /**
+     * CBMs that prevent installing this CBM
+     */
+    std::set<bionic_id> bionics_conflicts;
+    /**
      * Mutations/traits that prevent installing this CBM
      */
     std::set<trait_id> mutation_conflicts;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "CBMs can define replaced bodyparts, and removing a bionic limb removes CBMs in that limb"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Continuing to work on Exodii full-body cyborgs.  I would like to start allowing customization of the exodii frames by installing different types of arms and legs.  Using existing CBM infrastructure seems to be the most reasonable approach to this.  But, there's no easy way to prevent users from installing, e.g., more than one set of legs, outside of maybe some hacky JSON.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

New JSON field for bionics called `replaced_bodyparts`, that accepts an array of bodyparts.  It is empty by default.  If two CBMs have overlapping replaced_bodyparts, they cannot be installed together.

If you _remove_ a CBM that has `replaced_bodyparts` installed, you also remove any CBM that occupies an overlapping slot.  e.g., removing your bionic right arm will remove a monomolecular blade installed in it.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Using mutations/traits for all bionic limbs.  These can already have direct conflicts.

Just using bionic slots, e.g., by giving Exodii bodies frame-specific slots that are totally filled by limb types, so one can only install one.  Beyond slots not being mainlined, this seems like a convoluted way of doing things.

Exploiting `upgraded_bionic` and `available_upgrades` to make them conflict with each other.  This works but is hacky and leads to strange messaging in CBM installation menu.

Using `installable_weapon_flags` to swap out limbs.  This could work well, but is perhaps best saved for special types of installed limbs that can do quick-swaps, with some other downside.

A list of CBM conflicts, which would work more generally.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Built locally.  Made test bionics.  Installed and tried to install:

Character has `Bionic Left Arm Test A`. The CBM `Bionic Left Arm Test B` replaces overlapping bodyparts, so is in conflict. The CBM `Bionic Right Arm Test` replaces the right arm, which is available.

<img width="756" height="152" alt="image" src="https://github.com/user-attachments/assets/015c5c79-ebc5-45e4-b8bb-84fbb4aa088e" />

<img width="1115" height="137" alt="alsoremoves" src="https://github.com/user-attachments/assets/d21df986-18e7-4135-b579-fe59925c6add" />

<img width="551" height="137" alt="alsoremoved" src="https://github.com/user-attachments/assets/af0f4d13-e89f-4635-b1ff-bc8ddbfbbdfe" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

It may be good to use this data to determine if a CBM can be installed in the first place, but I don't see a use for that at the moment.  In base game these will only be available to Exodiified players, and the relevant CBMs will require an Exodii cyberframe CBM to install them, so nobody can just get ahold of these and lop their arm off, etc.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
