### PR TITLE
Make the advanced nomad jumpsuit require ice to function

### DIFF
--- a/data/json/items/armor/bespoke_armor/custom_bodysuits.json
+++ b/data/json/items/armor/bespoke_armor/custom_bodysuits.json
@@ -75,18 +75,26 @@
         "moves": 80,
         "max_item_length": "15 cm",
         "description": "Pants pocket."
+      },
+      {
+        "id": "power",
+        "magazine_well": "500 ml",
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "heavy_battery_cell" ]
+      },
+      {
+        "id": "ice",
+        "pocket_type": "MAGAZINE",
+        "watertight": true,
+        "flag_restriction": [ "COLD" ],
+        "ammo_restriction": { "water": 12 }
       }
     ],
-    "use_action": {
-      "type": "transform",
-      "msg": "You turn the climate control on.",
-      "target": "armor_nomad_advanced_on",
-      "need_charges": 1,
-      "need_charges_msg": "Your internal reservoir is empty."
-    },
+    "consumption_per_use": [ { "pocket": "power", "qty": 2 }, { "pocket": "ice", "qty": 1 } ],
+    "use_action": { "type": "transform", "msg": "You turn the climate control on.", "target": "armor_nomad_advanced_on", "ammo_scale": 0 },
     "warmth": 10,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "POCKETS", "STURDY", "USES_BIONIC_POWER", "MUNDANE" ],
+    "flags": [ "VARSIZE", "POCKETS", "STURDY", "USE_UPS", "MUNDANE" ],
     "tool_ammo": "battery",
     "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "well_distributed" ] }, { "id": "ench_climate_control_all" } ]
   },
@@ -99,11 +107,11 @@
     "description": "A reinforced but airy jumpsuit designed to survive the long-term wear and tear of exploring the apocalyptic wasteland.  Rather than advanced polymer fabrics which may not be available in many worlds, it is made of breathable twill fabric with leather reinforcements ensuring it can be produced easily regardless of technology level.  Its clever construction adds additional core support, helping you to carry more equipment.  The internal cooling tubes are active and humming.",
     "revert_to": "armor_nomad_advanced",
     "flags": [ "VARSIZE", "POCKETS", "STURDY", "USES_BIONIC_POWER", "MUNDANE", "SPAWN_ACTIVE" ],
-    "power_draw": "100 W",
+    "turns_per_charge": 900,
     "use_action": {
-      "ammo_scale": 0,
       "type": "transform",
       "menu_text": "Turn off",
+      "ammo_scale": 0,
       "msg": "The hum of the suit's climate control fades.",
       "target": "armor_nomad_advanced"
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Make the advanced nomad jumpsuit require ice to function"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently the advanced nomad jumpsuit cools the user through unknown means. There's mention of "cooling tubes" but that's it. Assuming those are supposed to be for liquid cooling, as active cooling garment are very much a thing, the jumpsuit should require a supply of cold water or ice to be pumped through.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Add a magazine pocket to the suit.
- Make the suit consume power and water to function. (Consumption is 1L of water/hour, with a 3L reserve maximum, consumption is supposed to be ~1.3 w but I rounded it to 2 as it's already insanely low, [source](https://cdn.shopifycdn.net/s/files/1/0014/8278/4871/files/Operation_manual_for_Backpack_ICE_Water_Cooling_System.pdf) )

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

The item doesn't work atm for 2 reasons:

1. Can't load properly because the pocket as a `COLD` flag requirement but spawns with water that doesn't (and can't, afaik) have it due to some limitation.
2. Can't reload, even with access to cold water for unknown reasons.

I know it *can* work, as removing the cold flag requirement solves every issue but having to make icy water to use the suit is an interesting and engaging mechanic imo and I want it.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Either remove the flag and see that the suit works as intended or as is observe that you get an error on load and can't reload the suit.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I'll keep this as a draft to point to in a possible further issue unless someone finds some solution that I didn't see.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
