### PR TITLE
calendar_ui: drop translated default arg from select_time_point

### DIFF
--- a/src/calendar_ui.cpp
+++ b/src/calendar_ui.cpp
@@ -11,6 +11,7 @@
 #include "input_popup.h"
 #include "string_formatter.h"
 #include "translation.h"
+#include "translations.h"
 #include "uilist.h"
 
 time_point calendar_ui::select_time_point( time_point initial_value, std::string_view title,

--- a/src/calendar_ui.h
+++ b/src/calendar_ui.h
@@ -5,7 +5,6 @@
 #include <string_view>
 
 #include "calendar.h"
-#include "translations.h"
 
 namespace calendar_ui
 {
@@ -24,7 +23,7 @@ enum class granularity : int {
  * Displays ui element that allows to select and return time point.
  */
 time_point select_time_point( time_point initial_value,
-                              std::string_view title = _( "Select time point" ),
+                              std::string_view title,
                               calendar_ui::granularity granularity_level = calendar_ui::granularity::turn );
 } // namespace calendar_ui
 

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -4370,7 +4370,7 @@ void debug()
             g->toggle_debug_hour_timer();
             break;
         case debug_menu_index::CHANGE_TIME:
-            calendar::turn = calendar_ui::select_time_point( calendar::turn );
+            calendar::turn = calendar_ui::select_time_point( calendar::turn, _( "Select time point" ) );
             break;
         case debug_menu_index::FORCE_TEMP:
             debug_menu_force_temperature();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
clang-tidy `cata-no-static-translation` flags `_()` inside default arguments. `select_time_point`'s default `title` trips it.

#### Describe the solution
Make `title` required, pass the literal at the one remaining default caller, move `translations.h` include from the header to the .cpp.

#### Describe alternatives you've considered
N/A

#### Testing
Compiles, lint clean.

#### Additional context
Split from #87072.