### PR TITLE
Add debug capture pipeline

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -273,6 +273,7 @@ std::string filter_name( debug_filter value )
         case DF_VEHICLE_DRAG: return "DF_VEHICLE_DRAG";
         case DF_VEHICLE_MOVE: return "DF_VEHICLE_MOVE";
         case DF_WOUNDS: return "DF_WOUNDS";
+        case DF_MONITOR: return "DF_MONITOR";
         // *INDENT-ON*
         case DF_LAST:
         default:

--- a/src/debug.h
+++ b/src/debug.h
@@ -290,6 +290,7 @@ enum debug_filter : int {
     DF_VEHICLE_DRAG, // vehicle coeff_air_drag()
     DF_VEHICLE_MOVE, // vehicle move generic
     DF_WOUNDS, // everything related to applying wounds
+    DF_MONITOR, // debug console per-object monitor snapshots
     DF_LAST // This is always the last entry
 };
 

--- a/src/debug_capture.cpp
+++ b/src/debug_capture.cpp
@@ -7,6 +7,8 @@
 #include <string_view>
 #include <utility>
 
+#include <flatbuffers/util.h>
+
 #include "calendar.h"
 #include "cata_variant.h"
 #include "debug.h"
@@ -31,52 +33,24 @@ class event_capture_sub : public event_subscriber
         void notify( const cata::event &e ) override;
 };
 
