### PR TITLE
wound worsening

### DIFF
--- a/data/core/external_options.json
+++ b/data/core/external_options.json
@@ -137,7 +137,7 @@
     "name": "WOUND_CHANCE",
     "//": "Probability to get a wound from taking damage.  0.25 means 25% to get a wound.",
     "stype": "float",
-    "value": 0.25
+    "value": 1.0
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/doc/JSON/WOUNDS.md
+++ b/doc/JSON/WOUNDS.md
@@ -17,6 +17,7 @@ Wound is a type, that affects specific bodyparts. It's similar in this to effect
     "pain": [ 1, 10 ], // when wound is applied, it would give character this random amount of pain rolled between this two numbers. Default 0
     "healing_time": [ "2 hours", "25 days" ], // how long this wound need time to be fully healed. Rolled randomly when applied, supposed to be adjusted by wound_fix.
             // Default infinite duration
+    "wound_progression": [ { "id": "deep_scratch", "chance": 10 } ], // taking damage on bodypart with this limb may worsen it. chance is range from 0% to 100%
     "whitelist_body_part_types": [ "leg", "arm" ], // if used, this wound can be applied only at bodyparts of this type. Possible values are: head, torso, sensor, mouth, arm, hand, leg, foot, wing, tail, other
     "blacklist_body_part_types": [ "torso", "sensor" ], // if used, this wound cannot be applied on bodyparts of this type.
     "whitelist_bp_with_flag": "LIMB_UPPER", // only body parts with this flag can receive the wound.

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -1116,10 +1116,10 @@ void bodypart::add_or_worsen_wound( const wound &wd )
                                id.str(),
                                wd.type.str(),
                                wd.get_pain(),
-                               to_string( wd.get_healing_time(), true ),
+                               to_string_writable( wd.get_healing_time() ),
                                new_wound.type.str(),
                                new_wound.get_pain(),
-                               to_string( new_wound.get_healing_time(), true )
+                               to_string_writable( new_wound.get_healing_time() )
                              );
 
                 remove_wound( *old_wound );
@@ -1134,7 +1134,7 @@ void bodypart::add_or_worsen_wound( const wound &wd )
                        id.str(),
                        wd.type.str(),
                        wd.get_pain(),
-                       to_string( wd.get_healing_time(), true )
+                       to_string_writable( wd.get_healing_time() )
                      );
 
         add_wound( wd );

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -18,6 +18,7 @@
 #include "json.h"
 #include "localized_comparator.h"
 #include "magic_enchantment.h"
+#include "messages.h"
 #include "pimpl.h"
 #include "rng.h"
 #include "subbodypart.h"
@@ -1090,6 +1091,56 @@ std::vector<wound> bodypart::get_wounds() const
     return wounds;
 }
 
+void bodypart::add_or_worsen_wound( const wound_type_id wd )
+{
+    wound wo = wound( wd );
+    add_or_worsen_wound( wo );
+}
+
+void bodypart::add_or_worsen_wound( const wound &wd )
+{
+    const std::vector<wound_progress> &wound_progression = wd.type->wound_progression;
+
+    // todo: move one_in( 2 ) to something more reasonable
+    // maybe checking hit_size of a limb against some new wound size property?
+    if( has_wound( wd.type ) && !wound_progression.empty() && one_in( 2 ) ) {
+        for( const wound_progress &wdp : wound_progression ) {
+            if( x_in_y( wdp.chance, 100 ) ) {
+
+                const wound *old_wound = get_wound( wd.type );
+                wound new_wound = wound( wdp.id );
+                new_wound += *old_wound;
+
+                add_msg_debug( debugmode::DF_WOUNDS,
+                               "at bodypart %s, wound %s (pain %d, duration %s) progresses to wound %s (pain %d, duration %s).",
+                               id.str(),
+                               wd.type.str(),
+                               wd.get_pain(),
+                               to_string( wd.get_healing_time(), true ),
+                               new_wound.type.str(),
+                               new_wound.get_pain(),
+                               to_string( new_wound.get_healing_time(), true )
+                             );
+
+                remove_wound( *old_wound );
+                add_wound( new_wound );
+            }
+        }
+
+    } else {
+
+        add_msg_debug( debugmode::DF_WOUNDS,
+                       "at bodypart %s, adding wound %s (pain %d, duration %s).",
+                       id.str(),
+                       wd.type.str(),
+                       wd.get_pain(),
+                       to_string( wd.get_healing_time(), true )
+                     );
+
+        add_wound( wd );
+    }
+}
+
 void bodypart::add_wound( const wound &wd )
 {
     wounds.emplace_back( wd );
@@ -1113,6 +1164,28 @@ bool bodypart::has_wound( const wound_type_id wd ) const
         }
     }
     return false;
