### PR TITLE
Fix multimag gun info crash and per-pocket capacity misreads

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -728,7 +728,7 @@ bool aim_activity_actor::load_RAS_weapon()
         return true;
     };
     item::reload_option opt = ammo_location_is_valid() ? item::reload_option( &you, weapon,
-                              you.ammo_location ) : you.select_ammo( used_gun );
+                              you.ammo_location, item::reload_option::POCKET_FALLBACK ) : you.select_ammo( used_gun );
     if( !opt ) {
         // Menu canceled
         return false;

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -77,6 +77,7 @@
 #include "item_contents.h"
 #include "item_group.h"
 #include "item_location.h"
+#include "item_pocket.h"
 #include "item_wakeup.h"
 #include "itype.h"
 #include "iuse.h"
@@ -8061,6 +8062,49 @@ void reload_activity_actor::finish( player_activity &act, Character &who )
     already_loaded += quantity - already_loaded;
     reload_msg( who, true );
     act.set_to_null();
+
+    // Auto-chain sibling wells so the player is not prompted once per well.
+    // Inventory only - map items were not part of the player's original pick
+    // and walking them can surface debugmsgs on unrelated nearby items.
+    if( !target_loc || !target_loc->uses_firing_requirements() ) {
+        return;
+    }
+    const std::vector<item_location> candidates =
+        who.find_ammo( *target_loc, /*empty=*/false, /*radius=*/ -1 );
+    if( candidates.empty() ) {
+        return;
+    }
+    int chain_pocket = -1;
+    item_location chain_ammo;
+    int idx = 0;
+    for( const item_pocket *p : target_loc->get_pockets( []( const item_pocket & ) {
+    return true;
+} ) ) {
+        if( p->is_type( pocket_type::MAGAZINE_WELL ) && p->magazine_current() == nullptr ) {
+            item_location match;
+            for( const item_location &cand : candidates ) {
+                if( p->can_reload_with( *cand, true ) ) {
+                    if( match ) {
+                        match = item_location();
+                        break;
+                    }
+                    match = cand;
+                }
+            }
+            if( match ) {
+                chain_pocket = idx;
+                chain_ammo = match;
+                break;
+            }
+        }
+        ++idx;
+    }
+    if( !chain_ammo || chain_pocket < 0 ) {
+        return;
+    }
+    const int extra_moves = target_loc->get_var( "dirt", 0 ) > 7800 ? 2500 : 0;
+    item::reload_option chain_opt( &who, target_loc, chain_ammo, chain_pocket );
+    who.assign_activity( reload_activity_actor( std::move( chain_opt ), extra_moves ) );
 }
 
 void reload_activity_actor::canceled( player_activity &act, Character &who )

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -67,6 +67,7 @@
 #include "ret_val.h"
 #include "string_formatter.h"
 #include "subbodypart.h"
+#include "translation.h"
 #include "translations.h"
 #include "trap.h"
 #include "type_id.h"
@@ -2437,6 +2438,25 @@ bool Character::add_or_drop_with_msg( item &it, const bool /*unloading*/, const 
     return true;
 }
 