-std::string json_escape( std::string_view s )
+// Escape a string into a complete JSON string literal, including the
+// surrounding double quotes. natural_utf8=false so control characters and
+// non-ASCII bytes become \uXXXX (valid JSON) rather than being emitted raw.
+std::string json_quoted( std::string_view s )
 {
     std::string out;
-    out.reserve( s.size() + 2 );
-    for( char c : s ) {
-        switch( c ) {
-            case '"':
-                out += "\\\"";
-                break;
-            case '\\':
-                out += "\\\\";
-                break;
-            case '\b':
-                out += "\\b";
-                break;
-            case '\f':
-                out += "\\f";
-                break;
-            case '\n':
-                out += "\\n";
-                break;
-            case '\r':
-                out += "\\r";
-                break;
-            case '\t':
-                out += "\\t";
-                break;
-            default:
-                if( static_cast<unsigned char>( c ) < 0x20 ) {
-                    static constexpr char hex[] = "0123456789abcdef";
-                    const unsigned char uc = static_cast<unsigned char>( c );
-                    out += R"(\u00)";
-                    out += hex[( uc >> 4 ) & 0xF ];
-                    out += hex[ uc & 0xF ];
-                } else {
-                    out += c;
-                }
-        }
-    }
+    flatbuffers::EscapeString( s.data(), s.size(), &out,
+                               /*allow_non_utf8=*/true, /*natural_utf8=*/false );
     return out;
 }
 } // namespace
 
 std::string capture_json_escape( std::string_view s )
 {
-    return json_escape( s );
+    // Same escaping as json_quoted, minus the surrounding quotes it always
+    // adds; callers that need a bare body supply their own quoting.
+    const std::string quoted = json_quoted( s );
+    return quoted.substr( 1, quoted.size() - 2 );
 }
 
 struct debug_capture::impl {
@@ -88,10 +62,10 @@ struct debug_capture::impl {
     event_capture_sub event_sub;
     bool event_sub_attached = false;
 
-    std::ofstream jsonl_file;
-    size_t jsonl_bytes = 0;
+    std::ofstream trace_file_stream;
+    size_t trace_file_bytes = 0;
     int lines_since_flush = 0;
-    static constexpr int jsonl_flush_batch = 64;
+    static constexpr int trace_file_flush_batch = 64;
 
     std::vector<monitor_entry> monitors;
     int next_monitor_id = 1;
@@ -100,9 +74,9 @@ struct debug_capture::impl {
     uint64_t feed_gen = 0;
 
     void trim_to_max();
-    void append_jsonl( const std::string &source, const std::string &json_payload );
-    void ensure_jsonl_open();
-    void rotate_jsonl_if_needed();
+    void append_trace_file( const std::string &source, const std::string &json_payload );
+    void ensure_trace_file_open();
+    void rotate_trace_file_if_needed();
 };
 
 void debug_capture::impl::trim_to_max()
@@ -134,100 +108,108 @@ static std::string csv_escape( std::string_view s )
     return out;
 }
 
-void debug_capture::impl::ensure_jsonl_open()
+void debug_capture::impl::ensure_trace_file_open()
 {
-    if( jsonl_file.is_open() || !settings.jsonl.enabled ) {
+    if( trace_file_stream.is_open() || !settings.trace_file.enabled ) {
         return;
     }
-    jsonl_file.open( settings.jsonl.path, std::ios::app | std::ios::out );
-    if( jsonl_file.is_open() ) {
+    trace_file_stream.open( settings.trace_file.path, std::ios::app | std::ios::out );
+    if( trace_file_stream.is_open() ) {
         // Rebase byte counter to existing file size so rotation triggers
         // correctly when appending to a prior session's log.
-        jsonl_file.seekp( 0, std::ios::end );
-        const auto pos = jsonl_file.tellp();
-        jsonl_bytes = pos > 0 ? static_cast<size_t>( pos ) : 0;
+        trace_file_stream.seekp( 0, std::ios::end );
+        const auto pos = trace_file_stream.tellp();
+        trace_file_bytes = pos > 0 ? static_cast<size_t>( pos ) : 0;
         lines_since_flush = 0;
-        if( settings.jsonl.format == capture_format::csv && jsonl_bytes == 0 ) {
+        if( settings.trace_file.format == capture_format::csv && trace_file_bytes == 0 ) {
             const std::string header = "turn,src,data\n";
-            jsonl_file.write( header.data(), header.size() );
-            jsonl_bytes += header.size();
+            trace_file_stream.write( header.data(), header.size() );
+            trace_file_bytes += header.size();
         }
     }
 }
 
-void debug_capture::impl::rotate_jsonl_if_needed()
+void debug_capture::impl::rotate_trace_file_if_needed()
 {
-    if( jsonl_bytes < settings.jsonl.rotate_mib * 1024 * 1024 ) {
+    if( trace_file_bytes < settings.trace_file.rotate_mib * 1024 * 1024 ) {
         return;
     }
-    jsonl_file.close();
-    const std::string &base = settings.jsonl.path;
+    trace_file_stream.close();
+    const std::string &base = settings.trace_file.path;
     const std::string r1 = base + ".1";
     const std::string r2 = base + ".2";
+    const std::string r2_tmp = r2 + ".tmp";
     // Errors here are recoverable (rotation just skipped this turn); we still
-    // reopen the base file fresh.
-    const int rm_rc = std::remove( r2.c_str() );
+    // reopen the base file fresh. Move the stale .2 aside with a rename rather
+    // than deleting it before the .1 -> .2 rename: on Windows a delete can
+    // leave the file briefly locked, which would make that rename fail.
+    const int rn0_rc = std::rename( r2.c_str(), r2_tmp.c_str() );
     const int rn1_rc = std::rename( r1.c_str(), r2.c_str() );
     const int rn2_rc = std::rename( base.c_str(), r1.c_str() );
-    ( void )rm_rc;
+    const int rm_rc = std::remove( r2_tmp.c_str() );
+    ( void )rn0_rc;
     ( void )rn1_rc;
     ( void )rn2_rc;
-    jsonl_file.open( base, std::ios::out | std::ios::trunc );
-    jsonl_bytes = 0;
+    ( void )rm_rc;
+    trace_file_stream.open( base, std::ios::out | std::ios::trunc );
+    trace_file_bytes = 0;
     lines_since_flush = 0;
-    if( jsonl_file.is_open() && settings.jsonl.format == capture_format::csv ) {
+    if( trace_file_stream.is_open() && settings.trace_file.format == capture_format::csv ) {
         const std::string header = "turn,src,data\n";
-        jsonl_file.write( header.data(), header.size() );
-        jsonl_bytes += header.size();
+        trace_file_stream.write( header.data(), header.size() );
+        trace_file_bytes += header.size();
     }
 }
 
-void debug_capture::impl::append_jsonl( const std::string &source,
-                                        const std::string &json_payload )
+void debug_capture::impl::append_trace_file( const std::string &source,
+        const std::string &json_payload )
 {
-    if( !settings.jsonl.enabled ) {
+    if( !settings.trace_file.wants( source ) ) {
         return;
     }
-    if( !settings.jsonl.sources.count( source ) ) {
+    ensure_trace_file_open();
+    if( !trace_file_stream.is_open() ) {
         return;
     }
-    ensure_jsonl_open();
-    if( !jsonl_file.is_open() ) {
-        return;
-    }
-    rotate_jsonl_if_needed();
+    rotate_trace_file_if_needed();
     const int turn = to_turns<int>( calendar::turn - calendar::turn_zero );
     std::string line;
-    if( settings.jsonl.format == capture_format::csv ) {
+    if( settings.trace_file.format == capture_format::csv ) {
         line = std::to_string( turn ) + "," +
                csv_escape( source ) + "," +
                csv_escape( json_payload ) + "\n";
     } else {
         line = R"({"turn":)" + std::to_string( turn ) +
-               R"(,"src":")" + json_escape( source ) +
-               R"(","data":)" + json_payload + "}\n";
+               R"(,"src":)" + json_quoted( source ) +
+               R"(,"data":)" + json_payload + "}\n";
     }
-    jsonl_file.write( line.data(), line.size() );
-    jsonl_bytes += line.size();
-    if( settings.jsonl.auto_flush
-        && ++lines_since_flush >= jsonl_flush_batch ) {
-        jsonl_file.flush();
+    trace_file_stream.write( line.data(), line.size() );
+    trace_file_bytes += line.size();
+    if( settings.trace_file.auto_flush
+        && ++lines_since_flush >= trace_file_flush_batch ) {
+        trace_file_stream.flush();
         lines_since_flush = 0;
     }
 }
 
-void debug_capture::flush_jsonl()
+void debug_capture::flush_trace_file()
 {
-    if( p->jsonl_file.is_open() ) {
-        p->jsonl_file.flush();
+    if( p->trace_file_stream.is_open() ) {
+        p->trace_file_stream.flush();
         p->lines_since_flush = 0;
     }
 }
 
 debug_capture &debug_capture::instance()
 {
-    static debug_capture inst;
-    return inst;
+    // Deliberately leaked, process-lifetime singleton. A function-local static
+    // would run its destructor during the atexit chain, racing ~game and other
+    // static destructors that may still touch capture (e.g. a log from another
+    // static dtor). Leaking sidesteps the teardown-order hazard entirely; the
+    // OS reclaims at exit, and buffered output is flushed by on_game_shutdown()
+    // and the auto-flush batch.
+    static debug_capture *const inst = new debug_capture();
+    return *inst;
 }
 
 bool debug_capture::is_initialized()
@@ -240,17 +222,9 @@ debug_capture::debug_capture() : p( std::make_unique<impl>() )
     g_initialized.store( true, std::memory_order_release );
 }
 
-debug_capture::~debug_capture()
-{
-    // Mark uninitialized first so any code racing this dtor (e.g. ~game later
-    // in the atexit chain, log_debug_msg from another static-dtor) skips the
-    // singleton instead of touching destroyed state.
-    g_initialized.store( false, std::memory_order_release );
-    if( p && p->jsonl_file.is_open() ) {
-        p->jsonl_file.flush();
-        p->jsonl_file.close();
-    }
-}
+// Defined out-of-line so unique_ptr<impl> sees a complete impl. The instance()
+// singleton is leaked, so this is never invoked at runtime.
+debug_capture::~debug_capture() = default;
 
 capture_settings &debug_capture::settings()
 {
@@ -274,9 +248,9 @@ void debug_capture::on_game_shutdown()
 {
     // event_subscriber dtor auto-unsubscribes from its bus when bus still exists.
     p->event_sub_attached = false;
-    if( p->jsonl_file.is_open() ) {
-        p->jsonl_file.flush();
-        p->jsonl_file.close();
+    if( p->trace_file_stream.is_open() ) {
+        p->trace_file_stream.flush();
+        p->trace_file_stream.close();
         p->lines_since_flush = 0;
     }
 }
@@ -287,21 +261,17 @@ void debug_capture::push_debug_log( debugmode::debug_filter type, const std::str
         return;
     }
     const bool ring_on = p->settings.add_msg_debug_capture;
-    const bool jsonl_on = p->settings.jsonl.enabled
-                          && p->settings.jsonl.sources.count( "log" );
-    if( !ring_on && !jsonl_on ) {
-        return;
-    }
+    const bool file_on = p->settings.trace_file.wants( "log" );
     if( ring_on ) {
         const int turn = to_turns<int>( calendar::turn - calendar::turn_zero );
-        p->log_ring.push_back( { type, msg, turn } );
+        p->log_ring.push_back( { turn, type, msg } );
         p->trim_to_max();
         ++p->feed_gen;
     }
-    if( jsonl_on ) {
-        std::string payload = R"({"category":")" + debugmode::filter_name( type ) +
-                              R"(","text":")" + json_escape( msg ) + R"("})";
-        p->append_jsonl( "log", payload );
+    if( file_on ) {
+        const std::string payload = R"({"category":)" + json_quoted( debugmode::filter_name( type ) ) +
+                                    R"(,"text":)" + json_quoted( msg ) + "}";
+        p->append_trace_file( "log", payload );
     }
 }
 
@@ -311,9 +281,9 @@ void debug_capture::push_event( const cata::event &e )
         return;
     }
     const bool ring_on = p->settings.event_bus_capture;
-    const bool jsonl_on = p->settings.jsonl.enabled
-                          && p->settings.jsonl.sources.count( "events" );
-    if( !ring_on && !jsonl_on ) {
+    const bool file_on = p->settings.trace_file.wants( "events" );
+    // Skip building the field string when no sink will consume it.
+    if( !ring_on && !file_on ) {
         return;
     }
     std::string oneline;
@@ -329,10 +299,10 @@ void debug_capture::push_event( const cata::event &e )
         p->trim_to_max();
         ++p->feed_gen;
     }
-    if( jsonl_on ) {
-        std::string payload = R"({"type":)" + std::to_string( static_cast<int>( e.type() ) ) +
-                              R"(,"fields":")" + json_escape( oneline ) + R"("})";
-        p->append_jsonl( "events", payload );
+    if( file_on ) {
+        const std::string payload = R"({"type":)" + std::to_string( static_cast<int>( e.type() ) ) +
+                                    R"(,"fields":)" + json_quoted( oneline ) + "}";
+        p->append_trace_file( "events", payload );
     }
 }
 
@@ -343,24 +313,20 @@ void debug_capture::push_eoc_trace( const std::string &eoc_id, bool success,
         return;
     }
     const bool ring_on = p->settings.eoc_trace_capture;
-    const bool jsonl_on = p->settings.jsonl.enabled
-                          && p->settings.jsonl.sources.count( "eoc" );
-    if( !ring_on && !jsonl_on ) {
-        return;
-    }
+    const bool file_on = p->settings.trace_file.wants( "eoc" );
     if( ring_on ) {
         const int turn = to_turns<int>( calendar::turn - calendar::turn_zero );
-        p->eoc_trace_ring.push_back( { turn, eoc_id, success,
-                                       static_cast<int64_t>( us.count() ), depth } );
+        p->eoc_trace_ring.push_back( { eoc_id, static_cast<int64_t>( us.count() ),
+                                       turn, depth, success } );
         p->trim_to_max();
         ++p->feed_gen;
     }
-    if( jsonl_on ) {
-        std::string payload = R"({"id":")" + json_escape( eoc_id ) + R"(","ok":)" +
-                              ( success ? "true" : "false" ) +
-                              R"(,"us":)" + std::to_string( us.count() ) +
-                              R"(,"depth":)" + std::to_string( depth ) + "}";
-        p->append_jsonl( "eoc", payload );
+    if( file_on ) {
+        const std::string payload = R"({"id":)" + json_quoted( eoc_id ) + R"(,"ok":)" +
+                                    ( success ? "true" : "false" ) +
+                                    R"(,"us":)" + std::to_string( us.count() ) +
+                                    R"(,"depth":)" + std::to_string( depth ) + "}";
+        p->append_trace_file( "eoc", payload );
     }
 }
 
@@ -399,23 +365,34 @@ void debug_capture::clear_eoc_traces()
 
 void debug_capture::resize_log_ring( size_t n )
 {
+    const size_t before = p->log_ring.size();
     p->settings.log_ring_size = n;
     p->trim_to_max();
-    ++p->feed_gen;
+    // Only bump the feed generation when entries were actually dropped; a grow
+    // or no-op resize leaves content unchanged.
+    if( p->log_ring.size() != before ) {
+        ++p->feed_gen;
+    }
 }
 
 void debug_capture::resize_event_ring( size_t n )
 {
+    const size_t before = p->event_ring.size();
     p->settings.event_ring_size = n;
     p->trim_to_max();
-    ++p->feed_gen;
+    if( p->event_ring.size() != before ) {
+        ++p->feed_gen;
+    }
 }
 
 void debug_capture::resize_eoc_trace_ring( size_t n )
 {
+    const size_t before = p->eoc_trace_ring.size();
     p->settings.eoc_trace_ring_size = n;
     p->trim_to_max();
-    ++p->feed_gen;
+    if( p->eoc_trace_ring.size() != before ) {
+        ++p->feed_gen;
+    }
 }
 
 uint64_t debug_capture::feed_generation() const noexcept
@@ -540,16 +517,18 @@ void debug_capture::save_settings( JsonOut &jo ) const
     jo.member( "log_ring_size", cs.log_ring_size );
     jo.member( "event_ring_size", cs.event_ring_size );
     jo.member( "eoc_trace_ring_size", cs.eoc_trace_ring_size );
+    // On-disk key is "jsonl" (not trace_file) for back-compat with existing
+    // config files.
     jo.member( "jsonl" );
     jo.start_object();
-    jo.member( "enabled", cs.jsonl.enabled );
-    jo.member( "auto_flush", cs.jsonl.auto_flush );
-    jo.member( "format", static_cast<int>( cs.jsonl.format ) );
-    jo.member( "path", cs.jsonl.path );
-    jo.member( "rotate_mib", cs.jsonl.rotate_mib );
+    jo.member( "enabled", cs.trace_file.enabled );
+    jo.member( "auto_flush", cs.trace_file.auto_flush );
+    jo.member( "format", static_cast<int>( cs.trace_file.format ) );
+    jo.member( "path", cs.trace_file.path );
+    jo.member( "rotate_mib", cs.trace_file.rotate_mib );
     jo.member( "sources" );
     jo.start_array();
-    for( const std::string &s : cs.jsonl.sources ) {
+    for( const std::string &s : cs.trace_file.sources ) {
         jo.write( s );
     }
     jo.end_array();
@@ -573,24 +552,25 @@ void debug_capture::load_settings( const JsonObject &jo )
     if( jo.read( "eoc_trace_ring_size", ring ) ) {
         resize_eoc_trace_ring( static_cast<size_t>( ring ) );
     }
+    // On-disk key is "jsonl" for back-compat (see save_settings).
     if( jo.has_object( "jsonl" ) ) {
         const JsonObject jl = jo.get_object( "jsonl" );
         jl.allow_omitted_members();
-        jl.read( "enabled", cs.jsonl.enabled );
-        jl.read( "auto_flush", cs.jsonl.auto_flush );
-        int fmt_int = static_cast<int>( cs.jsonl.format );
+        jl.read( "enabled", cs.trace_file.enabled );
+        jl.read( "auto_flush", cs.trace_file.auto_flush );
+        int fmt_int = static_cast<int>( cs.trace_file.format );
         if( jl.read( "format", fmt_int ) ) {
-            cs.jsonl.format = fmt_int == 1 ? capture_format::csv : capture_format::jsonl;
+            cs.trace_file.format = fmt_int == 1 ? capture_format::csv : capture_format::jsonl;
         }
-        jl.read( "path", cs.jsonl.path );
-        uint64_t rotate = cs.jsonl.rotate_mib;
+        jl.read( "path", cs.trace_file.path );
+        uint64_t rotate = cs.trace_file.rotate_mib;
         if( jl.read( "rotate_mib", rotate ) ) {
-            cs.jsonl.rotate_mib = static_cast<size_t>( rotate );
+            cs.trace_file.rotate_mib = static_cast<size_t>( rotate );
         }
         if( jl.has_array( "sources" ) ) {
-            cs.jsonl.sources.clear();
+            cs.trace_file.sources.clear();
             for( const JsonValue &s : jl.get_array( "sources" ) ) {
-                cs.jsonl.sources.insert( s.get_string() );
+                cs.trace_file.sources.insert( s.get_string() );
             }
         }
     }

--- a/src/debug_capture.cpp
+++ b/src/debug_capture.cpp
@@ -1,0 +1,599 @@
+#include "debug_capture.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cstdio>
+#include <fstream>
+#include <string_view>
+#include <utility>
+
+#include "calendar.h"
+#include "cata_variant.h"
+#include "debug.h"
+#include "event.h"
+#include "event_bus.h"
+#include "event_subscriber.h"
+#include "flexbuffer_json.h"
+#include "json.h"
+#include "messages.h"
+
+namespace debug_menu
+{
+
+namespace
+{
+std::atomic<bool> g_initialized{ false };
+
+class event_capture_sub : public event_subscriber
+{
+    public:
+        using event_subscriber::notify;
+        void notify( const cata::event &e ) override;
+};
+
+std::string json_escape( std::string_view s )
+{
+    std::string out;
+    out.reserve( s.size() + 2 );
+    for( char c : s ) {
+        switch( c ) {
+            case '"':
+                out += "\\\"";
+                break;
+            case '\\':
+                out += "\\\\";
+                break;
+            case '\b':
+                out += "\\b";
+                break;
+            case '\f':
+                out += "\\f";
+                break;
+            case '\n':
+                out += "\\n";
+                break;
+            case '\r':
+                out += "\\r";
+                break;
+            case '\t':
+                out += "\\t";
+                break;
+            default:
+                if( static_cast<unsigned char>( c ) < 0x20 ) {
+                    static constexpr char hex[] = "0123456789abcdef";
+                    const unsigned char uc = static_cast<unsigned char>( c );
+                    out += R"(\u00)";
+                    out += hex[( uc >> 4 ) & 0xF ];
+                    out += hex[ uc & 0xF ];
+                } else {
+                    out += c;
+                }
+        }
+    }
+    return out;
+}
+} // namespace
+
+std::string capture_json_escape( std::string_view s )
+{
+    return json_escape( s );
+}
+
+struct debug_capture::impl {
+    capture_settings settings;
+    std::deque<debug_log_entry> log_ring;
+    std::deque<event_log_entry> event_ring;
+    std::deque<eoc_trace_entry> eoc_trace_ring;
+
+    event_capture_sub event_sub;
+    bool event_sub_attached = false;
+
+    std::ofstream jsonl_file;
+    size_t jsonl_bytes = 0;
+    int lines_since_flush = 0;
+    static constexpr int jsonl_flush_batch = 64;
+
+    std::vector<monitor_entry> monitors;
+    int next_monitor_id = 1;
+
+    // See debug_capture::feed_generation().
+    uint64_t feed_gen = 0;
+
+    void trim_to_max();
+    void append_jsonl( const std::string &source, const std::string &json_payload );
+    void ensure_jsonl_open();
+    void rotate_jsonl_if_needed();
+};
+
+void debug_capture::impl::trim_to_max()
+{
+    while( log_ring.size() > settings.log_ring_size ) {
+        log_ring.pop_front();
+    }
+    while( event_ring.size() > settings.event_ring_size ) {
+        event_ring.pop_front();
+    }
+    while( eoc_trace_ring.size() > settings.eoc_trace_ring_size ) {
+        eoc_trace_ring.pop_front();
+    }
+}
+
+static std::string csv_escape( std::string_view s )
+{
+    std::string out;
+    out.reserve( s.size() + 2 );
+    out.push_back( '"' );
+    for( char c : s ) {
+        if( c == '"' ) {
+            out.append( "\"\"" );
+        } else {
+            out.push_back( c );
+        }
+    }
+    out.push_back( '"' );
+    return out;
+}
+
+void debug_capture::impl::ensure_jsonl_open()
+{
+    if( jsonl_file.is_open() || !settings.jsonl.enabled ) {
+        return;
+    }
+    jsonl_file.open( settings.jsonl.path, std::ios::app | std::ios::out );
+    if( jsonl_file.is_open() ) {
+        // Rebase byte counter to existing file size so rotation triggers
+        // correctly when appending to a prior session's log.
+        jsonl_file.seekp( 0, std::ios::end );
+        const auto pos = jsonl_file.tellp();
+        jsonl_bytes = pos > 0 ? static_cast<size_t>( pos ) : 0;
+        lines_since_flush = 0;
+        if( settings.jsonl.format == capture_format::csv && jsonl_bytes == 0 ) {
+            const std::string header = "turn,src,data\n";
+            jsonl_file.write( header.data(), header.size() );
+            jsonl_bytes += header.size();
+        }
+    }
+}
+
+void debug_capture::impl::rotate_jsonl_if_needed()
+{
+    if( jsonl_bytes < settings.jsonl.rotate_mib * 1024 * 1024 ) {
+        return;
+    }
+    jsonl_file.close();
+    const std::string &base = settings.jsonl.path;
+    const std::string r1 = base + ".1";
+    const std::string r2 = base + ".2";
+    // Errors here are recoverable (rotation just skipped this turn); we still
+    // reopen the base file fresh.
+    const int rm_rc = std::remove( r2.c_str() );
+    const int rn1_rc = std::rename( r1.c_str(), r2.c_str() );
+    const int rn2_rc = std::rename( base.c_str(), r1.c_str() );
+    ( void )rm_rc;
+    ( void )rn1_rc;
+    ( void )rn2_rc;
+    jsonl_file.open( base, std::ios::out | std::ios::trunc );
+    jsonl_bytes = 0;
+    lines_since_flush = 0;
+    if( jsonl_file.is_open() && settings.jsonl.format == capture_format::csv ) {
+        const std::string header = "turn,src,data\n";
+        jsonl_file.write( header.data(), header.size() );
+        jsonl_bytes += header.size();
+    }
+}
+
+void debug_capture::impl::append_jsonl( const std::string &source,
+                                        const std::string &json_payload )
+{
+    if( !settings.jsonl.enabled ) {
+        return;
+    }
+    if( !settings.jsonl.sources.count( source ) ) {
+        return;
+    }
+    ensure_jsonl_open();
+    if( !jsonl_file.is_open() ) {
+        return;
+    }
+    rotate_jsonl_if_needed();
+    const int turn = to_turns<int>( calendar::turn - calendar::turn_zero );
+    std::string line;
+    if( settings.jsonl.format == capture_format::csv ) {
+        line = std::to_string( turn ) + "," +
+               csv_escape( source ) + "," +
+               csv_escape( json_payload ) + "\n";
+    } else {
+        line = R"({"turn":)" + std::to_string( turn ) +
+               R"(,"src":")" + json_escape( source ) +
+               R"(","data":)" + json_payload + "}\n";
+    }
+    jsonl_file.write( line.data(), line.size() );
+    jsonl_bytes += line.size();
+    if( settings.jsonl.auto_flush
+        && ++lines_since_flush >= jsonl_flush_batch ) {
+        jsonl_file.flush();
+        lines_since_flush = 0;
+    }
+}
+
+void debug_capture::flush_jsonl()
+{
+    if( p->jsonl_file.is_open() ) {
+        p->jsonl_file.flush();
+        p->lines_since_flush = 0;
+    }
+}
+
+debug_capture &debug_capture::instance()
+{
+    static debug_capture inst;
+    return inst;
+}
+
+bool debug_capture::is_initialized()
+{
+    return g_initialized.load( std::memory_order_acquire );
+}
+
+debug_capture::debug_capture() : p( std::make_unique<impl>() )
+{
+    g_initialized.store( true, std::memory_order_release );
+}
+
+debug_capture::~debug_capture()
+{
+    // Mark uninitialized first so any code racing this dtor (e.g. ~game later
+    // in the atexit chain, log_debug_msg from another static-dtor) skips the
+    // singleton instead of touching destroyed state.
+    g_initialized.store( false, std::memory_order_release );
+    if( p && p->jsonl_file.is_open() ) {
+        p->jsonl_file.flush();
+        p->jsonl_file.close();
+    }
+}
+
+capture_settings &debug_capture::settings()
+{
+    return p->settings;
+}
+
+const capture_settings &debug_capture::settings() const
+{
+    return p->settings;
+}
+
+void debug_capture::on_game_load( event_bus &bus )
+{
+    if( !p->event_sub_attached ) {
+        bus.subscribe( &p->event_sub );
+        p->event_sub_attached = true;
+    }
+}
+
+void debug_capture::on_game_shutdown()
+{
+    // event_subscriber dtor auto-unsubscribes from its bus when bus still exists.
+    p->event_sub_attached = false;
+    if( p->jsonl_file.is_open() ) {
+        p->jsonl_file.flush();
+        p->jsonl_file.close();
+        p->lines_since_flush = 0;
+    }
+}
+
+void debug_capture::push_debug_log( debugmode::debug_filter type, const std::string &msg )
+{
+    if( !p->settings.main_enabled ) {
+        return;
+    }
+    const bool ring_on = p->settings.add_msg_debug_capture;
+    const bool jsonl_on = p->settings.jsonl.enabled
+                          && p->settings.jsonl.sources.count( "log" );
+    if( !ring_on && !jsonl_on ) {
+        return;
+    }
+    if( ring_on ) {
+        const int turn = to_turns<int>( calendar::turn - calendar::turn_zero );
+        p->log_ring.push_back( { type, msg, turn } );
+        p->trim_to_max();
+        ++p->feed_gen;
+    }
+    if( jsonl_on ) {
+        std::string payload = R"({"category":")" + debugmode::filter_name( type ) +
+                              R"(","text":")" + json_escape( msg ) + R"("})";
+        p->append_jsonl( "log", payload );
+    }
+}
+
+void debug_capture::push_event( const cata::event &e )
+{
+    if( !p->settings.main_enabled ) {
+        return;
+    }
+    const bool ring_on = p->settings.event_bus_capture;
+    const bool jsonl_on = p->settings.jsonl.enabled
+                          && p->settings.jsonl.sources.count( "events" );
+    if( !ring_on && !jsonl_on ) {
+        return;
+    }
+    std::string oneline;
+    for( const auto &kv : e.data() ) {
+        if( !oneline.empty() ) {
+            oneline += ", ";
+        }
+        oneline += kv.first + "=" + kv.second.get_string();
+    }
+    if( ring_on ) {
+        const int turn = to_turns<int>( calendar::turn - calendar::turn_zero );
+        p->event_ring.push_back( { turn, static_cast<int>( e.type() ), oneline } );
+        p->trim_to_max();
+        ++p->feed_gen;
+    }
+    if( jsonl_on ) {
+        std::string payload = R"({"type":)" + std::to_string( static_cast<int>( e.type() ) ) +
+                              R"(,"fields":")" + json_escape( oneline ) + R"("})";
+        p->append_jsonl( "events", payload );
+    }
+}
+
+void debug_capture::push_eoc_trace( const std::string &eoc_id, bool success,
+                                    std::chrono::microseconds us, int depth )
+{
+    if( !p->settings.main_enabled ) {
+        return;
+    }
+    const bool ring_on = p->settings.eoc_trace_capture;
+    const bool jsonl_on = p->settings.jsonl.enabled
+                          && p->settings.jsonl.sources.count( "eoc" );
+    if( !ring_on && !jsonl_on ) {
+        return;
+    }
+    if( ring_on ) {
+        const int turn = to_turns<int>( calendar::turn - calendar::turn_zero );
+        p->eoc_trace_ring.push_back( { turn, eoc_id, success,
+                                       static_cast<int64_t>( us.count() ), depth } );
+        p->trim_to_max();
+        ++p->feed_gen;
+    }
+    if( jsonl_on ) {
+        std::string payload = R"({"id":")" + json_escape( eoc_id ) + R"(","ok":)" +
+                              ( success ? "true" : "false" ) +
+                              R"(,"us":)" + std::to_string( us.count() ) +
+                              R"(,"depth":)" + std::to_string( depth ) + "}";
+        p->append_jsonl( "eoc", payload );
+    }
+}
+
+const std::deque<debug_log_entry> &debug_capture::logs() const
+{
+    return p->log_ring;
+}
+
+const std::deque<event_log_entry> &debug_capture::events() const
+{
+    return p->event_ring;
+}
+
+const std::deque<eoc_trace_entry> &debug_capture::eoc_traces() const
+{
+    return p->eoc_trace_ring;
+}
+
+void debug_capture::clear_logs()
+{
+    p->log_ring.clear();
+    ++p->feed_gen;
+}
+
+void debug_capture::clear_events()
+{
+    p->event_ring.clear();
+    ++p->feed_gen;
+}
+
+void debug_capture::clear_eoc_traces()
+{
+    p->eoc_trace_ring.clear();
+    ++p->feed_gen;
+}
+
+void debug_capture::resize_log_ring( size_t n )
+{
+    p->settings.log_ring_size = n;
+    p->trim_to_max();
+    ++p->feed_gen;
+}
+
+void debug_capture::resize_event_ring( size_t n )
+{
+    p->settings.event_ring_size = n;
+    p->trim_to_max();
+    ++p->feed_gen;
+}
+
+void debug_capture::resize_eoc_trace_ring( size_t n )
+{
+    p->settings.eoc_trace_ring_size = n;
+    p->trim_to_max();
+    ++p->feed_gen;
+}
+
+uint64_t debug_capture::feed_generation() const noexcept
+{
+    return p->feed_gen;
+}
+
+int debug_capture::add_monitor( std::string label,
+                                std::function<std::string()> snap, monitor_mode mode )
+{
+    monitor_entry e;
+    e.id = p->next_monitor_id++;
+    e.label = std::move( label );
+    e.snapshot = std::move( snap );
+    e.mode = mode;
+    e.enabled = true;
+    if( e.snapshot ) {
+        e.last_snapshot = e.snapshot();
+        e.last_snapshot_turn = to_turns<int>( calendar::turn - calendar::turn_zero );
+    }
+    p->monitors.push_back( std::move( e ) );
+    return p->monitors.back().id;
+}
+
+void debug_capture::remove_monitor( int id )
+{
+    p->monitors.erase(
+        std::remove_if( p->monitors.begin(), p->monitors.end(),
+    [id]( const monitor_entry & e ) {
+        return e.id == id;
+    } ),
+    p->monitors.end() );
+}
+
+void debug_capture::snapshot_monitor( int id )
+{
+    for( monitor_entry &e : p->monitors ) {
+        if( e.id == id && e.snapshot ) {
+            std::string s = e.snapshot();
+            push_debug_log( debugmode::DF_MONITOR,
+                            "[" + e.label + "] " + s );
+            e.last_snapshot = std::move( s );
+            e.last_snapshot_turn = to_turns<int>( calendar::turn - calendar::turn_zero );
+            return;
+        }
+    }
+}
+
+std::vector<monitor_entry> &debug_capture::monitors()
+{
+    return p->monitors;
+}
+
+void debug_capture::tick_monitors()
+{
+    if( !p->settings.main_enabled ) {
+        return;
+    }
+    const int now = to_turns<int>( calendar::turn - calendar::turn_zero );
+    for( monitor_entry &e : p->monitors ) {
+        if( !e.enabled || !e.snapshot || e.mode == monitor_mode::manual ) {
+            continue;
+        }
+        std::string s = e.snapshot();
+        const bool changed = s != e.last_snapshot;
+        if( e.mode == monitor_mode::every_turn || changed ) {
+            push_debug_log( debugmode::DF_MONITOR,
+                            "[" + e.label + "] " + s );
+            e.last_snapshot = std::move( s );
+            e.last_snapshot_turn = now;
+        }
+    }
+}
+
+void debug_capture::tick_if_active()
+{
+    if( !g_initialized.load( std::memory_order_acquire ) ) {
+        return;
+    }
+    // Skip the per-turn scan when nothing watches it. Eliminates work for
+    // sessions that never add a monitor (the common case).
+    debug_capture &inst = instance();
+    if( inst.p->monitors.empty() ) {
+        return;
+    }
+    inst.tick_monitors();
+}
+
+bool debug_capture::is_eoc_tracing()
+{
+    if( !g_initialized.load( std::memory_order_acquire ) ) {
+        return false;
+    }
+    return instance().p->settings.eoc_trace_capture;
+}
+
+void log_debug_msg( debugmode::debug_filter type, const std::string &msg )
+{
+    // Skip after the singleton destructor ran (process exit) so we never
+    // touch a destroyed instance via the macro hook in messages.h.
+    if( !debug_capture::is_initialized() ) {
+        return;
+    }
+    debug_capture::instance().push_debug_log( type, msg );
+}
+
+void event_capture_sub::notify( const cata::event &e )
+{
+    if( !debug_capture::is_initialized() ) {
+        return;
+    }
+    debug_capture::instance().push_event( e );
+}
+
+void debug_capture::save_settings( JsonOut &jo ) const
+{
+    const capture_settings &cs = settings();
+    jo.member( "main_enabled", cs.main_enabled );
+    jo.member( "add_msg_debug_capture", cs.add_msg_debug_capture );
+    jo.member( "event_bus_capture", cs.event_bus_capture );
+    jo.member( "eoc_trace_capture", cs.eoc_trace_capture );
+    jo.member( "log_ring_size", cs.log_ring_size );
+    jo.member( "event_ring_size", cs.event_ring_size );
+    jo.member( "eoc_trace_ring_size", cs.eoc_trace_ring_size );
+    jo.member( "jsonl" );
+    jo.start_object();
+    jo.member( "enabled", cs.jsonl.enabled );
+    jo.member( "auto_flush", cs.jsonl.auto_flush );
+    jo.member( "format", static_cast<int>( cs.jsonl.format ) );
+    jo.member( "path", cs.jsonl.path );
+    jo.member( "rotate_mib", cs.jsonl.rotate_mib );
+    jo.member( "sources" );
+    jo.start_array();
+    for( const std::string &s : cs.jsonl.sources ) {
+        jo.write( s );
+    }
+    jo.end_array();
+    jo.end_object();
+}
+
+void debug_capture::load_settings( const JsonObject &jo )
+{
+    capture_settings &cs = settings();
+    jo.read( "main_enabled", cs.main_enabled );
+    jo.read( "add_msg_debug_capture", cs.add_msg_debug_capture );
+    jo.read( "event_bus_capture", cs.event_bus_capture );
+    jo.read( "eoc_trace_capture", cs.eoc_trace_capture );
+    uint64_t ring = 0;
+    if( jo.read( "log_ring_size", ring ) ) {
+        resize_log_ring( static_cast<size_t>( ring ) );
+    }
+    if( jo.read( "event_ring_size", ring ) ) {
+        resize_event_ring( static_cast<size_t>( ring ) );
+    }
+    if( jo.read( "eoc_trace_ring_size", ring ) ) {
+        resize_eoc_trace_ring( static_cast<size_t>( ring ) );
+    }
+    if( jo.has_object( "jsonl" ) ) {
+        const JsonObject jl = jo.get_object( "jsonl" );
+        jl.allow_omitted_members();
+        jl.read( "enabled", cs.jsonl.enabled );
+        jl.read( "auto_flush", cs.jsonl.auto_flush );
+        int fmt_int = static_cast<int>( cs.jsonl.format );
+        if( jl.read( "format", fmt_int ) ) {
+            cs.jsonl.format = fmt_int == 1 ? capture_format::csv : capture_format::jsonl;
+        }
+        jl.read( "path", cs.jsonl.path );
+        uint64_t rotate = cs.jsonl.rotate_mib;
+        if( jl.read( "rotate_mib", rotate ) ) {
+            cs.jsonl.rotate_mib = static_cast<size_t>( rotate );
+        }
+        if( jl.has_array( "sources" ) ) {
+            cs.jsonl.sources.clear();
+            for( const JsonValue &s : jl.get_array( "sources" ) ) {
+                cs.jsonl.sources.insert( s.get_string() );
+            }
+        }
+    }
+}
+
+} // namespace debug_menu

