### PR TITLE
Spawn military weapons at Return to Sender convoy ambush

### DIFF
--- a/data/json/mapgen/robofaq_locs/robofac_mission_chunks.json
+++ b/data/json/mapgen/robofaq_locs/robofac_mission_chunks.json
@@ -40,7 +40,10 @@
       ],
       "items": { "@": { "item": "mon_zombie_scientist_death_drops", "chance": 100 } },
       "item": { "@": [ { "item": "rmi2_corpse" }, { "item": "robofac_hardcase" } ] },
-      "place_loot": [ { "item": "223_casing", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 100, "repeat": [ 20, 60 ] } ],
+      "place_loot": [
+        { "item": "223_casing", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 100, "repeat": [ 20, 60 ] },
+        { "group": "military_squad_guns", "x": [ 1, 22 ], "y": [ 1, 22 ], "chance": 100, "repeat": [ 5, 10 ] }
+      ],
       "monster": { "M": { "monster": "mon_zombie_armored" }, "A": { "monster": "mon_zombie_soldier_acid_1" } },
       "place_monsters": [ { "monster": "GROUP_MIL_STRONG", "x": [ 1, 22 ], "y": [ 1, 22 ], "density": 1.6 } ]
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Spawn military weapons at the Return to Sender convoy ambush site"

#### Purpose of change
Closes #81646 (second point). Convoy ambush spawns plenty of soldier zombies but no weapons on the ground, and soldier death drops only carry a 10% weapon chance. Site ends up looking like the soldiers ran off with their rifles.

#### Describe the solution
Add `military_squad_guns` to the chunk's `place_loot`, 5-10 across the 22x22 area. Same itemgroup `mx_military` and `mx_roadblock_mil` already use.

#### Describe alternatives you've considered
Bumping the global soldier drop rate. Would shift balance at every other military site too.

#### Testing
N/A

#### Additional context
N/A