+}
+
+wound *bodypart::get_wound( const wound_type_id wd_id )
+{
+    // picks the first one; maybe not desired?
+    auto it = std::find_if( wounds.begin(), wounds.end(), [wd_id]( wound wd ) {
+        return wd.type == wd_id;
+    } );
+
+    if( it == wounds.end() ) {
+        debugmsg( "Tried to get wound %s from bodypart %s, but none were found", wd_id.str(), id.str() );
+        return nullptr;
+    }
+    return &*it;
+}
+
+void bodypart::remove_wound( const wound wd )
+{
+    const auto it = std::find( wounds.begin(), wounds.end(), wd );
+    if( it != wounds.end() ) {
+        wounds.erase( it );
+    }
 }
 
 void bodypart::remove_wound( const wound_type_id wd )

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -503,10 +503,15 @@ class bodypart
 
         std::vector<wound> get_wounds() const;
 
+        void add_or_worsen_wound( const wound_type_id wd );
+        void add_or_worsen_wound( const wound &wd );
+
         void add_wound( const wound &wd );
         void add_wound( wound_type_id wd );
         bool has_wounds() const;
         bool has_wound( wound_type_id wd ) const;
+        wound *get_wound( const wound_type_id wd_id );
+        void remove_wound( const wound wd );
         void remove_wound( wound_type_id wd );
         void update_wounds( time_duration time_passed );
 

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -503,15 +503,15 @@ class bodypart
 
         std::vector<wound> get_wounds() const;
 
-        void add_or_worsen_wound( const wound_type_id wd );
+        void add_or_worsen_wound( wound_type_id wd );
         void add_or_worsen_wound( const wound &wd );
 
         void add_wound( const wound &wd );
         void add_wound( wound_type_id wd );
         bool has_wounds() const;
         bool has_wound( wound_type_id wd ) const;
-        wound *get_wound( const wound_type_id wd_id );
-        void remove_wound( const wound wd );
+        wound *get_wound( wound_type_id wd_id );
+        void remove_wound( wound wd );
         void remove_wound( wound_type_id wd );
         void update_wounds( time_duration time_passed );
 

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -2545,7 +2545,7 @@ int Character::vitamin_RDA( const vitamin_id &vitamin, int amount ) const
 void Character::apply_wound( bodypart_id bp, wound_type_id wd )
 {
     bodypart &body_bp = body.at( bp.id() );
-    body_bp.add_wound( wd );
+    body_bp.add_or_worsen_wound( wd );
     morale->on_stat_change( "perceived_pain", get_perceived_pain() );
 }
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -272,6 +272,7 @@ std::string filter_name( debug_filter value )
         case DF_VEHICLE: return "DF_VEHICLE";
         case DF_VEHICLE_DRAG: return "DF_VEHICLE_DRAG";
         case DF_VEHICLE_MOVE: return "DF_VEHICLE_MOVE";
+        case DF_WOUNDS: return "DF_WOUNDS";
         // *INDENT-ON*
         case DF_LAST:
         default:

--- a/src/debug.h
+++ b/src/debug.h
@@ -289,6 +289,7 @@ enum debug_filter : int {
     DF_VEHICLE, // vehicle generic
     DF_VEHICLE_DRAG, // vehicle coeff_air_drag()
     DF_VEHICLE_MOVE, // vehicle move generic
+    DF_WOUNDS, // everything related to applying wounds
     DF_LAST // This is always the last entry
 };
 

--- a/src/wound.cpp
+++ b/src/wound.cpp
@@ -26,6 +26,7 @@ void wound_type::load( const JsonObject &jo, const std::string_view & )
     optional( jo, was_loaded, "weight", weight, 1 );
     optional( jo, was_loaded, "limit", limit, 0 );
 
+    optional( jo, was_loaded, "wound_progression", wound_progression );
     optional( jo, was_loaded, "whitelist_bp_with_flag", whitelist_bp_with_flag );
     optional( jo, was_loaded, "whitelist_body_part_types", whitelist_body_part_types );
     optional( jo, was_loaded, "blacklist_bp_with_flag", blacklist_bp_with_flag );
@@ -190,6 +191,12 @@ void wound_fix::finalize()
         const_cast<wound_type &>( *fid ).fixes.emplace( id );
     }
     requirement_data::finalize();
+}
+
+void wound_progress::deserialize( const JsonObject &jo )
+{
+    mandatory( jo, false, "id", id );
+    optional( jo, false, "chance", chance, numeric_bound_reader<int> {0, 100} );
 }
 
 void wound_proficiency::deserialize( const JsonObject &jo )

--- a/src/wound.h
+++ b/src/wound.h
@@ -14,7 +14,6 @@
 #include "translation.h"
 #include "type_id.h"
 #include "value_ptr.h"
-#include "weighted_list.h"
 
 class JsonObject;
 class JsonOut;

--- a/src/wound.h
+++ b/src/wound.h
@@ -14,11 +14,19 @@
 #include "translation.h"
 #include "type_id.h"
 #include "value_ptr.h"
+#include "weighted_list.h"
 
 class JsonObject;
 class JsonOut;
 
 enum class bp_type;
+
+struct wound_progress {
+    wound_type_id id;
+    int chance;
+
+    void deserialize( const JsonObject &jo );
+};
 
 class wound_type
 {
@@ -59,6 +67,9 @@ class wound_type
         std::vector<bp_type> blacklist_body_part_types;
 
         std::set<wound_fix_id> fixes;
+
+        // list of wounds this wound can lead to
+        std::vector<wound_progress> wound_progression;
     private:
         translation name_;
         translation description_;
@@ -91,6 +102,20 @@ class wound
         time_duration get_healing_time() const;
         // update the wound healing progress, if it's healed, return true
         bool update_wound( time_duration time_passed );
+
+        wound &operator+=( const wound &wd ) {
+            healing_time += wd.get_healing_time();
+            pain += wd.get_pain();
+            // reset healing progress? maybe not necessary?
+            healing_progress = 0_seconds;
+
+            return *this;
+        }
+
+        bool operator==( const wound &wd ) {
+            return type == wd.type && healing_progress == wd.healing_progress ;
+        }
+
     private:
         // how long it takes for this wound to heal. Can be adjusted by wound fix.
         time_duration healing_time;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Wounds should be able to stack, but also they should be able to progress into worse state, like when you receive multiple of the same wound at the same location
#### Describe the solution
Do exactly that - wound can define what it will progress into, and this would result in wound A and wound B being combined, the wound healing being reset, and new combine wound appearing
Also added debug mode for wounds specifically
#### Testing

<img width="1181" height="48" alt="image" src="https://github.com/user-attachments/assets/17f54869-67c2-4542-8f3e-e72ecc15a983" />

#### Additional context
Depending on how good it will work, it would make sense to add something like that to faults