--- a/src/debug_capture.h
+++ b/src/debug_capture.h
@@ -1,0 +1,174 @@
+#pragma once
+#ifndef CATA_SRC_DEBUG_CAPTURE_H
+#define CATA_SRC_DEBUG_CAPTURE_H
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <set>
+#include <string>
+#include <string_view>
+#include <vector>
+
+class JsonObject;
+class JsonOut;
+
+namespace cata
+{
+class event;
+} // namespace cata
+
+class event_bus;
+
+namespace debugmode
+{
+enum debug_filter : int;
+} // namespace debugmode
+
+namespace debug_menu
+{
+
+struct debug_log_entry {
+    debugmode::debug_filter category;
+    std::string text;
+    int turn_num;
+};
+
+struct event_log_entry {
+    int turn_num;
+    int event_type_idx;
+    std::string fields_oneline;
+};
+
+struct eoc_trace_entry {
+    int turn_num;
+    std::string eoc_id;
+    bool success;
+    int64_t us;
+    int depth;
+};
+
+// JSON-escape a string for safe inclusion as a JSON string body (no surrounding quotes).
+std::string capture_json_escape( std::string_view s );
+
+enum class monitor_mode {
+    every_turn,
+    on_change,
+    manual,
+};
+
+struct monitor_entry {
+    int id;
+    std::string label;
+    // Snapshot returns a short human-readable string for the watched target.
+    std::function<std::string()> snapshot;
+    monitor_mode mode = monitor_mode::on_change;
+    std::string last_snapshot;
+    bool enabled = true;
+    // Turn of last snapshot. UI flags stale monitors via this vs current turn.
+    int last_snapshot_turn = -1;
+};
+
+enum class capture_format : int {
+    jsonl = 0,
+    csv = 1,
+};
+
+struct jsonl_settings {
+    bool enabled = false;
+    bool auto_flush = true;
+    capture_format format = capture_format::jsonl;
+    std::string path = "config/debug_trace.jsonl";
+    size_t rotate_mib = 50;
+    std::set<std::string> sources = { "events", "eoc", "monitors", "log" };
+};
+
+struct capture_settings {
+    size_t log_ring_size = 2000;
+    size_t event_ring_size = 5000;
+    size_t eoc_trace_ring_size = 5000;
+
+    // Main gate. When false, push_* and tick_monitors short-circuit
+    // (freeze capture without flipping every sub-toggle).
+    bool main_enabled = true;
+    bool add_msg_debug_capture = true;
+    bool event_bus_capture = false;
+    bool eoc_trace_capture = false;
+
+    jsonl_settings jsonl;
+};
+
+class debug_capture
+{
+    public:
+        static debug_capture &instance();
+        static bool is_initialized();
+
+        capture_settings &settings();
+        const capture_settings &settings() const;
+
+        void on_game_load( ::event_bus &bus );
+        void on_game_shutdown();
+        void flush_jsonl();
+
+        int add_monitor( std::string label, std::function<std::string()> snap,
+                         monitor_mode mode );
+        void remove_monitor( int id );
+        void snapshot_monitor( int id );
+        std::vector<monitor_entry> &monitors();
+        void tick_monitors();
+
+        void push_debug_log( debugmode::debug_filter type, const std::string &msg );
+        void push_event( const cata::event &e );
+        void push_eoc_trace( const std::string &eoc_id, bool success,
+                             std::chrono::microseconds us, int depth );
+
+        const std::deque<debug_log_entry> &logs() const;
+        const std::deque<event_log_entry> &events() const;
+        const std::deque<eoc_trace_entry> &eoc_traces() const;
+
+        void clear_logs();
+        void clear_events();
+        void clear_eoc_traces();
+
+        void resize_log_ring( size_t n );
+        void resize_event_ring( size_t n );
+        void resize_eoc_trace_ring( size_t n );
+
+        // Serialize / restore the user-facing capture toggles, ring sizes,
+        // and JSONL writer config into a flat object the caller wraps in
+        // its own "capture" member. Ring sizes route through the
+        // resize_*_ring helpers so the active rings re-trim on load.
+        void save_settings( JsonOut &jo ) const;
+        void load_settings( const JsonObject &jo );
+
+        // Monotonic counter bumped on any push/clear/resize. Safe under
+        // ring rotation: size() can stay identical while content
+        // changes, so consumers must compare this counter, not sizes.
+        uint64_t feed_generation() const noexcept;
+
+        static void tick_if_active();
+
+        // Fast `eoc_trace_capture` flag check without exposing the
+        // settings struct to the call site.
+        static bool is_eoc_tracing();
+
+        debug_capture( const debug_capture & ) = delete;
+        debug_capture &operator=( const debug_capture & ) = delete;
+        debug_capture( debug_capture && ) = delete;
+        debug_capture &operator=( debug_capture && ) = delete;
+
+    private:
+        debug_capture();
+        ~debug_capture();
+
+        struct impl;
+        std::unique_ptr<impl> p;
+};
+
+} // namespace debug_menu
+
+#endif // CATA_SRC_DEBUG_CAPTURE_H

