### PR TITLE
ImGui: route mouse events around game when ImGui captures pointer

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -704,6 +704,16 @@ bool cataimgui::client::any_window_shown()
     return any_window_shown;
 }
 
+bool cataimgui::client::want_capture_mouse()
+{
+    return ImGui::GetCurrentContext() != nullptr && ImGui::GetIO().WantCaptureMouse;
+}
+
+bool cataimgui::client::want_capture_keyboard()
+{
+    return ImGui::GetCurrentContext() != nullptr && ImGui::GetIO().WantCaptureKeyboard;
+}
+
 static ImGuiKey cata_key_to_imgui( int cata_key )
 {
     switch( cata_key ) {

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -100,6 +100,11 @@ class client
 #endif
         bool auto_size_frame_active();
         bool any_window_shown();
+
+        // True if ImGui is consuming mouse input (hover / drag / popup).
+        static bool want_capture_mouse();
+        // True if an ImGui text field or shortcut has keyboard focus.
+        static bool want_capture_keyboard();
 };
 
 void point_to_imvec2( point *src, ImVec2 *dest );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3475,17 +3475,25 @@ static void CheckMessages()
                     }
                     if( get_option<std::string>( "HIDE_CURSOR" ) == "show" ||
                         get_option<std::string>( "HIDE_CURSOR" ) == "hidekb" ) {
+                        // Cursor visibility must run even when ImGui owns
+                        // the mouse, otherwise hidekb keeps the cursor
+                        // hidden over ImGui windows after keyboard use.
                         if( !IsCursorVisible() ) {
                             ShowCursor();
                         }
-
-                        // Only monitor motion when cursor is visible
-                        last_input = input_event( MouseInput::Move, input_event_t::mouse );
+                        // Only feed game's mouseover/highlight pipeline when
+                        // ImGui isn't already consuming the event.
+                        if( !cataimgui::client::want_capture_mouse() ) {
+                            last_input = input_event( MouseInput::Move, input_event_t::mouse );
+                        }
                     }
                     break;
 
                 case CATA_MOUSEBUTTONDOWN:
                     if( ! mouse.enabled ) {
+                        break;
+                    }
+                    if( cataimgui::client::want_capture_mouse() ) {
                         break;
                     }
                     switch( ev.button.button ) {
@@ -3508,6 +3516,9 @@ static void CheckMessages()
                     if( ! mouse.enabled ) {
                         break;
                     }
+                    if( cataimgui::client::want_capture_mouse() ) {
+                        break;
+                    }
                     switch( ev.button.button ) {
                         case SDL_BUTTON_LEFT:
                             last_input = input_event( MouseInput::LeftButtonReleased, input_event_t::mouse );
@@ -3526,6 +3537,9 @@ static void CheckMessages()
 
                 case CATA_MOUSEWHEEL:
                     if( ! mouse.enabled ) {
+                        break;
+                    }
+                    if( cataimgui::client::want_capture_mouse() ) {
                         break;
                     }
                     if( ev.wheel.y > 0 ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Stop game from reacting to clicks aimed at ImGui windows"

#### Purpose of change
ImGui windows received events but the game pipeline processed the same click, so clicking inside a debug window also clicked the world tile behind it.

#### Describe the solution
Add `cataimgui::client::want_capture_mouse` / `want_capture_keyboard` helpers. Skip game mouse handlers when ImGui owns input. Keep hidekb cursor-restore on motion.

#### Describe alternatives you've considered
N/A

#### Testing
Verified in-game by clicking inside debug ImGui windows.

#### Additional context
Split from #87072. Stacked on #87093.