+static bool has_drainable_integral_pocket( const item &target )
+{
+    if( !target.uses_firing_requirements() ) {
+        return false;
+    }
+    const std::vector<const item_pocket *> integral_pockets = target.get_pockets(
+    []( const item_pocket & p ) {
+        return p.is_type( pocket_type::MAGAZINE );
+    } );
+    for( const item_pocket *p : integral_pockets ) {
+        for( const item *e : p->all_items_top() ) {
+            if( !e->has_flag( flag_CASING ) && e->is_ammo() ) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 bool Character::unload( item_location &loc, bool bypass_activity,
                         const item_location &new_container )
 {
@@ -2567,24 +2587,74 @@ bool Character::unload( item_location &loc, bool bypass_activity,
         }
         return true;
 
-    } else if( !target->magazines_current().empty() ) {
-        // Snapshot the loaded magazine pointers up front; the vector will shift
-        // as we remove magazines from the wells.
+    } else if( !target->magazines_current().empty() ||
+               has_drainable_integral_pocket( *target ) ) {
         std::vector<item *> mags_to_eject = target->magazines_current();
-        if( !bypass_activity && mags_to_eject.size() > 1 ) {
-            std::vector<std::string> mag_msgs;
-            mag_msgs.reserve( mags_to_eject.size() + 1 );
-            for( const item *mag : mags_to_eject ) {
-                mag_msgs.emplace_back( mag->tname() );
+        struct integral_source {
+            item_pocket *pocket;
+            std::string label;
+            int total_qty;
+        };
+        std::vector<integral_source> integral_sources;
+        if( target->uses_firing_requirements() ) {
+            std::vector<item_pocket *> integral_pockets = target->get_pockets(
+            []( const item_pocket & p ) {
+                return p.is_type( pocket_type::MAGAZINE );
+            } );
+            for( item_pocket *p : integral_pockets ) {
+                std::string entry_name;
+                int amount = 0;
+                for( const item *e : p->all_items_top() ) {
+                    if( e->has_flag( flag_CASING ) || !e->is_ammo() ) {
+                        continue;
+                    }
+                    amount += e->charges > 0 ? e->charges : 1;
+                    if( entry_name.empty() ) {
+                        entry_name = e->tname();
+                    }
+                }
+                if( amount == 0 ) {
+                    continue;
+                }
+                const pocket_data *pd = p->get_pocket_data();
+                std::string label = entry_name;
+                if( pd != nullptr ) {
+                    const std::string display = pd->pocket_name.translated();
+                    if( !display.empty() ) {
+                        label = string_format( "%s (%s)", entry_name, display );
+                    } else if( !pd->pocket_id.empty() ) {
+                        label = string_format( "%s (%s)", entry_name, pd->pocket_id );
+                    }
+                }
+                integral_sources.push_back( { p, label, amount } );
             }
-            mag_msgs.emplace_back( _( "All" ) );
-            const int ret = uilist( _( "Unload which magazine?" ), mag_msgs );
+        }
+        const int total_sources = static_cast<int>( mags_to_eject.size() +
+                                  integral_sources.size() );
+        if( !bypass_activity && total_sources > 1 ) {
+            std::vector<std::string> msgs_v;
+            msgs_v.reserve( total_sources + 1 );
+            for( const item *mag : mags_to_eject ) {
+                msgs_v.emplace_back( mag->tname() );
+            }
+            for( const integral_source &src : integral_sources ) {
+                msgs_v.emplace_back( src.label );
+            }
+            msgs_v.emplace_back( _( "All" ) );
+            const int ret = uilist( _( "Unload which source?" ), msgs_v );
             if( ret < 0 ) {
                 return false;
             }
-            if( ret < static_cast<int>( mags_to_eject.size() ) ) {
-                item *picked = mags_to_eject[ret];
-                mags_to_eject = { picked };
+            if( ret < total_sources ) {
+                if( ret < static_cast<int>( mags_to_eject.size() ) ) {
+                    item *picked = mags_to_eject[ret];
+                    mags_to_eject = { picked };
+                    integral_sources.clear();
+                } else {
+                    integral_source picked = integral_sources[ret - mags_to_eject.size()];
+                    integral_sources = { picked };
+                    mags_to_eject.clear();
+                }
             }
         }
         for( item *mag : mags_to_eject ) {
@@ -2597,6 +2667,37 @@ bool Character::unload( item_location &loc, bool bypass_activity,
             target->remove_items_with( [mag]( const item & e ) {
                 return &e == mag;
             } );
+        }
+        for( const integral_source &src : integral_sources ) {
+            std::vector<item *> to_remove;
+            const item *rep = nullptr;
+            for( item *e : src.pocket->all_items_top() ) {
+                if( e->has_flag( flag_CASING ) || !e->is_ammo() ) {
+                    continue;
+                }
+                item dropped = *e;
+                if( target->is_filthy() ) {
+                    dropped.set_flag( flag_FILTHY );
+                }
+                if( !this->add_or_drop_with_msg( dropped,
+                                                 dropped.count_by_charges() && dropped.charges > 1 ) ) {
+                    return false;
+                }
+                if( rep == nullptr ) {
+                    rep = e;
+                }
+                to_remove.push_back( e );
+            }
+            if( rep != nullptr ) {
+                this->mod_moves( -this->item_reload_cost( *target, *rep, src.total_qty ) / 2 );
+            }
+            for( item *e : to_remove ) {
+                src.pocket->remove_item( *e );
+            }
+            src.pocket->on_contents_changed();
+        }
+        if( !integral_sources.empty() ) {
+            target->on_contents_changed();
         }
 
     } else if( target->ammo_remaining( ) ) {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -3349,10 +3349,16 @@ item::reload_option game_menus::inv::select_ammo( Character &you, const item_loc
                 return true;
             } ) ) {
                     if( idx == rt.pocket_index && p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                        const pocket_data *pd = p->get_pocket_data();
+                        const std::string display = pd ? pd->pocket_name.translated() : std::string();
                         const itype_id default_mag = p->magazine_default();
-                        well_desc = default_mag.is_null()
-                                    ? string_format( _( "magazine well %d" ), rt.ui_well_index + 1 )
-                                    : item::find_type( default_mag )->nname( 1 );
+                        if( !display.empty() ) {
+                            well_desc = display;
+                        } else if( !default_mag.is_null() ) {
+                            well_desc = item::find_type( default_mag )->nname( 1 );
+                        } else {
+                            well_desc = string_format( _( "magazine well %d" ), rt.ui_well_index + 1 );
+                        }
                         break;
                     }
                     ++idx;
@@ -3364,7 +3370,25 @@ item::reload_option game_menus::inv::select_ammo( Character &you, const item_loc
                     label = string_format( _( "%1$s (well %2$d)" ), label, n );
                 }
             } else if( rt.kind == reload_target::kind::integral_magazine ) {
-                label = string_format( _( "%s: integral magazine" ), rt.owner->tname() );
+                int idx = 0;
+                std::string mag_desc;
+                for( const item_pocket *p : rt.owner->get_pockets(
+                []( const item_pocket & ) {
+                return true;
+            } ) ) {
+                    if( idx == rt.pocket_index && p->is_type( pocket_type::MAGAZINE ) ) {
+                        const pocket_data *pd = p->get_pocket_data();
+                        const std::string display = pd ? pd->pocket_name.translated() : std::string();
+                        if( !display.empty() ) {
+                            mag_desc = display;
+                        }
+                        break;
+                    }
+                    ++idx;
+                }
+                label = mag_desc.empty()
+                        ? string_format( _( "%s: integral magazine" ), rt.owner->tname() )
+                        : string_format( _( "%s: %s" ), rt.owner->tname(), mag_desc );
             } else {
                 //~ %1$s is the gun or gunmod that holds the magazine, %2$s is the magazine's tname
                 label = string_format( _( "%1$s: top up %2$s" ), rt.owner->tname(),

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -3186,7 +3186,8 @@ class select_ammo_inventory_preset : public inventory_selector_preset
             }, _( "AMOUNT" ) );
 
             append_cell( [&you, &target]( const item_location & loc ) {
-                item::reload_option opt( &you, target, loc );
+                item::reload_option opt( &you, target, loc,
+                                         item::reload_option::POCKET_FALLBACK );
                 // propagate entry.chosen_count here somehow?
                 return std::to_string( opt.moves() );
             }, _( "MOVES" ) );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -4129,7 +4129,11 @@ void ammo_inventory_selector::set_all_entries_chosen_count()
                     }
                     ++idx;
                 }
-                if( well != nullptr && !well->magazine_default().is_null() ) {
+                const pocket_data *pd = well ? well->get_pocket_data() : nullptr;
+                const std::string display = pd ? pd->pocket_name.translated() : std::string();
+                if( !display.empty() ) {
+                    label = display;
+                } else if( well != nullptr && !well->magazine_default().is_null() ) {
                     label = string_format( _( "%s well" ), item::nname( well->magazine_default() ) );
                 } else {
                     label = _( "magazine well" );

--- a/src/item.h
+++ b/src/item.h
@@ -611,19 +611,18 @@ class item : public visitable
                 reload_option( const reload_option & );
                 reload_option &operator=( const reload_option & );
 
-                reload_option( const Character *who, const item_location &target, const item_location &ammo );
                 reload_option( const Character *who, const item_location &target, const item_location &ammo,
                                int pocket_index );
+
+                // pocket_index sentinel: defer well choice to reload runtime.
+                static constexpr int POCKET_FALLBACK = -1;
 
                 const Character *who = nullptr;
                 item_location target;
                 item_location ammo;
                 bool is_reload_one = false;
-                // MAGAZINE_WELL pocket index in target->contents. Negative =
-                // first-compatible-well fallback.
-                // TODO(multimag): drop the default once all callers carry an
-                // explicit pocket_index.
-                int pocket_index = -1;
+                // MAGAZINE_WELL index in target->contents, or POCKET_FALLBACK.
+                int pocket_index = POCKET_FALLBACK;
 
                 int qty() const {
                     return qty_;
@@ -2877,6 +2876,11 @@ class item : public visitable
         // gun.ammo, then any such well, then any loaded well, then any well.
         // nullptr if no MAGAZINE_WELL exists.
         const item_pocket *primary_ammo_pocket() const;
+
+        // Pocket (well or integral mag) that accepts `at`. Beats
+        // magazine_current() which returns the first loaded mag regardless
+        // of ammotype.
+        const item_pocket *pocket_for_ammo( const ammotype &at ) const;
 
         // Magazine driving ammo-identity queries: primary_ammo_pocket's mag
         // for multimag guns, magazine_current otherwise.

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2416,12 +2416,16 @@ void Item_factory::check_definitions() const
             for( const std::string &id : referenced ) {
                 bool found = false;
                 bool right_type = false;
+                bool spawnable = false;
                 for( const pocket_data &p : type->pockets ) {
                     if( p.pocket_id == id ) {
                         found = true;
-                        if( p.type == pocket_type::MAGAZINE_WELL ||
-                            ( p.type == pocket_type::MAGAZINE && !p.ammo_restriction.empty() ) ) {
+                        if( p.type == pocket_type::MAGAZINE_WELL ) {
                             right_type = true;
+                            spawnable = !p.default_magazine.is_null();
+                        } else if( p.type == pocket_type::MAGAZINE && !p.ammo_restriction.empty() ) {
+                            right_type = true;
+                            spawnable = true;
                         }
                         break;
                     }
@@ -2432,6 +2436,10 @@ void Item_factory::check_definitions() const
                 } else if( !right_type ) {
                     msg += string_format(
                                "firing_requirements references pocket id \"%s\" which is neither a MAGAZINE_WELL nor a MAGAZINE with ammo_restriction\n",
+                               id );
+                } else if( !spawnable ) {
+                    msg += string_format(
+                               "firing_requirements references MAGAZINE_WELL pocket \"%s\" with no default_magazine; spawn paths cannot populate it\n",
                                id );
                 }
             }

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -1422,6 +1422,27 @@ int item::ammo_remaining( const map &here, const std::set<ammotype> &ammo, const
         ret += mag->ammo_remaining( );
     }
 
+    // Integral MAGAZINE pockets sitting alongside wells (multimag).
+    // is_magazine() hosts are covered by the dedicated branch below.
+    if( !is_magazine() ) {
+        for( const item_pocket *p : get_pockets( []( const item_pocket & q ) {
+        return q.is_type( pocket_type::MAGAZINE );
+        } ) ) {
+            for( const item *e : p->all_items_top() ) {
+                if( e->has_flag( flag_CASING ) ) {
+                    continue;
+                }
+                if( !e->is_ammo() ) {
+                    continue;
+                }
+                if( !ammo.empty() && ammo.find( e->ammo_type() ) == ammo.end() ) {
+                    continue;
+                }
+                ret += e->charges > 0 ? e->charges : 1;
+            }
+        }
+    }
+
     // Cable connections
     if( include_linked && link_length() >= 0 && link().efficiency >= MIN_LINK_EFFICIENCY ) {
         if( link().t_veh ) {
@@ -1671,12 +1692,37 @@ int item::ammo_capacity( const ammotype &ammo, bool include_linked ) const
 {
     map &here = get_map();
 
-    const item *mag = magazine_current();
     if( include_linked && has_link_data() ) {
         return link().t_veh ? link().t_veh->connected_battery_power_level( here ).second : 0;
-    } else if( mag ) {
+    }
+
+    // Route per-ammotype lookup through the matching pocket; magazine_current()
+    // returns the first loaded mag regardless of ammotype and misreports here.
+    if( const item_pocket *p = pocket_for_ammo( ammo ) ) {
+        if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+            if( const item *mag = p->magazine_current() ) {
+                return mag->ammo_capacity( ammo );
+            }
+            // Unloaded well: use default magazine's capacity for this ammotype.
+            const itype_id default_mag = p->magazine_default();
+            if( !default_mag.is_null() && default_mag->magazine ) {
+                return default_mag->magazine->capacity;
+            }
+        } else {
+            const auto &restrictions = p->get_pocket_data()
+                                       ? p->get_pocket_data()->ammo_restriction
+                                       : std::map<ammotype, int> {};
+            const auto it = restrictions.find( ammo );
+            if( it != restrictions.end() ) {
+                return it->second;
+            }
+        }
+    }
+
+    if( const item *mag = magazine_current() ) {
         return mag->ammo_capacity( ammo );
-    } else if( has_flag( flag_USES_BIONIC_POWER ) ) {
+    }
+    if( has_flag( flag_USES_BIONIC_POWER ) ) {
         return units::to_kilojoule( get_player_character().get_max_power_level() );
     }
 
@@ -2398,6 +2444,54 @@ const item_pocket *item::primary_ammo_pocket() const
     return wells.front();
 }
 
+const item_pocket *item::pocket_for_ammo( const ammotype &at ) const
+{
+    if( at.is_null() ) {
+        return nullptr;
+    }
+    const std::vector<const item_pocket *> wells = get_pockets(
+    []( const item_pocket & p ) {
+        return p.is_type( pocket_type::MAGAZINE_WELL ) ||
+               p.is_type( pocket_type::MAGAZINE );
+    } );
+    auto matches = [&at]( const item_pocket * p ) {
+        for( const ammotype &pt : p->ammo_types() ) {
+            if( pt == at ) {
+                return true;
+            }
+        }
+        for( const itype_id &allowed : p->item_type_restrictions() ) {
+            if( !allowed->magazine ) {
+                continue;
+            }
+            for( const ammotype &slot : allowed->magazine->type ) {
+                if( slot == at ) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    };
+    for( const item_pocket *p : wells ) {
+        if( !matches( p ) ) {
+            continue;
+        }
+        if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+            if( p->magazine_current() != nullptr ) {
+                return p;
+            }
+        } else if( !p->empty() ) {
+            return p;
+        }
+    }
+    for( const item_pocket *p : wells ) {
+        if( matches( p ) ) {
+            return p;
+        }
+    }
+    return nullptr;
+}
+
 const item *item::ammo_identity_mag() const
 {
     if( uses_firing_requirements() && type && type->gun ) {
@@ -3072,10 +3166,6 @@ void item::gun_cycle_mode()
 item::reload_option::reload_option( const reload_option & ) = default;
 
 item::reload_option &item::reload_option::operator=( const reload_option & ) = default;
-
-item::reload_option::reload_option( const Character *who, const item_location &target,
-                                    const item_location &ammo ) :
-    reload_option( who, target, ammo, -1 ) {}
 
 item::reload_option::reload_option( const Character *who, const item_location &target,
                                     const item_location &ammo, int pocket_index ) :

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -1703,10 +1703,14 @@ int item::ammo_capacity( const ammotype &ammo, bool include_linked ) const
             if( const item *mag = p->magazine_current() ) {
                 return mag->ammo_capacity( ammo );
             }
-            // Unloaded well: use default magazine's capacity for this ammotype.
-            const itype_id default_mag = p->magazine_default();
-            if( !default_mag.is_null() && default_mag->magazine ) {
-                return default_mag->magazine->capacity;
+            // Multimag hosts surface the default mag's capacity for unloaded
+            // wells so item info shows the projected per-well number. Single-
+            // well guns keep returning 0 so "is this loaded?" stays correct.
+            if( uses_firing_requirements() ) {
+                const itype_id default_mag = p->magazine_default();
+                if( !default_mag.is_null() && default_mag->magazine ) {
+                    return default_mag->magazine->capacity;
+                }
             }
         } else {
             const auto &restrictions = p->get_pocket_data()

--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -1399,7 +1399,17 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
                 if( adata == nullptr || amount == 0 ) {
                     continue;
                 }
-                loaded_lines.emplace_back( adata->nname( amount ) );
+                std::string entry = adata->nname( amount );
+                const pocket_data *pd = p->get_pocket_data();
+                if( pd != nullptr ) {
+                    const std::string display = pd->pocket_name.translated();
+                    if( !display.empty() ) {
+                        entry = string_format( "%s: %s", display, entry );
+                    } else if( !pd->pocket_id.empty() ) {
+                        entry = string_format( "%s: %s", pd->pocket_id, entry );
+                    }
+                }
+                loaded_lines.emplace_back( entry );
             }
             if( !loaded_lines.empty() ) {
                 std::string joined;

--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -1083,7 +1083,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
     const item *loaded_mod = mod;
     item tmp;
     const itype *curammo = nullptr;
-    if( mod->ammo_required() && !mod->ammo_remaining( ) ) {
+    if( mod->ammo_required() && !mod->has_ammo_data() ) {
         tmp = *mod;
         if( tmp.ammo_types().size() == 1 && *tmp.ammo_types().begin() == ammotype::NULL_ID() ) {
             itype_id default_bore_type_id = itype_id::NULL_ID();
@@ -1159,6 +1159,10 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
         }
     } else {
         curammo = loaded_mod->ammo_data();
+        if( curammo == nullptr ) {
+            // Defensive: has_ammo_data() above should have covered this branch.
+            return;
+        }
     }
 
     if( parts->test( iteminfo_parts::GUN_DAMAGE ) ) {
@@ -1300,7 +1304,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
         const bool is_default_fire_mode = loaded_mod->gun_current_mode().tname() == "DEFAULT";
         //if empty, use the temporary gun loaded with default ammo
         const item::sound_data data = ( mod->ammo_required() &&
-                                        !mod->ammo_remaining( ) ) ? tmp.gun_noise( is_default_fire_mode ) : loaded_mod->gun_noise(
+                                        !mod->has_ammo_data() ) ? tmp.gun_noise( is_default_fire_mode ) : loaded_mod->gun_noise(
                                           is_default_fire_mode );
         const int loudness = data.volume;
         info.emplace_back( "GUN", _( "Loudness with current fire mode: " ), "", iteminfo::lower_is_better,
@@ -1327,11 +1331,26 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
                                string_format( "<stat>%s</stat>", mag_names ) );
         }
         if( !mod->ammo_types().empty() && parts->test( iteminfo_parts::GUN_CAPACITY ) ) {
+            const bool annotate_wells = mod->uses_firing_requirements();
             for( const ammotype &at : mod->ammo_types() ) {
+                std::string label = _( "Capacity: " );
+                if( annotate_wells ) {
+                    if( const item_pocket *p = mod->pocket_for_ammo( at ) ) {
+                        const pocket_data *pd = p->get_pocket_data();
+                        if( pd != nullptr ) {
+                            const std::string display = pd->pocket_name.translated();
+                            if( !display.empty() ) {
+                                label = string_format( _( "Capacity (%s): " ), display );
+                            } else if( !pd->pocket_id.empty() ) {
+                                label = string_format( _( "Capacity (%s): " ), pd->pocket_id );
+                            }
+                        }
+                    }
+                }
                 const std::string fmt = string_format( n_gettext( "<num> round of %s",
                                                        "<num> rounds of %s",
                                                        mod->ammo_capacity( at ) ), at->name() );
-                info.emplace_back( "GUN", _( "Capacity: " ), fmt, iteminfo::no_flags,
+                info.emplace_back( "GUN", label, fmt, iteminfo::no_flags,
                                    mod->ammo_capacity( at ) );
                 std::string ammo_details = print_ammo( at );
                 if( !ammo_details.empty() && !magazine_integral() ) {
@@ -1349,9 +1368,54 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
         }
     }
 
-    if( mod->has_ammo_data() && parts->test( iteminfo_parts::AMMO_REMAINING ) ) {
-        info.emplace_back( "AMMO", _( "Ammunition: " ), string_format( "<stat>%s</stat>",
-                           mod->ammo_data()->nname( mod->ammo_remaining( ) ) ) );
+    if( parts->test( iteminfo_parts::AMMO_REMAINING ) ) {
+        if( mod->uses_firing_requirements() ) {
+            // One Ammunition entry per loaded pocket so multimag siblings
+            // do not collapse into a single misleading line.
+            std::vector<std::string> loaded_lines;
+            for( const item_pocket *p : mod->get_pockets(
+            []( const item_pocket & q ) {
+            return q.is_type( pocket_type::MAGAZINE_WELL ) ||
+                       q.is_type( pocket_type::MAGAZINE );
+            } ) ) {
+                int amount = 0;
+                const itype *adata = nullptr;
+                if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+                    if( const item *m = p->magazine_current() ) {
+                        amount = m->ammo_remaining();
+                        adata = m->ammo_data();
+                    }
+                } else {
+                    for( const item *e : p->all_items_top() ) {
+                        if( e->has_flag( flag_CASING ) ) {
+                            continue;
+                        }
+                        amount += e->charges > 0 ? e->charges : 1;
+                        if( adata == nullptr && e->is_ammo() ) {
+                            adata = e->type;
+                        }
+                    }
+                }
+                if( adata == nullptr || amount == 0 ) {
+                    continue;
+                }
+                loaded_lines.emplace_back( adata->nname( amount ) );
+            }
+            if( !loaded_lines.empty() ) {
+                std::string joined;
+                for( size_t i = 0; i < loaded_lines.size(); ++i ) {
+                    if( i > 0 ) {
+                        joined += ", ";
+                    }
+                    joined += loaded_lines[i];
+                }
+                info.emplace_back( "AMMO", _( "Ammunition: " ),
+                                   string_format( "<stat>%s</stat>", joined ) );
+            }
+        } else if( mod->has_ammo_data() ) {
+            info.emplace_back( "AMMO", _( "Ammunition: " ), string_format( "<stat>%s</stat>",
+                               mod->ammo_data()->nname( mod->ammo_remaining( ) ) ) );
+        }
     }
 
     if( mod->ammo_required() > 1 && parts->test( iteminfo_parts::AMMO_TO_FIRE ) ) {
@@ -1362,6 +1426,26 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
     if( mod->get_gun_energy_drain() > 0_kJ && parts->test( iteminfo_parts::AMMO_UPSCOST ) ) {
         info.emplace_back( "AMMO", _( "Energy per shot: " ), string_format( "<stat>%s</stat>",
                            units::display( mod->get_gun_energy_drain() ) ) );
+    }
+
+    if( mod->uses_firing_requirements() && parts->test( iteminfo_parts::AMMO_TO_FIRE ) ) {
+        // Per-mode draw shows the player which wells fire together.
+        const std::map<gun_mode_id, gun_mode> modes = mod->gun_all_modes();
+        std::set<gun_mode_id> printed;
+        for( const std::pair<const gun_mode_id, gun_mode> &m : modes ) {
+            if( !printed.insert( m.first ).second ) {
+                continue;
+            }
+            const std::string per_shot =
+                mod->format_consumption_requirements( std::string(), m.first, 1 );
+            if( per_shot.empty() ) {
+                continue;
+            }
+            info.emplace_back( "AMMO",
+                               string_format( _( "Per-shot consumption (%s): " ),
+                                              m.second.tname() ),
+                               string_format( "<stat>%s</stat>", per_shot ) );
+        }
     }
 
     if( parts->test( iteminfo_parts::GUN_AIMING_STATS ) ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -848,7 +848,8 @@ bool Character::handle_gun_damage( item &it )
         // Default chance is 1/10000 unless set via json, damage is proportional to caliber(see below).
         // Can be toned down with 'consume_divisor.'
 
-    } else if( it.has_flag( flag_CONSUMABLE ) && !curammo_effects.count( ammo_effect_LASER ) &&
+    } else if( it.has_flag( flag_CONSUMABLE ) && it.ammo_data() != nullptr &&
+               !curammo_effects.count( ammo_effect_LASER ) &&
                !curammo_effects.count( ammo_effect_PLASMA ) && !curammo_effects.count( ammo_effect_EMP ) ) {
         int uncork = ( ( 10 * it.ammo_data()->ammo->loudness )
                        + ( it.ammo_data()->ammo->recoil / 2 ) ) / 100;
@@ -2473,7 +2474,8 @@ int RAS_time( const Character &p, const item_location &loc )
         const item_location gun = p.get_wielded_item();
         int sta_percent = ( 100 * p.get_stamina() ) / p.get_stamina_max();
         time += ( sta_percent < 25 ) ? ( ( 25 - sta_percent ) * 2 ) : 0;
-        item::reload_option opt = item::reload_option( &p, gun, loc );
+        item::reload_option opt = item::reload_option( &p, gun, loc,
+                                  item::reload_option::POCKET_FALLBACK );
         time += opt.moves();
     }
     return time;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1066,11 +1066,19 @@ void npc::pretend_fire( npc *source, int shots, item &gun )
     if( one_in( 50 ) ) {
         add_msg_if_player_sees( *source, m_info, _( "%s shoots something." ), source->disp_name() );
     }
+    map &here = get_map();
     while( curshot != shots ) {
-        const int required = gun.ammo_required();
-        if( gun.ammo_consume( required, pos_bub(), this ) != required ) {
-            debugmsg( "Unexpected shortage of ammo whilst firing %s", gun.tname().c_str() );
-            break;
+        if( gun.uses_firing_requirements() ) {
+            if( gun.consume_one_shot( here, pos_bub( here ), this ) != 1 ) {
+                debugmsg( "Unexpected shortage of ammo whilst firing %s", gun.tname().c_str() );
+                break;
+            }
+        } else {
+            const int required = gun.ammo_required();
+            if( gun.ammo_consume( required, pos_bub(), this ) != required ) {
+                debugmsg( "Unexpected shortage of ammo whilst firing %s", gun.tname().c_str() );
+                break;
+            }
         }
 
         item *weapon = &gun;

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -47,6 +47,7 @@ static const enchantment_id enchantment_ENCH_TEST_ALT_ARMS( "ENCH_TEST_ALT_ARMS"
 static const itype_id itype_attachable_ear_muffs( "attachable_ear_muffs" );
 static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_ballistic_vest_esapi( "ballistic_vest_esapi" );
+static const itype_id itype_battery( "battery" );
 static const itype_id itype_bio_ethanol( "bio_ethanol" );
 static const itype_id itype_bio_nostril( "bio_nostril" );
 static const itype_id itype_bio_power_storage( "bio_power_storage" );
@@ -56,6 +57,7 @@ static const itype_id itype_candle_wax( "candle_wax" );
 static const itype_id itype_dress_shirt( "dress_shirt" );
 static const itype_id itype_face_shield( "face_shield" );
 static const itype_id itype_hat_hard( "hat_hard" );
+static const itype_id itype_heavy_battery_cell( "heavy_battery_cell" );
 static const itype_id itype_icecream( "icecream" );
 static const itype_id itype_iodine( "iodine" );
 static const itype_id itype_match( "match" );
@@ -99,6 +101,7 @@ static const itype_id itype_test_jug_plastic( "test_jug_plastic" );
 static const itype_id itype_test_longshirt( "test_longshirt" );
 static const itype_id itype_test_matches( "test_matches" );
 static const itype_id itype_test_meower_armor( "test_meower_armor" );
+static const itype_id itype_test_multimag_gun_integral_ammo( "test_multimag_gun_integral_ammo" );
 static const itype_id itype_test_nuclear_carafe( "test_nuclear_carafe" );
 static const itype_id itype_test_pants_faux_fur( "test_pants_faux_fur" );
 static const itype_id itype_test_pine_nuts( "test_pine_nuts" );
@@ -1936,6 +1939,32 @@ TEST_CASE( "gun_armor_piercing_dispersion_and_other_stats", "[iteminfo][gun][mis
     //CHECK( item_info_str( glock, ammo_remain ).empty() );
     //CHECK( item_info_str( glock, ammo_upscost ).empty() );
     //CHECK( item_info_str( glock, gun_casings ).empty() );
+}
+
+// Battery-only-loaded multimag: gun_info must render without crash, report
+// the projectile pocket's true capacity, and surface the per-shot draw.
+TEST_CASE( "multimag_gun_info_with_battery_only_loaded", "[iteminfo][gun][multimag]" )
+{
+    clear_avatar();
+
+    item gun( itype_test_multimag_gun_integral_ammo );
+    REQUIRE( gun.uses_firing_requirements() );
+
+    item battery( itype_heavy_battery_cell );
+    battery.ammo_set( itype_battery, 100 );
+    REQUIRE( gun.put_in( battery, pocket_type::MAGAZINE_WELL ).success() );
+
+    const std::vector<iteminfo_parts> capacity_parts = { iteminfo_parts::GUN_CAPACITY };
+    const std::string capacity = item_info_str( gun, capacity_parts );
+    CAPTURE( capacity );
+    CHECK( capacity.find( "Capacity" ) != std::string::npos );
+    CHECK( capacity.find( ">1</color> round of " ) != std::string::npos );
+    CHECK( capacity.find( ">0</color> round" ) == std::string::npos );
+
+    const std::vector<iteminfo_parts> per_shot_parts = { iteminfo_parts::AMMO_TO_FIRE };
+    const std::string per_shot = item_info_str( gun, per_shot_parts );
+    CAPTURE( per_shot );
+    CHECK( per_shot.find( "Per-shot consumption" ) != std::string::npos );
 }
 
 // Related JSON fields:

--- a/tests/multimag_test.cpp
+++ b/tests/multimag_test.cpp
@@ -1079,6 +1079,44 @@ TEST_CASE( "multimag_reload_chains_to_sibling_well",
     CHECK( mags.size() == 2 );
 }
 
+// Unload on a multimag host with both a loaded MAGAZINE_WELL and a live
+// integral MAGAZINE pocket must drain both, not only the well.
+TEST_CASE( "multimag_unload_drains_integral_and_well",
+           "[multimag][unload]" )
+{
+    clear_avatar();
+    Character &you = get_player_character();
+    you.wear_item( item( itype_backpack ) );
+
+    item gun( itype_test_multimag_gun_integral_ammo );
+    REQUIRE( gun.uses_firing_requirements() );
+
+    item battery( itype_heavy_battery_cell );
+    battery.ammo_set( itype_battery, 100 );
+    REQUIRE( gun.put_in( battery, pocket_type::MAGAZINE_WELL ).success() );
+    REQUIRE( gun.put_in( item( itype_9mm, calendar::turn, 1 ),
+                         pocket_type::MAGAZINE ).success() );
+
+    item_location gun_loc = you.i_add( gun );
+    REQUIRE( gun_loc );
+    REQUIRE_FALSE( gun_loc->magazines_current().empty() );
+
+    const bool unloaded = you.unload( gun_loc, /*bypass_activity=*/true );
+    REQUIRE( unloaded );
+
+    CHECK( gun_loc->magazines_current().empty() );
+    const item &const_gun = *gun_loc;
+    const std::vector<const item_pocket *> integral_pockets = const_gun.get_pockets(
+    []( const item_pocket & p ) {
+        return p.is_type( pocket_type::MAGAZINE );
+    } );
+    for( const item_pocket *p : integral_pockets ) {
+        for( const item *e : p->all_items_top() ) {
+            CHECK( e->has_flag( flag_CASING ) );
+        }
+    }
+}
+
 TEST_CASE( "wield_collision_sees_mags_from_every_well",
            "[multimag][wield]" )
 {

--- a/tests/multimag_test.cpp
+++ b/tests/multimag_test.cpp
@@ -41,6 +41,11 @@
 #include "units.h"
 #include "visitable.h"
 
+static const ammotype ammo_9mm( "9mm" );
+static const ammotype ammo_battery( "battery" );
+
+static const flag_id json_flag_CASING( "CASING" );
+
 static const gun_mode_id gun_mode_AUTO( "AUTO" );
 static const gun_mode_id gun_mode_BURST( "BURST" );
 static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );
@@ -50,6 +55,7 @@ static const item_group_id Item_spawn_data_test_multimag_full_load( "test_multim
 static const itype_id itype_38_special( "38_special" );
 static const itype_id itype_556( "556" );
 static const itype_id itype_9mm( "9mm" );
+static const itype_id itype_9mm_casing( "9mm_casing" );
 static const itype_id itype_UPS_ON( "UPS_ON" );
 static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_battery( "battery" );
@@ -689,7 +695,7 @@ TEST_CASE( "reload_option_qty_forces_1_for_pocket_targeted_reloads",
     }
     REQUIRE( glock_idx >= 0 );
 
-    item::reload_option opt( &you, gun_loc, mag_loc );
+    item::reload_option opt( &you, gun_loc, mag_loc, item::reload_option::POCKET_FALLBACK );
     opt.pocket_index = glock_idx;
     opt.qty( 1000 );
     CHECK( opt.qty() == 1 );
@@ -1772,6 +1778,54 @@ TEST_CASE( "multimag_loaded_ammo_does_not_borrow_sibling_pocket",
     const item &loaded = gun.loaded_ammo();
     CHECK_FALSE( loaded.is_null() );
     CHECK( loaded.typeId() == itype_9mm );
+}
+
+// Casings in the integral projectile pocket must not count as loaded ammo.
+// Pins ammo_remaining()'s explicit CASING skip.
+TEST_CASE( "multimag_integral_pocket_skips_casings", "[multimag][ammo_data]" )
+{
+    item gun( itype_test_multimag_gun_integral_ammo );
+    REQUIRE( gun.uses_firing_requirements() );
+
+    item battery( itype_heavy_battery_cell );
+    battery.ammo_set( itype_battery, 100 );
+    REQUIRE( gun.put_in( battery, pocket_type::MAGAZINE_WELL ).success() );
+
+    // Casing alone in the projectile pocket: not loaded ammo.
+    gun.force_insert_item( item( itype_9mm_casing, calendar::turn,
+                                 1 ).set_flag( json_flag_CASING ),
+                           pocket_type::MAGAZINE );
+    CHECK_FALSE( gun.has_ammo() );
+    CHECK_FALSE( gun.has_ammo_data() );
+    CHECK( gun.ammo_data() == nullptr );
+    CHECK( gun.ammo_remaining() == 100 );
+
+    // Live slug alongside the casing: identity resolves to slug, count is 1.
+    REQUIRE( gun.put_in( item( itype_9mm, calendar::turn, 1 ),
+                         pocket_type::MAGAZINE ).success() );
+    CHECK( gun.has_ammo() );
+    CHECK( gun.has_ammo_data() );
+    CHECK( gun.ammo_remaining() == 101 );
+}
+
+// Per-ammotype capacity routes through the matching pocket so a
+// battery-only-loaded multimag gun still reports projectile slug capacity.
+TEST_CASE( "multimag_ammo_capacity_resolves_per_pocket", "[multimag][capacity]" )
+{
+    item gun( itype_test_multimag_gun_integral_ammo );
+    REQUIRE( gun.uses_firing_requirements() );
+
+    // Empty: still reports projectile pocket capacity for 9mm.
+    CHECK( gun.ammo_capacity( ammo_9mm ) == 1 );
+
+    item battery( itype_heavy_battery_cell );
+    battery.ammo_set( itype_battery, 100 );
+    REQUIRE( gun.put_in( battery, pocket_type::MAGAZINE_WELL ).success() );
+
+    // Battery loaded, slug pocket empty: slug capacity still from integral pocket.
+    CHECK( gun.ammo_capacity( ammo_9mm ) == 1 );
+    CHECK( gun.ammo_capacity( ammo_battery ) ==
+           battery.ammo_capacity( ammo_battery ) );
 }
 
 // Firing a multimag gun with only the power source loaded must abort cleanly

--- a/tests/multimag_test.cpp
+++ b/tests/multimag_test.cpp
@@ -19,6 +19,7 @@
 #include "coordinates.h"
 #include "debug.h"
 #include "flag.h"
+#include "flat_set.h"
 #include "item.h"
 #include "item_group.h"
 #include "item_location.h"
@@ -1024,6 +1025,58 @@ TEST_CASE( "reload_activity_actor_serializes_pocket_index",
     const std::string serialized = oss.str();
     CAPTURE( serialized );
     CHECK( serialized.find( "\"pocket_index\":0" ) != std::string::npos );
+}
+
+// Pins the auto-chain reload: finishing a multimag reload must queue the
+// next well when carrier inventory has unambiguous ammo for it.
+TEST_CASE( "multimag_reload_chains_to_sibling_well",
+           "[multimag][reload][activity]" )
+{
+    clear_avatar();
+    Character &you = get_player_character();
+    you.wear_item( item( itype_backpack ) );
+
+    item_location gun_loc = you.i_add( item( itype_test_multimag_turret_gun ) );
+    REQUIRE( gun_loc );
+    REQUIRE( gun_loc->uses_firing_requirements() );
+    REQUIRE( gun_loc->magazines_current().empty() );
+
+    item glock_mag( itype_glockmag );
+    glock_mag.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+    item_location glock_loc = you.i_add( glock_mag );
+    REQUIRE( glock_loc );
+    item batt( itype_heavy_battery_cell );
+    batt.ammo_set( itype_battery, 100 );
+    you.i_add( batt );
+
+    int glock_idx = -1;
+    int idx = 0;
+    for( const item_pocket *p : gun_loc->get_pockets( []( const item_pocket & ) {
+    return true;
+} ) ) {
+        if( p->is_type( pocket_type::MAGAZINE_WELL ) ) {
+            for( const itype_id &id : p->item_type_restrictions() ) {
+                if( id == itype_glockmag ) {
+                    glock_idx = idx;
+                    break;
+                }
+            }
+            if( glock_idx >= 0 ) {
+                break;
+            }
+        }
+        ++idx;
+    }
+    REQUIRE( glock_idx >= 0 );
+
+    item::reload_option opt( &you, gun_loc, glock_loc, glock_idx );
+    you.assign_activity( reload_activity_actor( std::move( opt ) ) );
+    REQUIRE( you.activity );
+
+    process_activity( you );
+
+    const std::vector<item *> mags = gun_loc->magazines_current();
+    CHECK( mags.size() == 2 );
 }
 
 TEST_CASE( "wield_collision_sees_mags_from_every_well",

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -1994,7 +1994,7 @@ static const std::vector<std::function<player_activity()>> test_activities {
         dummy->wear_item( item( itype_test_backpack, calendar::turn ), false );
         item_location target = dummy->i_add( item( itype_test_oxytorch, calendar::turn ) );
         item_location ammo = dummy->i_add( item( itype_test_weldtank, calendar::turn ) );
-        item::reload_option opt( dummy, target, ammo );
+        item::reload_option opt( dummy, target, ammo, item::reload_option::POCKET_FALLBACK );
         return player_activity( reload_activity_actor( std::move( opt ) ) );
     },
     [] { return player_activity( safecracking_activity_actor( get_avatar().pos_bub() + tripoint_rel_ms::north ) ); },

--- a/tests/reload_option_test.cpp
+++ b/tests/reload_option_test.cpp
@@ -41,17 +41,19 @@ TEST_CASE( "revolver_reload_option", "[reload] [reload_option] [gun]" )
     REQUIRE( gun->has_flag( json_flag_RELOAD_ONE ) );
     REQUIRE( gun->ammo_remaining( ) == 0 );
 
-    const item::reload_option gun_option( &dummy, gun, ammo );
+    const item::reload_option gun_option( &dummy, gun, ammo, item::reload_option::POCKET_FALLBACK );
     REQUIRE( gun_option.qty() == 7 );
 
     item_location speedloader = dummy.i_add( item( itype_38_speedloader, calendar::turn_zero, 0 ) );
     REQUIRE( speedloader->ammo_remaining( ) == 0 );
 
-    const item::reload_option speedloader_option( &dummy, speedloader, ammo );
+    const item::reload_option speedloader_option( &dummy, speedloader, ammo,
+            item::reload_option::POCKET_FALLBACK );
     CHECK( speedloader_option.qty() == speedloader->ammo_capacity( gun_ammo_type ) );
 
     speedloader->put_in( *ammo, pocket_type::MAGAZINE );
-    const item::reload_option gun_speedloader_option( &dummy, gun, speedloader );
+    const item::reload_option gun_speedloader_option( &dummy, gun, speedloader,
+            item::reload_option::POCKET_FALLBACK );
     CHECK( gun_speedloader_option.qty() == speedloader->ammo_capacity( gun_ammo_type ) );
 }
 
@@ -65,12 +67,13 @@ TEST_CASE( "magazine_reload_option", "[reload] [reload_option] [gun]" )
     item_location ammo = dummy.i_add( item( itype_9mm, calendar::turn_zero,
                                             magazine->ammo_capacity( mag_ammo_type ) ) );
 
-    const item::reload_option magazine_option( &dummy, magazine, ammo );
+    const item::reload_option magazine_option( &dummy, magazine, ammo,
+            item::reload_option::POCKET_FALLBACK );
     CHECK( magazine_option.qty() == magazine->ammo_capacity( mag_ammo_type ) );
 
     magazine->put_in( *ammo, pocket_type::MAGAZINE );
     item_location gun = dummy.i_add( item( itype_glock_19, calendar::turn_zero, 0 ) );
-    const item::reload_option gun_option( &dummy, gun, magazine );
+    const item::reload_option gun_option( &dummy, gun, magazine, item::reload_option::POCKET_FALLBACK );
     CHECK( gun_option.qty() == 1 );
 }
 
@@ -90,13 +93,13 @@ TEST_CASE( "belt_reload_option", "[reload] [reload_option] [gun]" )
     belt->ammo_unset();
 
     REQUIRE( belt->ammo_remaining( ) == 0 );
-    const item::reload_option belt_option( &dummy, belt, ammo );
+    const item::reload_option belt_option( &dummy, belt, ammo, item::reload_option::POCKET_FALLBACK );
     CHECK( belt_option.qty() == belt->ammo_capacity( belt_ammo_type ) );
 
     belt->put_in( *ammo, pocket_type::MAGAZINE );
     item_location gun = dummy.i_add( item( itype_m134, calendar::turn_zero, 0 ) );
 
-    const item::reload_option gun_option( &dummy, gun, belt );
+    const item::reload_option gun_option( &dummy, gun, belt, item::reload_option::POCKET_FALLBACK );
 
     CHECK( gun_option.qty() == 1 );
 }
@@ -113,12 +116,14 @@ TEST_CASE( "canteen_reload_option", "[reload] [reload_option] [liquid]" )
     item_location water_bottle = dummy.i_add( plastic_bottle );
     water_bottle->put_in( water, pocket_type::CONTAINER );
 
-    const item::reload_option bottle_option( &dummy, bottle, water_bottle );
+    const item::reload_option bottle_option( &dummy, bottle, water_bottle,
+            item::reload_option::POCKET_FALLBACK );
     CHECK( bottle_option.qty() == bottle->get_remaining_capacity_for_liquid( water, true ) );
 
     item_location canteen = dummy.i_add( item( itype_2lcanteen ) );
 
-    const item::reload_option canteen_option( &dummy, canteen, water_bottle );
+    const item::reload_option canteen_option( &dummy, canteen, water_bottle,
+            item::reload_option::POCKET_FALLBACK );
 
     CHECK( canteen_option.qty() == 2 );
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix multimag gun info crash and per-pocket capacity misreads"

#### Purpose of change
Per #85928. A multimag gun (integral projectile pocket + battery well, firing_requirements) crashes opening item info when only the battery is loaded, and Capacity shows 0 for the projectile ammotype. Both come from the same pattern: weak `ammo_data()` checks and per-ammotype lookups that pick the first loaded mag regardless of ammotype.

#### Describe the solution
gun_info checks `has_ammo_data()` before using `ammo_data()`, so the empty projectile pocket falls back to tmp ammo instead of dereferencing null.

`ammo_capacity(ammotype)` and `ammo_remaining()` go through a new `pocket_for_ammo()` resolver that walks both MAGAZINE_WELL and integral MAGAZINE pockets. Per-ammotype reads hit the right pocket and the aggregate stops missing integral projectile ammo.

UI: per-well display_name on Capacity and Ammunition, a "Per-shot consumption (mode):" line so the player sees which wells fire together, multi-row reload picker labels, and an unload picker that drains live integral pockets alongside loaded wells.

Misc: named `POCKET_FALLBACK` sentinel in place of bare -1 on `reload_option`, auto-chain reload for sibling wells, `npc::pretend_fire` uses `consume_one_shot` for firing_requirements guns, and a validator check requiring `default_magazine` on any MAGAZINE_WELL named by `firing_requirements`.

#### Describe alternatives you've considered
Considered a separate `effective_ammo_for_firing()` instead of touching `ammo_remaining()`, but every caller already meant the aggregate as "ammo on the host," so fixing it was simpler than adding a second accessor everyone has to remember.

NPC weapon eval and per-well NPC reload are still out of scope.

#### Testing
Verified in-game across battery-only, slug-only, both, and empty states. Reload chains to the next well, unload picker offers both sources. Added 5 test cases for the gun_info regression, CASING skip, per-ammotype capacity, reload chain, and dual-source unload.

#### Additional context
N/A