--- a/src/debug_capture.h
+++ b/src/debug_capture.h
@@ -32,9 +32,9 @@ namespace debug_menu
 {
 
 struct debug_log_entry {
+    int turn_num;
     debugmode::debug_filter category;
     std::string text;
-    int turn_num;
 };
 
 struct event_log_entry {
@@ -44,11 +44,13 @@ struct event_log_entry {
 };
 
 struct eoc_trace_entry {
-    int turn_num;
+    // Field order packs the 8/4/4/1-byte members after the string to minimize
+    // padding.
     std::string eoc_id;
-    bool success;
     int64_t us;
+    int turn_num;
     int depth;
+    bool success;
 };
 
 // JSON-escape a string for safe inclusion as a JSON string body (no surrounding quotes).
@@ -77,13 +79,18 @@ enum class capture_format : int {
     csv = 1,
 };
 
-struct jsonl_settings {
+struct trace_file_settings {
     bool enabled = false;
     bool auto_flush = true;
     capture_format format = capture_format::jsonl;
     std::string path = "config/debug_trace.jsonl";
     size_t rotate_mib = 50;
     std::set<std::string> sources = { "events", "eoc", "monitors", "log" };
+
+    // Whether this source should currently be written to the trace file.
+    bool wants( const std::string &src ) const {
+        return enabled && sources.count( src ) != 0;
+    }
 };
 
 struct capture_settings {
@@ -98,7 +105,7 @@ struct capture_settings {
     bool event_bus_capture = false;
     bool eoc_trace_capture = false;
 
-    jsonl_settings jsonl;
+    trace_file_settings trace_file;
 };
 
 class debug_capture
@@ -112,7 +119,7 @@ class debug_capture
 
         void on_game_load( ::event_bus &bus );
         void on_game_shutdown();
-        void flush_jsonl();
+        void flush_trace_file();
 
         int add_monitor( std::string label, std::function<std::string()> snap,
                          monitor_mode mode );

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -29,6 +29,7 @@
 #include "clzones.h"
 #include "coordinates.h"
 #include "debug.h"
+#include "debug_capture.h"
 #include "enums.h"
 #include "event.h"
 #include "event_bus.h"
@@ -797,5 +798,6 @@ bool game::do_turn()
     EM_ASM( window.game_unsaved = true; );
 #endif
 
+    debug_menu::debug_capture::tick_if_active();
     return false;
 }

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -1,6 +1,7 @@
 #include "effect_on_condition.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <iterator>
 #include <list>
@@ -19,6 +20,7 @@
 #include "condition.h"
 #include "creature.h"
 #include "debug.h"
+#include "debug_capture.h"
 #include "event.h"
 #include "flexbuffer_json.h"
 #include "game.h"
@@ -348,6 +350,10 @@ void effect_on_conditions::process_reactivate()
 
 bool effect_on_condition::activate( dialogue &d, bool require_callstack_check ) const
 {
+    const bool tracing = debug_menu::debug_capture::is_eoc_tracing();
+    const std::chrono::steady_clock::time_point trace_start = tracing
+            ? std::chrono::steady_clock::now()
+            : std::chrono::steady_clock::time_point{};
     bool retval = false;
     if( require_callstack_check ) {
         d.amend_callstack( "EOC: " + id.str() );
@@ -377,6 +383,16 @@ bool effect_on_condition::activate( dialogue &d, bool require_callstack_check ) 
                 false_effect.apply( d_npc );
             }
         }
+    }
+    if( tracing ) {
+        // Read callstack depth at trace time regardless of require_callstack_check
+        // (recursive EOC fires pass false but we still want depth > 0).
+        const int trace_depth = static_cast<int>( d.get_callstack().size() );
+        debug_menu::debug_capture::instance().push_eoc_trace(
+            id.str(), retval,
+            std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::steady_clock::now() - trace_start ),
+            trace_depth );
     }
     return retval;
 }

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -351,9 +351,10 @@ void effect_on_conditions::process_reactivate()
 bool effect_on_condition::activate( dialogue &d, bool require_callstack_check ) const
 {
     const bool tracing = debug_menu::debug_capture::is_eoc_tracing();
-    const std::chrono::steady_clock::time_point trace_start = tracing
-            ? std::chrono::steady_clock::now()
-            : std::chrono::steady_clock::time_point{};
+    std::chrono::steady_clock::time_point trace_start;
+    if( tracing ) {
+        trace_start = std::chrono::steady_clock::now();
+    }
     bool retval = false;
     if( require_callstack_check ) {
         d.amend_callstack( "EOC: " + id.str() );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -85,6 +85,7 @@
 #include "cursesport.h" // IWYU pragma: keep
 #include "damage.h"
 #include "debug.h"
+#include "debug_capture.h"
 #include "debug_menu.h"
 #include "dependency_tree.h"
 #include "dialogue.h"
@@ -477,12 +478,23 @@ game::game() :
     events().subscribe( &*achievements_tracker_ptr );
     events().subscribe( &*spell_events_ptr );
     events().subscribe( &*eoc_events_ptr );
+    debug_menu::debug_capture::instance().on_game_load( events() );
     world_generator = std::make_unique<worldfactory>();
     // do nothing, everything that was in here is moved to init_data() which is called immediately after g = new game; in main.cpp
     // The reason for this move is so that g is not uninitialized when it gets to installing the parts into vehicles.
 }
 
-game::~game() = default;
+game::~game()
+{
+    // event_bus_ptr about to die; let debug_capture drop its sticky
+    // subscribe flag and release the JSONL file. Without this, a later
+    // `game` instance would never resubscribe.
+    // is_initialized guard: debug_capture's function-local static dies
+    // before `g` at process exit, so unguarded access would segfault.
+    if( debug_menu::debug_capture::is_initialized() ) {
+        debug_menu::debug_capture::instance().on_game_shutdown();
+    }
+}
 
 #if defined(TUI)
 // in ncurses_def.cpp

--- a/src/messages.h
+++ b/src/messages.h
@@ -172,12 +172,19 @@ inline T &&clang_tidy_no_translations( T &&t )
 #define add_msg_debug_if(condition, type, ...)                                                          \
     do {                                                                                                \
         if( debug_mode && Messages::has_debug_filter( type ) && ( condition ) ) {                       \
-            Messages::add_msg( m_debug, clang_tidy_no_translations( string_format( __VA_ARGS__ ) ) );   \
+            std::string cata_dbg_msg = clang_tidy_no_translations( string_format( __VA_ARGS__ ) );      \
+            Messages::add_msg( m_debug, cata_dbg_msg );                                                 \
+            debug_menu::log_debug_msg( type, cata_dbg_msg );                                            \
         }                                                                                               \
     } while( false )
 
 #define add_msg_debug(type, ...) \
     add_msg_debug_if( true, type, __VA_ARGS__ )
+
+namespace debug_menu
+{
+void log_debug_msg( debugmode::debug_filter type, const std::string &msg );
+} // namespace debug_menu
 
 void modify_msg_with_exclamations( std::string &msg, game_message_type type );
 

--- a/tests/debug_capture_test.cpp
+++ b/tests/debug_capture_test.cpp
@@ -1,0 +1,125 @@
+#include <chrono>
+#include <cstdio>
+#include <deque>
+#include <fstream>
+#include <functional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "cata_catch.h"
+#include "debug.h"
+#include "debug_capture.h"
+
+TEST_CASE( "capture_json_escape_round_trip", "[debug_capture]" )
+{
+    SECTION( "plain ASCII passes through" ) {
+        CHECK( debug_menu::capture_json_escape( "hello world" ) == "hello world" );
+    }
+    SECTION( "quote and backslash get escaped" ) {
+        CHECK( debug_menu::capture_json_escape( "say \"hi\"" ) == "say \\\"hi\\\"" );
+        CHECK( debug_menu::capture_json_escape( "back\\slash" ) == "back\\\\slash" );
+    }
+    SECTION( "newline + tab + CR" ) {
+        std::string in;
+        in += 'a';
+        in += '\n';
+        in += 'b';
+        in += '\t';
+        in += 'c';
+        in += '\r';
+        in += 'd';
+        CHECK( debug_menu::capture_json_escape( in ) == "a\\nb\\tc\\rd" );
+    }
+    SECTION( "control char below 0x20 -> \\u escape" ) {
+        const std::string in( 1, '\x01' );
+        const std::string out = debug_menu::capture_json_escape( in );
+        CHECK( out == "\\u0001" );
+    }
+}
+
+TEST_CASE( "capture_ring_trimming", "[debug_capture]" )
+{
+    debug_menu::debug_capture &cap = debug_menu::debug_capture::instance();
+    cap.clear_logs();
+    cap.resize_log_ring( 5 );
+    cap.settings().add_msg_debug_capture = true;
+    for( int i = 0; i < 20; i++ ) {
+        cap.push_debug_log( debugmode::DF_GAME, "msg " + std::to_string( i ) );
+    }
+    CHECK( cap.logs().size() == 5 );
+    // Ring is FIFO: oldest popped, last 5 retained.
+    CHECK( cap.logs().front().text == "msg 15" );
+    CHECK( cap.logs().back().text == "msg 19" );
+    // Restore default for other tests.
+    cap.resize_log_ring( 2000 );
+    cap.clear_logs();
+}
+
+TEST_CASE( "capture_eoc_trace_ring", "[debug_capture]" )
+{
+    debug_menu::debug_capture &cap = debug_menu::debug_capture::instance();
+    cap.clear_eoc_traces();
+    cap.resize_eoc_trace_ring( 3 );
+    cap.settings().eoc_trace_capture = true;
+    for( int i = 0; i < 10; i++ ) {
+        cap.push_eoc_trace( "EOC_" + std::to_string( i ), true,
+                            std::chrono::microseconds( 100 ), i );
+    }
+    CHECK( cap.eoc_traces().size() == 3 );
+    CHECK( cap.eoc_traces().back().depth == 9 );
+    cap.resize_eoc_trace_ring( 5000 );
+    cap.clear_eoc_traces();
+    cap.settings().eoc_trace_capture = false;
+}
+
+TEST_CASE( "capture_monitor_basic", "[debug_capture]" )
+{
+    debug_menu::debug_capture &cap = debug_menu::debug_capture::instance();
+    cap.clear_logs();
+    cap.settings().add_msg_debug_capture = true;
+    int counter = 0;
+    const int id = cap.add_monitor( "test", [&counter]() {
+        return std::to_string( ++counter );
+    }, debug_menu::monitor_mode::every_turn );
+    // Adding takes initial snapshot (counter=1) but no log push.
+    CHECK( cap.logs().empty() );
+    cap.tick_monitors();
+    CHECK( cap.logs().size() == 1 );
+    CHECK( cap.logs().back().category == debugmode::DF_MONITOR );
+    cap.tick_monitors();
+    CHECK( cap.logs().size() == 2 );
+    cap.remove_monitor( id );
+    CHECK( cap.monitors().empty() );
+    cap.clear_logs();
+}
+
+TEST_CASE( "capture_jsonl_byte_counter_rebase_on_existing_file", "[debug_capture]" )
+{
+    // Write a placeholder file, then attach JSONL output to it -- the byte
+    // counter should reflect existing file size, not zero.
+    const std::string path = "test_jsonl_rebase.jsonl";
+    {
+        std::ofstream pre( path, std::ios::trunc );
+        for( int i = 0; i < 100; i++ ) {
+            pre << "{\"placeholder\":" << i << "}\n";
+        }
+    }
+    debug_menu::debug_capture &cap = debug_menu::debug_capture::instance();
+    cap.settings().jsonl.path = path;
+    cap.settings().jsonl.rotate_mib = 100; // far above test size, won't rotate
+    cap.settings().jsonl.enabled = true;
+    cap.settings().jsonl.sources = { "log" };
+    cap.settings().add_msg_debug_capture = true;
+    cap.push_debug_log( debugmode::DF_GAME, "trigger open" );
+    cap.flush_jsonl();
+    // Verify file size grew vs placeholder size (counter was rebased; new
+    // line appended).
+    std::ifstream f( path, std::ios::ate );
+    const auto sz = f.tellg();
+    CHECK( sz > 100 );
+    cap.settings().jsonl.enabled = false;
+    cap.on_game_shutdown();
+    const int rm_rc = std::remove( path.c_str() );
+    ( void )rm_rc;
+}

--- a/tests/debug_capture_test.cpp
+++ b/tests/debug_capture_test.cpp
@@ -1,8 +1,10 @@
 #include <chrono>
+#include <cstdint>
 #include <cstdio>
 #include <deque>
 #include <fstream>
 #include <functional>
+#include <initializer_list>
 #include <set>
 #include <string>
 #include <vector>
@@ -106,20 +108,106 @@ TEST_CASE( "capture_jsonl_byte_counter_rebase_on_existing_file", "[debug_capture
         }
     }
     debug_menu::debug_capture &cap = debug_menu::debug_capture::instance();
