### PR TITLE
Optimize away redrawing clear weather

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -348,8 +348,7 @@ input_context game::get_player_input( std::string &action )
                 WEATHER_DRIZZLE | WEATHER_LIGHT_DRIZZLE | WEATHER_RAINY | WEATHER_RAINSTORM | WEATHER_THUNDER | WEATHER_LIGHTNING = "weather_rain_drop"
                 WEATHER_FLURRIES | WEATHER_SNOW | WEATHER_SNOWSTORM = "weather_snowflake"
                 */
-                invalidate_main_ui_adaptor();
-
+                const bool had_weather_animation = !wPrint.vdrops.empty();
                 wPrint.vdrops.clear();
 
                 for( int i = 0; i < dropCount; i++ ) {
@@ -366,6 +365,9 @@ input_context game::get_player_input( std::string &action )
                         // Suppress if a critter is there
                         wPrint.vdrops.emplace_back( iRand.x, iRand.y );
                     }
+                }
+                if( had_weather_animation || !wPrint.vdrops.empty() ) {
+                    invalidate_main_ui_adaptor();
                 }
             }
             // don't bother calculating SCT if we won't show it


### PR DESCRIPTION
Fixes idle detection, when recording with asciinema -i <idletime>

#### Summary
Bugfixes "ASCII: Fix idle detection in asciinema"

#### Purpose of change

When idling in the & crafting screen, nothing is redrawn, and [asciinema](https://asciinema.org/) will collapse any amount of idle time into just one frame.
When idling in the main game screen, weather animation keeps constantly redrawing the screen, even if the weather is clean. Asciinema will not detect this as idle time, and will record all the redraws, bloating the recording size and making it unskippable.

#### Describe the solution

This commit skips the flush when weather was a no-op, eliminating the redraw.

#### Describe alternatives you've considered

none

#### Testing

Manual testing: `asciinema rec -i 1`, then idle a while. Verify that `asciinema play` collapses any idling time into 1 second.

#### Additional context