### PR TITLE
Add bulk reading map caches to electronic device menu

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -273,6 +273,7 @@ static const itype_id itype_cigar_lit( "cigar_lit" );
 static const itype_id itype_cow_bell( "cow_bell" );
 static const itype_id itype_detergent( "detergent" );
 static const itype_id itype_ecig( "ecig" );
+static const itype_id itype_efile_map( "efile_map" );
 static const itype_id itype_efile_photos( "efile_photos" );
 static const itype_id itype_fire( "fire" );
 static const itype_id itype_geiger_on( "geiger_on" );
@@ -5656,23 +5657,45 @@ std::optional<int> iuse::efiledevice( Character *p, item *it, const tripoint_bub
         }
     };
 
+    auto read_all_map_caches = [&p, &used_edevice]() {
+        avatar *a = p->as_avatar();
+        if( a ) {
+            const std::vector<item *> efiles_snapshot = used_edevice->efiles();
+            for( item *efile : efiles_snapshot ) {
+                if( efile->typeId() == itype_efile_map && efile->get_var( "map_cache" ) != "read" ) {
+                    a->use( item_location( used_edevice, efile ) );
+                }
+            }
+        } else {
+            debugmsg( "NPC attempted to read e-file; not yet supported" );
+        }
+    };
+
     uilist amenu;
 
     enum {
-        efd_invalid, efd_browse, efd_read_this, efd_read_external, efd_move_off_this, efd_move_onto_this, efd_combo_bm, efd_copy_onto_this, efd_copy_from_this, efd_wipe
+        efd_invalid, efd_browse, efd_read_this, efd_read_external, efd_move_off_this, efd_move_onto_this, efd_combo_bm, efd_copy_onto_this, efd_copy_from_this, efd_wipe, efd_read_all_map_caches
     };
 
     amenu.text = _( "Select operation:" );
     amenu.addentry( efd_combo_bm, true, 'a', _( "Browse + move files from all devices" ) );
     amenu.addentry( efd_browse, true, 'b', _( "Browse devices" ) );
-    const bool has_files = !used_edevice->efiles().empty();
     if( used_edevice->is_browsed() ) {
+        const std::vector<item *> device_efiles = used_edevice->efiles();
+        const bool has_files = !device_efiles.empty();
         amenu.addentry( efd_read_this, has_files, 'r', _( "Read files on this device" ) );
         amenu.addentry( efd_read_external, true, 'e', _( "Read files on external devices" ) );
         amenu.addentry( efd_move_onto_this, true, 'm', _( "Move files onto this device" ) );
         amenu.addentry( efd_copy_onto_this, true, 'c', _( "Copy files onto this device" ) );
         amenu.addentry( efd_move_off_this, has_files, 'o', _( "Move files off of this device" ) );
         amenu.addentry( efd_copy_from_this, has_files, 'f', _( "Copy files off of this device" ) );
+        const int unread_map_caches = std::count_if( device_efiles.begin(),
+                                      device_efiles.end(),
+                                      []( const item * efile ) {
+            return efile->typeId() == itype_efile_map && efile->get_var( "map_cache" ) != "read";
+        } );
+        amenu.addentry( efd_read_all_map_caches, unread_map_caches > 0, 'p',
+                        string_format( _( "Process all map caches on this device (%d)" ), unread_map_caches ) );
         amenu.addentry( efd_wipe, true, 'W', _( "Wipe files from devices" ) );
     }
 
@@ -5696,6 +5719,10 @@ std::optional<int> iuse::efiledevice( Character *p, item *it, const tripoint_bub
             break;
         case efd_read_external:
             read_edevice( true );
+            return std::nullopt;
+            break;
+        case efd_read_all_map_caches:
+            read_all_map_caches();
             return std::nullopt;
             break;
         case efd_move_onto_this:

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5691,7 +5691,7 @@ std::optional<int> iuse::efiledevice( Character *p, item *it, const tripoint_bub
         amenu.addentry( efd_copy_from_this, has_files, 'f', _( "Copy files off of this device" ) );
         const int unread_map_caches = std::count_if( device_efiles.begin(),
                                       device_efiles.end(),
-                                      []( const item * efile ) {
+        []( const item * efile ) {
             return efile->typeId() == itype_efile_map && efile->get_var( "map_cache" ) != "read";
         } );
         amenu.addentry( efd_read_all_map_caches, unread_map_caches > 0, 'p',


### PR DESCRIPTION
#### Summary
Interface "Add bulk reading map caches to electronic device menu"

#### Purpose of change
Reading map caches on electronic devices is tedious when multiple files need to be processed. Reading a single cache requires navigating several menus, and this has to be repeated for each file. Since bulk collection is easy, bulk processing should be too.

#### Describe the solution
Add a menu option to read all map caches at once to the electronic device menu. The entry shows the count of unread map caches and is disabled when none are present.

Unread map cache are present:
<img width="457" height="287" alt="Screenshot 2026-05-18 201407" src="https://github.com/user-attachments/assets/6f7eb958-238b-4314-bb7b-326aeeb74e7a" />

No unread map cache:
<img width="459" height="286" alt="Screenshot 2026-05-18 201529" src="https://github.com/user-attachments/assets/1269438c-e2cc-4d02-bf77-a09dacd3e596" />

#### Describe alternatives you've considered
Adding a "read all" entry to the file picker `efile_select`. This was not chosen because it mixes a bulk operation into a per-file selection UI, and the file picker is shared across all efile actions (move, copy, wipe).

#### Testing
Compiled in Windows.
Loaded a game and verified unread map caches are registered in the menu with correct count.
Verified the menu entry is disabled (grayed out) when no unread map caches are present.
Verified that after reading, no unread map caches are registered.

#### Additional context