-    cap.settings().jsonl.path = path;
-    cap.settings().jsonl.rotate_mib = 100; // far above test size, won't rotate
-    cap.settings().jsonl.enabled = true;
-    cap.settings().jsonl.sources = { "log" };
+    cap.settings().trace_file.path = path;
+    cap.settings().trace_file.rotate_mib = 100; // far above test size, won't rotate
+    cap.settings().trace_file.enabled = true;
+    cap.settings().trace_file.sources = { "log" };
     cap.settings().add_msg_debug_capture = true;
     cap.push_debug_log( debugmode::DF_GAME, "trigger open" );
-    cap.flush_jsonl();
+    cap.flush_trace_file();
     // Verify file size grew vs placeholder size (counter was rebased; new
     // line appended).
     std::ifstream f( path, std::ios::ate );
     const auto sz = f.tellg();
     CHECK( sz > 100 );
-    cap.settings().jsonl.enabled = false;
+    cap.settings().trace_file.enabled = false;
     cap.on_game_shutdown();
     const int rm_rc = std::remove( path.c_str() );
     ( void )rm_rc;
+}
+
+TEST_CASE( "capture_json_escape_produces_valid_json", "[debug_capture]" )
+{
+    // Control chars and non-ASCII become \uXXXX, so the result is a valid JSON
+    // string body once wrapped in quotes.
+    SECTION( "non-ASCII is \\u-escaped, not emitted raw" ) {
+        // U+00E9 (e-acute) in UTF-8 is 0xC3 0xA9; EscapeString emits uppercase hex.
+        const std::string in = "caf\xC3\xA9";
+        const std::string out = debug_menu::capture_json_escape( in );
+        CHECK( out == "caf\\u00E9" );
+    }
+    SECTION( "embedded control char between text" ) {
+        std::string in = "a";
+        in += '\x1f';
+        in += "b";
+        CHECK( debug_menu::capture_json_escape( in ) == "a\\u001Fb" );
+    }
+    SECTION( "empty string" ) {
+        CHECK( debug_menu::capture_json_escape( "" ).empty() );
+    }
+}
+
+TEST_CASE( "capture_resize_feed_generation", "[debug_capture]" )
+{
+    debug_menu::debug_capture &cap = debug_menu::debug_capture::instance();
+    cap.clear_logs();
+    cap.resize_log_ring( 100 );
+    cap.settings().add_msg_debug_capture = true;
+    for( int i = 0; i < 10; i++ ) {
+        cap.push_debug_log( debugmode::DF_GAME, "m" );
+    }
+    SECTION( "growing / keeping size leaves generation unchanged" ) {
+        const uint64_t gen = cap.feed_generation();
+        cap.resize_log_ring( 100 ); // same
+        CHECK( cap.feed_generation() == gen );
+        cap.resize_log_ring( 500 ); // grow, 10 entries kept
+        CHECK( cap.feed_generation() == gen );
+    }
+    SECTION( "shrinking below the entry count bumps generation" ) {
+        const uint64_t gen = cap.feed_generation();
+        cap.resize_log_ring( 4 ); // drops 6 entries
+        CHECK( cap.feed_generation() > gen );
+        CHECK( cap.logs().size() == 4 );
+    }
+    cap.resize_log_ring( 2000 );
+    cap.clear_logs();
+}
+
+TEST_CASE( "capture_trace_file_rotation", "[debug_capture]" )
+{
+    const std::string base = "test_trace_rotate.jsonl";
+    const std::string r1 = base + ".1";
+    const std::string r2 = base + ".2";
+    const std::string r2_tmp = r2 + ".tmp";
+    for( const std::string &p : {
+             base, r1, r2, r2_tmp
+         } ) {
+        const int rc = std::remove( p.c_str() );
+        ( void )rc;
+    }
+    debug_menu::debug_capture &cap = debug_menu::debug_capture::instance();
+    cap.settings().trace_file.path = base;
+    cap.settings().trace_file.rotate_mib = 0; // rotate on the first append
+    cap.settings().trace_file.enabled = true;
+    cap.settings().trace_file.format = debug_menu::capture_format::jsonl;
+    cap.settings().trace_file.sources = { "log" };
+    cap.settings().add_msg_debug_capture = true;
+    // First append opens the file; with rotate_mib 0 the next append rotates.
+    cap.push_debug_log( debugmode::DF_GAME, "first" );
+    cap.push_debug_log( debugmode::DF_GAME, "second" );
+    cap.flush_trace_file();
+    // base rolled to .1; no stray .tmp left behind.
+    std::ifstream rolled( r1 );
+    CHECK( rolled.good() );
+    std::ifstream tmp( r2_tmp );
+    CHECK_FALSE( tmp.good() );
+    cap.settings().trace_file.enabled = false;
+    cap.settings().trace_file.rotate_mib = 50;
+    cap.on_game_shutdown();
+    for( const std::string &p : {
+             base, r1, r2, r2_tmp
+         } ) {
+        const int rc = std::remove( p.c_str() );
+        ( void )rc;
+    }
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Ring-buffered capture for debug messages, events, and EOC fires"

#### Purpose of change
Existing debug traces only flushed to stdout or files. No way to ring-buffer, attach monitors, or export selectively.

#### Describe the solution
- Ring buffers for `add_msg_debug`, `event_bus` events, EOC fire traces
- Optional JSONL/CSV writer with size-based rotation
- Monitor subsystem with `every_turn` / `on_change` / `manual` modes; `DF_MONITOR` filter
- Hooks in `add_msg_debug`, EOC activate, `do_turn`, `~game`

#### Describe alternatives you've considered
N/A

#### Testing
`debug_capture_test` covers escape, ring trim, monitor, JSONL rebase.

#### Additional context
Split from #87072. Stacked on #87093, #87094, #87096.