### PR TITLE
Fix fling drowning people in shallow water

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9193,7 +9193,7 @@ bool game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
     }
 
     // Fall down to the ground - always on the last reached tile
-    if( !here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos ) ) {
+    if( !here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, pos ) ) {
         // Didn't smash into a wall or a floor so only take the fall damage
         if( thru && here.is_open_air( pos ) ) {
             here.creature_on_trap( *c, false );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #87074

#### Describe the solution
Fling properly checks if the water would actually submerge, instead of just any water.

#### Describe alternatives you've considered
Shallow water isn't actually swimmable so I'm not sure why it has this flag to begin with?

#### Testing


#### Additional context
The reason this couldn't drown the avatar is because game::walk_move() blindly sets underwater to false every turn regardless of other circumstances (relying on avatar-specific swim handling to re-set it as needed)