### PR TITLE
More support for BY_VOLUME/BY_WEIGHT/BY_LENGTH

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1786,11 +1786,14 @@ std::string item::display_name( unsigned int quantity ) const
                     } else {
                         charges_color = c_light_green;
                     }
-                    amt = string_format( " (%s%s)", colorize( string_format( "%i/%i", amount, max_amount ),
-                                         charges_color ),
+                    amt = string_format( " (%s%s)",
+                                         colorize( string_format( "%s/%s",
+                                                   type->count_or_volume_or_weight_prefix( amount ),
+                                                   type->count_or_volume_or_weight_prefix( max_amount ) ),
+                                                   charges_color ),
                                          ammotext );
-                } else if( !type->dont_display_count_or_charges() )  {
-                    amt = string_format( " (%i%s)", amount, ammotext );
+                } else  {
+                    amt = string_format( " (%s%s)", type->count_or_volume_or_weight_prefix( amount ), ammotext );
                 }
             }
         } else if( !ammotext.empty() ) {

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -222,7 +222,7 @@ std::string craft( item const &it, unsigned int /* quantity */,
         } else {
             maintext = string_format( _( "in progress %s" ), it.get_making().result_name() );
         }
-        if( it.charges > 1 && !it.type->dont_display_count_or_charges() ) {
+        if( it.charges > 1 ) {
             maintext += string_format( " (%d)", it.charges );
         }
         int effective_counter = it.item_counter;

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -127,11 +127,6 @@ std::string itype::get_item_type_string() const
     return "misc";
 }
 
-bool itype::dont_display_count_or_charges() const
-{
-    return display_type != item_display_type::DEFAULT;
-}
-
 std::string itype::count_or_volume_or_weight_prefix( unsigned int quantity ) const
 {
     if( display_type == item_display_type::BY_WEIGHT ) {

--- a/src/itype.h
+++ b/src/itype.h
@@ -1679,8 +1679,6 @@ struct itype {
 
         std::string count_or_volume_or_weight_prefix( unsigned int quantity ) const;
 
-        bool dont_display_count_or_charges() const;
-
         // Returns the name of the item type in the correct language and with respect to its grammatical number,
         // based on quantity (example: item type "anvil", nname(4) would return "anvils" (as in "4 anvils").
         std::string nname( unsigned int quantity ) const;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Clean water in the consume menu always shows up without a number or indicator of how much is there.

<img width="1299" height="485" alt="image" src="https://github.com/user-attachments/assets/c10bb650-598e-4d2e-be26-9c8e8cef66b9" />

This was previously meant to be handled by item::tname(), hence item::display_name() was already assembling tname and didn't need this redundantly added.

We ended up switching away from putting it in tname, but the charges were still being blocked from being shown here, so you saw no indicator at all.

#### Describe the solution
Fix that by displaying count/volume/weight/length appropriately.

+ Remove redundant function (from before the switch away from item::tname() )

#### Describe alternatives you've considered


#### Testing
<img width="1221" height="389" alt="image" src="https://github.com/user-attachments/assets/d880d4b6-e0e0-4934-9c32-a0a7c25e9db4" />

Also made sure that non-charge, non-ammo stuff works in this menu:
<img width="1219" height="384" alt="image" src="https://github.com/user-attachments/assets/6b765c28-e0d9-4d24-bd82-c1e0fb425d5a" />


#### Additional context
