### PR TITLE
Properly migrate and obsolete the old lmoe shelters

### DIFF
--- a/data/json/obsoletion_and_migration_0.J/obsolete_overmap_special.json
+++ b/data/json/obsoletion_and_migration_0.J/obsolete_overmap_special.json
@@ -135,5 +135,10 @@
     "type": "overmap_special_migration",
     "id": "office_tower_hiddenlab",
     "//": "Removed in 0.J experimental"
+  },
+  {
+    "type": "overmap_special_migration",
+    "id": "Occupied LMOE Shelter",
+    "new_id": "LMOE Shelter"
   }
 ]

--- a/data/json/obsoletion_and_migration_0.J/obsolete_overmap_terrain.json
+++ b/data/json/obsoletion_and_migration_0.J/obsolete_overmap_terrain.json
@@ -597,11 +597,26 @@
   {
     "type": "oter_id_migration",
     "oter_ids": {
-      "lmoe_prepperquest": "omt_obsolete",
-      "lmoe_roof": "omt_obsolete",
-      "lmoe_zombie": "omt_obsolete",
-      "lmoe_under_empty": "lmoe_under",
-      "lmoe_zombie_under_empty": "lmoe_under"
+      "lmoe_prepperquest_north": "field",
+      "lmoe_roof_north": "open_air",
+      "lmoe_zombie_north": "field",
+      "lmoe_under_empty_north": "lmoe_under",
+      "lmoe_zombie_under_empty_north": "lmoe_under",
+      "lmoe_prepperquest_east": "field",
+      "lmoe_roof_east": "open_air",
+      "lmoe_zombie_east": "field",
+      "lmoe_under_empty_east": "lmoe_under",
+      "lmoe_zombie_under_empty_east": "lmoe_under",
+      "lmoe_prepperquest_south": "field",
+      "lmoe_roof_south": "open_air",
+      "lmoe_zombie_south": "field",
+      "lmoe_under_empty_south": "lmoe_under",
+      "lmoe_zombie_under_empty_south": "lmoe_under",
+      "lmoe_prepperquest_west": "field",
+      "lmoe_roof_west": "open_air",
+      "lmoe_zombie_west": "field",
+      "lmoe_under_empty_west": "lmoe_under",
+      "lmoe_zombie_under_empty_west": "lmoe_under"
     }
   }
 ]

--- a/data/json/obsoletion_and_migration_0.J/obsolete_overmap_terrain.json
+++ b/data/json/obsoletion_and_migration_0.J/obsolete_overmap_terrain.json
@@ -593,5 +593,15 @@
     "type": "oter_id_migration",
     "//": "Corrected rotation in 0.J experimental",
     "oter_ids": { "hw_supports": "hw_supports_north" }
+  },
+  {
+    "type": "oter_id_migration",
+    "oter_ids": {
+      "lmoe_prepperquest": "omt_obsolete",
+      "lmoe_roof": "omt_obsolete",
+      "lmoe_zombie": "omt_obsolete",
+      "lmoe_under_empty": "lmoe_under",
+      "lmoe_zombie_under_empty": "lmoe_under"
+    }
   }
 ]

--- a/data/json/obsoletion_and_migration_0.J/obsolete_overmap_terrain.json
+++ b/data/json/obsoletion_and_migration_0.J/obsolete_overmap_terrain.json
@@ -600,23 +600,23 @@
       "lmoe_prepperquest_north": "field",
       "lmoe_roof_north": "open_air",
       "lmoe_zombie_north": "field",
-      "lmoe_under_empty_north": "lmoe_under",
-      "lmoe_zombie_under_empty_north": "lmoe_under",
+      "lmoe_under_empty_north": "lmoe_under_north",
+      "lmoe_zombie_under_empty_north": "lmoe_under_north",
       "lmoe_prepperquest_east": "field",
       "lmoe_roof_east": "open_air",
       "lmoe_zombie_east": "field",
-      "lmoe_under_empty_east": "lmoe_under",
-      "lmoe_zombie_under_empty_east": "lmoe_under",
+      "lmoe_under_empty_east": "lmoe_under_east",
+      "lmoe_zombie_under_empty_east": "lmoe_under_east",
       "lmoe_prepperquest_south": "field",
       "lmoe_roof_south": "open_air",
       "lmoe_zombie_south": "field",
-      "lmoe_under_empty_south": "lmoe_under",
-      "lmoe_zombie_under_empty_south": "lmoe_under",
+      "lmoe_under_empty_south": "lmoe_under_south",
+      "lmoe_zombie_under_empty_south": "lmoe_under_south",
       "lmoe_prepperquest_west": "field",
       "lmoe_roof_west": "open_air",
       "lmoe_zombie_west": "field",
-      "lmoe_under_empty_west": "lmoe_under",
-      "lmoe_zombie_under_empty_west": "lmoe_under"
+      "lmoe_under_empty_west": "lmoe_under_west",
+      "lmoe_zombie_under_empty_west": "lmoe_under_west"
     }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#86971 functionally obsoleted a lot of old lmoe shelters that were basically duplicates, that had the effect of orphaning some mapgen ids, making saves crash.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Properly migrate the ids when applicable, obsoleting them when not.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Hope I didn't forget any of them.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I don't have an old save version to test it on. (Yes I know I could go the extra mile of installing an old version, spawning a shelter, saving, updating and loading the save to see if it migrates but 💀 )
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Fixes #87007 and #87044.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
