### PR TITLE
Upgrade vendored plf_colony to v7.6.13 and plf_list to v2.8.02

### DIFF
--- a/src/colony.h
+++ b/src/colony.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_COLONY_H
 #define CATA_SRC_COLONY_H
 
+#include <cstddef>
 #include <memory>
 
 #include <plf/colony.h> // IWYU pragma: export
@@ -10,6 +11,28 @@ namespace cata
 {
 template<class T, class Allocator = std::allocator<T>>
 using colony = plf::colony<T, Allocator>;
+
+// plf::colony has no index<->iterator member helpers; use ADL friend
+// advance/distance on the iterator (std::distance is not specialized for
+// plf iterators and would fall back to a linear walk).
+template<class T, class Allocator>
+inline std::size_t get_index_from_iterator( const colony<T, Allocator> &c,
+        typename colony<T, Allocator>::const_iterator it )
+{
+    return static_cast<std::size_t>( distance( c.cbegin(), it ) );
+}
+
+template<class T, class Allocator>
+inline typename colony<T, Allocator>::iterator get_iterator_from_index(
+    colony<T, Allocator> &c, std::size_t idx )
+{
+    typename colony<T, Allocator>::iterator it = c.begin();
+    if( idx == 0 || c.empty() ) {
+        return it;
+    }
+    advance( it, static_cast<typename colony<T, Allocator>::iterator::difference_type>( idx ) );
+    return it;
+}
 } // namespace cata
 
 #endif // CATA_SRC_COLONY_H

--- a/src/item_stack.cpp
+++ b/src/item_stack.cpp
@@ -70,17 +70,17 @@ item_stack::const_reverse_iterator item_stack::rend() const
 
 item_stack::iterator item_stack::get_iterator_from_pointer( item *it )
 {
-    return items->get_iterator_from_pointer( it );
+    return items->get_iterator( it );
 }
 
 item_stack::iterator item_stack::get_iterator_from_index( size_t idx )
 {
-    return items->get_iterator_from_index( idx );
+    return cata::get_iterator_from_index( *items, idx );
 }
 
 size_t item_stack::get_index_from_iterator( const item_stack::const_iterator &it )
 {
-    return items->get_index_from_iterator( it );
+    return cata::get_index_from_iterator( *items, it );
 }
 
 item &item_stack::only_item()

--- a/src/item_wakeup.cpp
+++ b/src/item_wakeup.cpp
@@ -478,7 +478,7 @@ void item_wakeup_manager::process( time_point now )
 
 void item_wakeup_manager::clear()
 {
-    entries_.clear();
+    entries_.reset();
     by_key_.clear();
     heap_.clear();
     stats_ = stats{};

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5573,7 +5573,7 @@ void map::i_clear( const tripoint_bub_ms &p )
         set_lightmap_cache_dirty( p.z() );
     }
     current_submap->set_lum( l, 0 );
-    current_submap->get_items( l ).clear();
+    current_submap->get_items( l ).reset();
 }
 
 std::vector<item *> map::spawn_items( const tripoint_bub_ms &p, const std::vector<item> &new_items )
@@ -5935,7 +5935,7 @@ void map::make_active( item_location &loc )
         return;
     }
     cata::colony<item> &item_stack = current_submap->get_items( l );
-    cata::colony<item>::iterator iter = item_stack.get_iterator_from_pointer( target );
+    cata::colony<item>::iterator iter = item_stack.get_iterator( target );
 
     if( current_submap->active_items.add( *iter, l ) ) {
         tripoint_abs_sm const smloc( abs_sub.x() + loc.pos_bub( *this ).x() / SEEX,

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -454,7 +454,7 @@ void Pickup::autopickup( const tripoint_bub_ms &p )
     }
     // which items are we grabbing?
     std::vector<item_stack::iterator> here;
-    const map_stack mapitems = local.i_at( p );
+    map_stack mapitems = local.i_at( p );
     here.reserve( mapitems.size() );
     for( item_stack::iterator it = mapitems.begin(); it != mapitems.end(); ++it ) {
         here.push_back( it );

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -470,7 +470,7 @@ void overmap::unserialize( const JsonObject &jsobj )
         std::vector<std::pair<tripoint_om_omt, int>> flat_index;
         jsobj.read( "mapgen_arg_index", flat_index, true );
         for( const std::pair<tripoint_om_omt, int> &p : flat_index ) {
-            auto it = mapgen_arg_storage.get_iterator_from_index( p.second );
+            auto it = cata::get_iterator_from_index( mapgen_arg_storage, p.second );
             mapgen_args_index.emplace( p.first, &*it );
         }
     }
@@ -488,7 +488,7 @@ void overmap::unserialize( const JsonObject &jsobj )
         std::vector<std::pair<tripoint_om_omt, int>> flat_index;
         jsobj.read( "pp_decisions_index", flat_index, true );
         for( const std::pair<tripoint_om_omt, int> &p : flat_index ) {
-            auto it = pp_decision_storage.get_iterator_from_index( p.second );
+            auto it = cata::get_iterator_from_index( pp_decision_storage, p.second );
             pp_decisions_index.emplace( p.first, &*it );
         }
     }
@@ -1558,8 +1558,8 @@ void overmap::serialize( std::ostream &fout ) const
          mapgen_args_index ) {
         json.start_array();
         json.write( p.first );
-        auto it = mapgen_arg_storage.get_iterator_from_pointer( p.second );
-        int index = mapgen_arg_storage.get_index_from_iterator( it );
+        auto it = mapgen_arg_storage.get_iterator( p.second );
+        int index = cata::get_index_from_iterator( mapgen_arg_storage, it );
         json.write( index );
         json.end_array();
     }
@@ -1585,8 +1585,8 @@ void overmap::serialize( std::ostream &fout ) const
          pp_decisions_index ) {
         json.start_array();
         json.write( p.first );
-        auto it = pp_decision_storage.get_iterator_from_pointer( p.second );
-        int index = pp_decision_storage.get_index_from_iterator( it );
+        auto it = pp_decision_storage.get_iterator( p.second );
+        int index = cata::get_index_from_iterator( pp_decision_storage, it );
         json.write( index );
         json.end_array();
     }

--- a/src/third-party/plf/colony.h
+++ b/src/third-party/plf/colony.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Matthew Bentley (mattreecebentley@gmail.com) www.plflib.org
+// Copyright (c) 2026, Matthew Bentley (mattreecebentley@gmail.com) www.plflib.org
 
 // zLib license (https://www.zlib.net/zlib_license.html):
 // This software is provided 'as-is', without any express or implied
@@ -10,11 +10,11 @@
 // freely, subject to the following restrictions:
 //
 // 1. The origin of this software must not be misrepresented; you must not
-//    claim that you wrote the original software. If you use this software
-//    in a product, an acknowledgement in the product documentation would be
-//    appreciated but is not required.
+// 	claim that you wrote the original software. If you use this software
+// 	in a product, an acknowledgement in the product documentation would be
+// 	appreciated but is not required.
 // 2. Altered source versions must be plainly marked as such, and must not be
-//    misrepresented as being the original software.
+// 	misrepresented as being the original software.
 // 3. This notice may not be removed or altered from any source distribution.
 
 
@@ -22,210 +22,257 @@
 #define PLF_COLONY_H
 
 
-// Compiler-specific defines used by colony:
+// Compiler-specific defines:
 
-#if defined(_MSC_VER)
-	#define PLF_COLONY_FORCE_INLINE __forceinline
+// Define default cases before possibly redefining:
+#define PLF_NOEXCEPT throw()
+#define PLF_NOEXCEPT_ALLOCATOR
+#define PLF_CONSTEXPR
+#define PLF_CONSTFUNC
 
-	#if _MSC_VER < 1600
-		#define PLF_COLONY_NOEXCEPT throw()
-		#define PLF_COLONY_NOEXCEPT_SWAP(the_allocator)
-		#define PLF_COLONY_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) throw()
-	#elif _MSC_VER == 1600
-		#define PLF_COLONY_MOVE_SEMANTICS_SUPPORT
-		#define PLF_COLONY_NOEXCEPT throw()
-		#define PLF_COLONY_NOEXCEPT_SWAP(the_allocator)
-		#define PLF_COLONY_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) throw()
-	#elif _MSC_VER == 1700
-		#define PLF_COLONY_TYPE_TRAITS_SUPPORT
-		#define PLF_COLONY_ALLOCATOR_TRAITS_SUPPORT
-		#define PLF_COLONY_MOVE_SEMANTICS_SUPPORT
-		#define PLF_COLONY_NOEXCEPT throw()
-		#define PLF_COLONY_NOEXCEPT_SWAP(the_allocator)
-		#define PLF_COLONY_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) throw()
-	#elif _MSC_VER == 1800
-		#define PLF_COLONY_TYPE_TRAITS_SUPPORT
-		#define PLF_COLONY_ALLOCATOR_TRAITS_SUPPORT
-		#define PLF_COLONY_VARIADICS_SUPPORT // Variadics, in this context, means both variadic templates and variadic macros are supported
-		#define PLF_COLONY_MOVE_SEMANTICS_SUPPORT
-		#define PLF_COLONY_NOEXCEPT throw()
-		#define PLF_COLONY_NOEXCEPT_SWAP(the_allocator)
-		#define PLF_COLONY_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) throw()
-		#define PLF_COLONY_INITIALIZER_LIST_SUPPORT
-	#elif _MSC_VER >= 1900
-		#define PLF_COLONY_ALIGNMENT_SUPPORT
-		#define PLF_COLONY_TYPE_TRAITS_SUPPORT
-		#define PLF_COLONY_ALLOCATOR_TRAITS_SUPPORT
-		#define PLF_COLONY_VARIADICS_SUPPORT
-		#define PLF_COLONY_MOVE_SEMANTICS_SUPPORT
-		#define PLF_COLONY_NOEXCEPT noexcept
-		#define PLF_COLONY_NOEXCEPT_SWAP(the_allocator) noexcept(std::allocator_traits<the_allocator>::propagate_on_container_swap::value)
-		#define PLF_COLONY_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept(std::allocator_traits<the_allocator>::is_always_equal::value)
-		#define PLF_COLONY_INITIALIZER_LIST_SUPPORT
+#define PLF_EXCEPTIONS_SUPPORT
+
+#if ((defined(__clang__) || defined(__GNUC__)) && !defined(__EXCEPTIONS)) || (defined(_MSC_VER) && !defined(_CPPUNWIND))
+	#undef PLF_EXCEPTIONS_SUPPORT
+	#include <exception> // std::terminate
+#endif
+
+
+#if defined(_MSC_VER) && !defined(__clang__) && !defined(__GNUC__)
+	 // Suppress incorrect (unfixed MSVC bug at warning level 4) warnings re: constant expressions in constexpr-if statements
+	#pragma warning ( push )
+	#pragma warning ( disable : 4127 )
+
+	#if _MSC_VER >= 1600
+		#define PLF_MOVE_SEMANTICS_SUPPORT
+	#endif
+	#if _MSC_VER >= 1700
+		#define PLF_TYPE_TRAITS_SUPPORT
+		#define PLF_ALLOCATOR_TRAITS_SUPPORT
+	#endif
+	#if _MSC_VER >= 1800
+		#define PLF_VARIADICS_SUPPORT // Variadics, in this context, means both variadic templates and variadic macros are supported
+		#define PLF_DEFAULT_SUPPORT // Both support for default template arguments and defaulted class functions
+		#define PLF_INITIALIZER_LIST_SUPPORT
+	#endif
+	#if _MSC_VER >= 1900
+		#define PLF_ALIGNMENT_SUPPORT
+		#undef PLF_NOEXCEPT
+		#undef PLF_NOEXCEPT_ALLOCATOR
+		#define PLF_NOEXCEPT noexcept
+		#define PLF_NOEXCEPT_ALLOCATOR noexcept(noexcept(allocator_type()))
+		#define PLF_IS_ALWAYS_EQUAL_SUPPORT
 	#endif
 
 	#if defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L)
-		#define PLF_COLONY_CONSTEXPR constexpr
-	#else
-		#define PLF_COLONY_CONSTEXPR
+		#undef PLF_CONSTEXPR
+		#define PLF_CONSTEXPR constexpr
 	#endif
 
+	#if defined(_MSVC_LANG) && (_MSVC_LANG >= 202002L) && _MSC_VER >= 1929
+		#define PLF_CPP20_SUPPORT
+		#undef PLF_CONSTFUNC
+		#define PLF_CONSTFUNC constexpr
+	#endif
 #elif defined(__cplusplus) && __cplusplus >= 201103L // C++11 support, at least
-	#define PLF_COLONY_FORCE_INLINE // note: GCC creates faster code without forcing inline
-
 	#if defined(__GNUC__) && defined(__GNUC_MINOR__) && !defined(__clang__) // If compiler is GCC/G++
-		#if (__GNUC__ == 4 && __GNUC_MINOR__ >= 3) || __GNUC__ > 4 // 4.2 and below do not support variadic templates
-			#define PLF_COLONY_VARIADICS_SUPPORT
+		#if (__GNUC__ == 4 && __GNUC_MINOR__ >= 3) || __GNUC__ > 4
+			#define PLF_MOVE_SEMANTICS_SUPPORT
+			#define PLF_VARIADICS_SUPPORT
 		#endif
-		#if (__GNUC__ == 4 && __GNUC_MINOR__ >= 4) || __GNUC__ > 4 // 4.3 and below do not support initializer lists
-			#define PLF_COLONY_INITIALIZER_LIST_SUPPORT
+		#if (__GNUC__ == 4 && __GNUC_MINOR__ >= 4) || __GNUC__ > 4
+			#define PLF_DEFAULT_SUPPORT
+			#define PLF_INITIALIZER_LIST_SUPPORT
 		#endif
-		#if (__GNUC__ == 4 && __GNUC_MINOR__ < 6) || __GNUC__ < 4
-			#define PLF_COLONY_NOEXCEPT throw()
-			#define PLF_COLONY_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator)
-			#define PLF_COLONY_NOEXCEPT_SWAP(the_allocator)
-		#elif __GNUC__ < 6
-			#define PLF_COLONY_NOEXCEPT noexcept
-			#define PLF_COLONY_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept
-			#define PLF_COLONY_NOEXCEPT_SWAP(the_allocator) noexcept
-		#else // C++17 support
-			#define PLF_COLONY_NOEXCEPT noexcept
-			#define PLF_COLONY_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept(std::allocator_traits<the_allocator>::is_always_equal::value)
-			#define PLF_COLONY_NOEXCEPT_SWAP(the_allocator) noexcept(std::allocator_traits<the_allocator>::propagate_on_container_swap::value)
+		#if (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || __GNUC__ > 4
+			#undef PLF_NOEXCEPT
+			#undef PLF_NOEXCEPT_ALLOCATOR
+			#define PLF_NOEXCEPT noexcept
+			#define PLF_NOEXCEPT_ALLOCATOR noexcept(noexcept(allocator_type()))
 		#endif
 		#if (__GNUC__ == 4 && __GNUC_MINOR__ >= 7) || __GNUC__ > 4
-			#define PLF_COLONY_ALLOCATOR_TRAITS_SUPPORT
+			#define PLF_ALLOCATOR_TRAITS_SUPPORT
 		#endif
 		#if (__GNUC__ == 4 && __GNUC_MINOR__ >= 8) || __GNUC__ > 4
-			#define PLF_COLONY_ALIGNMENT_SUPPORT
+			#define PLF_ALIGNMENT_SUPPORT
 		#endif
 		#if __GNUC__ >= 5 // GCC v4.9 and below do not support std::is_trivially_copyable
-			#define PLF_COLONY_TYPE_TRAITS_SUPPORT
+			#define PLF_TYPE_TRAITS_SUPPORT
+		#endif
+		#if __GNUC__ > 6
+			#define PLF_IS_ALWAYS_EQUAL_SUPPORT
+		#endif
+	#elif defined(__clang__) && !defined(__GLIBCXX__) && !defined(_LIBCPP_CXX03_LANG) && __clang_major__ >= 3
+		#define PLF_DEFAULT_SUPPORT
+		#define PLF_ALLOCATOR_TRAITS_SUPPORT
+		#define PLF_TYPE_TRAITS_SUPPORT
+
+		#if __has_feature(cxx_alignas) && __has_feature(cxx_alignof)
+			#define PLF_ALIGNMENT_SUPPORT
+		#endif
+		#if __has_feature(cxx_noexcept)
+			#undef PLF_NOEXCEPT
+			#undef PLF_NOEXCEPT_ALLOCATOR
+			#define PLF_NOEXCEPT noexcept
+			#define PLF_NOEXCEPT_ALLOCATOR noexcept(noexcept(allocator_type()))
+			#define PLF_IS_ALWAYS_EQUAL_SUPPORT
+		#endif
+		#if __has_feature(cxx_rvalue_references) && !defined(_LIBCPP_HAS_NO_RVALUE_REFERENCES)
+			#define PLF_MOVE_SEMANTICS_SUPPORT
+		#endif
+		#if __has_feature(cxx_variadic_templates) && !defined(_LIBCPP_HAS_NO_VARIADICS)
+			#define PLF_VARIADICS_SUPPORT
+		#endif
+		#if (__clang_major__ == 3 && __clang_minor__ >= 1) || __clang_major__ > 3
+			#define PLF_INITIALIZER_LIST_SUPPORT
 		#endif
 	#elif defined(__GLIBCXX__) // Using another compiler type with libstdc++ - we are assuming full c++11 compliance for compiler - which may not be true
-		#if __GLIBCXX__ >= 20080606 	// libstdc++ 4.2 and below do not support variadic templates
-			#define PLF_COLONY_VARIADICS_SUPPORT
+		#define PLF_DEFAULT_SUPPORT
+
+		#if __GLIBCXX__ >= 20080606
+			#define PLF_MOVE_SEMANTICS_SUPPORT
+			#define PLF_VARIADICS_SUPPORT
 		#endif
-		#if __GLIBCXX__ >= 20090421 	// libstdc++ 4.3 and below do not support initializer lists
-			#define PLF_COLONY_INITIALIZER_LIST_SUPPORT
+		#if __GLIBCXX__ >= 20090421
+			#define PLF_INITIALIZER_LIST_SUPPORT
 		#endif
-		#if __GLIBCXX__ >= 20160111
-			#define PLF_COLONY_ALLOCATOR_TRAITS_SUPPORT
-			#define PLF_COLONY_NOEXCEPT noexcept
-			#define PLF_COLONY_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept(std::allocator_traits<the_allocator>::is_always_equal::value)
-			#define PLF_COLONY_NOEXCEPT_SWAP(the_allocator) noexcept(std::allocator_traits<the_allocator>::propagate_on_container_swap::value)
-		#elif __GLIBCXX__ >= 20120322
-			#define PLF_COLONY_ALLOCATOR_TRAITS_SUPPORT
-			#define PLF_COLONY_NOEXCEPT noexcept
-			#define PLF_COLONY_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept
-			#define PLF_COLONY_NOEXCEPT_SWAP(the_allocator) noexcept
-		#else
-			#define PLF_COLONY_NOEXCEPT throw()
-			#define PLF_COLONY_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator)
-			#define PLF_COLONY_NOEXCEPT_SWAP(the_allocator)
+		#if __GLIBCXX__ >= 20120322
+			#define PLF_ALLOCATOR_TRAITS_SUPPORT
+			#undef PLF_NOEXCEPT
+			#undef PLF_NOEXCEPT_ALLOCATOR
+			#define PLF_NOEXCEPT noexcept
+			#define PLF_NOEXCEPT_ALLOCATOR noexcept(noexcept(allocator_type()))
 		#endif
 		#if __GLIBCXX__ >= 20130322
-			#define PLF_COLONY_ALIGNMENT_SUPPORT
+			#define PLF_ALIGNMENT_SUPPORT
 		#endif
 		#if __GLIBCXX__ >= 20150422 // libstdc++ v4.9 and below do not support std::is_trivially_copyable
-			#define PLF_COLONY_TYPE_TRAITS_SUPPORT
+			#define PLF_TYPE_TRAITS_SUPPORT
 		#endif
-	#elif defined(_LIBCPP_VERSION)
-		#define PLF_COLONY_ALLOCATOR_TRAITS_SUPPORT
-		#define PLF_COLONY_VARIADICS_SUPPORT
-		#define PLF_COLONY_INITIALIZER_LIST_SUPPORT
-		#define PLF_COLONY_ALIGNMENT_SUPPORT
-		#define PLF_COLONY_NOEXCEPT noexcept
-		#define PLF_COLONY_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept(std::allocator_traits<the_allocator>::is_always_equal::value)
-		#define PLF_COLONY_NOEXCEPT_SWAP(the_allocator) noexcept
-
-		#if !(defined(_LIBCPP_CXX03_LANG) || defined(_LIBCPP_HAS_NO_RVALUE_REFERENCES))
-			#define PLF_COLONY_TYPE_TRAITS_SUPPORT
+		#if __GLIBCXX__ >= 20160111
+			#define PLF_IS_ALWAYS_EQUAL_SUPPORT
 		#endif
-	#else // Assume type traits and initializer support for other compilers and standard libraries
-		#define PLF_COLONY_ALLOCATOR_TRAITS_SUPPORT
-		#define PLF_COLONY_ALIGNMENT_SUPPORT
-		#define PLF_COLONY_VARIADICS_SUPPORT
-		#define PLF_COLONY_INITIALIZER_LIST_SUPPORT
-		#define PLF_COLONY_TYPE_TRAITS_SUPPORT
-		#define PLF_COLONY_NOEXCEPT noexcept
-		#define PLF_COLONY_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept(std::allocator_traits<the_allocator>::is_always_equal::value)
-		#define PLF_COLONY_NOEXCEPT_SWAP(the_allocator) noexcept
+	#elif defined(_LIBCPP_CXX03_LANG) || defined(_LIBCPP_HAS_NO_RVALUE_REFERENCES) // Special case for checking C++11 support with libCPP
+		#if !defined(_LIBCPP_HAS_NO_VARIADICS)
+			#define PLF_VARIADICS_SUPPORT
+		#endif
+	#else // Assume type traits and initializer support for other compilers and standard library implementations
+		#define PLF_DEFAULT_SUPPORT
+		#define PLF_MOVE_SEMANTICS_SUPPORT
+		#define PLF_VARIADICS_SUPPORT
+		#define PLF_TYPE_TRAITS_SUPPORT
+		#define PLF_ALLOCATOR_TRAITS_SUPPORT
+		#define PLF_ALIGNMENT_SUPPORT
+		#define PLF_INITIALIZER_LIST_SUPPORT
+		#undef PLF_NOEXCEPT
+		#undef PLF_NOEXCEPT_ALLOCATOR
+		#define PLF_NOEXCEPT noexcept
+		#define PLF_NOEXCEPT_ALLOCATOR noexcept(noexcept(allocator_type()))
+		#define PLF_IS_ALWAYS_EQUAL_SUPPORT
 	#endif
 
-	#if __cplusplus >= 201703L
-		#if defined(__clang__) && ((__clang_major__ == 3 && __clang_minor__ == 9) || __clang_major__ > 3)
-			#define PLF_COLONY_CONSTEXPR constexpr
-		#elif defined(__GNUC__) && __GNUC__ >= 7
-			#define PLF_COLONY_CONSTEXPR constexpr
-		#elif !defined(__clang__) && !defined(__GNUC__)
-			#define PLF_COLONY_CONSTEXPR constexpr // assume correct C++17 implementation for other compilers
-		#else
-			#define PLF_COLONY_CONSTEXPR
-		#endif
-	#else
-		#define PLF_COLONY_CONSTEXPR
+	#if __cplusplus >= 201703L && ((defined(__clang__) && ((__clang_major__ == 3 && __clang_minor__ == 9) || __clang_major__ > 3)) || (defined(__GNUC__) && __GNUC__ >= 7) || (!defined(__clang__) && !defined(__GNUC__))) // assume correct C++17 implementation for non-gcc/clang compilers
+		#undef PLF_CONSTEXPR
+		#define PLF_CONSTEXPR constexpr
 	#endif
 
-	#define PLF_COLONY_MOVE_SEMANTICS_SUPPORT
+	#if __cplusplus > 201704L && ((((defined(__clang__) && !defined(__APPLE_CC__) && __clang_major__ >= 14) || (defined(__GNUC__) && (__GNUC__ > 11 || (__GNUC__ == 11 && __GNUC_MINOR__ > 0)))) && ((defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 14) || (defined(__GLIBCXX__) && __GLIBCXX__ >= 201806L))) || (!defined(__clang__) && !defined(__GNUC__)))
+		#define PLF_CPP20_SUPPORT
+		#undef PLF_CONSTFUNC
+		#define PLF_CONSTFUNC constexpr
+	#endif
+#endif
+
+#if defined(PLF_IS_ALWAYS_EQUAL_SUPPORT) && defined(PLF_MOVE_SEMANTICS_SUPPORT) && (__cplusplus >= 201703L || (defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L)))
+	#define PLF_NOEXCEPT_MOVE_ASSIGN(the_allocator) noexcept(std::allocator_traits<the_allocator>::propagate_on_container_move_assignment::value || std::allocator_traits<the_allocator>::is_always_equal::value)
+	#define PLF_NOEXCEPT_SWAP(the_allocator) noexcept(std::allocator_traits<the_allocator>::propagate_on_container_swap::value || std::allocator_traits<the_allocator>::is_always_equal::value)
 #else
-	#define PLF_COLONY_FORCE_INLINE
-	#define PLF_COLONY_NOEXCEPT throw()
-	#define PLF_COLONY_NOEXCEPT_SWAP(the_allocator)
-	#define PLF_COLONY_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator)
-	#define PLF_COLONY_CONSTEXPR
+	#define PLF_NOEXCEPT_MOVE_ASSIGN(the_allocator)
+	#define PLF_NOEXCEPT_SWAP(the_allocator)
+#endif
+
+#ifdef PLF_ALLOCATOR_TRAITS_SUPPORT
+	#ifdef PLF_VARIADICS_SUPPORT
+		#define PLF_CONSTRUCT(the_allocator, allocator_instance, location, ...) std::allocator_traits<the_allocator>::construct(allocator_instance, location, __VA_ARGS__)
+	#else
+		#define PLF_CONSTRUCT(the_allocator, allocator_instance, location, data)	std::allocator_traits<the_allocator>::construct(allocator_instance, location, data)
+	#endif
+
+	#define PLF_DESTROY(the_allocator, allocator_instance, location)				std::allocator_traits<the_allocator>::destroy(allocator_instance, location)
+	#define PLF_ALLOCATE(the_allocator, allocator_instance, size, hint)			std::allocator_traits<the_allocator>::allocate(allocator_instance, size, hint)
+	#define PLF_DEALLOCATE(the_allocator, allocator_instance, location, size)	std::allocator_traits<the_allocator>::deallocate(allocator_instance, location, size)
+#else
+	#ifdef PLF_VARIADICS_SUPPORT
+		#define PLF_CONSTRUCT(the_allocator, allocator_instance, location, ...) 	(allocator_instance).construct(location, __VA_ARGS__)
+	#else
+		#define PLF_CONSTRUCT(the_allocator, allocator_instance, location, data)	(allocator_instance).construct(location, data)
+	#endif
+
+	#define PLF_DESTROY(the_allocator, allocator_instance, location)				(allocator_instance).destroy(location)
+	#define PLF_ALLOCATE(the_allocator, allocator_instance, size, hint)			(allocator_instance).allocate(size, hint)
+	#define PLF_DEALLOCATE(the_allocator, allocator_instance, location, size)	(allocator_instance).deallocate(location, size)
 #endif
 
 
+#define PLF_CONSTRUCT_ELEMENT(location, element) PLF_CONSTRUCT(allocator_type, *this, pointer_cast<pointer>(location), element)
 
 
-
-#ifdef PLF_COLONY_ALLOCATOR_TRAITS_SUPPORT
-	#ifdef PLF_COLONY_VARIADICS_SUPPORT
-		#define PLF_COLONY_CONSTRUCT(the_allocator, allocator_instance, location, ...)	std::allocator_traits<the_allocator>::construct(allocator_instance, location, __VA_ARGS__)
-	#else
-		#define PLF_COLONY_CONSTRUCT(the_allocator, allocator_instance, location, data) std::allocator_traits<the_allocator>::construct(allocator_instance, location, data)
-	#endif
-
-	#define PLF_COLONY_DESTROY(the_allocator, allocator_instance, location) 			std::allocator_traits<the_allocator>::destroy(allocator_instance, location)
-	#define PLF_COLONY_ALLOCATE(the_allocator, allocator_instance, size, hint) 			std::allocator_traits<the_allocator>::allocate(allocator_instance, size, hint)
- 	#define PLF_COLONY_ALLOCATE_INITIALIZATION(the_allocator, size, hint) 				std::allocator_traits<the_allocator>::allocate(*this, size, hint)
-	#define PLF_COLONY_DEALLOCATE(the_allocator, allocator_instance, location, size) 	std::allocator_traits<the_allocator>::deallocate(allocator_instance, location, size)
-#else
-	#ifdef PLF_COLONY_VARIADICS_SUPPORT
-		#define PLF_COLONY_CONSTRUCT(the_allocator, allocator_instance, location, ...)	allocator_instance.construct(location, __VA_ARGS__)
-	#else
-		#define PLF_COLONY_CONSTRUCT(the_allocator, allocator_instance, location, data) allocator_instance.construct(location, data)
-	#endif
-
-	#define PLF_COLONY_DESTROY(the_allocator, allocator_instance, location) 			allocator_instance.destroy(location)
-	#define PLF_COLONY_ALLOCATE(the_allocator, allocator_instance, size, hint)	 		allocator_instance.allocate(size, hint)
-	#define PLF_COLONY_ALLOCATE_INITIALIZATION(the_allocator, size, hint) 				the_allocator::allocate(size, hint)
-	#define PLF_COLONY_DEALLOCATE(the_allocator, allocator_instance, location, size) 	allocator_instance.deallocate(location, size)
+#ifndef PLF_SORT_FUNCTION
+	#define PLF_SORT_FUNCTION std::sort
+	#define PLF_SORT_FUNCTION_DEFINED
 #endif
 
-
-
-#include <algorithm> // std::sort and std::fill_n
-
-#include <cstring>	// memset, memcpy
+#include <algorithm> // std::fill_n, std::sort, std::swap
 #include <cassert>	// assert
+#include <cstring>	// memset, memcpy, size_t
 #include <limits>  // std::numeric_limits
-#include <memory>	// std::allocator
-#include <iterator> // std::bidirectional_iterator_tag
+#include <memory> // std::allocator, std::to_address
+#include <iterator> // std::bidirectional_iterator_tag, iterator_traits, std::move_iterator, std::distance for range insert
+#include <stdexcept> // std::length_error
 
 
-#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
+#ifdef PLF_TYPE_TRAITS_SUPPORT
 	#include <cstddef> // offsetof, used in blank()
-	#include <type_traits> // std::is_trivially_destructible, etc
+	#include <type_traits> // std::is_trivially_destructible, type_identity_t, etc
 #endif
 
-#ifdef PLF_COLONY_MOVE_SEMANTICS_SUPPORT
+#ifdef PLF_MOVE_SEMANTICS_SUPPORT
 	#include <utility> // std::move
 #endif
 
-#ifdef PLF_COLONY_INITIALIZER_LIST_SUPPORT
+#ifdef PLF_INITIALIZER_LIST_SUPPORT
 	#include <initializer_list>
+#endif
+
+
+#ifdef PLF_CPP20_SUPPORT
+	#include <concepts>
+	#include <compare> // std::strong_ordering
+	#include <ranges>
+
+
+	namespace plf
+	{
+
+		// For getting std:: overload for reverse_iterator to match colony iterators specifically (see bottom of header):
+		template <class T>
+		concept colony_iterator_concept = requires { typename T::colony_iterator_tag; };
+
+		#ifndef PLF_RANGES
+			#define PLF_RANGES
+
+			// For matching ranges which return input_iterator's and match the container's element type:
+			template <typename range_type, class element_type>
+			concept compatible_range = std::ranges::input_range<range_type> && std::convertible_to<std::ranges::range_reference_t<range_type>, element_type>;
+
+			// Until such point as standard libraries include std::ranges::from_range_t, including this so the rangesv3 constructor overloads will work unambiguously:
+			namespace ranges
+			{
+				struct from_range_t {};
+				constexpr from_range_t from_range;
+			}
+		#endif
+	}
 #endif
 
 
@@ -234,834 +281,380 @@ namespace plf
 {
 
 
-template <class element_type, class element_allocator_type = std::allocator<element_type>, typename element_skipfield_type = unsigned short > class colony : private element_allocator_type  // Empty base class optimisation - inheriting allocator functions
-// Note: unsigned short is equivalent to uint_least16_t ie. Using 16-bit unsigned integer in best-case scenario, greater-than-16-bit unsigned integer where platform doesn't support 16-bit types
+
+#ifndef PLF_TOOLS
+	#define PLF_TOOLS
+
+	// std:: tool replacements for C++03/98/11 support:
+	template <bool condition, class T = void>
+	struct enable_if
+	{
+		typedef T type;
+	};
+
+	template <class T>
+	struct enable_if<false, T>
+	{};
+
+
+
+	template <bool flag, class is_true, class is_false> struct conditional;
+
+	template <class is_true, class is_false> struct conditional<true, is_true, is_false>
+	{
+		typedef is_true type;
+	};
+
+	template <class is_true, class is_false> struct conditional<false, is_true, is_false>
+	{
+		typedef is_false type;
+	};
+
+
+
+	template <class element_type>
+	struct less
+	{
+		bool operator() (const element_type &a, const element_type &b) const PLF_NOEXCEPT
+		{
+			return a < b;
+		}
+	};
+
+
+
+	template<class element_type>
+	struct equal_to
+	{
+		const element_type &value;
+
+		explicit equal_to(const element_type &store_value) PLF_NOEXCEPT:
+			value(store_value)
+		{}
+
+		bool operator() (const element_type &compare_value) const PLF_NOEXCEPT
+		{
+			return value == compare_value;
+		}
+	};
+
+
+
+	// For converting the underlying skipfield storage * type to void * when the allocator supplies non-trivial pointers.
+	// The void * conversion is technically unnecessary since it will be implicitly converted when required, but it's more straightforward than having to identify the underlying storage type:
+	template <class source_pointer_type>
+	static PLF_CONSTFUNC void * void_cast(const source_pointer_type source_pointer) PLF_NOEXCEPT
+	{
+		#ifdef PLF_CPP20_SUPPORT
+			return static_cast<void *>(std::to_address(source_pointer));
+		#else
+			return static_cast<void *>(&*source_pointer);
+		#endif
+	}
+
+
+
+	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+		template <class iterator_type>
+		static PLF_CONSTFUNC std::move_iterator<iterator_type> make_move_iterator(iterator_type it)
+		{
+			return std::move_iterator<iterator_type>(std::move(it));
+		}
+	#endif
+
+
+	enum priority { performance = 1, memory_use = 4};
+
+#endif
+
+
+
+struct limits
 {
+	size_t min, max;
+	PLF_CONSTFUNC limits(const size_t minimum, const size_t maximum) PLF_NOEXCEPT : min(minimum), max(maximum) {}
+};
+
+
+
+
+template <class element_type, class allocator_type = std::allocator<element_type>, plf::priority priority = performance>
+class colony : private allocator_type // Empty base class optimisation - inheriting allocator functions
+{
+	#ifdef PLF_ALIGNMENT_SUPPORT
+		typedef typename plf::conditional<(priority == performance && (sizeof(element_type) > 10 || alignof(element_type) > 10)), unsigned short, unsigned char>::type		skipfield_type; // Note: unsigned short is equivalent to uint_least16_t ie. Using 16-bit unsigned integer in best-case scenario, greater-than-16-bit unsigned integer where platform doesn't support 16-bit types. unsigned char is always == 1 byte, as opposed to uint_8, which may not be.
+	#else
+		typedef typename plf::conditional<(priority == performance && sizeof(element_type) > 10), unsigned short, unsigned char>::type		skipfield_type;
+	#endif
+
 public:
 	// Standard container typedefs:
-	typedef element_type																				value_type;
-	typedef element_allocator_type																		allocator_type;
-	typedef element_skipfield_type																		skipfield_type;
 
-	#ifdef PLF_COLONY_ALIGNMENT_SUPPORT
-		typedef typename std::aligned_storage<sizeof(element_type), (alignof(element_type) > (sizeof(element_skipfield_type) * 2)) ? alignof(element_type) : (sizeof(element_skipfield_type) * 2)>::type	aligned_element_type;
+	#ifdef PLF_ALLOCATOR_TRAITS_SUPPORT
+		typedef typename std::allocator_traits<allocator_type>::size_type 			size_type;
+		typedef typename std::allocator_traits<allocator_type>::difference_type 	difference_type;
+		typedef typename std::allocator_traits<allocator_type>::pointer				pointer;
+		typedef typename std::allocator_traits<allocator_type>::const_pointer		const_pointer;
 	#else
-		typedef element_type																				aligned_element_type;
+		typedef typename allocator_type::size_type			size_type;
+		typedef typename allocator_type::difference_type	difference_type;
+		typedef typename allocator_type::pointer				pointer;
+		typedef typename allocator_type::const_pointer		const_pointer;
 	#endif
 
-	#ifdef PLF_COLONY_ALLOCATOR_TRAITS_SUPPORT
-		typedef typename std::allocator_traits<element_allocator_type>::size_type							size_type;
-		typedef typename std::allocator_traits<element_allocator_type>::difference_type 					difference_type;
-		typedef element_type &																				reference;
-		typedef const element_type &																		const_reference;
-		typedef typename std::allocator_traits<element_allocator_type>::pointer 							pointer;
-		typedef typename std::allocator_traits<element_allocator_type>::const_pointer						const_pointer;
-	#else
-		typedef typename element_allocator_type::size_type			size_type;
-		typedef typename element_allocator_type::difference_type	difference_type;
-		typedef typename element_allocator_type::reference			reference;
-		typedef typename element_allocator_type::const_reference	const_reference;
-		typedef typename element_allocator_type::pointer			pointer;
-		typedef typename element_allocator_type::const_pointer		const_pointer;
-	#endif
+	typedef element_type value_type;
+	typedef element_type &			reference;
+	typedef const element_type &	const_reference;
 
 
-	// Iterator declarations:
-	template <bool is_const> class		colony_iterator;
-	typedef colony_iterator<false>		iterator;
-	typedef colony_iterator<true>		const_iterator;
-	friend class colony_iterator<false>; // Using above typedef name here is illegal under C++03
+	// Iterator forward declarations:
+	template <bool is_const> class			colony_iterator;
+	typedef colony_iterator<false>			iterator;
+	typedef colony_iterator<true> 			const_iterator;
+	friend class colony_iterator<false>;
 	friend class colony_iterator<true>;
 
-	template <bool r_is_const> class		colony_reverse_iterator;
+	template <bool is_const_r> class			colony_reverse_iterator;
 	typedef colony_reverse_iterator<false>	reverse_iterator;
 	typedef colony_reverse_iterator<true>	const_reverse_iterator;
 	friend class colony_reverse_iterator<false>;
 	friend class colony_reverse_iterator<true>;
 
 
+	#ifdef PLF_ALIGNMENT_SUPPORT
+		// The element as allocated in memory needs to be at-least 2*skipfield_type width in order to support free list indexes in erased element memory space, so:
+		// make the size of this struct the larger of alignof(T), sizeof(T) or 2*skipfield_type (the latter is only relevant for type char/uchar), and
+		// make the alignment alignof(T).
+		// This type is used mainly for correct pointer arithmetic while iterating over elements in memory.
+		struct alignas(alignof(element_type)) aligned_element_struct
+		{
+			 // Using char as sizeof is always guaranteed to be 1 byte regardless of the number of bits in a byte on given computer, whereas for example, uint8_t would fail on machines where there are more than 8 bits in a byte eg. Texas Instruments C54x DSPs.
+			char data[
+			(sizeof(element_type) < (sizeof(skipfield_type) * 2)) ?
+			((sizeof(skipfield_type) * 2) < alignof(element_type) ? alignof(element_type) : (sizeof(skipfield_type) * 2)) :
+			((sizeof(element_type) < alignof(element_type)) ? alignof(element_type) : sizeof(element_type))
+			];
+		};
+
+
+		// We combine the allocation of elements and skipfield into one allocation to save performance. This memory must be allocated as an aligned type with the same alignment as T in order for the elements to align with memory boundaries correctly (which won't happen if we allocate as char or uint_8). But the larger the sizeof in the type we use for allocation, the greater the chance of creating a lot of unused memory in the skipfield portion of the allocated block. So we create a type that is sizeof(alignof(T)), as in most cases alignof(T) < sizeof(T). If alignof(t) >= sizeof(t) this makes no difference.
+		struct alignas(alignof(element_type)) aligned_allocation_struct
+		{
+		  char data[alignof(element_type)];
+		};
+	#else
+		struct aligned_element_struct
+		{
+			char data[(sizeof(element_type) < (sizeof(skipfield_type) * 2)) ? (sizeof(skipfield_type) * 2) : sizeof(element_type)];
+		};
+
+		struct aligned_allocation_struct
+		{
+		  char data[sizeof(skipfield_type)];
+		};
+	#endif
+
+
 private:
 
+	// Calculate the capacity of a group's elements+skipfield memory block when expressed in multiples of the value_type's alignment (rounding up).
+	static size_type get_aligned_block_capacity(const skipfield_type elements_per_group)
+	{
+		return ((elements_per_group * (sizeof(aligned_element_struct) + sizeof(skipfield_type))) + sizeof(skipfield_type) + sizeof(aligned_allocation_struct) - 1) / sizeof(aligned_allocation_struct);
+	}
 
-	struct group; // forward declaration for typedefs below
 
-	#ifdef PLF_COLONY_ALLOCATOR_TRAITS_SUPPORT
-		typedef typename std::allocator_traits<element_allocator_type>::template rebind_alloc<aligned_element_type>	aligned_element_allocator_type;
-		typedef typename std::allocator_traits<element_allocator_type>::template rebind_alloc<group>				group_allocator_type;
-		typedef typename std::allocator_traits<element_allocator_type>::template rebind_alloc<skipfield_type>		skipfield_allocator_type;
-		typedef typename std::allocator_traits<element_allocator_type>::template rebind_alloc<unsigned char>		uchar_allocator_type; // Using uchar as the generic allocator type, as sizeof is always guaranteed to be 1 byte regardless of the number of bits in a byte on given computer, whereas for example, uint8_t would fail on machines where there are more than 8 bits in a byte eg. Texas Instruments C54x DSPs.
+	// forward declarations for typedefs below
+	struct group;
+	struct item_index_tuple; // for use in sort()
 
-		typedef typename std::allocator_traits<aligned_element_allocator_type>::pointer		aligned_pointer_type; // Different typedef to 'pointer' - this is a pointer to the overaligned element type, not the original element type
-		typedef typename std::allocator_traits<group_allocator_type>::pointer 				group_pointer_type;
-		typedef typename std::allocator_traits<skipfield_allocator_type>::pointer 			skipfield_pointer_type;
+	// These two need to be raw pointers as instances of this type have pointer arithmetic done on them:
+	typedef aligned_element_struct *	aligned_pointer_type; // pointer to the (potentially overaligned) element type, not the original element type
+	typedef skipfield_type *			skipfield_pointer_type;
+
+	#ifdef PLF_ALLOCATOR_TRAITS_SUPPORT
+		typedef typename std::allocator_traits<allocator_type>::template rebind_alloc<group>							group_allocator_type;
+		typedef typename std::allocator_traits<allocator_type>::template rebind_alloc<skipfield_type>				skipfield_allocator_type;
+		typedef typename std::allocator_traits<allocator_type>::template rebind_alloc<aligned_allocation_struct> aligned_struct_allocator_type;
+		typedef typename std::allocator_traits<allocator_type>::template rebind_alloc<item_index_tuple> 			tuple_allocator_type;
+		typedef typename std::allocator_traits<allocator_type>::template rebind_alloc<unsigned char> 				uchar_allocator_type;
+
+		typedef typename std::allocator_traits<group_allocator_type>::pointer				group_pointer_type;
+		typedef typename std::allocator_traits<aligned_struct_allocator_type>::pointer	aligned_struct_pointer_type;
+		typedef typename std::allocator_traits<tuple_allocator_type>::pointer				tuple_pointer_type;
 		typedef typename std::allocator_traits<uchar_allocator_type>::pointer				uchar_pointer_type;
-
-		typedef typename std::allocator_traits<element_allocator_type>::template rebind_alloc<pointer>	pointer_allocator_type;
 	#else
-		typedef typename element_allocator_type::template rebind<aligned_element_type>::other	aligned_element_allocator_type;  // In case compiler supports alignment but not allocator_traits
-		typedef typename element_allocator_type::template rebind<group>::other					group_allocator_type;
-		typedef typename element_allocator_type::template rebind<skipfield_type>::other			skipfield_allocator_type;
-		typedef typename element_allocator_type::template rebind<unsigned char>::other			uchar_allocator_type;
+		typedef typename allocator_type::template rebind<group>::other 						group_allocator_type;
+		typedef typename allocator_type::template rebind<skipfield_type>::other 			skipfield_allocator_type;
+		typedef typename allocator_type::template rebind<aligned_allocation_struct>::other	aligned_struct_allocator_type;
+		typedef typename allocator_type::template rebind<item_index_tuple>::other			tuple_allocator_type;
+		typedef typename allocator_type::template rebind<unsigned char>::other				uchar_allocator_type;
 
-		typedef typename aligned_element_allocator_type::pointer	aligned_pointer_type;
-		typedef typename group_allocator_type::pointer 				group_pointer_type;
-		typedef typename skipfield_allocator_type::pointer 			skipfield_pointer_type;
+		typedef typename group_allocator_type::pointer				group_pointer_type;
+		typedef typename aligned_struct_allocator_type::pointer	aligned_struct_pointer_type;
+		typedef typename tuple_allocator_type::pointer				tuple_pointer_type;
 		typedef typename uchar_allocator_type::pointer				uchar_pointer_type;
-
-		typedef typename element_allocator_type::template rebind<pointer>::other pointer_allocator_type;
 	#endif
 
 
 
-	// Colony groups:
-	struct group : private uchar_allocator_type	// Empty base class optimisation (EBCO) - inheriting allocator functions
+	// To simplify conversion when allocator supplies non-raw pointers:
+	template <class destination_pointer_type, class source_pointer_type>
+	static PLF_CONSTFUNC destination_pointer_type pointer_cast(const source_pointer_type source_pointer) PLF_NOEXCEPT
 	{
-		aligned_pointer_type				last_endpoint; 				// The address that is one past the highest cell number that's been used so far in this group - does not change with erase command but may change with insert (if no previously-erased locations are available) - is necessary because an iterator cannot access the colony's end_iterator. Most-used variable in colony use (operator ++, --) so first in struct
-		group_pointer_type					next_group; 				// Next group in the intrusive list of all groups. NULL if no next group
-		const aligned_pointer_type			elements; 					// Element storage
-		const skipfield_pointer_type		skipfield; 					// Skipfield storage. The element and skipfield arrays are allocated contiguously, hence the skipfield pointer also functions as a 'one-past-end' pointer for the elements array. There will always be one additional skipfield node allocated compared to the number of elements. This is to ensure a faster ++ iterator operation (fewer checks are required when this is present). The extra node is unused and always zero, but checked, and not having it will result in out-of-bounds memory errors.
-		group_pointer_type					previous_group; 			// previous group in the intrusive list of all groups. NULL if no preceding group
-		skipfield_type						free_list_head; 			// The index of the last erased element in the group. The last erased element will, in turn, contain the number of the index of the next erased element, and so on. If this is == maximum skipfield_type value then free_list is empty ie. no erasures have occurred in the group (or if they have, the erased locations have then been reused via insert()).
-		const skipfield_type				capacity; 						// The element capacity of this particular group
-		skipfield_type						number_of_elements; 		// indicates total number of active elements in group - changes with insert and erase commands - used to check for empty group in erase function, as an indication to remove the group
-		group_pointer_type					erasures_list_next_group; 	// The next group in the intrusive singly-linked list of groups with erasures ie. with active erased-element free lists
-		size_type							group_number; 				// Used for comparison (> < >= <=) iterator operators (used by distance function and user)
+		#if defined(PLF_TYPE_TRAITS_SUPPORT) && defined(PLF_CPP20_SUPPORT) // constexpr necessary to avoid a branch for every call
+			if constexpr (std::is_trivially_constructible<destination_pointer_type>::value)
+			{
+				if constexpr (std::is_trivially_constructible<source_pointer_type>::value)
+				{
+					return reinterpret_cast<destination_pointer_type>(source_pointer);
+				}
+				else
+				{
+					return reinterpret_cast<destination_pointer_type>(std::to_address(source_pointer));
+				}
+			}
+			else
+			{
+				return destination_pointer_type(std::to_address(source_pointer));
+			}
+		#else
+			return destination_pointer_type(&*source_pointer);
+		#endif
+	}
 
 
-		#ifdef PLF_COLONY_VARIADICS_SUPPORT
-			group(const skipfield_type elements_per_group, group_pointer_type const previous = NULL):
-				last_endpoint(reinterpret_cast<aligned_pointer_type>(PLF_COLONY_ALLOCATE_INITIALIZATION(uchar_allocator_type, ((elements_per_group * (sizeof(aligned_element_type))) + ((elements_per_group + 1u) * sizeof(skipfield_type))), (previous == NULL) ? 0 : previous->elements))), /* allocating to here purely because it is first in the struct sequence - actual pointer is elements, last_endpoint is only initialised to element's base value initially, then incremented by one below */
+
+	// Function purely to save typing:
+	template <class source_pointer_type>
+	static PLF_CONSTFUNC aligned_pointer_type to_aligned_pointer(const source_pointer_type source_pointer) PLF_NOEXCEPT
+	{
+		return pointer_cast<aligned_pointer_type>(source_pointer);
+	}
+
+
+	// group == element memory block + skipfield + block metadata
+
+	// Skipfield implementation notes:
+	// (1) Follows low-complexity jump-counting pattern rules as described here: archive.org/details/matt_bentley_-_the_low_complexity_jump-counting_pattern
+	// (2) Initialized to 0 by-default, which means 'non-erased' ie. either no element has ever been constructed there, or an element has been constructed there. Whereas non-zero means an element has been constructed there and subsequently erased. The value of the first and last non-zero nodes in a run of non-zero nodes determines jump length. See the paper for details.
+	// (3) This definition means we can bulk-initialize each group's skipfield to 0, rather than bulk-initialize to non-zero then subsequently change individual skipfield nodes to 0 upon insertion - which is obviously slower. Defining unconstructed elements as 0 has no impact on iteration since they're after end(). Note that this definition is violated slightly during splice: unconstructed element nodes at the end of the destination colony's back block will have their corresponding skipfield nodes flipped to 'erased' in order to make iteration work, because they will not longer be after end() once the source colony's blocks are appended.
+	// (4) There will always be one additional skipfield node allocated compared to the group's number of elements. This ensures a faster ++ iterator operation (fewer checks are required when it is present). The extra node is unused and always 0, but checked, and not having it will result in out-of-bounds memory errors.
+
+
+	struct group
+	{
+		skipfield_pointer_type					skipfield;			// Skipfield storage. The element and skipfield arrays are allocated contiguously, in a single allocation, in this implementation, hence the skipfield pointer also functions as a 'one-past-end' pointer for the elements array. This is present before elements in the group struct as it is referenced constantly by the ++ operator, hence having it first results in a minor performance increase.
+		group_pointer_type						next_group;			// Next group in the linked list of all groups. NULL if no following group. 2nd in struct because it is so frequently used during iteration.
+		const aligned_struct_pointer_type 	elements;			// Element storage. Allocated as a block of chars, this memory is then divided between elements & skipfield
+		group_pointer_type						previous_group;	// Previous group in the linked list of all groups. NULL if no preceding group.
+		skipfield_type 							free_list_head;	// The index of the last erased element in the group. The last erased element will, in turn, contain the number of the index of the next erased element, and so on. If this is == maximum skipfield_type value then free_list is empty ie. no erasures have occurred in the group (or if they have, the erased locations have subsequently been reused via insert/emplace/assign).
+		const skipfield_type 					capacity;			// The element capacity of this particular group - can also be calculated from reinterpret_cast<aligned_pointer_type>(group->skipfield) - group->elements, however this space is effectively free due to struct padding and the sizeof(skipfield_type), and calculating it once is faster in benchmarking.
+		skipfield_type 							size; 				// The total number of active elements in group - changes with insert and erase commands - used to check for empty group in erase function, as an indication to remove the group. Also used in combination with capacity to check if group is full, which is used in the next/previous/advance/distance overloads, and range-erase.
+		group_pointer_type						erasures_list_next_group, erasures_list_previous_group; // The next and previous groups in the list of groups with erasures ie. with active erased-element free lists. NULL if no next or previous group.
+		size_type									group_number;		// Used for comparison (> < >= <= <=>) iterator operators (used by distance function and user).
+
+
+
+
+		#ifdef PLF_VARIADICS_SUPPORT
+			group(aligned_struct_allocator_type &aligned_struct_allocator, const skipfield_type elements_per_group, const group_pointer_type previous):
 				next_group(NULL),
-				elements(last_endpoint++),
-				skipfield(reinterpret_cast<skipfield_pointer_type>(elements + elements_per_group)),
+				elements(PLF_ALLOCATE(aligned_struct_allocator_type, aligned_struct_allocator, get_aligned_block_capacity(elements_per_group), (previous == NULL) ? NULL : previous->elements)),
 				previous_group(previous),
 				free_list_head(std::numeric_limits<skipfield_type>::max()),
 				capacity(elements_per_group),
-				number_of_elements(1),
+				size(1),
 				erasures_list_next_group(NULL),
+				erasures_list_previous_group(NULL),
 				group_number((previous == NULL) ? 0 : previous->group_number + 1u)
 			{
-				// Static casts to unsigned int from short not necessary as C++ automatically promotes lesser types for arithmetic purposes.
-				std::memset(&*skipfield, 0, sizeof(skipfield_type) * (elements_per_group + 1u)); // &* to avoid problems with non-trivial pointers
+				skipfield = pointer_cast<skipfield_pointer_type>(to_aligned_pointer(elements) + elements_per_group);
+				std::memset(plf::void_cast(skipfield), 0, sizeof(skipfield_type) * (static_cast<size_type>(elements_per_group) + 1u));
 			}
-
 		#else
-			// This is a hack around the fact that element_allocator_type::construct only supports copy construction in C++03 and copy elision does not occur on the vast majority of compilers in this circumstance. And to avoid running out of memory (and losing performance) from allocating the same block twice, we're allocating in this constructor and moving data in the copy constructor.
-			group(const skipfield_type elements_per_group, group_pointer_type const previous = NULL):
-				last_endpoint(reinterpret_cast<aligned_pointer_type>(PLF_COLONY_ALLOCATE_INITIALIZATION(uchar_allocator_type, ((elements_per_group * (sizeof(aligned_element_type))) + ((elements_per_group + 1) * sizeof(skipfield_type))), (previous == NULL) ? 0 : previous->elements))),
-				elements(NULL),
-				skipfield(reinterpret_cast<skipfield_pointer_type>(last_endpoint + elements_per_group)),
+			// This is a hack around the fact that allocator_type::construct only supports copy construction in C++03 and copy elision does not occur on the vast majority of compilers in this circumstance. So to avoid running out of memory (and losing performance) from allocating the same block twice, we 'move' in the 'copy' constructor.
+			group(aligned_struct_allocator_type &aligned_struct_allocator, const skipfield_type elements_per_group, const group_pointer_type previous) PLF_NOEXCEPT:
+				elements(PLF_ALLOCATE(aligned_struct_allocator_type, aligned_struct_allocator, get_aligned_block_capacity(elements_per_group), (previous == NULL) ? 0 : previous->elements)),
 				previous_group(previous),
 				capacity(elements_per_group)
-			{
-				std::memset(&*skipfield, 0, sizeof(skipfield_type) * (elements_per_group + 1u));
-			}
+			{}
 
 
 
 			// Not a real copy constructor ie. actually a move constructor. Only used for allocator.construct in C++03 for reasons stated above:
-			group(const group &source) PLF_COLONY_NOEXCEPT:
-				uchar_allocator_type(source),
-				last_endpoint(source.last_endpoint + 1),
+			group(const group &source):
+				skipfield(pointer_cast<skipfield_pointer_type>(to_aligned_pointer(source.elements) + source.capacity)),
 				next_group(NULL),
-				elements(source.last_endpoint),
-				skipfield(source.skipfield),
+				elements(source.elements),
 				previous_group(source.previous_group),
 				free_list_head(std::numeric_limits<skipfield_type>::max()),
 				capacity(source.capacity),
-				number_of_elements(1),
+				size(1),
 				erasures_list_next_group(NULL),
+				erasures_list_previous_group(NULL),
 				group_number((source.previous_group == NULL) ? 0 : source.previous_group->group_number + 1u)
-			{}
+			{
+				std::memset(plf::void_cast(skipfield), 0, sizeof(skipfield_type) * (static_cast<size_type>(capacity) + 1u));
+			}
 		#endif
 
 
 
-		~group() PLF_COLONY_NOEXCEPT
+		void reset(const skipfield_type increment, const group_pointer_type next, const group_pointer_type previous, const size_type group_num) PLF_NOEXCEPT
 		{
-			// Null check not necessary (for copied group as above) as delete will also perform a null check.
-			PLF_COLONY_DEALLOCATE(uchar_allocator_type, (*this), reinterpret_cast<uchar_pointer_type>(elements), (capacity * sizeof(aligned_element_type)) + ((capacity + 1u) * sizeof(skipfield_type)));
+			next_group = next;
+			free_list_head = std::numeric_limits<skipfield_type>::max();
+			previous_group = previous;
+			size = increment;
+			erasures_list_next_group = NULL;
+			erasures_list_previous_group = NULL;
+			group_number = group_num;
+
+			std::memset(plf::void_cast(skipfield), 0, sizeof(skipfield_type) * static_cast<size_type>(capacity)); // capacity + 1 is not necessary here as the final skipfield node is never written to after initialization
 		}
 	};
 
 
 
+	// colony member variables:
 
-	// Implement const/non-const iterator switching pattern:
-	template <bool flag, class is_true, class is_false> struct choose;
+	iterator 				end_iterator, begin_iterator;
+	group_pointer_type	erasure_groups_head,	// Head of doubly-linked list of groups which have erased-element memory locations available for re-use
+								unused_groups_head;	// Head of singly-linked list of reserved groups retained by erase()/clear() or created by reserve()
+	size_type				total_size, total_capacity;
+	skipfield_type 		min_block_capacity, max_block_capacity;
 
-	template <class is_true, class is_false> struct choose<true, is_true, is_false>
+	// Under most compilers, the following will be 1 byte each - since the skipfield types are 2 bytes each at max, the following add nothing to the class sizeof in a 64-bit build, due to padding
+	group_allocator_type group_allocator;
+	aligned_struct_allocator_type aligned_struct_allocator;
+	skipfield_allocator_type skipfield_allocator;
+	tuple_allocator_type tuple_allocator;
+
+
+
+	void check_capacities_conformance(const plf::limits capacities) const
 	{
-		typedef is_true type;
-	};
+		PLF_CONSTFUNC plf::limits hard_capacities = block_capacity_hard_limits();
 
-	template <class is_true, class is_false> struct choose<false, is_true, is_false>
-	{
-		typedef is_false type;
-	};
-
-
-public:
-
-
-	// Iterators:
-	template <bool is_const> class colony_iterator
-	{
-	private:
-		group_pointer_type		group_pointer;
-		aligned_pointer_type	element_pointer;
-		skipfield_pointer_type	skipfield_pointer;
-
-	public:
-		typedef std::bidirectional_iterator_tag 	iterator_category;
-		typedef typename colony::value_type 		value_type;
-		typedef typename colony::difference_type 	difference_type;
-		typedef typename choose<is_const, typename colony::const_pointer, typename colony::pointer>::type		pointer;
-		typedef typename choose<is_const, typename colony::const_reference, typename colony::reference>::type	reference;
-
-		friend class colony;
-		friend class colony_reverse_iterator<false>;
-		friend class colony_reverse_iterator<true>;
-
-
-
-		inline colony_iterator & operator = (const colony_iterator &source) PLF_COLONY_NOEXCEPT
+		if (capacities.min < hard_capacities.min || capacities.min > capacities.max || capacities.max > hard_capacities.max)
 		{
-			group_pointer = source.group_pointer;
-			element_pointer = source.element_pointer;
-			skipfield_pointer = source.skipfield_pointer;
-			return *this;
+			#ifdef PLF_EXCEPTIONS_SUPPORT
+				throw std::length_error("Supplied memory block capacity limits are either invalid or outside of block_capacity_hard_limits()");
+			#else
+				std::terminate();
+			#endif
 		}
-
-
-
-		inline colony_iterator & operator = (const colony_iterator<!is_const> &source) PLF_COLONY_NOEXCEPT
-		{
-			group_pointer = source.group_pointer;
-			element_pointer = source.element_pointer;
-			skipfield_pointer = source.skipfield_pointer;
-			return *this;
-		}
-
-
-
-		#ifdef PLF_COLONY_MOVE_SEMANTICS_SUPPORT
-			// Move assignment - only really necessary if the allocator uses non-standard ie. smart pointers
-			inline colony_iterator & operator = (colony_iterator &&source) PLF_COLONY_NOEXCEPT // Move is a copy in this scenario
-			{
-				assert (&source != this);
-				group_pointer = std::move(source.group_pointer);
-				element_pointer = std::move(source.element_pointer);
-				skipfield_pointer = std::move(source.skipfield_pointer);
-				return *this;
-			}
-
-
-
-			inline colony_iterator & operator = (colony_iterator<!is_const> &&source) PLF_COLONY_NOEXCEPT
-			{
-				assert (&source != this);
-				group_pointer = std::move(source.group_pointer);
-				element_pointer = std::move(source.element_pointer);
-				skipfield_pointer = std::move(source.skipfield_pointer);
-				return *this;
-			}
-		#endif
-
-
-
-		inline PLF_COLONY_FORCE_INLINE bool operator == (const colony_iterator &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return (element_pointer == rh.element_pointer);
-		}
-
-
-
-		inline PLF_COLONY_FORCE_INLINE bool operator == (const colony_iterator<!is_const> &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return (element_pointer == rh.element_pointer);
-		}
-
-
-
-		inline PLF_COLONY_FORCE_INLINE bool operator != (const colony_iterator &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return (element_pointer != rh.element_pointer);
-		}
-
-
-
-		inline PLF_COLONY_FORCE_INLINE bool operator != (const colony_iterator<!is_const> &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return (element_pointer != rh.element_pointer);
-		}
-
-
-
-		inline PLF_COLONY_FORCE_INLINE reference operator * () const // may cause exception with uninitialized iterator
-		{
-			return *(reinterpret_cast<pointer>(element_pointer));
-		}
-
-
-
-		inline PLF_COLONY_FORCE_INLINE pointer operator -> () const PLF_COLONY_NOEXCEPT
-		{
-			return reinterpret_cast<pointer>(element_pointer);
-		}
-
-
-
-#if defined(_MSC_VER) && _MSC_VER <= 1600 // MSVC 2010 needs a bit of a helping hand when it comes to optimizing
-		inline PLF_COLONY_FORCE_INLINE colony_iterator & operator ++ ()
-#else
-		colony_iterator & operator ++ ()
-#endif
-		{
-			assert(group_pointer != NULL); // covers uninitialised colony_iterator
-			assert(!(element_pointer == group_pointer->last_endpoint && group_pointer->next_group != NULL)); // Assert that iterator is not already at end()
-
-			skipfield_type skip = *(++skipfield_pointer);
-
-			if ((element_pointer += skip + 1) == group_pointer->last_endpoint && group_pointer->next_group != NULL) // ie. beyond end of available data
-			{
-				group_pointer = group_pointer->next_group;
-				skip = *(group_pointer->skipfield);
-				element_pointer = group_pointer->elements + skip;
-				skipfield_pointer = group_pointer->skipfield;
-			}
-
-			skipfield_pointer += skip;
-			return *this;
-		}
-
-
-
-		inline colony_iterator operator ++(int)
-		{
-			const colony_iterator copy(*this);
-			++*this;
-			return copy;
-		}
-
-
-
-	private:
-		inline PLF_COLONY_FORCE_INLINE void check_for_end_of_group_and_progress() // used by erase
-		{
-			if (element_pointer == group_pointer->last_endpoint && group_pointer->next_group != NULL)
-			{
-				group_pointer = group_pointer->next_group;
-				skipfield_pointer = group_pointer->skipfield;
-				element_pointer = group_pointer->elements + *skipfield_pointer;
-				skipfield_pointer += *skipfield_pointer;
-			}
-		}
-
-
-
-	public:
-
-		colony_iterator & operator -- ()
-		{
-			assert(group_pointer != NULL);
-			assert(!(element_pointer == group_pointer->elements && group_pointer->previous_group == NULL)); // Assert that we are not already at begin() - this is not required to be tested in the code below as we don't need a special condition to progress to begin(), like we do with end() in operator ++
-
-			if (element_pointer != group_pointer->elements) // ie. not already at beginning of group
-			{
-				const skipfield_type skip = *(--skipfield_pointer);
-				skipfield_pointer -= skip;
-
-				if ((element_pointer -= skip + 1) != group_pointer->elements - 1) // ie. iterator was not already at beginning of colony (with some previous consecutive deleted elements), and skipfield does not takes us into the previous group)
-				{
-					return *this;
-				}
-			}
-
-			group_pointer = group_pointer->previous_group;
-			skipfield_pointer = group_pointer->skipfield + group_pointer->capacity - 1;
-			element_pointer = (reinterpret_cast<colony::aligned_pointer_type>(group_pointer->skipfield) - 1) - *skipfield_pointer;
-			skipfield_pointer -= *skipfield_pointer;
-
-			return *this;
-		}
-
-
-
-		inline colony_iterator operator -- (int)
-		{
-			const colony_iterator copy(*this);
-			--*this;
-			return copy;
-		}
-
-
-
-		inline bool operator > (const colony_iterator &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return ((group_pointer == rh.group_pointer) & (element_pointer > rh.element_pointer)) || (group_pointer != rh.group_pointer && group_pointer->group_number > rh.group_pointer->group_number);
-		}
-
-
-
-		inline bool operator < (const colony_iterator &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return rh > *this;
-		}
-
-
-
-		inline bool operator >= (const colony_iterator &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return !(rh > *this);
-		}
-
-
-
-		inline bool operator <= (const colony_iterator &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return !(*this > rh);
-		}
-
-
-
-		inline bool operator > (const colony_iterator<!is_const> &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return ((group_pointer == rh.group_pointer) & (element_pointer > rh.element_pointer)) || (group_pointer != rh.group_pointer && group_pointer->group_number > rh.group_pointer->group_number);
-		}
-
-
-
-		inline bool operator < (const colony_iterator<!is_const> &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return rh > *this;
-		}
-
-
-
-		inline bool operator >= (const colony_iterator<!is_const> &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return !(rh > *this);
-		}
-
-
-
-		inline bool operator <= (const colony_iterator<!is_const> &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return !(*this > rh);
-		}
-
-
-		colony_iterator() PLF_COLONY_NOEXCEPT: group_pointer(NULL), element_pointer(NULL), skipfield_pointer(NULL)  {}
-
-
-
-	private:
-		// Used by cend(), erase() etc:
-		colony_iterator(const group_pointer_type group_p, const aligned_pointer_type element_p, const skipfield_pointer_type skipfield_p) PLF_COLONY_NOEXCEPT: group_pointer(group_p), element_pointer(element_p), skipfield_pointer(skipfield_p) {}
-
-
-
-	public:
-
-		inline colony_iterator (const colony_iterator &source) PLF_COLONY_NOEXCEPT:
-			group_pointer(source.group_pointer),
-			element_pointer(source.element_pointer),
-			skipfield_pointer(source.skipfield_pointer)
-		{}
-
-
-		inline colony_iterator(const colony_iterator<!is_const> &source) PLF_COLONY_NOEXCEPT:
-			group_pointer(source.group_pointer),
-			element_pointer(source.element_pointer),
-			skipfield_pointer(source.skipfield_pointer)
-		{}
-
-
-
-		#ifdef PLF_COLONY_MOVE_SEMANTICS_SUPPORT
-			// move constructor
-			inline colony_iterator(colony_iterator &&source) PLF_COLONY_NOEXCEPT:
-				group_pointer(std::move(source.group_pointer)),
-				element_pointer(std::move(source.element_pointer)),
-				skipfield_pointer(std::move(source.skipfield_pointer))
-			{}
-
-
-			inline colony_iterator(colony_iterator<!is_const> &&source) PLF_COLONY_NOEXCEPT:
-				group_pointer(std::move(source.group_pointer)),
-				element_pointer(std::move(source.element_pointer)),
-				skipfield_pointer(std::move(source.skipfield_pointer))
-			{}
-		#endif
-
-
-	}; // colony_iterator
-
-
-
-
-
-	// Reverse iterators:
-
-	template <bool r_is_const> class colony_reverse_iterator
-	{
-	private:
-		iterator it;
-
-	public:
-		typedef std::bidirectional_iterator_tag iterator_category;
-		typedef typename colony::value_type 		value_type;
-		typedef typename colony::difference_type 	difference_type;
-		typedef typename choose<r_is_const, typename colony::const_pointer, typename colony::pointer>::type		pointer;
-		typedef typename choose<r_is_const, typename colony::const_reference, typename colony::reference>::type	reference;
-
-		friend class colony;
-
-
-		inline colony_reverse_iterator& operator = (const colony_reverse_iterator &source) PLF_COLONY_NOEXCEPT
-		{
-			it = source.it;
-			return *this;
-		}
-
-
-
-		#ifdef PLF_COLONY_MOVE_SEMANTICS_SUPPORT
-			// move assignment
-			inline colony_reverse_iterator& operator = (colony_reverse_iterator &&source) PLF_COLONY_NOEXCEPT
-			{
-				it = std::move(source.it);
-				return *this;
-			}
-		#endif
-
-
-
-		inline PLF_COLONY_FORCE_INLINE bool operator == (const colony_reverse_iterator &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return (it == rh.it);
-		}
-
-
-
-		inline PLF_COLONY_FORCE_INLINE bool operator != (const colony_reverse_iterator &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return (it != rh.it);
-		}
-
-
-
-		inline PLF_COLONY_FORCE_INLINE reference operator * () const PLF_COLONY_NOEXCEPT
-		{
-			return *(reinterpret_cast<pointer>(it.element_pointer));
-		}
-
-
-
-		inline PLF_COLONY_FORCE_INLINE pointer * operator -> () const PLF_COLONY_NOEXCEPT
-		{
-			return reinterpret_cast<pointer>(it.element_pointer);
-		}
-
-
-
-		// In this case we have to redefine the algorithm, rather than using the internal iterator's -- operator, in order for the reverse_iterator to be allowed to reach rend() ie. begin_iterator - 1
-		colony_reverse_iterator & operator ++ ()
-		{
-			colony::group_pointer_type &group_pointer = it.group_pointer;
-			colony::aligned_pointer_type &element_pointer = it.element_pointer;
-			colony::skipfield_pointer_type &skipfield_pointer = it.skipfield_pointer;
-
-			assert(group_pointer != NULL);
-			assert(!(element_pointer == group_pointer->elements - 1 && group_pointer->previous_group == NULL)); // Assert that we are not already at rend()
-
-			if (element_pointer != group_pointer->elements) // ie. not already at beginning of group
-			{
-				element_pointer -= *(--skipfield_pointer) + 1;
-				skipfield_pointer -= *skipfield_pointer;
-
-				if (!(element_pointer == group_pointer->elements - 1 && group_pointer->previous_group == NULL)) // ie. iterator is not == rend()
-				{
-					return *this;
-				}
-			}
-
-			if (group_pointer->previous_group != NULL) // ie. not first group in colony
-			{
-				group_pointer = group_pointer->previous_group;
-				skipfield_pointer = group_pointer->skipfield + group_pointer->capacity - 1;
-				element_pointer = (reinterpret_cast<colony::aligned_pointer_type>(group_pointer->skipfield) - 1) - *skipfield_pointer;
-				skipfield_pointer -= *skipfield_pointer;
-			}
-			else // necessary so that reverse_iterator can end up == rend(), if we were already at first element in colony
-			{
-				--element_pointer;
-				--skipfield_pointer;
-			}
-
-			return *this;
-		}
-
-
-
-		inline colony_reverse_iterator operator ++ (int)
-		{
-			const colony_reverse_iterator copy(*this);
-			++*this;
-			return copy;
-		}
-
-
-
-		inline PLF_COLONY_FORCE_INLINE colony_reverse_iterator & operator -- ()
-		{
-			assert(!(it.element_pointer == it.group_pointer->last_endpoint - 1 && it.group_pointer->next_group == NULL)); // ie. Check that we are not already at rbegin()
-			++it;
-			return *this;
-		}
-
-
-
-		inline colony_reverse_iterator operator -- (int)
-		{
-			const colony_reverse_iterator copy(*this);
-			--*this;
-			return copy;
-		}
-
-
-
-		inline typename colony::iterator base() const
-		{
-			return ++(typename colony::iterator(it));
-		}
-
-
-
-		inline bool operator > (const colony_reverse_iterator &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return (rh.it > it);
-		}
-
-
-
-		inline bool operator < (const colony_reverse_iterator &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return (it > rh.it);
-		}
-
-
-
-		inline bool operator >= (const colony_reverse_iterator &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return !(it > rh.it);
-		}
-
-
-
-		inline bool operator <= (const colony_reverse_iterator &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return !(rh.it > it);
-		}
-
-
-
-		inline PLF_COLONY_FORCE_INLINE bool operator == (const colony_reverse_iterator<!r_is_const> &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return (it == rh.it);
-		}
-
-
-
-		inline PLF_COLONY_FORCE_INLINE bool operator != (const colony_reverse_iterator<!r_is_const> &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return (it != rh.it);
-		}
-
-
-
-		inline bool operator > (const colony_reverse_iterator<!r_is_const> &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return (rh.it > it);
-		}
-
-
-
-		inline bool operator < (const colony_reverse_iterator<!r_is_const> &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return (it > rh.it);
-		}
-
-
-
-		inline bool operator >= (const colony_reverse_iterator<!r_is_const> &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return !(it > rh.it);
-		}
-
-
-
-		inline bool operator <= (const colony_reverse_iterator<!r_is_const> &rh) const PLF_COLONY_NOEXCEPT
-		{
-			return !(rh.it > it);
-		}
-
-
-
-		colony_reverse_iterator () PLF_COLONY_NOEXCEPT
-		{}
-
-
-
-		colony_reverse_iterator (const colony_reverse_iterator &source) PLF_COLONY_NOEXCEPT:
-			it(source.it)
-		{}
-
-
-
-		colony_reverse_iterator (const typename colony::iterator &source) PLF_COLONY_NOEXCEPT:
-			it(source)
-		{}
-
-
-
-	private:
-		// Used by rend(), etc:
-		colony_reverse_iterator(const group_pointer_type group_p, const aligned_pointer_type element_p, const skipfield_pointer_type skipfield_p) PLF_COLONY_NOEXCEPT: it(group_p, element_p, skipfield_p) {}
-
-
-
-	public:
-
-		#ifdef PLF_COLONY_MOVE_SEMANTICS_SUPPORT
-			// move constructors
-			colony_reverse_iterator (colony_reverse_iterator &&source) PLF_COLONY_NOEXCEPT:
-				it(std::move(source.it))
-			{}
-
-			colony_reverse_iterator (typename colony::iterator &&source) PLF_COLONY_NOEXCEPT:
-				it(std::move(source))
-			{}
-		#endif
-
-	}; // colony_reverse_iterator
-
-
-
-
-private:
-
-	// Used to prevent fill-insert/constructor calls being mistakenly resolved to range-insert/constructor calls
-	template <bool condition, class T = void>
-	struct plf_enable_if_c
-	{
-		typedef T type;
-	};
-
-	template <class T>
-	struct plf_enable_if_c<false, T>
-	{};
-
-
-	iterator				end_iterator, begin_iterator;
-	group_pointer_type	groups_with_erasures_list_head; // Head of a singly-linked intrusive list of groups which have erased-element memory locations available for reuse
-	size_type				total_number_of_elements, total_capacity;
-
-	struct ebco_pair2 : pointer_allocator_type // Packaging the element pointer allocator with a lesser-used member variable, for empty-base-class optimisation
-	{
-		skipfield_type min_elements_per_group;
-		explicit ebco_pair2(const skipfield_type min_elements) PLF_COLONY_NOEXCEPT: min_elements_per_group(min_elements) {}
-	}						pointer_allocator_pair;
-
-	struct ebco_pair : group_allocator_type
-	{
-		skipfield_type max_elements_per_group;
-		explicit ebco_pair(const skipfield_type max_elements) PLF_COLONY_NOEXCEPT: max_elements_per_group(max_elements) {}
-	}						group_allocator_pair;
-
-
-public:
-
-	// Default constuctor:
-
-	colony() PLF_COLONY_NOEXCEPT:
-		element_allocator_type(element_allocator_type()),
-		groups_with_erasures_list_head(NULL),
-		total_number_of_elements(0),
-		total_capacity(0),
-		pointer_allocator_pair((sizeof(aligned_element_type) * 8 > (sizeof(*this) + sizeof(group)) * 2) ? 8 : (((sizeof(*this) + sizeof(group)) * 2) / sizeof(aligned_element_type))),
-		group_allocator_pair(std::numeric_limits<skipfield_type>::max())
-	{
-	 	assert(std::numeric_limits<skipfield_type>::is_integer & !std::numeric_limits<skipfield_type>::is_signed); // skipfield type must be of unsigned integer type (uchar, ushort, uint etc)
-
-		#ifndef PLF_COLONY_ALIGNMENT_SUPPORT
-			assert(sizeof(element_type) >= sizeof(skipfield_type) * 2); // eg. under C++03, aligned_storage is not available, so sizeof(skipfield type) * 2 must be larger or equal to sizeof(element_type), otherwise the doubly-linked free lists of erased element indexes will not work correctly. So if you're storing chars, for example, and using the default skipfield type (unsigned short), the compiler will flag you with this assert. You cannot store char or unsigned char in colony under C++03, and if storing short or unsigned short you must change your skipfield type to unsigned char. Or just use C++11 and above.
-		#endif
 	}
 
 
 
-	// Default constuctor (allocator-extended):
-
-	explicit colony(const element_allocator_type &alloc):
-		element_allocator_type(alloc),
-		groups_with_erasures_list_head(NULL),
-		total_number_of_elements(0),
-		total_capacity(0),
-		pointer_allocator_pair((sizeof(aligned_element_type) * 8 > (sizeof(*this) + sizeof(group)) * 2) ? 8 : (((sizeof(*this) + sizeof(group)) * 2) / sizeof(aligned_element_type))),
-		group_allocator_pair(std::numeric_limits<skipfield_type>::max())
+	void blank() PLF_NOEXCEPT
 	{
-	 	assert(std::numeric_limits<skipfield_type>::is_integer & !std::numeric_limits<skipfield_type>::is_signed);
-
-		#ifndef PLF_COLONY_ALIGNMENT_SUPPORT
-			assert(sizeof(element_type) >= sizeof(skipfield_type) * 2); // see default constructor explanation
-		#endif
-	}
-
-
-
-	// Copy constructor:
-
-	colony(const colony &source):
-		element_allocator_type(source),
-		groups_with_erasures_list_head(NULL),
-		total_number_of_elements(0),
-		total_capacity(0),
-		pointer_allocator_pair(static_cast<skipfield_type>((source.pointer_allocator_pair.min_elements_per_group > source.total_number_of_elements) ? source.pointer_allocator_pair.min_elements_per_group : ((source.total_number_of_elements > source.group_allocator_pair.max_elements_per_group) ? source.group_allocator_pair.max_elements_per_group : source.total_number_of_elements))), // Make the first colony group capacity the greater of min_elements_per_group or total_number_of_elements, so long as total_number_of_elements isn't larger than max_elements_per_group
-		group_allocator_pair(source.group_allocator_pair.max_elements_per_group)
-	{
-		insert(source.begin_iterator, source.end_iterator);
-		pointer_allocator_pair.min_elements_per_group = source.pointer_allocator_pair.min_elements_per_group; // reset to correct value for future clear() or erasures
-	}
-
-
-
-	// Copy constructor (allocator-extended):
-
-	colony(const colony &source, const allocator_type &alloc):
-		element_allocator_type(alloc),
-		groups_with_erasures_list_head(NULL),
-		total_number_of_elements(0),
-		total_capacity(0),
-		pointer_allocator_pair(static_cast<skipfield_type>((source.pointer_allocator_pair.min_elements_per_group > source.total_number_of_elements) ? source.pointer_allocator_pair.min_elements_per_group : ((source.total_number_of_elements > source.group_allocator_pair.max_elements_per_group) ? source.group_allocator_pair.max_elements_per_group : source.total_number_of_elements))),
-		group_allocator_pair(source.group_allocator_pair.max_elements_per_group)
-	{
-		insert(source.begin_iterator, source.end_iterator);
-		pointer_allocator_pair.min_elements_per_group = source.pointer_allocator_pair.min_elements_per_group;
-	}
-
-
-
-
-private:
-
-	inline void blank() PLF_COLONY_NOEXCEPT
-	{
-		#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-			if PLF_COLONY_CONSTEXPR (std::is_trivial<group_pointer_type>::value && std::is_trivial<aligned_pointer_type>::value && std::is_trivial<skipfield_pointer_type>::value)  // if all pointer types are trivial, we can just nuke it from orbit with memset (NULL is always 0 in C++):
-			{
-				std::memset(static_cast<void *>(this), 0, offsetof(colony, pointer_allocator_pair));
+		#ifdef PLF_IS_ALWAYS_EQUAL_SUPPORT // allocator_traits always available when is_always_equal is available
+			if PLF_CONSTEXPR (std::is_standard_layout<colony>::value && std::allocator_traits<allocator_type>::is_always_equal::value && std::is_trivially_destructible<group_pointer_type>::value)
+			{ // If all pointer types are trivial, we can just nuke the member variables from orbit with memset (NULL is always 0):
+				std::memset(static_cast<void *>(this), 0, offsetof(colony, min_block_capacity));
 			}
 			else
 		#endif
@@ -1072,9 +665,46 @@ private:
 			begin_iterator.group_pointer = NULL;
 			begin_iterator.element_pointer = NULL;
 			begin_iterator.skipfield_pointer = NULL;
-			groups_with_erasures_list_head = NULL;
-			total_number_of_elements = 0;
+			erasure_groups_head = NULL;
+			unused_groups_head = NULL;
+			total_size = 0;
 			total_capacity = 0;
+		}
+	}
+
+
+
+	static PLF_CONSTFUNC size_t max_size_static() PLF_NOEXCEPT
+	{
+		#ifdef PLF_ALLOCATOR_TRAITS_SUPPORT
+			return static_cast<size_t>(std::allocator_traits<allocator_type>::max_size(allocator_type()));
+		#else
+			return static_cast<size_t>(std::numeric_limits<size_type>::max() / sizeof(element_type)); // Substituting because allocator::max_size is not static
+		#endif
+	}
+
+
+
+	void reserve_and_fill(const size_type size, const element_type &element)
+	{
+		if (size != 0)
+		{
+			reserve(size);
+			end_iterator.group_pointer->next_group = unused_groups_head;
+			fill_unused_groups(size, element, 0, NULL, begin_iterator.group_pointer);
+		}
+	}
+
+
+
+	template <class iterator_type>
+	void reserve_and_range_fill(const size_type size, const iterator_type &it)
+	{
+		if (size != 0)
+		{
+			reserve(size);
+			end_iterator.group_pointer->next_group = unused_groups_head;
+			range_fill_unused_groups(size, it, 0, NULL, begin_iterator.group_pointer);
 		}
 	}
 
@@ -1082,36 +712,199 @@ private:
 
 public:
 
+	// Adaptive minimum based around aligned size, sizeof(group) and sizeof(colony):
+	static PLF_CONSTFUNC skipfield_type block_capacity_default_min() PLF_NOEXCEPT
+	{
+		const skipfield_type adaptive_size = static_cast<skipfield_type>(((sizeof(colony) + sizeof(group)) * 2) / sizeof(aligned_element_struct));
+		const skipfield_type max_block_capacity = block_capacity_default_max(); // Necessary to check against in situations with > 64bit pointer sizes and small sizeof(T)
+		return std::max(static_cast<skipfield_type>(8), std::min(adaptive_size, max_block_capacity));
+	}
 
 
-	#ifdef PLF_COLONY_MOVE_SEMANTICS_SUPPORT
-		// Move constructor:
 
-		colony(colony &&source) PLF_COLONY_NOEXCEPT:
-			element_allocator_type(source),
-			end_iterator(std::move(source.end_iterator)),
-			begin_iterator(std::move(source.begin_iterator)),
-			groups_with_erasures_list_head(std::move(source.groups_with_erasures_list_head)),
-			total_number_of_elements(source.total_number_of_elements),
+	// Adaptive maximum based on numeric_limits and best outcome from multiple benchmark's (on balance) in terms of memory usage and performance:
+	static PLF_CONSTFUNC skipfield_type block_capacity_default_max() PLF_NOEXCEPT
+	{
+		return static_cast<skipfield_type>(std::min(std::min(static_cast<size_t>(std::numeric_limits<skipfield_type>::max()), static_cast<size_t>(8192u)), max_size_static()));
+	}
+
+
+
+	static PLF_CONSTFUNC plf::limits block_capacity_default_limits() PLF_NOEXCEPT
+	{
+		return plf::limits(static_cast<size_t>(block_capacity_default_min()), static_cast<size_t>(block_capacity_default_max()));
+	}
+
+
+
+	// Default constructors:
+
+	PLF_CONSTFUNC explicit colony(const allocator_type &alloc) PLF_NOEXCEPT:
+		allocator_type(alloc),
+		erasure_groups_head(NULL),
+		unused_groups_head(NULL),
+		total_size(0),
+		total_capacity(0),
+		min_block_capacity(block_capacity_default_min()),
+		max_block_capacity(block_capacity_default_max()),
+		group_allocator(*this),
+		aligned_struct_allocator(*this),
+		skipfield_allocator(*this),
+		tuple_allocator(*this)
+	{}
+
+
+
+	PLF_CONSTFUNC colony() PLF_NOEXCEPT_ALLOCATOR:
+		erasure_groups_head(NULL),
+		unused_groups_head(NULL),
+		total_size(0),
+		total_capacity(0),
+		min_block_capacity(block_capacity_default_min()),
+		max_block_capacity(block_capacity_default_max()),
+		group_allocator(*this),
+		aligned_struct_allocator(*this),
+		skipfield_allocator(*this),
+		tuple_allocator(*this)
+	{}
+
+
+
+	PLF_CONSTFUNC colony(const plf::limits block_limits, const allocator_type &alloc):
+		allocator_type(alloc),
+		erasure_groups_head(NULL),
+		unused_groups_head(NULL),
+		total_size(0),
+		total_capacity(0),
+		min_block_capacity(static_cast<skipfield_type>(block_limits.min)),
+		max_block_capacity(static_cast<skipfield_type>(block_limits.max)),
+		group_allocator(*this),
+		aligned_struct_allocator(*this),
+		skipfield_allocator(*this),
+		tuple_allocator(*this)
+	{
+		check_capacities_conformance(block_limits);
+	}
+
+
+
+	PLF_CONSTFUNC explicit colony(const plf::limits block_limits):
+		erasure_groups_head(NULL),
+		unused_groups_head(NULL),
+		total_size(0),
+		total_capacity(0),
+		min_block_capacity(static_cast<skipfield_type>(block_limits.min)),
+		max_block_capacity(static_cast<skipfield_type>(block_limits.max)),
+		group_allocator(*this),
+		aligned_struct_allocator(*this),
+		skipfield_allocator(*this),
+		tuple_allocator(*this)
+	{
+		check_capacities_conformance(block_limits);
+	}
+
+
+
+	// Copy constructors:
+	#ifdef PLF_CPP20_SUPPORT
+		colony(const colony &source, const std::type_identity_t<allocator_type> &alloc):
+	#else
+		colony(const colony &source, const allocator_type &alloc):
+	#endif
+		allocator_type(alloc),
+		erasure_groups_head(NULL),
+		unused_groups_head(NULL),
+		total_size(0),
+		total_capacity(0),
+		min_block_capacity(std::max(source.min_block_capacity, static_cast<skipfield_type>(std::min(source.total_size, static_cast<size_type>(source.max_block_capacity))))), // min group size is set to value closest to total number of elements in source colony, in order to not create unnecessary small groups in the range-insert below, then reverts to the original min group size afterwards. This effectively saves a call to reserve.
+		max_block_capacity(source.max_block_capacity),
+		group_allocator(*this),
+		aligned_struct_allocator(*this),
+		skipfield_allocator(*this),
+		tuple_allocator(*this)
+	{ // can skip checking for skipfield conformance here as source will have already checked theirs. Same applies for other copy and move constructors below
+		reserve_and_range_fill(source.total_size, source.begin_iterator);
+		min_block_capacity = source.min_block_capacity; // reset to correct value for future operations
+	}
+
+
+
+	colony(const colony &source):
+		#if (defined(__cplusplus) && __cplusplus >= 201103L) || _MSC_VER >= 1700
+			allocator_type(std::allocator_traits<allocator_type>::select_on_container_copy_construction(source)),
+		#else
+			allocator_type(source),
+		#endif
+		erasure_groups_head(NULL),
+		unused_groups_head(NULL),
+		total_size(0),
+		total_capacity(0),
+		min_block_capacity(std::max(source.min_block_capacity, static_cast<skipfield_type>(std::min(source.total_size, static_cast<size_type>(source.max_block_capacity))))),
+		max_block_capacity(source.max_block_capacity),
+		group_allocator(*this),
+		aligned_struct_allocator(*this),
+		skipfield_allocator(*this),
+		tuple_allocator(*this)
+	{
+		reserve_and_range_fill(source.total_size, source.begin_iterator);
+		min_block_capacity = source.min_block_capacity; // reset to correct value for future operations
+	}
+
+
+
+	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+		// Move constructors:
+
+		#ifdef PLF_CPP20_SUPPORT
+			colony(colony &&source, const std::type_identity_t<allocator_type> &alloc):
+		#else
+			colony(colony &&source, const allocator_type &alloc):
+		#endif
+			allocator_type(alloc),
+			end_iterator(source.end_iterator),
+			begin_iterator(source.begin_iterator),
+			erasure_groups_head(source.erasure_groups_head),
+			unused_groups_head(source.unused_groups_head),
+			total_size(source.total_size),
 			total_capacity(source.total_capacity),
-			pointer_allocator_pair(source.pointer_allocator_pair.min_elements_per_group),
-			group_allocator_pair(source.group_allocator_pair.max_elements_per_group)
+			min_block_capacity(source.min_block_capacity),
+			max_block_capacity(source.max_block_capacity),
+			group_allocator(alloc),
+			aligned_struct_allocator(alloc),
+			skipfield_allocator(alloc),
+			tuple_allocator(alloc)
 		{
+			#ifdef PLF_IS_ALWAYS_EQUAL_SUPPORT
+				if PLF_CONSTEXPR (!std::allocator_traits<allocator_type>::is_always_equal::value)
+			#endif
+			{
+				if (alloc != static_cast<allocator_type &>(source))
+				{
+					blank();
+					reserve_and_range_fill(source.total_size, plf::make_move_iterator(source.begin_iterator));
+					source.destroy_all_data();
+				}
+			}
+
 			source.blank();
 		}
 
 
-		// Move constructor (allocator-extended):
 
-		colony(colony &&source, const allocator_type &alloc):
-			element_allocator_type(alloc),
+		colony(colony &&source) PLF_NOEXCEPT:
+			allocator_type(static_cast<allocator_type &>(source)),
 			end_iterator(std::move(source.end_iterator)),
 			begin_iterator(std::move(source.begin_iterator)),
-			groups_with_erasures_list_head(std::move(source.groups_with_erasures_list_head)),
-			total_number_of_elements(source.total_number_of_elements),
+			erasure_groups_head(std::move(source.erasure_groups_head)),
+			unused_groups_head(std::move(source.unused_groups_head)),
+			total_size(source.total_size),
 			total_capacity(source.total_capacity),
-			pointer_allocator_pair(source.pointer_allocator_pair.min_elements_per_group),
-			group_allocator_pair(source.group_allocator_pair.max_elements_per_group)
+			min_block_capacity(source.min_block_capacity),
+			max_block_capacity(source.max_block_capacity),
+			group_allocator(*this),
+			aligned_struct_allocator(*this),
+			skipfield_allocator(*this),
+			tuple_allocator(*this)
 		{
 			source.blank();
 		}
@@ -1119,203 +912,416 @@ public:
 
 
 
-	// Fill constructor:
+	// Fill constructors:
 
-	colony(const size_type fill_number, const element_type &element, const skipfield_type min_allocation_amount = 0, const skipfield_type max_allocation_amount = std::numeric_limits<skipfield_type>::max(), const element_allocator_type &alloc = element_allocator_type()):
-		element_allocator_type(alloc),
-		groups_with_erasures_list_head(NULL),
-		total_number_of_elements(0),
+	colony(const size_type fill_number, const element_type &element, const plf::limits block_limits, const allocator_type &alloc = allocator_type()):
+		allocator_type(alloc),
+		erasure_groups_head(NULL),
+		unused_groups_head(NULL),
+		total_size(0),
 		total_capacity(0),
-		pointer_allocator_pair((min_allocation_amount != 0) ? min_allocation_amount :
-			(fill_number > max_allocation_amount) ? max_allocation_amount :
-			(fill_number > 8) ? static_cast<skipfield_type>(fill_number) : 8),
-		group_allocator_pair(max_allocation_amount)
+		min_block_capacity(static_cast<skipfield_type>(block_limits.min)),
+		max_block_capacity(static_cast<skipfield_type>(block_limits.max)),
+		group_allocator(*this),
+		aligned_struct_allocator(*this),
+		skipfield_allocator(*this),
+		tuple_allocator(*this)
 	{
-	 	assert(std::numeric_limits<skipfield_type>::is_integer & !std::numeric_limits<skipfield_type>::is_signed);
-		assert((pointer_allocator_pair.min_elements_per_group > 2) & (pointer_allocator_pair.min_elements_per_group <= group_allocator_pair.max_elements_per_group));
-
-		#ifndef PLF_COLONY_ALIGNMENT_SUPPORT
-			assert(sizeof(element_type) >= sizeof(skipfield_type) * 2); // see default constructor explanation
-		#endif
-
-		insert(fill_number, element);
+		check_capacities_conformance(block_limits);
+		reserve_and_fill(fill_number, element);
 	}
 
 
 
-	// Range constructor:
+	colony(const size_type fill_number, const element_type &element, const allocator_type &alloc = allocator_type()) :
+		allocator_type(alloc),
+		erasure_groups_head(NULL),
+		unused_groups_head(NULL),
+		total_size(0),
+		total_capacity(0),
+		min_block_capacity(block_capacity_default_min()),
+		max_block_capacity(block_capacity_default_max()),
+		group_allocator(*this),
+		aligned_struct_allocator(*this),
+		skipfield_allocator(*this),
+		tuple_allocator(*this)
+	{
+		reserve_and_fill(fill_number, element);
+	}
+
+
+
+	// Default-value fill constructors:
+
+	colony(const size_type fill_number, const plf::limits block_limits, const allocator_type &alloc = allocator_type()):
+		allocator_type(alloc),
+		erasure_groups_head(NULL),
+		unused_groups_head(NULL),
+		total_size(0),
+		total_capacity(0),
+		min_block_capacity(static_cast<skipfield_type>(block_limits.min)),
+		max_block_capacity(static_cast<skipfield_type>(block_limits.max)),
+		group_allocator(*this),
+		aligned_struct_allocator(*this),
+		skipfield_allocator(*this),
+		tuple_allocator(*this)
+	{
+		check_capacities_conformance(block_limits);
+		reserve_and_fill(fill_number, element_type());
+	}
+
+
+
+	colony(const size_type fill_number, const allocator_type &alloc = allocator_type()):
+		allocator_type(alloc),
+		erasure_groups_head(NULL),
+		unused_groups_head(NULL),
+		total_size(0),
+		total_capacity(0),
+		min_block_capacity(block_capacity_default_min()),
+		max_block_capacity(block_capacity_default_max()),
+		group_allocator(*this),
+		aligned_struct_allocator(*this),
+		skipfield_allocator(*this),
+		tuple_allocator(*this)
+	{
+		reserve_and_fill(fill_number, element_type());
+	}
+
+
+
+	// Range constructors:
 
 	template<typename iterator_type>
-	colony(const typename plf_enable_if_c<!std::numeric_limits<iterator_type>::is_integer, iterator_type>::type &first, const iterator_type &last, const skipfield_type min_allocation_amount = 8, const skipfield_type max_allocation_amount = std::numeric_limits<skipfield_type>::max(), const element_allocator_type &alloc = element_allocator_type()):
-		element_allocator_type(alloc),
-		groups_with_erasures_list_head(NULL),
-		total_number_of_elements(0),
+	colony(const typename plf::enable_if<!std::numeric_limits<iterator_type>::is_integer, iterator_type>::type &first, const iterator_type &last, const plf::limits block_limits, const allocator_type &alloc = allocator_type()):
+		allocator_type(alloc),
+		erasure_groups_head(NULL),
+		unused_groups_head(NULL),
+		total_size(0),
 		total_capacity(0),
-		pointer_allocator_pair(min_allocation_amount),
-		group_allocator_pair(max_allocation_amount)
+		min_block_capacity(static_cast<skipfield_type>(block_limits.min)),
+		max_block_capacity(static_cast<skipfield_type>(block_limits.max)),
+		group_allocator(*this),
+		aligned_struct_allocator(*this),
+		skipfield_allocator(*this),
+		tuple_allocator(*this)
 	{
-	 	assert(std::numeric_limits<skipfield_type>::is_integer & !std::numeric_limits<skipfield_type>::is_signed);
-		assert((pointer_allocator_pair.min_elements_per_group > 2) & (pointer_allocator_pair.min_elements_per_group <= group_allocator_pair.max_elements_per_group));
-
-		#ifndef PLF_COLONY_ALIGNMENT_SUPPORT
-			assert(sizeof(element_type) >= sizeof(skipfield_type) * 2); // see default constructor explanation
-		#endif
-
-		insert<iterator_type>(first, last);
+		check_capacities_conformance(block_limits);
+		assign<iterator_type>(first, last);
 	}
 
 
 
-	// Initializer-list constructor:
+	template<typename iterator_type>
+	colony(const typename plf::enable_if<!std::numeric_limits<iterator_type>::is_integer, iterator_type>::type &first, const iterator_type &last, const allocator_type &alloc = allocator_type()):
+		allocator_type(alloc),
+		erasure_groups_head(NULL),
+		unused_groups_head(NULL),
+		total_size(0),
+		total_capacity(0),
+		min_block_capacity(block_capacity_default_min()),
+		max_block_capacity(block_capacity_default_max()),
+		group_allocator(*this),
+		aligned_struct_allocator(*this),
+		skipfield_allocator(*this),
+		tuple_allocator(*this)
+	{
+		assign<iterator_type>(first, last);
+	}
 
-	#ifdef PLF_COLONY_INITIALIZER_LIST_SUPPORT
-		colony(const std::initializer_list<element_type> &element_list, const skipfield_type min_allocation_amount = 0, const skipfield_type max_allocation_amount = std::numeric_limits<skipfield_type>::max(), const element_allocator_type &alloc = element_allocator_type()):
-			element_allocator_type(alloc),
-			groups_with_erasures_list_head(NULL),
-			total_number_of_elements(0),
+
+
+	#ifdef PLF_INITIALIZER_LIST_SUPPORT
+		// Initializer-list constructors:
+
+		colony(const std::initializer_list<element_type> &element_list, const plf::limits block_limits, const allocator_type &alloc = allocator_type()):
+			allocator_type(alloc),
+			erasure_groups_head(NULL),
+			unused_groups_head(NULL),
+			total_size(0),
 			total_capacity(0),
-			pointer_allocator_pair((min_allocation_amount != 0) ? min_allocation_amount :
-			(element_list.size() > max_allocation_amount) ? max_allocation_amount :
-			(element_list.size() > 8) ? static_cast<skipfield_type>(element_list.size()) : 8),
-			group_allocator_pair(max_allocation_amount)
+			min_block_capacity(static_cast<skipfield_type>(block_limits.min)),
+			max_block_capacity(static_cast<skipfield_type>(block_limits.max)),
+			group_allocator(*this),
+			aligned_struct_allocator(*this),
+			skipfield_allocator(*this),
+			tuple_allocator(*this)
 		{
-		 	assert(std::numeric_limits<skipfield_type>::is_integer & !std::numeric_limits<skipfield_type>::is_signed);
-			assert((pointer_allocator_pair.min_elements_per_group > 2) & (pointer_allocator_pair.min_elements_per_group <= group_allocator_pair.max_elements_per_group));
-
-			#ifndef PLF_COLONY_ALIGNMENT_SUPPORT
-				assert(sizeof(element_type) >= sizeof(skipfield_type) * 2); // see default constructor explanation
-			#endif
-
-			insert(element_list);
+			check_capacities_conformance(block_limits);
+			reserve_and_range_fill(static_cast<size_type>(element_list.size()), element_list.begin());
 		}
 
+
+
+		colony(const std::initializer_list<element_type> &element_list, const allocator_type &alloc = allocator_type()):
+			colony(element_list, block_capacity_default_limits(), alloc)
+		{}
 	#endif
 
 
 
-	inline PLF_COLONY_FORCE_INLINE iterator begin() PLF_COLONY_NOEXCEPT
+	#ifdef PLF_CPP20_SUPPORT
+		// Ranges v3 constructors:
+
+		template<compatible_range<element_type> range_type>
+		colony(ranges::from_range_t, range_type &&rg, const plf::limits block_limits, const allocator_type &alloc = allocator_type()):
+			allocator_type(alloc),
+			erasure_groups_head(NULL),
+			unused_groups_head(NULL),
+			total_size(0),
+			total_capacity(0),
+			min_block_capacity(static_cast<skipfield_type>(block_limits.min)),
+			max_block_capacity(static_cast<skipfield_type>(block_limits.max)),
+			group_allocator(*this),
+			aligned_struct_allocator(*this),
+			skipfield_allocator(*this),
+			tuple_allocator(*this)
+		{
+			check_capacities_conformance(block_limits);
+			reserve_and_range_fill(static_cast<size_type>(std::ranges::distance(rg)), std::ranges::begin(rg));
+		}
+
+
+
+		template<compatible_range<element_type> range_type>
+		colony(plf::ranges::from_range_t, range_type &&rg, const allocator_type &alloc = allocator_type()):
+			colony(plf::ranges::from_range, std::move(rg), block_capacity_default_limits(), alloc)
+		{}
+	#endif
+
+
+
+	// Everything else:
+
+	iterator begin() PLF_NOEXCEPT
 	{
 		return begin_iterator;
 	}
 
 
 
-	inline PLF_COLONY_FORCE_INLINE const iterator & begin() const PLF_COLONY_NOEXCEPT // To allow for functions which only take const colony & as a source eg. copy constructor
+	const_iterator begin() const PLF_NOEXCEPT
 	{
 		return begin_iterator;
 	}
 
 
 
-	inline PLF_COLONY_FORCE_INLINE iterator end() PLF_COLONY_NOEXCEPT
+	iterator end() PLF_NOEXCEPT
 	{
 		return end_iterator;
 	}
 
 
 
-	inline PLF_COLONY_FORCE_INLINE const iterator & end() const PLF_COLONY_NOEXCEPT
+	const_iterator end() const PLF_NOEXCEPT
 	{
 		return end_iterator;
 	}
 
 
 
-	inline const_iterator cbegin() const PLF_COLONY_NOEXCEPT
+	const_iterator cbegin() const PLF_NOEXCEPT
 	{
-		return const_iterator(begin_iterator.group_pointer, begin_iterator.element_pointer, begin_iterator.skipfield_pointer);
+		return begin_iterator;
 	}
 
 
 
-	inline const_iterator cend() const PLF_COLONY_NOEXCEPT
+	const_iterator cend() const PLF_NOEXCEPT
 	{
-		return const_iterator(end_iterator.group_pointer, end_iterator.element_pointer, end_iterator.skipfield_pointer);
+		return end_iterator;
 	}
 
 
 
-	inline reverse_iterator rbegin() const // May throw exception if colony is empty so end_iterator is uninitialized
+	reverse_iterator rbegin() PLF_NOEXCEPT
 	{
-		return ++reverse_iterator(end_iterator);
+		return (end_iterator.group_pointer != NULL) ? ++reverse_iterator(end_iterator.group_pointer, end_iterator.element_pointer, end_iterator.skipfield_pointer) : reverse_iterator(begin_iterator.group_pointer, begin_iterator.element_pointer - 1, begin_iterator.skipfield_pointer - 1);
 	}
 
 
 
-	inline reverse_iterator rend() const PLF_COLONY_NOEXCEPT
+	const_reverse_iterator rbegin() const PLF_NOEXCEPT
+	{
+		return crbegin();
+	}
+
+
+
+	reverse_iterator rend() PLF_NOEXCEPT
 	{
 		return reverse_iterator(begin_iterator.group_pointer, begin_iterator.element_pointer - 1, begin_iterator.skipfield_pointer - 1);
 	}
 
 
 
-	inline const_reverse_iterator crbegin() const
+	const_reverse_iterator rend() const PLF_NOEXCEPT
 	{
-		return ++const_reverse_iterator(end_iterator);
+		return crend();
 	}
 
 
 
-	inline const_reverse_iterator crend() const PLF_COLONY_NOEXCEPT
+	const_reverse_iterator crbegin() const PLF_NOEXCEPT
+	{
+		return (end_iterator.group_pointer != NULL) ? ++const_reverse_iterator(end_iterator.group_pointer, end_iterator.element_pointer, end_iterator.skipfield_pointer) : const_reverse_iterator(begin_iterator.group_pointer, begin_iterator.element_pointer - 1, begin_iterator.skipfield_pointer - 1);
+	}
+
+
+
+	const_reverse_iterator crend() const PLF_NOEXCEPT
 	{
 		return const_reverse_iterator(begin_iterator.group_pointer, begin_iterator.element_pointer - 1, begin_iterator.skipfield_pointer - 1);
 	}
 
 
 
-	~colony() PLF_COLONY_NOEXCEPT
+	~colony() PLF_NOEXCEPT
 	{
 		destroy_all_data();
 	}
 
 
 
+
 private:
 
-	void destroy_all_data() PLF_COLONY_NOEXCEPT
+	group_pointer_type allocate_new_group(const skipfield_type elements_per_group, const group_pointer_type previous = NULL)
 	{
-	#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-		if ((total_number_of_elements != 0) & !(std::is_trivially_destructible<element_type>::value)) // Amusingly enough, these changes from && to logical & actually do make a significant difference in debug mode
-	#else // If compiler doesn't support traits, iterate regardless - trivial destructors will not be called, hopefully compiler will optimise the 'destruct' loop out for POD types
-		if (total_number_of_elements != 0)
-	#endif
+		if (max_size() - total_capacity < elements_per_group) // Just in case max_size is a lower amount than the actual memory available (uncommon platform). Comparison avoids overflow.
 		{
-			total_number_of_elements = 0; // to avoid double-destruction
-
-			while (true)
-			{
-				const aligned_pointer_type end_pointer = begin_iterator.group_pointer->last_endpoint;
-
-				do
-				{
-					PLF_COLONY_DESTROY(element_allocator_type, (*this), reinterpret_cast<pointer>(begin_iterator.element_pointer));
-					++begin_iterator.skipfield_pointer;
-					begin_iterator.element_pointer += *begin_iterator.skipfield_pointer + 1;
-					begin_iterator.skipfield_pointer += *begin_iterator.skipfield_pointer;
-				} while(begin_iterator.element_pointer != end_pointer); // ie. beyond end of available data
-
-				const group_pointer_type next_group = begin_iterator.group_pointer->next_group;
-				PLF_COLONY_DESTROY(group_allocator_type, group_allocator_pair, begin_iterator.group_pointer);
-				PLF_COLONY_DEALLOCATE(group_allocator_type, group_allocator_pair, begin_iterator.group_pointer, 1);
-     			begin_iterator.group_pointer = next_group; // required to be before if statement in order for first_group to be NULL and avoid potential double-destruction in future
-
-				if (next_group == NULL)
-				{
-					return;
-				}
-
-				begin_iterator.element_pointer = next_group->elements + *(next_group->skipfield);
-				begin_iterator.skipfield_pointer = next_group->skipfield + *(next_group->skipfield);
-			}
+			#ifdef PLF_EXCEPTIONS_SUPPORT
+				throw std::length_error("New block allocation would create capacity greater than max_size()");
+			#else
+				std::terminate();
+			#endif
 		}
-		else // Avoid iteration for both empty groups and trivially-destructible types eg. POD, structs, classes with empty destructors
+
+		const group_pointer_type new_group = PLF_ALLOCATE(group_allocator_type, group_allocator, 1, end_iterator.group_pointer);
+		total_capacity += elements_per_group; // I don't know why GCC creates better/smaller codegen when this is placed here rather than at bottom of function, But it does.
+
+		#ifdef PLF_EXCEPTIONS_SUPPORT
+			try
+			{
+				#ifdef PLF_VARIADICS_SUPPORT
+					PLF_CONSTRUCT(group_allocator_type, group_allocator, new_group, aligned_struct_allocator, elements_per_group, previous);
+				#else
+					PLF_CONSTRUCT(group_allocator_type, group_allocator, new_group, group(aligned_struct_allocator, elements_per_group, previous));
+				#endif
+			}
+			catch (...)
+			{
+				PLF_DEALLOCATE(group_allocator_type, group_allocator, new_group, 1);
+				total_capacity -= elements_per_group;
+				throw;
+			}
+		#else
+			#ifdef PLF_VARIADICS_SUPPORT
+				PLF_CONSTRUCT(group_allocator_type, group_allocator, new_group, aligned_struct_allocator, elements_per_group, previous);
+			#else
+				PLF_CONSTRUCT(group_allocator_type, group_allocator, new_group, group(aligned_struct_allocator, elements_per_group, previous));
+			#endif
+		#endif
+
+		return new_group;
+	}
+
+
+
+	void deallocate_group(const group_pointer_type the_group) PLF_NOEXCEPT
+	{
+		PLF_DEALLOCATE(aligned_struct_allocator_type, aligned_struct_allocator, the_group->elements, get_aligned_block_capacity(the_group->capacity));
+		PLF_DEALLOCATE(group_allocator_type, group_allocator, the_group, 1);
+	}
+
+
+
+	void deallocate_group_remove_capacity(const group_pointer_type the_group) PLF_NOEXCEPT
+	{
+		total_capacity -= the_group->capacity;
+		deallocate_group(the_group);
+	}
+
+
+
+	PLF_CONSTFUNC void destroy_element(const aligned_pointer_type element) PLF_NOEXCEPT
+	{
+		#if defined(PLF_TYPE_TRAITS_SUPPORT) && defined(PLF_CPP20_SUPPORT)  // To avoid codegen for this function with trivially-destructible types. CPP20 because we don't want to trigger a branch for every destruction
+			if constexpr (!std::is_trivially_destructible<element_type>::value)
+		#endif
+		PLF_DESTROY(allocator_type, *this, pointer_cast<pointer>(element));
+	}
+
+
+
+	void destroy_remainder(const_iterator it) PLF_NOEXCEPT
+	{
+		#if defined(PLF_TYPE_TRAITS_SUPPORT)
+			if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
+		#endif
 		{
-			// Technically under a type-traits-supporting compiler total_number_of_elements could be non-zero at this point, but since begin_iterator.group_pointer would already be NULL in the case of double-destruction, it's unnecessary to zero total_number_of_elements
+			while (it != end_iterator) destroy_element(it++.element_pointer);
+		}
+	}
+
+
+
+	void destroy_group(const_iterator current, const aligned_pointer_type end) PLF_NOEXCEPT
+	{
+		#ifdef PLF_TYPE_TRAITS_SUPPORT
+			if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
+		#endif
+		{
+			do
+			{
+				destroy_element(current.element_pointer);
+				current.element_pointer += static_cast<size_type>(*++current.skipfield_pointer) + 1u;
+				current.skipfield_pointer += *current.skipfield_pointer;
+			} while(current.element_pointer != end);
+		}
+	}
+
+
+
+	void destroy_dealloc_begin_group(const aligned_pointer_type end) PLF_NOEXCEPT
+	{
+		destroy_group(begin_iterator, end);
+		deallocate_group(begin_iterator.group_pointer);
+	}
+
+
+
+	void destroy_all_data() PLF_NOEXCEPT
+	{
+		if (begin_iterator.group_pointer != NULL)
+		{
+			end_iterator.group_pointer->next_group = unused_groups_head; // Link used and unused_group lists together
+
+			#ifdef PLF_TYPE_TRAITS_SUPPORT
+				if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
+			#endif
+			{
+				if (total_size != 0)
+				{
+					while (begin_iterator.group_pointer != end_iterator.group_pointer) // Erase elements without bothering to update skipfield - much faster:
+					{
+						const group_pointer_type next_group = begin_iterator.group_pointer->next_group;
+						destroy_dealloc_begin_group(to_aligned_pointer(begin_iterator.group_pointer->skipfield));
+						begin_iterator.group_pointer = next_group;
+						begin_iterator.element_pointer = to_aligned_pointer(next_group->elements) + *(next_group->skipfield);
+						begin_iterator.skipfield_pointer = next_group->skipfield + *(next_group->skipfield);
+					}
+
+					destroy_dealloc_begin_group(end_iterator.element_pointer);
+					begin_iterator.group_pointer = unused_groups_head;
+				}
+			}
+
 			while (begin_iterator.group_pointer != NULL)
 			{
 				const group_pointer_type next_group = begin_iterator.group_pointer->next_group;
-				PLF_COLONY_DESTROY(group_allocator_type, group_allocator_pair, begin_iterator.group_pointer);
-				PLF_COLONY_DEALLOCATE(group_allocator_type, group_allocator_pair, begin_iterator.group_pointer, 1);
+				deallocate_group(begin_iterator.group_pointer);
 				begin_iterator.group_pointer = next_group;
 			}
 		}
@@ -1325,27 +1331,128 @@ private:
 
 	void initialize(const skipfield_type first_group_size)
 	{
-		begin_iterator.group_pointer = PLF_COLONY_ALLOCATE(group_allocator_type, group_allocator_pair, 1, 0);
-
-		try
-		{
-			#ifdef PLF_COLONY_VARIADICS_SUPPORT
-				PLF_COLONY_CONSTRUCT(group_allocator_type, group_allocator_pair, begin_iterator.group_pointer, first_group_size);
-			#else
-				PLF_COLONY_CONSTRUCT(group_allocator_type, group_allocator_pair, begin_iterator.group_pointer, group(first_group_size));
-			#endif
-		}
-		catch (...)
-		{
-			PLF_COLONY_DEALLOCATE(group_allocator_type, group_allocator_pair, begin_iterator.group_pointer, 1);
-			begin_iterator.group_pointer = NULL;
-			throw;
-		}
-
-		end_iterator.group_pointer = begin_iterator.group_pointer;
-		end_iterator.element_pointer = begin_iterator.element_pointer = begin_iterator.group_pointer->elements;
+		end_iterator.group_pointer = begin_iterator.group_pointer = allocate_new_group(first_group_size);
+		end_iterator.element_pointer = begin_iterator.element_pointer = to_aligned_pointer(begin_iterator.group_pointer->elements);
 		end_iterator.skipfield_pointer = begin_iterator.skipfield_pointer = begin_iterator.group_pointer->skipfield;
-		total_capacity = first_group_size;
+	}
+
+
+
+	void edit_free_list(const skipfield_pointer_type location, const skipfield_type value) PLF_NOEXCEPT
+	{
+		PLF_DESTROY(skipfield_allocator_type, skipfield_allocator, location);
+		PLF_CONSTRUCT(skipfield_allocator_type, skipfield_allocator, location, value);
+	}
+
+
+
+	void edit_free_list_prev(const aligned_pointer_type location, const skipfield_type value) PLF_NOEXCEPT // Write to the 'previous erased element' index in the erased element memory location
+	{
+		edit_free_list(pointer_cast<skipfield_pointer_type>(location), value);
+	}
+
+
+
+	void edit_free_list_next(const aligned_pointer_type location, const skipfield_type value) PLF_NOEXCEPT // Ditto 'next'
+	{
+		edit_free_list(pointer_cast<skipfield_pointer_type>(location) + 1, value);
+	}
+
+
+
+	void edit_free_list_head(const aligned_pointer_type location, const skipfield_type value) PLF_NOEXCEPT
+	{
+		const skipfield_pointer_type converted_location = pointer_cast<skipfield_pointer_type>(location);
+		edit_free_list(converted_location, value);
+		edit_free_list(converted_location + 1, std::numeric_limits<skipfield_type>::max());
+	}
+
+
+
+	void update_skipblock(const iterator &new_location, const skipfield_type prev_free_list_index) PLF_NOEXCEPT
+	{
+		const skipfield_type new_value = static_cast<skipfield_type>(*(new_location.skipfield_pointer) - 1);
+
+		if (new_value != 0) // ie. skipfield was not originally length 1, hence we need to truncate it
+		{
+			// set (new) start and (original) end of skipblock to new value:
+			*(new_location.skipfield_pointer + new_value) = *(new_location.skipfield_pointer + 1) = new_value;
+
+			// transfer free list node to new start node:
+			++(erasure_groups_head->free_list_head);
+
+			if (prev_free_list_index != std::numeric_limits<skipfield_type>::max()) // ie. not the tail free list node
+			{
+				edit_free_list_next(to_aligned_pointer(new_location.group_pointer->elements) + prev_free_list_index, erasure_groups_head->free_list_head);
+			}
+
+			edit_free_list_head(new_location.element_pointer + 1, prev_free_list_index);
+		}
+		else // single-node skipblock, remove skipblock
+		{
+			erasure_groups_head->free_list_head = prev_free_list_index;
+
+			if (prev_free_list_index != std::numeric_limits<skipfield_type>::max()) // ie. not the last free list node
+			{
+				edit_free_list_next(to_aligned_pointer(new_location.group_pointer->elements) + prev_free_list_index, std::numeric_limits<skipfield_type>::max());
+			}
+			else // remove this group from the list of groups with erasures
+			{
+				erasure_groups_head = erasure_groups_head->erasures_list_next_group; // update_skipblock is only used within insert/emplace, where the head group is being used, so no need for additional checks here
+			}
+		}
+
+		*(new_location.skipfield_pointer) = 0;
+		++(new_location.group_pointer->size);
+
+		if (new_location.group_pointer == begin_iterator.group_pointer && new_location.element_pointer < begin_iterator.element_pointer)
+		{ /* ie. begin_iterator was moved forwards as the result of an erasure at some point, this erased element is before the current begin, hence, set current begin iterator to this element */
+			begin_iterator = new_location;
+		}
+
+		++total_size;
+	}
+
+
+
+	void update_subsequent_group_numbers(size_type current_group_number, group_pointer_type update_group) PLF_NOEXCEPT
+	{
+		do
+		{
+			update_group->group_number = current_group_number++;
+			update_group = update_group->next_group;
+		} while (update_group != NULL);
+	}
+
+
+
+	void reset_group_numbers() PLF_NOEXCEPT
+	{
+		update_subsequent_group_numbers(0, begin_iterator.group_pointer);
+	}
+
+
+
+	void reset_group_numbers_if_necessary() PLF_NOEXCEPT
+	{
+		if (end_iterator.group_pointer->group_number == std::numeric_limits<size_type>::max())
+		#ifdef PLF_CPP20_SUPPORT
+			[[unlikely]]
+		#endif
+		{
+			reset_group_numbers();
+		}
+	}
+
+
+
+	group_pointer_type reuse_unused_group() PLF_NOEXCEPT
+	{
+		const group_pointer_type reused_group = unused_groups_head;
+		unused_groups_head = reused_group->next_group;
+		reset_group_numbers_if_necessary();
+		reused_group->reset(1, NULL, end_iterator.group_pointer, end_iterator.group_pointer->group_number + 1u);
+		return reused_group;
 	}
 
 
@@ -1353,497 +1460,373 @@ private:
 public:
 
 
+	void reset() PLF_NOEXCEPT
+	{
+		destroy_all_data();
+		blank();
+	}
+
+
+
 	iterator insert(const element_type &element)
 	{
 		if (end_iterator.element_pointer != NULL)
 		{
-			switch(((groups_with_erasures_list_head != NULL) << 1) | (end_iterator.element_pointer == reinterpret_cast<aligned_pointer_type>(end_iterator.group_pointer->skipfield)))
+			if (erasure_groups_head == NULL) // ie. there are no erased elements
 			{
-				case 0: // ie. there are no erased elements and end_iterator is not at end of current final group
+				if (end_iterator.element_pointer != to_aligned_pointer(end_iterator.group_pointer->skipfield)) // ie. end_iterator is not at end of block
 				{
-					const iterator return_iterator = end_iterator; /* Make copy for return before modifying end_iterator */
+					PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer, element);
 
-					#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-						if PLF_COLONY_CONSTEXPR (std::is_nothrow_copy_constructible<element_type>::value)
-						{ // For no good reason this compiles to faster code under GCC:
-							PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(end_iterator.element_pointer++), element);
-							end_iterator.group_pointer->last_endpoint = end_iterator.element_pointer;
-						}
-						else
-					#endif
-					{
-						PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(end_iterator.element_pointer), element);
-						end_iterator.group_pointer->last_endpoint = ++end_iterator.element_pointer; // Shift the addition to the second operation, avoiding problems if an exception is thrown during construction
-					}
-
-					++(end_iterator.group_pointer->number_of_elements);
+					const iterator return_iterator = end_iterator;
+					++end_iterator.element_pointer;
 					++end_iterator.skipfield_pointer;
-					++total_number_of_elements;
-
-					return return_iterator; // return value before incrementation
+					++(end_iterator.group_pointer->size);
+					++total_size;
+					return return_iterator;
 				}
-				case 1: // ie. there are no erased elements and end_iterator is at end of current final group - ie. colony is full - create new group
+				else
 				{
-					end_iterator.group_pointer->next_group = PLF_COLONY_ALLOCATE(group_allocator_type, group_allocator_pair, 1, end_iterator.group_pointer);
-					group &next_group = *(end_iterator.group_pointer->next_group);
-					const skipfield_type new_group_size = (total_number_of_elements < static_cast<size_type>(group_allocator_pair.max_elements_per_group)) ? static_cast<skipfield_type>(total_number_of_elements) : group_allocator_pair.max_elements_per_group;
+					group_pointer_type next_group;
 
-					try
+					if (unused_groups_head == NULL)
 					{
-						#ifdef PLF_COLONY_VARIADICS_SUPPORT
-							PLF_COLONY_CONSTRUCT(group_allocator_type, group_allocator_pair, &next_group, new_group_size, end_iterator.group_pointer);
+						reset_group_numbers_if_necessary();
+						next_group = allocate_new_group(static_cast<skipfield_type>(std::min(total_size, static_cast<size_type>(max_block_capacity))), end_iterator.group_pointer);
+
+						#ifndef PLF_EXCEPTIONS_SUPPORT
+							PLF_CONSTRUCT_ELEMENT(next_group->elements, element);
 						#else
-							PLF_COLONY_CONSTRUCT(group_allocator_type, group_allocator_pair, &next_group, group(new_group_size, end_iterator.group_pointer));
+							#ifdef PLF_TYPE_TRAITS_SUPPORT
+								if PLF_CONSTEXPR (std::is_nothrow_copy_constructible<element_type>::value)
+								{
+									PLF_CONSTRUCT_ELEMENT(next_group->elements, element);
+								}
+								else
+							#endif
+							{
+								try
+								{
+									PLF_CONSTRUCT_ELEMENT(next_group->elements, element);
+								}
+								catch (...)
+								{
+									deallocate_group_remove_capacity(next_group);
+									throw;
+								}
+							}
 						#endif
-					}
-					catch (...)
-					{
-						PLF_COLONY_DEALLOCATE(group_allocator_type, group_allocator_pair, &next_group, 1);
-						end_iterator.group_pointer->next_group = NULL;
-						throw;
-					}
-
-					#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-						if PLF_COLONY_CONSTEXPR (std::is_nothrow_copy_constructible<element_type>::value)
-						{
-							PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(next_group.elements), element);
-						}
-						else
-					#endif
-					{
-						try
-						{
-							PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(next_group.elements), element);
-						}
-						catch (...)
-						{
-							PLF_COLONY_DESTROY(group_allocator_type, group_allocator_pair, &next_group);
-							PLF_COLONY_DEALLOCATE(group_allocator_type, group_allocator_pair, &next_group, 1);
-							end_iterator.group_pointer->next_group = NULL;
-							throw;
-						}
-					}
-
-					end_iterator.group_pointer = &next_group;
-					end_iterator.element_pointer = next_group.last_endpoint;
-					end_iterator.skipfield_pointer = next_group.skipfield + 1;
-					++total_number_of_elements;
-					total_capacity += new_group_size;
-
-					return iterator(end_iterator.group_pointer, next_group.elements, next_group.skipfield); /* returns value before incrementation */
-				}
-				default: // ie. there are erased elements, reuse previous-erased element locations
-				{
-					iterator new_location;
-					new_location.group_pointer = groups_with_erasures_list_head;
-					new_location.element_pointer = groups_with_erasures_list_head->elements + groups_with_erasures_list_head->free_list_head;
-					new_location.skipfield_pointer = groups_with_erasures_list_head->skipfield + groups_with_erasures_list_head->free_list_head;
-
-					// always at start of skipblock, update skipblock:
-					const skipfield_type prev_free_list_index = *(reinterpret_cast<skipfield_pointer_type>(new_location.element_pointer));
-
-					PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(new_location.element_pointer), element);
-
-					// Update skipblock:
-					const skipfield_type new_value = *(new_location.skipfield_pointer) - 1;
-
-					if (new_value != 0) // ie. skipfield was not 1, ie. a single-node skipblock, with no additional nodes to update
-					{
-						// set (new) start and (original) end of skipblock to new value:
-						*(new_location.skipfield_pointer + new_value) = *(new_location.skipfield_pointer + 1) = new_value;
-
-						// transfer free list node to new start node:
-						++(groups_with_erasures_list_head->free_list_head);
-
-						if (prev_free_list_index != std::numeric_limits<skipfield_type>::max()) // ie. not the tail free list node
-						{
-							*(reinterpret_cast<skipfield_pointer_type>(new_location.group_pointer->elements + prev_free_list_index) + 1) = groups_with_erasures_list_head->free_list_head;
-						}
-
-						*(reinterpret_cast<skipfield_pointer_type>(new_location.element_pointer + 1)) = prev_free_list_index;
-						*(reinterpret_cast<skipfield_pointer_type>(new_location.element_pointer + 1) + 1) = std::numeric_limits<skipfield_type>::max();
 					}
 					else
 					{
-						groups_with_erasures_list_head->free_list_head = prev_free_list_index;
-
-						if (prev_free_list_index != std::numeric_limits<skipfield_type>::max()) // ie. not the last free list node
-						{
-							*(reinterpret_cast<skipfield_pointer_type>(new_location.group_pointer->elements + prev_free_list_index) + 1) = std::numeric_limits<skipfield_type>::max();
-						}
-						else
-						{
-							groups_with_erasures_list_head = groups_with_erasures_list_head->erasures_list_next_group;
-						}
+						PLF_CONSTRUCT_ELEMENT(unused_groups_head->elements, element);
+						next_group = reuse_unused_group();
 					}
 
-					*(new_location.skipfield_pointer) = 0;
-					++(new_location.group_pointer->number_of_elements);
+					end_iterator.group_pointer->next_group = next_group;
+					end_iterator.group_pointer = next_group;
+					end_iterator.element_pointer = to_aligned_pointer(next_group->elements) + 1;
+					end_iterator.skipfield_pointer = next_group->skipfield + 1;
+					++total_size;
 
-					if (new_location.group_pointer == begin_iterator.group_pointer && new_location.element_pointer < begin_iterator.element_pointer)
-					{ /* ie. begin_iterator was moved forwards as the result of an erasure at some point, this erased element is before the current begin, hence, set current begin iterator to this element */
-						begin_iterator = new_location;
-					}
-
-					++total_number_of_elements;
-					return new_location;
+					return iterator(next_group, to_aligned_pointer(next_group->elements), next_group->skipfield);
 				}
+			}
+			else // there are erased elements, reuse those memory locations
+			{
+				iterator new_location(erasure_groups_head, to_aligned_pointer(erasure_groups_head->elements) + erasure_groups_head->free_list_head, erasure_groups_head->skipfield + erasure_groups_head->free_list_head);
+
+				// We always reuse the element at the start of the skipblock, this is also where the free-list information for that skipblock is stored. Get the previous free-list node's index from this memory space, before we write to our element to it. 'Next' index is always the free_list_head (as represented by the maximum value of the skipfield type) here so we don't need to get it:
+				const skipfield_type prev_free_list_index = *pointer_cast<skipfield_pointer_type>(new_location.element_pointer);
+				PLF_CONSTRUCT_ELEMENT(new_location.element_pointer, element);
+				update_skipblock(new_location, prev_free_list_index);
+
+				return new_location;
 			}
 		}
 		else // ie. newly-constructed colony, no insertions yet and no groups
 		{
-			initialize(pointer_allocator_pair.min_elements_per_group);
+			initialize(min_block_capacity);
 
-			#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-				if PLF_COLONY_CONSTEXPR (std::is_nothrow_copy_constructible<element_type>::value)
+			#ifndef PLF_EXCEPTIONS_SUPPORT
+				PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer++, element);
+			#else
+				#ifdef PLF_TYPE_TRAITS_SUPPORT
+					if PLF_CONSTEXPR (std::is_nothrow_copy_constructible<element_type>::value)
+					{
+						PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer++, element);
+					}
+					else
+				#endif
 				{
-					PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(end_iterator.element_pointer++), element);
+					try
+					{
+						PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer++, element);
+					}
+					catch (...)
+					{
+						reset();
+						throw;
+					}
 				}
-				else
 			#endif
-			{
-				try
-				{
-					PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(end_iterator.element_pointer++), element);
-				}
-				catch (...)
-				{
-					clear();
-					throw;
-				}
-			}
 
 			++end_iterator.skipfield_pointer;
-			total_number_of_elements = 1;
+			total_size = 1;
 			return begin_iterator;
 		}
 	}
 
 
 
-	#ifdef PLF_COLONY_MOVE_SEMANTICS_SUPPORT
-		iterator insert(element_type &&element) // The move-insert function is near-identical to the regular insert function, with the exception of the element construction method and is_nothrow tests.
+	#ifdef PLF_CPP20_SUPPORT
+		iterator insert([[maybe_unused]] const_iterator &hint, const element_type &element) // Note: hint is ignored, purely to serve other standard library functions
 		{
-			if (end_iterator.element_pointer != NULL)
-			{
-				switch(((groups_with_erasures_list_head != NULL) << 1) | (end_iterator.element_pointer == reinterpret_cast<aligned_pointer_type>(end_iterator.group_pointer->skipfield)))
-				{
-					case 0:
-					{
-						const iterator return_iterator = end_iterator;
-
-						#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-							if PLF_COLONY_CONSTEXPR (std::is_nothrow_move_constructible<element_type>::value)
-							{
-								PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(end_iterator.element_pointer++), std::move(element));
-								end_iterator.group_pointer->last_endpoint = end_iterator.element_pointer;
-							}
-							else
-						#endif
-						{
-							PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(end_iterator.element_pointer), std::move(element));
-							end_iterator.group_pointer->last_endpoint = ++end_iterator.element_pointer;
-						}
-
-						++(end_iterator.group_pointer->number_of_elements);
-						++end_iterator.skipfield_pointer;
-						++total_number_of_elements;
-
-						return return_iterator;
-					}
-					case 1:
-					{
-						end_iterator.group_pointer->next_group = PLF_COLONY_ALLOCATE(group_allocator_type, group_allocator_pair, 1, end_iterator.group_pointer);
-						group &next_group = *(end_iterator.group_pointer->next_group);
-						const skipfield_type new_group_size = (total_number_of_elements < static_cast<size_type>(group_allocator_pair.max_elements_per_group)) ? static_cast<skipfield_type>(total_number_of_elements) : group_allocator_pair.max_elements_per_group;
-
-						try
-						{
-							#ifdef PLF_COLONY_VARIADICS_SUPPORT
-								PLF_COLONY_CONSTRUCT(group_allocator_type, group_allocator_pair, &next_group, new_group_size, end_iterator.group_pointer);
-							#else
-								PLF_COLONY_CONSTRUCT(group_allocator_type, group_allocator_pair, &next_group, group(new_group_size, end_iterator.group_pointer));
-							#endif
-						}
-						catch (...)
-						{
-							PLF_COLONY_DEALLOCATE(group_allocator_type, group_allocator_pair, &next_group, 1);
-							end_iterator.group_pointer->next_group = NULL;
-							throw;
-						}
-
-						#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-							if PLF_COLONY_CONSTEXPR (std::is_nothrow_move_constructible<element_type>::value)
-							{
-								PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(next_group.elements), std::move(element));
-							}
-							else
-						#endif
-						{
-							try
-							{
-								PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(next_group.elements), std::move(element));
-							}
-							catch (...)
-							{
-								PLF_COLONY_DESTROY(group_allocator_type, group_allocator_pair, &next_group);
-								PLF_COLONY_DEALLOCATE(group_allocator_type, group_allocator_pair, &next_group, 1);
-								end_iterator.group_pointer->next_group = NULL;
-								throw;
-							}
-						}
-
-						end_iterator.group_pointer = &next_group;
-						end_iterator.element_pointer = next_group.last_endpoint;
-						end_iterator.skipfield_pointer = next_group.skipfield + 1;
-						++total_number_of_elements;
-						total_capacity += new_group_size;
-
-						return iterator(end_iterator.group_pointer, next_group.elements, next_group.skipfield);
-					}
-					default:
-					{
-						iterator new_location;
-						new_location.group_pointer = groups_with_erasures_list_head;
-						new_location.element_pointer = groups_with_erasures_list_head->elements + groups_with_erasures_list_head->free_list_head;
-						new_location.skipfield_pointer = groups_with_erasures_list_head->skipfield + groups_with_erasures_list_head->free_list_head;
-
-						const skipfield_type prev_free_list_index = *(reinterpret_cast<skipfield_pointer_type>(new_location.element_pointer));
-						PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(new_location.element_pointer), std::move(element));
-
-						const skipfield_type new_value = *(new_location.skipfield_pointer) - 1;
-
-						if (new_value != 0)
-						{
-							*(new_location.skipfield_pointer + new_value) = *(new_location.skipfield_pointer + 1) = new_value;
-							++(groups_with_erasures_list_head->free_list_head);
-
-							if (prev_free_list_index != std::numeric_limits<skipfield_type>::max())
-							{
-								*(reinterpret_cast<skipfield_pointer_type>(new_location.group_pointer->elements + prev_free_list_index) + 1) = groups_with_erasures_list_head->free_list_head;
-							}
-
-							*(reinterpret_cast<skipfield_pointer_type>(new_location.element_pointer + 1)) = prev_free_list_index;
-							*(reinterpret_cast<skipfield_pointer_type>(new_location.element_pointer + 1) + 1) = std::numeric_limits<skipfield_type>::max();
-						}
-						else
-						{
-							groups_with_erasures_list_head->free_list_head = prev_free_list_index;
-
-							if (prev_free_list_index != std::numeric_limits<skipfield_type>::max())
-							{
-								*(reinterpret_cast<skipfield_pointer_type>(new_location.group_pointer->elements + prev_free_list_index) + 1) = std::numeric_limits<skipfield_type>::max();
-							}
-							else
-							{
-								groups_with_erasures_list_head = groups_with_erasures_list_head->erasures_list_next_group;
-							}
-						}
-
-						*(new_location.skipfield_pointer) = 0;
-						++(new_location.group_pointer->number_of_elements);
-
-						if (new_location.group_pointer == begin_iterator.group_pointer && new_location.element_pointer < begin_iterator.element_pointer)
-						{
-							begin_iterator = new_location;
-						}
-
-						++total_number_of_elements;
-
-						return new_location;
-					}
-				}
-			}
-			else
-			{
-				initialize(pointer_allocator_pair.min_elements_per_group);
-
-				#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-					if PLF_COLONY_CONSTEXPR (std::is_nothrow_move_constructible<element_type>::value)
-					{
-						PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(end_iterator.element_pointer++), std::move(element));
-					}
-					else
-				#endif
-				{
-					try
-					{
-						PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(end_iterator.element_pointer++), std::move(element));
-					}
-					catch (...)
-					{
-						clear();
-						throw;
-					}
-				}
-
-				++end_iterator.skipfield_pointer;
-				total_number_of_elements = 1;
-				return begin_iterator;
-			}
+			return insert(element);
 		}
 	#endif
 
 
 
-
-	#ifdef PLF_COLONY_VARIADICS_SUPPORT
-		template<typename... arguments>
-		iterator emplace(arguments &&... parameters) // The emplace function is near-identical to the regular insert function, with the exception of the element construction method, removal of internal VARIADICS support checks, and change to is_nothrow tests.
+	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+		iterator insert(element_type &&element) // The move-insert function is near-identical to the regular insert function, with the exception of the element construction method and is_nothrow tests.
 		{
 			if (end_iterator.element_pointer != NULL)
 			{
-				switch(((groups_with_erasures_list_head != NULL) << 1) | (end_iterator.element_pointer == reinterpret_cast<aligned_pointer_type>(end_iterator.group_pointer->skipfield)))
+				if (erasure_groups_head == NULL)
 				{
-					case 0:
+					if (end_iterator.element_pointer != to_aligned_pointer(end_iterator.group_pointer->skipfield))
 					{
+						PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer, std::move(element));
+
 						const iterator return_iterator = end_iterator;
-
-						#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-							if PLF_COLONY_CONSTEXPR (std::is_nothrow_constructible<element_type, arguments ...>::value)
-							{
-								PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(end_iterator.element_pointer++), std::forward<arguments>(parameters)...);
-								end_iterator.group_pointer->last_endpoint = end_iterator.element_pointer;
-							}
-							else
-						#endif
-						{
-							PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(end_iterator.element_pointer), std::forward<arguments>(parameters)...);
-							end_iterator.group_pointer->last_endpoint = ++end_iterator.element_pointer;
-						}
-
-						++(end_iterator.group_pointer->number_of_elements);
+						++end_iterator.element_pointer;
 						++end_iterator.skipfield_pointer;
-						++total_number_of_elements;
+						++(end_iterator.group_pointer->size);
+						++total_size;
 
 						return return_iterator;
 					}
-					case 1:
+					else
 					{
-						end_iterator.group_pointer->next_group = PLF_COLONY_ALLOCATE(group_allocator_type, group_allocator_pair, 1, end_iterator.group_pointer);
-						group &next_group = *(end_iterator.group_pointer->next_group);
-						const skipfield_type new_group_size = (total_number_of_elements < static_cast<size_type>(group_allocator_pair.max_elements_per_group)) ? static_cast<skipfield_type>(total_number_of_elements) : group_allocator_pair.max_elements_per_group;
+						group_pointer_type next_group;
 
-						try
+						if (unused_groups_head == NULL)
 						{
-							PLF_COLONY_CONSTRUCT(group_allocator_type, group_allocator_pair, &next_group, new_group_size, end_iterator.group_pointer);
-						}
-						catch (...)
-						{
-							PLF_COLONY_DEALLOCATE(group_allocator_type, group_allocator_pair, &next_group, 1);
-							end_iterator.group_pointer->next_group = NULL;
-							throw;
-						}
+							reset_group_numbers_if_necessary();
+							next_group = allocate_new_group(static_cast<skipfield_type>(std::min(total_size, static_cast<size_type>(max_block_capacity))), end_iterator.group_pointer);
 
-						#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-							if PLF_COLONY_CONSTEXPR (std::is_nothrow_constructible<element_type, arguments ...>::value)
-							{
-								PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(next_group.elements), std::forward<arguments>(parameters)...);
-							}
-							else
-						#endif
-						{
-							try
-							{
-								PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(next_group.elements), std::forward<arguments>(parameters)...);
-							}
-							catch (...)
-							{
-								PLF_COLONY_DESTROY(group_allocator_type, group_allocator_pair, &next_group);
-								PLF_COLONY_DEALLOCATE(group_allocator_type, group_allocator_pair, &next_group, 1);
-								end_iterator.group_pointer->next_group = NULL;
-								throw;
-							}
-						}
-
-						end_iterator.group_pointer = &next_group;
-						end_iterator.element_pointer = next_group.last_endpoint;
-						end_iterator.skipfield_pointer = next_group.skipfield + 1;
-						total_capacity += new_group_size;
-						++total_number_of_elements;
-
-						return iterator(end_iterator.group_pointer, next_group.elements, next_group.skipfield);
-					}
-					default:
-					{
-						iterator new_location;
-						new_location.group_pointer = groups_with_erasures_list_head;
-						new_location.element_pointer = groups_with_erasures_list_head->elements + groups_with_erasures_list_head->free_list_head;
-						new_location.skipfield_pointer = groups_with_erasures_list_head->skipfield + groups_with_erasures_list_head->free_list_head;
-
-						const skipfield_type prev_free_list_index = *(reinterpret_cast<skipfield_pointer_type>(new_location.element_pointer));
-						PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(new_location.element_pointer), std::forward<arguments>(parameters) ...);
-						const skipfield_type new_value = *(new_location.skipfield_pointer) - 1;
-
-						if (new_value != 0)
-						{
-							*(new_location.skipfield_pointer + new_value) = *(new_location.skipfield_pointer + 1) = new_value;
-							++(groups_with_erasures_list_head->free_list_head);
-
-							if (prev_free_list_index != std::numeric_limits<skipfield_type>::max())
-							{
-								*(reinterpret_cast<skipfield_pointer_type>(new_location.group_pointer->elements + prev_free_list_index) + 1) = groups_with_erasures_list_head->free_list_head;
-							}
-
-							*(reinterpret_cast<skipfield_pointer_type>(new_location.element_pointer + 1)) = prev_free_list_index;
-							*(reinterpret_cast<skipfield_pointer_type>(new_location.element_pointer + 1) + 1) = std::numeric_limits<skipfield_type>::max();
+							#ifndef PLF_EXCEPTIONS_SUPPORT
+								PLF_CONSTRUCT_ELEMENT(next_group->elements, std::move(element));
+							#else
+								#ifdef PLF_TYPE_TRAITS_SUPPORT
+									if PLF_CONSTEXPR (std::is_nothrow_move_constructible<element_type>::value)
+									{
+										PLF_CONSTRUCT_ELEMENT(next_group->elements, std::move(element));
+									}
+									else
+								#endif
+								{
+									try
+									{
+										PLF_CONSTRUCT_ELEMENT(next_group->elements, std::move(element));
+									}
+									catch (...)
+									{
+										deallocate_group_remove_capacity(next_group);
+										throw;
+									}
+								}
+							#endif
 						}
 						else
 						{
-							groups_with_erasures_list_head->free_list_head = prev_free_list_index;
-
-							if (prev_free_list_index != std::numeric_limits<skipfield_type>::max())
-							{
-								*(reinterpret_cast<skipfield_pointer_type>(new_location.group_pointer->elements + prev_free_list_index) + 1) = std::numeric_limits<skipfield_type>::max();
-							}
-							else
-							{
-								groups_with_erasures_list_head = groups_with_erasures_list_head->erasures_list_next_group;
-							}
+							PLF_CONSTRUCT_ELEMENT(unused_groups_head->elements, std::move(element));
+							next_group = reuse_unused_group();
 						}
 
-						*(new_location.skipfield_pointer) = 0;
-						++(new_location.group_pointer->number_of_elements);
+						end_iterator.group_pointer->next_group = next_group;
+						end_iterator.group_pointer = next_group;
+						end_iterator.element_pointer = to_aligned_pointer(next_group->elements) + 1;
+						end_iterator.skipfield_pointer = next_group->skipfield + 1;
+						++total_size;
 
-						if (new_location.group_pointer == begin_iterator.group_pointer && new_location.element_pointer < begin_iterator.element_pointer)
-						{
-							begin_iterator = new_location;
-						}
-
-						++total_number_of_elements;
-
-						return new_location;
+						return iterator(next_group, to_aligned_pointer(next_group->elements), next_group->skipfield);
 					}
+				}
+				else
+				{
+					iterator new_location(erasure_groups_head, to_aligned_pointer(erasure_groups_head->elements) + erasure_groups_head->free_list_head, erasure_groups_head->skipfield + erasure_groups_head->free_list_head);
+
+					const skipfield_type prev_free_list_index = *pointer_cast<skipfield_pointer_type>(new_location.element_pointer);
+					PLF_CONSTRUCT_ELEMENT(new_location.element_pointer, std::move(element));
+					update_skipblock(new_location, prev_free_list_index);
+
+					return new_location;
 				}
 			}
 			else
 			{
-				initialize(pointer_allocator_pair.min_elements_per_group);
+				initialize(min_block_capacity);
 
-				#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-					if PLF_COLONY_CONSTEXPR (std::is_nothrow_constructible<element_type, arguments ...>::value)
+				#ifndef PLF_EXCEPTIONS_SUPPORT
+					PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer++, std::move(element));
+				#else
+					#ifdef PLF_TYPE_TRAITS_SUPPORT
+						if PLF_CONSTEXPR (std::is_nothrow_move_constructible<element_type>::value)
+						{
+							PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer++, std::move(element));
+						}
+						else
+					#endif
 					{
-						PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(end_iterator.element_pointer++), std::forward<arguments>(parameters) ...);
+						try
+						{
+							PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer++, std::move(element));
+						}
+						catch (...)
+						{
+							reset();
+							throw;
+						}
 					}
-					else
 				#endif
-				{
-					try
-					{
-						PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(end_iterator.element_pointer++), std::forward<arguments>(parameters) ...);
-					}
-					catch (...)
-					{
-						clear();
-						throw;
-					}
-				}
 
 				++end_iterator.skipfield_pointer;
-				total_number_of_elements = 1;
+				total_size = 1;
 				return begin_iterator;
 			}
 		}
+
+
+
+		#ifdef PLF_CPP20_SUPPORT
+			iterator insert([[maybe_unused]] const_iterator &hint, element_type &&element)
+			{
+				return insert(std::forward<element_type &&>(element));
+			}
+		#endif
+	#endif
+
+
+
+	#ifdef PLF_VARIADICS_SUPPORT
+		template<typename... arguments>
+		iterator emplace(arguments &&... parameters) // The emplace function is near-identical to the regular insert function, with the exception of the element construction method, and change to is_nothrow tests.
+		{
+			if (end_iterator.element_pointer != NULL)
+			{
+				if (erasure_groups_head == NULL)
+				{
+					if (end_iterator.element_pointer != to_aligned_pointer(end_iterator.group_pointer->skipfield))
+					{
+						PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer, std::forward<arguments>(parameters) ...);
+
+						const iterator return_iterator = end_iterator;
+						++end_iterator.element_pointer;
+						++end_iterator.skipfield_pointer;
+						++(end_iterator.group_pointer->size);
+						++total_size;
+						return return_iterator;
+					}
+
+					group_pointer_type next_group;
+
+					if (unused_groups_head == NULL)
+					{
+						reset_group_numbers_if_necessary();
+						next_group = allocate_new_group(static_cast<skipfield_type>(std::min(total_size, static_cast<size_type>(max_block_capacity))), end_iterator.group_pointer);
+
+						#ifndef PLF_EXCEPTIONS_SUPPORT
+							PLF_CONSTRUCT_ELEMENT(next_group->elements, std::forward<arguments>(parameters) ...);
+						#else
+							#ifdef PLF_TYPE_TRAITS_SUPPORT
+								if PLF_CONSTEXPR (std::is_nothrow_constructible<element_type, arguments...>::value)
+								{
+									PLF_CONSTRUCT_ELEMENT(next_group->elements, std::forward<arguments>(parameters) ...);
+								}
+								else
+							#endif
+							{
+								try
+								{
+									PLF_CONSTRUCT_ELEMENT(next_group->elements, std::forward<arguments>(parameters) ...);
+								}
+								catch (...)
+								{
+									deallocate_group_remove_capacity(next_group);
+									throw;
+								}
+							}
+						#endif
+					}
+					else
+					{
+						PLF_CONSTRUCT_ELEMENT(unused_groups_head->elements, std::forward<arguments>(parameters) ...);
+						next_group = reuse_unused_group();
+					}
+
+					end_iterator.group_pointer->next_group = next_group;
+					end_iterator.group_pointer = next_group;
+					end_iterator.element_pointer = to_aligned_pointer(next_group->elements) + 1;
+					end_iterator.skipfield_pointer = next_group->skipfield + 1;
+					++total_size;
+
+					return iterator(next_group, to_aligned_pointer(next_group->elements), next_group->skipfield);
+				}
+				else
+				{
+					iterator new_location(erasure_groups_head, to_aligned_pointer(erasure_groups_head->elements) + erasure_groups_head->free_list_head, erasure_groups_head->skipfield + erasure_groups_head->free_list_head);
+
+					const skipfield_type prev_free_list_index = *pointer_cast<skipfield_pointer_type>(new_location.element_pointer);
+					PLF_CONSTRUCT_ELEMENT(new_location.element_pointer, std::forward<arguments>(parameters) ...);
+					update_skipblock(new_location, prev_free_list_index);
+
+					return new_location;
+				}
+			}
+			else
+			{
+				initialize(min_block_capacity);
+
+				#ifndef PLF_EXCEPTIONS_SUPPORT
+					PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer++, std::forward<arguments>(parameters) ...);
+				#else
+					#ifdef PLF_TYPE_TRAITS_SUPPORT
+						if PLF_CONSTEXPR (std::is_nothrow_constructible<element_type, arguments...>::value)
+						{
+							PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer++, std::forward<arguments>(parameters) ...);
+						}
+						else
+					#endif
+					{
+						try
+						{
+							PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer++, std::forward<arguments>(parameters) ...);
+						}
+						catch (...)
+						{
+							reset();
+							throw;
+						}
+					}
+				#endif
+
+				++end_iterator.skipfield_pointer;
+				total_size = 1;
+				return begin_iterator;
+			}
+		}
+
+
+
+		#ifdef PLF_CPP20_SUPPORT
+			template<typename... arguments>
+			iterator emplace_hint([[maybe_unused]] const_iterator &hint, arguments &&... parameters)
+			{
+				return emplace(std::forward<arguments>(parameters) ...);
+			}
+		#endif
 	#endif
 
 
@@ -1851,144 +1834,171 @@ public:
 
 private:
 
-	// Internal functions for fill insert:
-
-	void group_create(const skipfield_type number_of_elements)
+	// For catch blocks in fill() and range_fill()
+	void recover_from_partial_fill()
 	{
-		const group_pointer_type next_group = end_iterator.group_pointer->next_group = PLF_COLONY_ALLOCATE(group_allocator_type, group_allocator_pair, 1, end_iterator.group_pointer);
-
-		try
-		{
-			#ifdef PLF_COLONY_VARIADICS_SUPPORT
-				PLF_COLONY_CONSTRUCT(group_allocator_type, group_allocator_pair, next_group, number_of_elements, end_iterator.group_pointer);
-			#else
-				PLF_COLONY_CONSTRUCT(group_allocator_type, group_allocator_pair, next_group, group(number_of_elements, end_iterator.group_pointer));
+		#ifdef PLF_EXCEPTIONS_SUPPORT
+			#ifdef PLF_TYPE_TRAITS_SUPPORT
+				if PLF_CONSTEXPR ((!std::is_copy_constructible<element_type>::value && !std::is_nothrow_move_constructible<element_type>::value) || !std::is_nothrow_copy_constructible<element_type>::value) // to avoid unnecessary codegen, since this function will never be called if this line isn't true
 			#endif
-		}
-		catch (...)
-		{
-			PLF_COLONY_DESTROY(group_allocator_type, group_allocator_pair, next_group);
-			PLF_COLONY_DEALLOCATE(group_allocator_type, group_allocator_pair, next_group, 1);
-			end_iterator.group_pointer->next_group = NULL;
-			throw;
-		}
-
-		end_iterator.group_pointer = next_group;
-		end_iterator.element_pointer = next_group->elements;
-		next_group->number_of_elements = 0; // group constructor sets this to 1 by default to allow for faster insertion during insertion/emplace in other cases
-		total_capacity += number_of_elements;
+			{
+				const skipfield_type elements_constructed_before_exception = static_cast<skipfield_type>(end_iterator.element_pointer - to_aligned_pointer(end_iterator.group_pointer->elements));
+				end_iterator.group_pointer->size = elements_constructed_before_exception;
+				end_iterator.skipfield_pointer = end_iterator.group_pointer->skipfield + elements_constructed_before_exception;
+				total_size += elements_constructed_before_exception;
+				unused_groups_head = end_iterator.group_pointer->next_group;
+				end_iterator.group_pointer->next_group = NULL;
+			}
+		#endif
 	}
 
 
 
-	void group_fill(const element_type &element, const skipfield_type number_of_elements)
+	void fill(const element_type &element, const skipfield_type size)
 	{
-		#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-			if PLF_COLONY_CONSTEXPR (std::is_trivially_copyable<element_type>::value && std::is_trivially_copy_constructible<element_type>::value && std::is_nothrow_copy_constructible<element_type>::value) // ie. we can get away with using the cheaper fill_n here if there is no chance of an exception being thrown:
+		#ifdef PLF_TYPE_TRAITS_SUPPORT
+			if PLF_CONSTEXPR (std::is_nothrow_copy_constructible<element_type>::value)
 			{
-				#ifdef PLF_COLONY_ALIGNMENT_SUPPORT
-					if PLF_COLONY_CONSTEXPR (sizeof(aligned_element_type) == sizeof(element_type))
-					{
-						std::fill_n(reinterpret_cast<pointer>(end_iterator.element_pointer), number_of_elements, element);
-					}
-					else
-					{
-						alignas (sizeof(aligned_element_type)) element_type aligned_copy = element; // to avoid potentially violating memory boundaries in line below, create an initial copy object of same (but aligned) type
-						std::fill_n(end_iterator.element_pointer, number_of_elements, *(reinterpret_cast<aligned_pointer_type>(&aligned_copy)));
-					}
-				#else // type is not aligned to anything so is safe to use fill_n anyway:
-					std::fill_n(reinterpret_cast<pointer>(end_iterator.element_pointer), number_of_elements, element);
-				#endif
+				if PLF_CONSTEXPR (sizeof(aligned_element_struct) != sizeof(element_type))
+				{
+					alignas (alignof(aligned_element_struct)) element_type aligned_copy = element; // to avoid potentially violating memory boundaries in line below, create an initial object copy of same (but aligned) type
+					std::uninitialized_fill_n(end_iterator.element_pointer, size, *to_aligned_pointer(&aligned_copy));
+				}
+				else
+				{
+					std::uninitialized_fill_n(pointer_cast<pointer>(end_iterator.element_pointer), size, element);
+				}
 
-				end_iterator.element_pointer += number_of_elements;
+				end_iterator.element_pointer += size;
 			}
 			else
 		#endif
 		{
-			const aligned_pointer_type fill_end = end_iterator.element_pointer + number_of_elements;
+			const aligned_pointer_type fill_end = end_iterator.element_pointer + size;
 
 			do
 			{
-				try
-				{
-					PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(end_iterator.element_pointer++), element);
-				}
-				catch (...)
-				{
-					end_iterator.group_pointer->last_endpoint = --end_iterator.element_pointer;
-					const skipfield_type elements_constructed_before_exception = static_cast<skipfield_type>(end_iterator.element_pointer - end_iterator.group_pointer->elements);
-					end_iterator.group_pointer->number_of_elements = elements_constructed_before_exception;
-					end_iterator.skipfield_pointer = end_iterator.group_pointer->skipfield + elements_constructed_before_exception;
-					throw;
-				}
-			} while (end_iterator.element_pointer != fill_end);
+				#ifdef PLF_EXCEPTIONS_SUPPORT
+					try
+					{
+						PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer, element);
+					}
+					catch (...)
+					{
+						recover_from_partial_fill();
+						throw;
+					}
+				#else
+					PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer, element);
+				#endif
+			} while (++end_iterator.element_pointer != fill_end);
 		}
 
-		end_iterator.group_pointer->last_endpoint = end_iterator.element_pointer;
-		end_iterator.group_pointer->number_of_elements += number_of_elements;
+		total_size += size;
 	}
 
 
 
-	void fill_skipblock(const element_type &element, aligned_pointer_type const location, skipfield_pointer_type const skipfield_pointer, const skipfield_type number_of_elements)
+	// For catch blocks in range_fill_skipblock and fill_skipblock - update existing skipblock and free-list indexes to reflect partially-reused skipblock:
+	void recover_from_partial_skipblock_fill(const aligned_pointer_type location, const aligned_pointer_type current_location, const skipfield_pointer_type skipfield_pointer, const skipfield_type prev_free_list_node)
 	{
-		#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-			if PLF_COLONY_CONSTEXPR (std::is_trivially_copyable<element_type>::value && std::is_trivially_copy_constructible<element_type>::value && std::is_nothrow_copy_constructible<element_type>::value) // ie. we can get away with using the cheaper fill_n here if there is no chance of an exception being thrown:
+		#ifdef PLF_EXCEPTIONS_SUPPORT
+			#ifdef PLF_TYPE_TRAITS_SUPPORT
+				if PLF_CONSTEXPR ((!std::is_copy_constructible<element_type>::value && !std::is_nothrow_move_constructible<element_type>::value) || !std::is_nothrow_copy_constructible<element_type>::value) // to avoid unnecessary codegen
+			#endif
 			{
-				#ifdef PLF_COLONY_ALIGNMENT_SUPPORT
-					if PLF_COLONY_CONSTEXPR (sizeof(aligned_element_type) == sizeof(element_type))
-					{
-						std::fill_n(reinterpret_cast<pointer>(location), number_of_elements, element);
-					}
-					else
-					{
-						alignas (sizeof(aligned_element_type)) element_type aligned_copy = element; // to avoid potentially violating memory boundaries in line below, create an initial copy object of same (but aligned) type
-						std::fill_n(location, number_of_elements, *(reinterpret_cast<aligned_pointer_type>(&aligned_copy)));
-					}
-				#else // type is not aligned to anything so is safe to use fill_n anyway:
-					std::fill_n(reinterpret_cast<pointer>(location), number_of_elements, element);
-				#endif
+				const skipfield_type elements_constructed_before_exception = static_cast<skipfield_type>(current_location - location);
+				erasure_groups_head->size += elements_constructed_before_exception;
+				total_size += elements_constructed_before_exception;
+
+				// Update skipblock:
+				const skipfield_type new_start_node_value = *skipfield_pointer - elements_constructed_before_exception;
+				const skipfield_pointer_type new_start_node = skipfield_pointer + elements_constructed_before_exception;
+				std::memset(void_cast(skipfield_pointer), 0, elements_constructed_before_exception * sizeof(skipfield_type)); // Reset skipfield for elements written before exception
+				*new_start_node = *(new_start_node + new_start_node_value - 1) = new_start_node_value; // Create new skipblock for unused elements
+
+				// Update free list of erased elements:
+				edit_free_list_head(location + elements_constructed_before_exception, prev_free_list_node);
+
+				const skipfield_type new_skipblock_head_index = static_cast<skipfield_type>(current_location - to_aligned_pointer(erasure_groups_head->elements));
+				erasure_groups_head->free_list_head = new_skipblock_head_index;
+
+				if (prev_free_list_node != std::numeric_limits<skipfield_type>::max())
+				{
+					edit_free_list_next(to_aligned_pointer(erasure_groups_head->elements) + prev_free_list_node, new_skipblock_head_index);
+				}
+			}
+		#endif
+	}
+
+
+
+	void fill_skipblock(const element_type &element, const aligned_pointer_type location, const skipfield_pointer_type skipfield_pointer, const skipfield_type size)
+	{
+		#ifdef PLF_TYPE_TRAITS_SUPPORT
+			if PLF_CONSTEXPR (std::is_nothrow_copy_constructible<element_type>::value)
+			{
+				if PLF_CONSTEXPR (sizeof(aligned_element_struct) != sizeof(element_type))
+				{
+					alignas (alignof(aligned_element_struct)) element_type aligned_copy = element;
+					std::uninitialized_fill_n(location, size, *to_aligned_pointer(&aligned_copy));
+				}
+				else
+				{
+					std::uninitialized_fill_n(pointer_cast<pointer>(location), size, element);
+				}
 			}
 			else
 		#endif
 		{
-			const skipfield_type prev_free_list_node = *(reinterpret_cast<skipfield_pointer_type>(location)); // in case of exception, grabbing indexes before free_list node is reused
-			const aligned_pointer_type fill_end = location + number_of_elements;
+			const aligned_pointer_type fill_end = location + size;
+			#ifdef PLF_EXCEPTIONS_SUPPORT
+				const skipfield_type prev_free_list_node = *pointer_cast<skipfield_pointer_type>(location); // in case of exception, grabbing indexes before free_list node is reused
+			#endif
 
 			for (aligned_pointer_type current_location = location; current_location != fill_end; ++current_location)
 			{
-				try
-				{
-					PLF_COLONY_CONSTRUCT(element_allocator_type, (*this), reinterpret_cast<pointer>(current_location), element);
-				}
-				catch (...)
-				{
-					// Reconstruct existing skipblock and free-list indexes to reflect partially-reused skipblock:
-					const skipfield_type elements_constructed_before_exception = static_cast<skipfield_type>((current_location - 1) - location);
-					groups_with_erasures_list_head->number_of_elements += elements_constructed_before_exception;
-					total_number_of_elements += elements_constructed_before_exception;
-
-					std::memset(skipfield_pointer, 0, elements_constructed_before_exception * sizeof(skipfield_type));
-
-					*(reinterpret_cast<skipfield_pointer_type>(location + elements_constructed_before_exception)) = prev_free_list_node;
-					*(reinterpret_cast<skipfield_pointer_type>(location + elements_constructed_before_exception) + 1) = std::numeric_limits<skipfield_type>::max();
-
-					const skipfield_type new_skipblock_head_index = static_cast<skipfield_type>(location - groups_with_erasures_list_head->elements) + elements_constructed_before_exception;
-					groups_with_erasures_list_head->free_list_head = new_skipblock_head_index;
-
-					if (prev_free_list_node != std::numeric_limits<skipfield_type>::max())
+				#ifdef PLF_EXCEPTIONS_SUPPORT
+					try
 					{
-						*(reinterpret_cast<skipfield_pointer_type>(groups_with_erasures_list_head->elements + prev_free_list_node) + 1) = new_skipblock_head_index;
+						PLF_CONSTRUCT_ELEMENT(current_location, element);
 					}
-
-					throw;
-				}
+					catch (...)
+					{
+						recover_from_partial_skipblock_fill(location, current_location, skipfield_pointer, prev_free_list_node);
+						throw;
+					}
+				#else
+					PLF_CONSTRUCT_ELEMENT(current_location, element);
+				#endif
 			}
 		}
 
-		std::memset(skipfield_pointer, 0, number_of_elements * sizeof(skipfield_type)); // reset skipfield nodes within skipblock to 0
-		groups_with_erasures_list_head->number_of_elements += number_of_elements;
-		total_number_of_elements += number_of_elements;
+		std::memset(void_cast(skipfield_pointer), 0, size * sizeof(skipfield_type)); // reset skipfield nodes within skipblock to 0
+		erasure_groups_head->size += size;
+		total_size += size;
+	}
+
+
+
+	void fill_unused_groups(size_type size, const element_type &element, size_type group_number, group_pointer_type previous_group, const group_pointer_type current_group)
+	{
+		for (end_iterator.group_pointer = current_group; end_iterator.group_pointer->capacity < size; end_iterator.group_pointer = end_iterator.group_pointer->next_group)
+		{
+			const skipfield_type capacity = end_iterator.group_pointer->capacity;
+			end_iterator.group_pointer->reset(capacity, end_iterator.group_pointer->next_group, previous_group, group_number++);
+			previous_group = end_iterator.group_pointer;
+			size -= static_cast<size_type>(capacity);
+			end_iterator.element_pointer = to_aligned_pointer(end_iterator.group_pointer->elements);
+			fill(element, capacity);
+		}
+
+		// Deal with final group (partial fill)
+		unused_groups_head = end_iterator.group_pointer->next_group;
+		end_iterator.group_pointer->reset(static_cast<skipfield_type>(size), NULL, previous_group, group_number);
+		end_iterator.element_pointer = to_aligned_pointer(end_iterator.group_pointer->elements);
+		end_iterator.skipfield_pointer = end_iterator.group_pointer->skipfield + size;
+		fill(element, static_cast<skipfield_type>(size));
 	}
 
 
@@ -1997,161 +2007,432 @@ public:
 
 	// Fill insert
 
-	void insert(size_type number_of_elements, const element_type &element)
+	void insert(size_type size, const element_type &element)
 	{
-		if (number_of_elements == 0)
+		if (size == 0)
 		{
 			return;
 		}
-		else if (number_of_elements == 1)
+		else if (size == 1)
 		{
 			insert(element);
 			return;
 		}
 
-		if (begin_iterator.group_pointer == NULL) // Empty colony, no groups created yet
+		if (total_size == 0)
 		{
-			initialize((number_of_elements > group_allocator_pair.max_elements_per_group) ? group_allocator_pair.max_elements_per_group : (number_of_elements < pointer_allocator_pair.min_elements_per_group) ? pointer_allocator_pair.min_elements_per_group : static_cast<skipfield_type>(number_of_elements)); // Construct first group
-			begin_iterator.group_pointer->number_of_elements = 0;
-		}
-
-		if (total_number_of_elements != 0) // ie. not an uninitialized colony or a situation where reserve has been called
-		{
-			// Use up erased locations if available:
-			if (groups_with_erasures_list_head != NULL)
-			{
-				do // skipblock loop: breaks when group is exhausted of reusable skipblocks, or returns if number_of_elements == 0
-				{
-					aligned_pointer_type const element_pointer = groups_with_erasures_list_head->elements + groups_with_erasures_list_head->free_list_head;
-					skipfield_pointer_type const skipfield_pointer = groups_with_erasures_list_head->skipfield + groups_with_erasures_list_head->free_list_head;
-					const skipfield_type skipblock_size = *skipfield_pointer;
-
-					if (groups_with_erasures_list_head == begin_iterator.group_pointer && element_pointer < begin_iterator.element_pointer)
-					{
-						begin_iterator.element_pointer = element_pointer;
-						begin_iterator.skipfield_pointer = skipfield_pointer;
-					}
-
-					if (skipblock_size <= number_of_elements)
-					{
-						groups_with_erasures_list_head->free_list_head = *(reinterpret_cast<skipfield_pointer_type>(element_pointer)); // set free list head to previous free list node
-						fill_skipblock(element, element_pointer, skipfield_pointer, skipblock_size);
-						number_of_elements -= skipblock_size;
-
-						if (groups_with_erasures_list_head->free_list_head != std::numeric_limits<skipfield_type>::max())
-						{
-							*(reinterpret_cast<skipfield_pointer_type>(groups_with_erasures_list_head->elements + groups_with_erasures_list_head->free_list_head) + 1) = std::numeric_limits<skipfield_type>::max(); // set 'next' index of new free list head to 'end' (numeric max)
-						}
-						else
-						{
-							groups_with_erasures_list_head = groups_with_erasures_list_head->erasures_list_next_group; // change groups
-
-							if (groups_with_erasures_list_head == NULL)
-							{
-								break;
-							}
-						}
-					}
-					else // skipblock is larger than remaining number of elements
-					{
-						const skipfield_type prev_index = *(reinterpret_cast<skipfield_pointer_type>(element_pointer)); // save before element location is overwritten
-						fill_skipblock(element, element_pointer, skipfield_pointer, static_cast<skipfield_type>(number_of_elements));
-						const skipfield_type new_skipblock_size = static_cast<skipfield_type>(skipblock_size - number_of_elements);
-
-						// Update skipfield (earlier nodes already memset'd in fill_skipblock function):
-						*(skipfield_pointer + number_of_elements) = new_skipblock_size;
-						*(skipfield_pointer + skipblock_size - 1) = new_skipblock_size;
-						groups_with_erasures_list_head->free_list_head += static_cast<skipfield_type>(number_of_elements); // set free list head to new start node
-
-						// Update free list with new head:
-						*(reinterpret_cast<skipfield_pointer_type>(element_pointer + number_of_elements)) = prev_index;
-						*(reinterpret_cast<skipfield_pointer_type>(element_pointer + number_of_elements) + 1) = std::numeric_limits<skipfield_type>::max();
-
-						if (prev_index != std::numeric_limits<skipfield_type>::max())
-						{
-							*(reinterpret_cast<skipfield_pointer_type>(groups_with_erasures_list_head->elements + prev_index) + 1) = groups_with_erasures_list_head->free_list_head; // set 'next' index of previous skipblock to new start of skipblock
-						}
-
-						return;
-					}
-				} while(number_of_elements != 0);
-			}
-
-
-			// Use up remaining available element locations in end group:
-			const skipfield_type group_remainder = (static_cast<skipfield_type>(reinterpret_cast<aligned_pointer_type>(end_iterator.group_pointer->skipfield) - end_iterator.element_pointer) > number_of_elements) ? static_cast<skipfield_type>(number_of_elements) : static_cast<skipfield_type>(reinterpret_cast<aligned_pointer_type>(end_iterator.group_pointer->skipfield) - end_iterator.element_pointer);
-
-			if (group_remainder != 0)
-			{
-				group_fill(element, group_remainder);
-				total_number_of_elements += group_remainder;
-				number_of_elements -= group_remainder;
-			}
-		}
-		else if (end_iterator.group_pointer->capacity >= number_of_elements)
-		{
-			group_fill(element, static_cast<skipfield_type>(number_of_elements));
-			end_iterator.skipfield_pointer = end_iterator.group_pointer->skipfield + number_of_elements;
-			total_number_of_elements = number_of_elements;
+			prepare_groups_for_assign(size);
+			fill_unused_groups(size, element, 0, NULL, begin_iterator.group_pointer);
 			return;
 		}
-		else
+
+		reserve(total_size + size);
+
+		// Use up erased locations if available:
+		while(erasure_groups_head != NULL) // skipblock loop: breaks when colony is exhausted of reusable skipblocks, or returns if size == 0
 		{
-			group_fill(element, end_iterator.group_pointer->capacity);
-			total_number_of_elements = end_iterator.group_pointer->capacity;
-			number_of_elements -= end_iterator.group_pointer->capacity;
-		}
+			const aligned_pointer_type element_pointer = to_aligned_pointer(erasure_groups_head->elements) + erasure_groups_head->free_list_head;
+			const skipfield_pointer_type skipfield_pointer = erasure_groups_head->skipfield + erasure_groups_head->free_list_head;
+			const skipfield_type skipblock_size = *skipfield_pointer;
 
-
-		// If there's some elements left that need to be created, create new groups and fill:
-		if (number_of_elements > group_allocator_pair.max_elements_per_group)
-		{
-			size_type multiples = (number_of_elements / static_cast<size_type>(group_allocator_pair.max_elements_per_group));
-			const skipfield_type element_remainder = static_cast<skipfield_type>(number_of_elements - (multiples * static_cast<size_type>(group_allocator_pair.max_elements_per_group)));
-
-			while (multiples-- != 0)
+			if (erasure_groups_head == begin_iterator.group_pointer && element_pointer < begin_iterator.element_pointer)
 			{
-				group_create(group_allocator_pair.max_elements_per_group);
-				group_fill(element, group_allocator_pair.max_elements_per_group);
+				begin_iterator.element_pointer = element_pointer;
+				begin_iterator.skipfield_pointer = skipfield_pointer;
 			}
 
-			if (element_remainder != 0)
+			if (skipblock_size <= size)
 			{
-				group_create(group_allocator_pair.max_elements_per_group);
-				group_fill(element, element_remainder);
+				erasure_groups_head->free_list_head = *pointer_cast<skipfield_pointer_type>(element_pointer); // set free list head to previous free list node
+				fill_skipblock(element, element_pointer, skipfield_pointer, skipblock_size);
+				size -= skipblock_size;
+
+				if (erasure_groups_head->free_list_head != std::numeric_limits<skipfield_type>::max()) // ie. there are more skipblocks to be filled in this group
+				{
+					edit_free_list_next(to_aligned_pointer(erasure_groups_head->elements) + erasure_groups_head->free_list_head, std::numeric_limits<skipfield_type>::max()); // set 'next' index of new free list head to 'end' (numeric max)
+				}
+				else
+				{
+					erasure_groups_head = erasure_groups_head->erasures_list_next_group; // change groups
+				}
+
+				if (size == 0) return;
+			}
+			else // skipblock is larger than remaining number of elements
+			{
+				const skipfield_type prev_index = *pointer_cast<skipfield_pointer_type>(element_pointer); // save before element location is overwritten
+				fill_skipblock(element, element_pointer, skipfield_pointer, static_cast<skipfield_type>(size));
+				const skipfield_type new_skipblock_size = static_cast<skipfield_type>(skipblock_size - size);
+
+				// Update skipfield (earlier nodes already memset'd in fill_skipblock function):
+				*(skipfield_pointer + size) = new_skipblock_size;
+				*(skipfield_pointer + skipblock_size - 1) = new_skipblock_size;
+				erasure_groups_head->free_list_head += static_cast<skipfield_type>(size); // set free list head to new start node
+
+				// Update free list with new head:
+				edit_free_list_head(element_pointer + size, prev_index);
+
+				if (prev_index != std::numeric_limits<skipfield_type>::max())
+				{
+					edit_free_list_next(to_aligned_pointer(erasure_groups_head->elements) + prev_index,  erasure_groups_head->free_list_head); // set 'next' index of previous skipblock to new start of skipblock
+				}
+
+				return;
 			}
 		}
-		else if (number_of_elements != 0)
+
+
+		// Use up remaining available element locations in end group:
+		// This variable is either the remaining capacity of the group or the number of elements yet to be inserted, whichever is smaller:
+		const skipfield_type group_remainder = static_cast<skipfield_type>(std::min(static_cast<size_type>(to_aligned_pointer(end_iterator.group_pointer->skipfield) - end_iterator.element_pointer), size));
+
+		if (group_remainder != 0)
 		{
-			group_create(static_cast<skipfield_type>((number_of_elements > total_number_of_elements) ? number_of_elements : total_number_of_elements));
-			group_fill(element, static_cast<skipfield_type>(number_of_elements));
+			fill(element, group_remainder);
+			end_iterator.group_pointer->size += group_remainder;
+
+			if (size == group_remainder) // ie. remaining capacity was >= remaining elements to be filled
+			{
+				end_iterator.skipfield_pointer = end_iterator.group_pointer->skipfield + end_iterator.group_pointer->size;
+				return;
+			}
+
+			size -= group_remainder;
 		}
 
-		total_number_of_elements += number_of_elements; // Adds the remainder from the last if-block - the insert functions in the first if/else block will already have incremented total_number_of_elements
-		end_iterator.skipfield_pointer = end_iterator.group_pointer->skipfield + (end_iterator.element_pointer - end_iterator.group_pointer->elements);
+
+		// Use unused groups:
+		end_iterator.group_pointer->next_group = unused_groups_head;
+
+		if ((std::numeric_limits<size_type>::max() - end_iterator.group_pointer->group_number) < size)
+		#ifdef PLF_CPP20_SUPPORT
+			[[unlikely]]
+		#endif
+		{
+			reset_group_numbers();
+		}
+
+		fill_unused_groups(size, element, end_iterator.group_pointer->group_number + 1u, end_iterator.group_pointer, unused_groups_head);
 	}
 
 
 
-	// Range insert
+private:
 
 	template <class iterator_type>
-	inline void insert (typename plf_enable_if_c<!std::numeric_limits<iterator_type>::is_integer, iterator_type>::type first, const iterator_type last)
+	void range_fill(iterator_type &it, const skipfield_type size)
 	{
-		while (first != last)
+		const aligned_pointer_type fill_end = end_iterator.element_pointer + size;
+
+		#ifdef PLF_TYPE_TRAITS_SUPPORT
+			if PLF_CONSTEXPR (std::is_nothrow_copy_constructible<element_type>::value)
+			{
+				do
+				{
+					PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer, *it++);
+				} while (++end_iterator.element_pointer != fill_end);
+			}
+			#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+				else if PLF_CONSTEXPR (std::is_nothrow_move_constructible<element_type>::value && !std::is_copy_constructible<element_type>::value)
+				{
+					do
+					{
+						PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer, std::move(*it++));
+					} while (++end_iterator.element_pointer != fill_end);
+				}
+			#endif
+			else
+		#endif
 		{
-			insert(*first++);
+			do
+			{
+				#ifdef PLF_EXCEPTIONS_SUPPORT
+					try
+					{
+				#endif
+					#ifdef PLF_TYPE_TRAITS_SUPPORT
+						if PLF_CONSTEXPR (!std::is_copy_constructible<element_type>::value)
+						{
+							PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer, std::move(*it++));
+						}
+						else
+					#endif
+						PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer, *it++);
+				#ifdef PLF_EXCEPTIONS_SUPPORT
+					}
+					catch (...)
+					{
+						recover_from_partial_fill();
+						throw;
+					}
+				#endif
+			} while (++end_iterator.element_pointer != fill_end);
 		}
+
+		total_size += size;
 	}
 
 
 
-	// Initializer-list insert
+	template <class iterator_type>
+	void range_fill_skipblock(iterator_type &it, const aligned_pointer_type location, const skipfield_pointer_type skipfield_pointer, const skipfield_type size)
+	{
+		const aligned_pointer_type fill_end = location + size;
 
-	#ifdef PLF_COLONY_INITIALIZER_LIST_SUPPORT
-		inline void insert (const std::initializer_list<element_type> &element_list)
-		{ // use range insert:
-			insert(element_list.begin(), element_list.end());
+		#ifdef PLF_TYPE_TRAITS_SUPPORT
+			if PLF_CONSTEXPR (std::is_nothrow_copy_constructible<element_type>::value)
+			{
+				for (aligned_pointer_type current_location = location; current_location != fill_end; ++current_location)
+				{
+					PLF_CONSTRUCT_ELEMENT(current_location, *it++);
+				}
+			}
+			#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+				else if PLF_CONSTEXPR (std::is_nothrow_move_constructible<element_type>::value && !std::is_copy_constructible<element_type>::value)
+				{
+					for (aligned_pointer_type current_location = location; current_location != fill_end; ++current_location)
+					{
+						PLF_CONSTRUCT_ELEMENT(current_location, std::move(*it++));
+					}
+				}
+			#endif
+			else
+		#endif
+		{
+			#ifdef PLF_EXCEPTIONS_SUPPORT
+				const skipfield_type prev_free_list_node = *pointer_cast<skipfield_pointer_type>(location); // in case of exception, grabbing indexes before free_list node is reused
+			#endif
+
+			for (aligned_pointer_type current_location = location; current_location != fill_end; ++current_location)
+			{
+				#ifdef PLF_EXCEPTIONS_SUPPORT
+					try
+					{
+				#endif
+					#ifdef PLF_TYPE_TRAITS_SUPPORT
+						if PLF_CONSTEXPR (!std::is_copy_constructible<element_type>::value)
+						{
+							PLF_CONSTRUCT_ELEMENT(current_location, std::move(*it++));
+						}
+						else
+					#endif
+					PLF_CONSTRUCT_ELEMENT(current_location, *it++);
+				#ifdef PLF_EXCEPTIONS_SUPPORT
+					}
+					catch (...)
+					{
+						recover_from_partial_skipblock_fill(location, current_location, skipfield_pointer, prev_free_list_node);
+						throw;
+					}
+				#endif
+			}
+		}
+
+		std::memset(void_cast(skipfield_pointer), 0, size * sizeof(skipfield_type)); // reset skipfield nodes within skipblock to 0
+		erasure_groups_head->size += size;
+		total_size += size;
+	}
+
+
+
+	template <class iterator_type>
+	void range_fill_unused_groups(size_type size, iterator_type it, size_type group_number, group_pointer_type previous_group, const group_pointer_type current_group)
+	{
+		for (end_iterator.group_pointer = current_group; end_iterator.group_pointer->capacity < size; end_iterator.group_pointer = end_iterator.group_pointer->next_group)
+		{
+			const skipfield_type capacity = end_iterator.group_pointer->capacity;
+			end_iterator.group_pointer->reset(capacity, end_iterator.group_pointer->next_group, previous_group, group_number++);
+			previous_group = end_iterator.group_pointer;
+			size -= static_cast<size_type>(capacity);
+			end_iterator.element_pointer = to_aligned_pointer(end_iterator.group_pointer->elements);
+			range_fill(it, capacity);
+		}
+
+		// Deal with final group (partial fill)
+		unused_groups_head = end_iterator.group_pointer->next_group;
+		end_iterator.group_pointer->reset(static_cast<skipfield_type>(size), NULL, previous_group, group_number);
+		end_iterator.element_pointer = to_aligned_pointer(end_iterator.group_pointer->elements);
+		end_iterator.skipfield_pointer = end_iterator.group_pointer->skipfield + size;
+		range_fill(it, static_cast<skipfield_type>(size));
+	}
+
+
+
+	template <class iterator_type>
+	void range_insert (iterator_type it, size_type size) // this is near-identical to the fill insert, with the only alteration being incrementing an iterator for construction, rather than using a const element. And the fill etc function calls are changed to range_fill to match this pattern. See fill insert for code explanations
+	{
+		if (size == 0)
+		{
+			return;
+		}
+		else if (size == 1)
+		{
+			insert(*it);
+			return;
+		}
+
+		if (total_size == 0)
+		{
+			prepare_groups_for_assign(size);
+			range_fill_unused_groups(size, it, 0, NULL, begin_iterator.group_pointer);
+			return;
+		}
+
+		reserve(total_size + size);
+
+		while(erasure_groups_head != NULL)
+		{
+			const aligned_pointer_type element_pointer = to_aligned_pointer(erasure_groups_head->elements) + erasure_groups_head->free_list_head;
+			const skipfield_pointer_type skipfield_pointer = erasure_groups_head->skipfield + erasure_groups_head->free_list_head;
+			const skipfield_type skipblock_size = *skipfield_pointer;
+
+			if (erasure_groups_head == begin_iterator.group_pointer && element_pointer < begin_iterator.element_pointer)
+			{
+				begin_iterator.element_pointer = element_pointer;
+				begin_iterator.skipfield_pointer = skipfield_pointer;
+			}
+
+			if (skipblock_size <= size)
+			{
+				erasure_groups_head->free_list_head = *pointer_cast<skipfield_pointer_type>(element_pointer);
+				range_fill_skipblock(it, element_pointer, skipfield_pointer, skipblock_size);
+				size -= skipblock_size;
+
+				if (erasure_groups_head->free_list_head != std::numeric_limits<skipfield_type>::max())
+				{
+					edit_free_list_next(to_aligned_pointer(erasure_groups_head->elements) + erasure_groups_head->free_list_head, std::numeric_limits<skipfield_type>::max());
+				}
+				else
+				{
+					erasure_groups_head = erasure_groups_head->erasures_list_next_group;
+				}
+
+				if (size == 0) return;
+			}
+			else
+			{
+				const skipfield_type prev_index = *pointer_cast<skipfield_pointer_type>(element_pointer);
+				range_fill_skipblock(it, element_pointer, skipfield_pointer, static_cast<skipfield_type>(size));
+				const skipfield_type new_skipblock_size = static_cast<skipfield_type>(skipblock_size - size);
+
+				*(skipfield_pointer + size) = new_skipblock_size;
+				*(skipfield_pointer + skipblock_size - 1) = new_skipblock_size;
+				erasure_groups_head->free_list_head += static_cast<skipfield_type>(size);
+				edit_free_list_head(element_pointer + size, prev_index);
+
+				if (prev_index != std::numeric_limits<skipfield_type>::max())
+				{
+					edit_free_list_next(to_aligned_pointer(erasure_groups_head->elements) + prev_index, erasure_groups_head->free_list_head);
+				}
+
+				return;
+			}
+		}
+
+		const skipfield_type group_remainder = static_cast<skipfield_type>(std::min(static_cast<size_type>(to_aligned_pointer(end_iterator.group_pointer->skipfield) - end_iterator.element_pointer), size));
+
+		if (group_remainder != 0)
+		{
+			range_fill(it, group_remainder);
+			end_iterator.group_pointer->size += group_remainder;
+
+			if (size == group_remainder)
+			{
+				end_iterator.skipfield_pointer = end_iterator.group_pointer->skipfield + end_iterator.group_pointer->size;
+				return;
+			}
+
+			size -= group_remainder;
+		}
+
+
+		end_iterator.group_pointer->next_group = unused_groups_head;
+
+		if ((std::numeric_limits<size_type>::max() - end_iterator.group_pointer->group_number) < size)
+		#ifdef PLF_CPP20_SUPPORT
+			[[unlikely]]
+		#endif
+		{
+			reset_group_numbers();
+		}
+
+		range_fill_unused_groups(size, it, end_iterator.group_pointer->group_number + 1u, end_iterator.group_pointer, unused_groups_head);
+	}
+
+
+
+public:
+
+	// Range insert:
+
+	template <class iterator_type>
+	void insert (const typename plf::enable_if<!std::numeric_limits<iterator_type>::is_integer, iterator_type>::type first, const iterator_type last)
+	{
+		range_insert(first, static_cast<size_type>(std::distance(first, last)));
+	}
+
+
+
+	template <class iterator_type>
+	void insert (const iterator &first, const iterator &last)
+	{
+		range_insert(first, static_cast<size_type>(first.distance(last)));
+	}
+
+
+
+	template <class iterator_type>
+	void insert (const const_iterator &first, const const_iterator &last)
+	{
+		range_insert(first, static_cast<size_type>(first.distance(last)));
+	}
+
+
+
+	template <class iterator_type>
+	void insert (const reverse_iterator &first, const reverse_iterator &last)
+	{
+		range_insert(first, static_cast<size_type>(first.distance(last)));
+	}
+
+
+
+	template <class iterator_type>
+	void insert (const const_reverse_iterator &first, const const_reverse_iterator &last)
+	{
+		range_insert(first, static_cast<size_type>(first.distance(last)));
+	}
+
+
+
+	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+		// Range insert, move_iterator overload:
+
+		template <class iterator_type>
+		void insert (const std::move_iterator<iterator_type> first, const std::move_iterator<iterator_type> last)
+		{
+			range_insert(first, static_cast<size_type>(std::distance(first.base(), last.base())));
+		}
+	#endif
+
+
+
+	#ifdef PLF_INITIALIZER_LIST_SUPPORT
+		// Initializer-list insert:
+
+		void insert (const std::initializer_list<element_type> &element_list)
+		{
+			range_insert(element_list.begin(), static_cast<size_type>(element_list.size()));
+		}
+	#endif
+
+
+
+	#ifdef PLF_CPP20_SUPPORT
+		template<compatible_range<element_type> range_type>
+		void insert_range(range_type &&the_range)
+		{
+			range_insert(std::ranges::begin(the_range), static_cast<size_type>(std::ranges::distance(the_range)));
 		}
 	#endif
 
@@ -2159,422 +2440,436 @@ public:
 
 private:
 
-	inline PLF_COLONY_FORCE_INLINE void update_subsequent_group_numbers(group_pointer_type current_group) PLF_COLONY_NOEXCEPT
+
+	void add_to_groups_with_erasures_list(const group_pointer_type group_to_add) PLF_NOEXCEPT
 	{
-		do
+		group_to_add->erasures_list_next_group = erasure_groups_head;
+
+		if (erasure_groups_head != NULL)
 		{
-			--(current_group->group_number);
-			current_group = current_group->next_group;
-		} while (current_group != NULL);
+			erasure_groups_head->erasures_list_previous_group = group_to_add;
+		}
+
+		erasure_groups_head = group_to_add;
 	}
 
 
 
-	inline PLF_COLONY_FORCE_INLINE void consolidate() // get all elements contiguous in memory and shrink to fit, remove erasures and erasure free lists
+	void remove_from_groups_with_erasures_list(const group_pointer_type group_to_remove) PLF_NOEXCEPT
 	{
-		#ifdef PLF_COLONY_MOVE_SEMANTICS_SUPPORT
-			colony temp;
-			temp.change_group_sizes(static_cast<skipfield_type>((pointer_allocator_pair.min_elements_per_group > total_number_of_elements) ? pointer_allocator_pair.min_elements_per_group : ((total_number_of_elements > group_allocator_pair.max_elements_per_group) ? group_allocator_pair.max_elements_per_group : total_number_of_elements)), group_allocator_pair.max_elements_per_group); // Make first allocated group as large total number of elements, where possible
+		if (group_to_remove != erasure_groups_head)
+		{
+			group_to_remove->erasures_list_previous_group->erasures_list_next_group = group_to_remove->erasures_list_next_group;
 
-			#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-				if PLF_COLONY_CONSTEXPR (std::is_move_assignable<element_type>::value && std::is_move_constructible<element_type>::value)
+			if (group_to_remove->erasures_list_next_group != NULL)
+			{
+				group_to_remove->erasures_list_next_group->erasures_list_previous_group = group_to_remove->erasures_list_previous_group;
+			}
+		}
+		else
+		{
+			erasure_groups_head = erasure_groups_head->erasures_list_next_group;
+		}
+	}
+
+
+
+	void reset_only_group_left(const group_pointer_type group_pointer) PLF_NOEXCEPT
+	{
+		erasure_groups_head = NULL;
+		group_pointer->reset(0, NULL, NULL, 0);
+
+		// Reset begin and end iterators:
+		end_iterator.element_pointer = begin_iterator.element_pointer = to_aligned_pointer(group_pointer->elements);
+		end_iterator.skipfield_pointer = begin_iterator.skipfield_pointer = group_pointer->skipfield;
+	}
+
+
+
+	void add_to_unused_groups_list(const group_pointer_type group_pointer) PLF_NOEXCEPT
+	{
+		group_pointer->next_group = unused_groups_head;
+		unused_groups_head = group_pointer;
+	}
+
+
+
+
+public:
+
+	iterator erase(const const_iterator &it) // if uninitialized/invalid iterator supplied, function could generate an exception
+	{
+		assert(total_size != 0);
+		assert(it.group_pointer != NULL); // ie. not uninitialized iterator
+		assert(it.element_pointer != end_iterator.element_pointer); // ie. != end()
+		assert(*(it.skipfield_pointer) == 0); // ie. element pointed to by iterator has not been erased previously
+
+		#ifdef PLF_TYPE_TRAITS_SUPPORT
+			if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value) // Avoid the function call if possible
+		#endif
+		destroy_element(it.element_pointer);
+		--total_size;
+
+		if (--(it.group_pointer->size) != 0) // ie. non-empty group at this point in time, don't consolidate
+		{
+			// Code logic for following section:
+			// ---------------------------------
+			// If current skipfield node has no skipblock on either side, create new skipblock of size 1
+			// If node only has skipblock on left, set current node and start node of the skipblock to left node value + 1.
+			// If node only has skipblock on right, make this node the start node of the skipblock and update end node
+			// If node has skipblocks on left and right, set start node of left skipblock and end node of right skipblock to the values of the left + right nodes + 1
+
+			// Optimization explanation:
+			// The contextual logic below is the same as that in the insert() functions but in this case the value of the current skipfield node will always be
+			// zero (since it is not yet erased), meaning no additional manipulations are necessary for the previous skipfield node comparison - we only have to check against zero
+			const char prev_skipfield = *(it.skipfield_pointer - (it.skipfield_pointer != it.group_pointer->skipfield)) != 0; // true if previous node is erased or this node is at beginning of skipfield
+			const char after_skipfield = *(it.skipfield_pointer + 1) != 0;  // NOTE: boundary test (checking against end-of-elements) is able to be skipped due to the extra skipfield node (compared to element field) - which is present to enable faster iterator operator ++ operations
+			skipfield_type update_value = 1;
+
+			if (!(prev_skipfield | after_skipfield)) // no consecutive erased elements
+			{
+				*it.skipfield_pointer = 1; // solo skipped node
+				const skipfield_type index = static_cast<skipfield_type>(it.element_pointer - to_aligned_pointer(it.group_pointer->elements));
+
+				if (it.group_pointer->free_list_head != std::numeric_limits<skipfield_type>::max()) // ie. if this group already has some erased elements
 				{
-					temp.insert(std::make_move_iterator(begin_iterator), std::make_move_iterator(end_iterator));
+					edit_free_list_next(to_aligned_pointer(it.group_pointer->elements) + it.group_pointer->free_list_head, index); // set prev free list head's 'next index' number to the index of the current element
 				}
 				else
-			#endif
+				{
+					add_to_groups_with_erasures_list(it.group_pointer);
+				}
+
+				edit_free_list_head(it.element_pointer, it.group_pointer->free_list_head);
+				it.group_pointer->free_list_head = index;
+			}
+			else if (prev_skipfield & (!after_skipfield)) // previous erased consecutive elements, none following
 			{
-				temp.insert(begin_iterator, end_iterator);
+				*(it.skipfield_pointer - *(it.skipfield_pointer - 1)) = *it.skipfield_pointer = static_cast<skipfield_type>(*(it.skipfield_pointer - 1) + 1);
+			}
+			else if ((!prev_skipfield) & after_skipfield) // following erased consecutive elements, none preceding
+			{
+				const skipfield_type following_value = static_cast<skipfield_type>(*(it.skipfield_pointer + 1) + 1);
+				*(it.skipfield_pointer + following_value - 1) = *(it.skipfield_pointer) = following_value;
+
+				const skipfield_type following_previous = *(pointer_cast<skipfield_pointer_type>(it.element_pointer + 1));
+				const skipfield_type following_next = *(pointer_cast<skipfield_pointer_type>(it.element_pointer + 1) + 1);
+				edit_free_list_prev(it.element_pointer, following_previous);
+				edit_free_list_next(it.element_pointer, following_next);
+
+				const skipfield_type index = static_cast<skipfield_type>(it.element_pointer - to_aligned_pointer(it.group_pointer->elements));
+
+				if (following_previous != std::numeric_limits<skipfield_type>::max())
+				{
+					edit_free_list_next(to_aligned_pointer(it.group_pointer->elements) + following_previous, index); // Set next index of previous free list node to this node's 'next' index
+				}
+
+				if (following_next != std::numeric_limits<skipfield_type>::max())
+				{
+					edit_free_list_prev(to_aligned_pointer(it.group_pointer->elements) + following_next, index);	// Set previous index of next free list node to this node's 'previous' index
+				}
+				else
+				{
+					it.group_pointer->free_list_head = index;
+				}
+
+				update_value = following_value;
+			}
+			else // both preceding and following consecutive erased elements - erased element is between two skipblocks
+			{
+				*(it.skipfield_pointer) = 1; // This line necessary in order for get_iterator() to work - ensures that erased element skipfield nodes are always non-zero
+				const skipfield_type preceding_value = *(it.skipfield_pointer - 1);
+				const skipfield_type following_value = static_cast<skipfield_type>(*(it.skipfield_pointer + 1) + 1);
+
+				// Join the skipblocks
+				*(it.skipfield_pointer - preceding_value) = *(it.skipfield_pointer + following_value - 1) = static_cast<skipfield_type>(preceding_value + following_value);
+
+				// Remove the following skipblock's entry from the free list
+				const skipfield_type following_previous = *(pointer_cast<skipfield_pointer_type>(it.element_pointer + 1));
+				const skipfield_type following_next = *(pointer_cast<skipfield_pointer_type>(it.element_pointer + 1) + 1);
+
+				if (following_previous != std::numeric_limits<skipfield_type>::max())
+				{
+					edit_free_list_next(to_aligned_pointer(it.group_pointer->elements) + following_previous, following_next); // Set next index of previous free list node to this node's 'next' index
+				}
+
+				if (following_next != std::numeric_limits<skipfield_type>::max())
+				{
+					edit_free_list_prev(to_aligned_pointer(it.group_pointer->elements) + following_next, following_previous); // Set previous index of next free list node to this node's 'previous' index
+				}
+				else
+				{
+					it.group_pointer->free_list_head = following_previous;
+				}
+
+				update_value = following_value;
 			}
 
-			temp.pointer_allocator_pair.min_elements_per_group = pointer_allocator_pair.min_elements_per_group; // reset to correct value for future clear() or erasures
-			*this = std::move(temp); // Avoid generating 2nd temporary
-		#else
-			colony temp(*this);
-			swap(temp);
-		#endif
+			iterator return_iterator(it.group_pointer, it.element_pointer + update_value, it.skipfield_pointer + update_value);
+
+			if (return_iterator.element_pointer == to_aligned_pointer(it.group_pointer->skipfield) && it.group_pointer != end_iterator.group_pointer)
+			{
+				return_iterator.group_pointer = it.group_pointer->next_group;
+				const aligned_pointer_type elements = to_aligned_pointer(return_iterator.group_pointer->elements);
+				const skipfield_pointer_type skipfield = return_iterator.group_pointer->skipfield;
+				const skipfield_type skip = *skipfield;
+				return_iterator.element_pointer = elements + skip;
+				return_iterator.skipfield_pointer = skipfield + skip;
+			}
+
+			if (it.element_pointer == begin_iterator.element_pointer) begin_iterator = return_iterator; // If original iterator was first element in colony, update it's value with the next non-erased element:
+
+			return return_iterator;
+		}
+
+		// else: group is empty, consolidate groups
+		const bool in_back_block = (it.group_pointer->next_group == NULL), in_front_block = (it.group_pointer == begin_iterator.group_pointer);
+
+		if (in_back_block & in_front_block) // ie. only group in colony
+		{
+			// Reset skipfield and free list rather than clearing - leads to fewer allocations/deallocations:
+			reset_only_group_left(it.group_pointer);
+			return end_iterator;
+		}
+		else if ((!in_back_block) & in_front_block) // ie. Remove first group, change first group to next group
+		{
+			it.group_pointer->next_group->previous_group = NULL; // Cut off this group from the chain
+			begin_iterator.group_pointer = it.group_pointer->next_group; // Make the next group the first group
+
+			if (it.group_pointer->free_list_head != std::numeric_limits<skipfield_type>::max()) // Erasures present within the group, ie. was part of the linked list of groups with erasures.
+			{
+				remove_from_groups_with_erasures_list(it.group_pointer);
+			}
+
+			deallocate_group_remove_capacity(it.group_pointer);
+
+			// note: end iterator only needs to be changed if the deleted group was the final group in the chain ie. not in this case
+			begin_iterator.element_pointer = to_aligned_pointer(begin_iterator.group_pointer->elements) + *(begin_iterator.group_pointer->skipfield); // If the beginning index has been erased (ie. skipfield != 0), skip to next non-erased element
+			begin_iterator.skipfield_pointer = begin_iterator.group_pointer->skipfield + *(begin_iterator.group_pointer->skipfield);
+
+			return begin_iterator;
+		}
+		else if (!(in_back_block | in_front_block)) // this is a non-first group but not final group in chain: delete the group, then link previous group to the next group in the chain:
+		{
+			it.group_pointer->next_group->previous_group = it.group_pointer->previous_group;
+			const group_pointer_type return_group = it.group_pointer->previous_group->next_group = it.group_pointer->next_group; // close the chain, removing this group from it
+
+			if (it.group_pointer->free_list_head != std::numeric_limits<skipfield_type>::max())
+			{
+				remove_from_groups_with_erasures_list(it.group_pointer);
+			}
+
+			if PLF_CONSTEXPR (priority == performance)
+			{
+				if (it.group_pointer->next_group != end_iterator.group_pointer)
+				{
+					deallocate_group_remove_capacity(it.group_pointer);
+				}
+				else
+				{ // ie. second to last block in iterative sequence
+					add_to_unused_groups_list(it.group_pointer);
+				}
+			}
+			else
+			{
+				deallocate_group_remove_capacity(it.group_pointer);
+			}
+
+			// Return next group's first non-erased element:
+			return iterator(return_group, to_aligned_pointer(return_group->elements) + *(return_group->skipfield), return_group->skipfield + *(return_group->skipfield));
+		}
+		else // this is a non-first group and the final group in the chain
+		{
+			if (it.group_pointer->free_list_head != std::numeric_limits<skipfield_type>::max())
+			{
+				remove_from_groups_with_erasures_list(it.group_pointer);
+			}
+
+			it.group_pointer->previous_group->next_group = NULL;
+			end_iterator.group_pointer = it.group_pointer->previous_group; // end iterator needs to be changed as element supplied was the back element of the colony
+			end_iterator.element_pointer = to_aligned_pointer(end_iterator.group_pointer->skipfield);
+			end_iterator.skipfield_pointer = end_iterator.group_pointer->skipfield + end_iterator.group_pointer->capacity;
+
+			if PLF_CONSTEXPR (priority == performance)
+			{
+				add_to_unused_groups_list(it.group_pointer);
+			}
+			else
+			{
+				if (unused_groups_head != NULL) // priority == memory_use, if there are other reserved blocks already, get rid of this one
+				{
+					deallocate_group_remove_capacity(it.group_pointer);
+				}
+				else // otherwise, retain - prevents unnecessary allocations/deallocations with stack-like usage
+				{
+					add_to_unused_groups_list(it.group_pointer);
+				}
+			}
+
+			return end_iterator;
+		}
 	}
 
 
 
-	void remove_from_groups_with_erasures_list(const group_pointer_type group_to_remove) PLF_COLONY_NOEXCEPT
+private:
+
+
+	void partially_erase_group(const const_iterator &start, const aligned_pointer_type end)
 	{
-		if (group_to_remove == groups_with_erasures_list_head)
+		// For the partial block erasures, we have to remove the existing skipblocks within the range from the intra-block free list of skipblocks. However if there're no erasures in the block, we can avoid doing so.
+		const_iterator current = start;
+		skipfield_type erasure_count = 0;
+
+		// First erase all elements until end of block & remove all skipblocks post-initial position from the free_list. Then, either update preceding skipblock or create new one:
+
+		if (start.group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()) // ie. no other erasures/skipblocks in block
 		{
-			groups_with_erasures_list_head = groups_with_erasures_list_head->erasures_list_next_group;
-			return;
+			erasure_count += static_cast<skipfield_type>(end - start.element_pointer);
+			add_to_groups_with_erasures_list(start.group_pointer);
+
+			#ifdef PLF_TYPE_TRAITS_SUPPORT
+				if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
+			#endif
+			{
+				do // Avoid checking skipfield as there are no erased elements
+				{
+					destroy_element(current.element_pointer);
+				} while (++current.element_pointer != end);
+			}
+		}
+		else
+		{
+			while (current.element_pointer != end)
+			{
+				if (*current.skipfield_pointer == 0)
+				{
+					#ifdef PLF_TYPE_TRAITS_SUPPORT
+						if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
+					#endif
+					destroy_element(current.element_pointer);
+
+					++erasure_count;
+					++current.element_pointer;
+					++current.skipfield_pointer;
+				}
+				else // remove skipblock
+				{
+					const skipfield_type prev_free_list_index = *(pointer_cast<skipfield_pointer_type>(current.element_pointer));
+					const skipfield_type next_free_list_index = *(pointer_cast<skipfield_pointer_type>(current.element_pointer) + 1);
+
+					current.element_pointer += *(current.skipfield_pointer);
+					current.skipfield_pointer += *(current.skipfield_pointer);
+
+					if (next_free_list_index == std::numeric_limits<skipfield_type>::max() && prev_free_list_index == std::numeric_limits<skipfield_type>::max()) // if this is the last skipblock in the free list
+					{
+						current.group_pointer->free_list_head = std::numeric_limits<skipfield_type>::max();
+						erasure_count += static_cast<skipfield_type>(end - current.element_pointer);
+
+						#ifdef PLF_TYPE_TRAITS_SUPPORT
+							if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
+						#endif
+						{
+							while (current.element_pointer != end) destroy_element(current.element_pointer++); // Avoids checking skipfield, as there are no erased elements left in block
+						}
+
+						break; // end overall while loop
+					}
+					else if (next_free_list_index == std::numeric_limits<skipfield_type>::max()) // if this is the head of the free list
+					{
+						current.group_pointer->free_list_head = prev_free_list_index; // make free list head equal to next free list node
+						edit_free_list_next(to_aligned_pointer(current.group_pointer->elements) + prev_free_list_index, std::numeric_limits<skipfield_type>::max());
+					}
+					else // either a tail or middle free list node
+					{
+						edit_free_list_prev(to_aligned_pointer(current.group_pointer->elements) + next_free_list_index, prev_free_list_index);
+
+						if (prev_free_list_index != std::numeric_limits<skipfield_type>::max()) // ie. not the tail free list node
+						{
+							edit_free_list_next(to_aligned_pointer(current.group_pointer->elements) + prev_free_list_index, next_free_list_index);
+						}
+					}
+				}
+			}
 		}
 
-		group_pointer_type previous_group = groups_with_erasures_list_head, current_group = groups_with_erasures_list_head->erasures_list_next_group;
+		// Update jump-counting skipfield:
+		const size_type distance_to_end = static_cast<skipfield_type>(end - start.element_pointer);
+		const skipfield_type start_index = static_cast<skipfield_type>(start.element_pointer - to_aligned_pointer(start.group_pointer->elements)); // distance between start element and start of block
+		const size_type previous_node_value = (start_index == 0) ? 0 : *(start.skipfield_pointer - 1);
 
-		while (group_to_remove != current_group)
+		if (previous_node_value == 0) // start element is either at start of block, or previous element is non-erased so no adjacent skipblock
 		{
-			previous_group = current_group;
-			current_group = current_group->erasures_list_next_group;
+			*(start.skipfield_pointer) = *(start.skipfield_pointer + distance_to_end - 1) = static_cast<skipfield_type>(distance_to_end); // set start and end node of skipblock
+
+			if (start.group_pointer->free_list_head != std::numeric_limits<skipfield_type>::max()) // ie. if this group already has some erased elements
+			{
+				edit_free_list_next(to_aligned_pointer(start.group_pointer->elements) + start.group_pointer->free_list_head, start_index);
+			}
+
+			edit_free_list_head(start.element_pointer, start.group_pointer->free_list_head);
+			start.group_pointer->free_list_head = start_index;
+		}
+		else
+		{
+			// Just update existing skipblock, no need to create new free list node:
+			*(start.skipfield_pointer - previous_node_value) = *(start.skipfield_pointer + distance_to_end - 1) = static_cast<skipfield_type>(previous_node_value + distance_to_end);
 		}
 
-		previous_group->erasures_list_next_group = current_group->erasures_list_next_group;
+		if (distance_to_end > 2) // if the skipblock is longer than 2 nodes, fill in the middle nodes with non-zero values so that get_iterator() will work
+		{
+			std::memset(void_cast(start.skipfield_pointer + 1), 1, sizeof(skipfield_type) * (distance_to_end - 2));
+		}
+
+		// Update group and hive size:
+		start.group_pointer->size -= erasure_count;
+		total_size -= erasure_count;
 	}
 
 
 
 public:
 
-	// must return iterator to subsequent non-erased element (or end()), in case the group containing the element which the iterator points to becomes empty after the erasure, and is thereafter removed from the colony chain, making the current iterator invalid and unusable in a ++ operation:
-	iterator erase(const const_iterator &it) // if uninitialized/invalid iterator supplied, function could generate an exception
-	{
-		assert(!empty());
-		const group_pointer_type group_pointer = it.group_pointer;
-		assert(group_pointer != NULL); // ie. not uninitialized iterator
-		assert(it.element_pointer != group_pointer->last_endpoint); // ie. != end()
-		assert(*(it.skipfield_pointer) == 0); // ie. element pointed to by iterator has not been erased previously
-
-		#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-			if PLF_COLONY_CONSTEXPR (!(std::is_trivially_destructible<element_type>::value)) // This if-statement should be removed by the compiler on resolution of element_type. For some optimizing compilers this step won't be necessary (for MSVC 2013 it makes a difference)
-		#endif
-		{
-			PLF_COLONY_DESTROY(element_allocator_type, (*this), reinterpret_cast<pointer>(it.element_pointer)); // Destruct element
-		}
-
-		--total_number_of_elements;
-
-		if (group_pointer->number_of_elements-- != 1) // ie. non-empty group at this point in time, don't consolidate - optimization note: GCC optimizes postfix + 1 comparison better than prefix + 1 comparison in many cases.
-		{
-			// Code logic for following section:
-			// ---------------------------------
-			// If current skipfield node has no skipped node on either side, continue as usual
-			// If node only has skipped node on left, set current node and start node of the skipblock to left node value + 1.
-			// If node only has skipped node on right, make this node the start node of the skipblock and update end node
-			// If node has skipped nodes on left and right, set start node of left skipblock and end node of right skipblock to the values of the left + right nodes + 1
-
-			// Optimization explanation:
-			// The contextual logic below is the same as that in the insert() functions but in this case the value of the current skipfield node will always be
-			// zero (since it is not yet erased), meaning no additional manipulations are necessary for the previous skipfield node comparison - we only have to check against zero
-			const char prev_skipfield = *(it.skipfield_pointer - (it.skipfield_pointer != group_pointer->skipfield)) != 0;
-			const char after_skipfield = *(it.skipfield_pointer + 1) != 0;  // NOTE: boundary test (checking against end-of-elements) is able to be skipped due to the extra skipfield node (compared to element field) - which is present to enable faster iterator operator ++ operations
-			skipfield_type update_value = 1;
-
-			switch ((after_skipfield << 1) | prev_skipfield)
-			{
-				case 0: // no consecutive erased elements
-				{
-					*it.skipfield_pointer = 1; // solo skipped node
-					const skipfield_type index = static_cast<skipfield_type>(it.element_pointer - group_pointer->elements);
-
-					if (group_pointer->free_list_head != std::numeric_limits<skipfield_type>::max()) // ie. if this group already has some erased elements
-					{
-						*(reinterpret_cast<skipfield_pointer_type>(group_pointer->elements + group_pointer->free_list_head) + 1) = index; // set prev free list head's 'next index' number to the index of the current element
-					}
-					else
-					{
-						group_pointer->erasures_list_next_group = groups_with_erasures_list_head; // add it to the groups-with-erasures free list
-						groups_with_erasures_list_head = group_pointer;
-					}
-
-					*(reinterpret_cast<skipfield_pointer_type>(it.element_pointer)) = group_pointer->free_list_head;
-					*(reinterpret_cast<skipfield_pointer_type>(it.element_pointer) + 1) = std::numeric_limits<skipfield_type>::max();
-					group_pointer->free_list_head = index;
-					break;
-				}
-				case 1: // previous erased consecutive elements, none following
-				{
-					*(it.skipfield_pointer - *(it.skipfield_pointer - 1)) = *it.skipfield_pointer = *(it.skipfield_pointer - 1) + 1;
-					break;
-				}
-				case 2: // following erased consecutive elements, none preceding
-				{
-					const skipfield_type following_value = *(it.skipfield_pointer + 1) + 1;
-					*(it.skipfield_pointer + following_value - 1) = *(it.skipfield_pointer) = following_value;
-
-					const skipfield_type following_previous = *(reinterpret_cast<skipfield_pointer_type>(it.element_pointer + 1));
-					const skipfield_type following_next = *(reinterpret_cast<skipfield_pointer_type>(it.element_pointer + 1) + 1);
-					*(reinterpret_cast<skipfield_pointer_type>(it.element_pointer)) = following_previous;
-					*(reinterpret_cast<skipfield_pointer_type>(it.element_pointer) + 1) = following_next;
-
-					const skipfield_type index = static_cast<skipfield_type>(it.element_pointer - group_pointer->elements);
-
-					if (following_previous != std::numeric_limits<skipfield_type>::max())
-					{
-						*(reinterpret_cast<skipfield_pointer_type>(group_pointer->elements + following_previous) + 1) = index; // Set next index of previous free list node to this node's 'next' index
-					}
-
-					if (following_next != std::numeric_limits<skipfield_type>::max())
-					{
-						*(reinterpret_cast<skipfield_pointer_type>(group_pointer->elements + following_next)) = index;  // Set previous index of next free list node to this node's 'previous' index
-					}
-					else
-					{
-						group_pointer->free_list_head = index;
-					}
-
-					update_value = following_value;
-					break;
-				}
-				case 3: // both preceding and following consecutive erased elements
-				{
-					const skipfield_type preceding_value = *(it.skipfield_pointer - 1);
-					const skipfield_type following_value = *(it.skipfield_pointer + 1) + 1;
-
-					// Join the skipblocks
-					*(it.skipfield_pointer - preceding_value) = *(it.skipfield_pointer + following_value - 1) = preceding_value + following_value;
-
-					// Remove the following skipblock's entry from the free list
-					const skipfield_type following_previous = *(reinterpret_cast<skipfield_pointer_type>(it.element_pointer + 1));
-					const skipfield_type following_next = *(reinterpret_cast<skipfield_pointer_type>(it.element_pointer + 1) + 1);
-
-					if (following_previous != std::numeric_limits<skipfield_type>::max())
-					{
-						*(reinterpret_cast<skipfield_pointer_type>(group_pointer->elements + following_previous) + 1) = following_next; // Set next index of previous free list node to this node's 'next' index
-					}
-
-					if (following_next != std::numeric_limits<skipfield_type>::max())
-					{
-						*(reinterpret_cast<skipfield_pointer_type>(group_pointer->elements + following_next)) = following_previous; // Set previous index of next free list node to this node's 'previous' index
-					}
-					else
-					{
-						group_pointer->free_list_head = following_previous;
-					}
-
-					update_value = following_value;
-					break;
-				}
-			}
-
-			iterator return_iterator(it.group_pointer, it.element_pointer + update_value, it.skipfield_pointer + update_value);
-			return_iterator.check_for_end_of_group_and_progress();
-
-			if (it.element_pointer == begin_iterator.element_pointer) // If original iterator was first element in colony, update it's value with the next non-erased element:
-			{
-				begin_iterator = return_iterator;
-			}
-
-			return return_iterator;
-		}
-
-		// else: group is empty, consolidate groups
-		switch((group_pointer->next_group != NULL) | ((group_pointer != begin_iterator.group_pointer) << 1))
-		{
-			case 0: // ie. group_pointer == begin_iterator.group_pointer && group_pointer->next_group == NULL; only group in colony
-			{
-				// Reset skipfield and free list rather than clearing - leads to fewer allocations/deallocations:
-				std::memset(&*(group_pointer->skipfield), 0, sizeof(skipfield_type) * group_pointer->capacity); // &* to avoid problems with non-trivial pointers. Although there is one more skipfield than group_pointer->capacity, capacity + 1 is not necessary here as the end skipfield is never written to after initialization
-				group_pointer->free_list_head = std::numeric_limits<skipfield_type>::max();
-				groups_with_erasures_list_head = NULL;
-
-				// Reset begin and end iterators:
-				end_iterator.element_pointer = begin_iterator.element_pointer = group_pointer->last_endpoint = group_pointer->elements;
-				end_iterator.skipfield_pointer = begin_iterator.skipfield_pointer = group_pointer->skipfield;
-
-				return end_iterator;
-			}
-			case 1: // ie. group_pointer == begin_iterator.group_pointer && group_pointer->next_group != NULL. Remove first group, change first group to next group
-			{
-				group_pointer->next_group->previous_group = NULL; // Cut off this group from the chain
-				begin_iterator.group_pointer = group_pointer->next_group; // Make the next group the first group
-
-				update_subsequent_group_numbers(begin_iterator.group_pointer);
-
-				if (group_pointer->free_list_head != std::numeric_limits<skipfield_type>::max()) // Erasures present within the group, ie. was part of the intrusive list of groups with erasures.
-				{
-					remove_from_groups_with_erasures_list(group_pointer);
-				}
-
-				total_capacity -= group_pointer->capacity;
-				PLF_COLONY_DESTROY(group_allocator_type, group_allocator_pair, group_pointer);
-				PLF_COLONY_DEALLOCATE(group_allocator_type, group_allocator_pair, group_pointer, 1);
-
-				// note: end iterator only needs to be changed if the deleted group was the final group in the chain ie. not in this case
-				begin_iterator.element_pointer = begin_iterator.group_pointer->elements + *(begin_iterator.group_pointer->skipfield); // If the beginning index has been erased (ie. skipfield != 0), skip to next non-erased element
-				begin_iterator.skipfield_pointer = begin_iterator.group_pointer->skipfield + *(begin_iterator.group_pointer->skipfield);
-
-				return begin_iterator;
-			}
-			case 3: // this is a non-first group but not final group in chain: delete the group, then link previous group to the next group in the chain:
-			{
-				group_pointer->next_group->previous_group = group_pointer->previous_group;
-				const group_pointer_type return_group = group_pointer->previous_group->next_group = group_pointer->next_group; // close the chain, removing this group from it
-
-				update_subsequent_group_numbers(return_group);
-
-				if (group_pointer->free_list_head != std::numeric_limits<skipfield_type>::max())
-				{
-					remove_from_groups_with_erasures_list(group_pointer);
-				}
-
-				total_capacity -= group_pointer->capacity;
-				PLF_COLONY_DESTROY(group_allocator_type, group_allocator_pair, group_pointer);
-				PLF_COLONY_DEALLOCATE(group_allocator_type, group_allocator_pair, group_pointer, 1);
-
-				// Return next group's first non-erased element:
-				return iterator(return_group, return_group->elements + *(return_group->skipfield), return_group->skipfield + *(return_group->skipfield));
-			}
-			default: // this is a non-first group and the final group in the chain
-			{
-				if (group_pointer->free_list_head != std::numeric_limits<skipfield_type>::max())
-				{
-					remove_from_groups_with_erasures_list(group_pointer);
-				}
-
-				group_pointer->previous_group->next_group = NULL;
-				end_iterator.group_pointer = group_pointer->previous_group; // end iterator needs to be changed as element supplied was the back element of the colony
-				end_iterator.element_pointer = reinterpret_cast<aligned_pointer_type>(end_iterator.group_pointer->skipfield);
-				end_iterator.skipfield_pointer = end_iterator.group_pointer->skipfield + end_iterator.group_pointer->capacity;
-
-				total_capacity -= group_pointer->capacity;
-				PLF_COLONY_DESTROY(group_allocator_type, group_allocator_pair, group_pointer);
-				PLF_COLONY_DEALLOCATE(group_allocator_type, group_allocator_pair, group_pointer, 1);
-
-				return end_iterator;
-			}
-		}
-	}
-
-
 
 	// Range erase:
 
-	void erase(const const_iterator &iterator1, const const_iterator &iterator2)  // if uninitialized/invalid iterators supplied, function could generate an exception. If iterator1 > iterator2, behaviour is undefined.
+	iterator erase(const const_iterator &iterator1, const const_iterator &iterator2)	// if uninitialized/invalid iterators supplied, function could generate an exception. If iterator1 > iterator2, behaviour is undefined.
 	{
+		// General code logic: if iterator1 and iterator2 point to elements in the same block, we skip to code section 3 (final block).
+		// If they aren't and iterator1 isn't the first non-erased element in first block, we erase part of that block and update accordingly in code Section 1.
+		// If it is the first non-erased element, it gets handled in code section 2.
+		// In code Section 2 we fully erase and remove all intermediate blocks which aren't the final block. This's optimal as we can just discard the blocks and not do any skipfield or free list updating.
+		// In code Section 3 we either partially or fully erase (if iterator2 == end()) the final block in the supplied sequence. If iterator2 was the first non-erased element in it's block or iterator1 == iterator2, this is caught at this point and no action is taken.
+
 		assert(iterator1 <= iterator2);
 
-		iterator current = iterator1;
+		const_iterator current = iterator1;
 
-		if (current.group_pointer != iterator2.group_pointer)
+		if (iterator1.group_pointer != iterator2.group_pointer)
 		{
-			if (current.element_pointer != current.group_pointer->elements + *(current.group_pointer->skipfield)) // if iterator1 is not the first non-erased element in it's group - most common case
+			// Section 1: process first block, if partial block erasure
+			// ========================================================
+			if (current.element_pointer != to_aligned_pointer(current.group_pointer->elements) + *(current.group_pointer->skipfield)) // if iterator1 is not the first non-erased element in it's block - most common case
 			{
-				size_type number_of_group_erasures = 0;
-
-				// Now update skipfield:
-				const aligned_pointer_type end = iterator1.group_pointer->last_endpoint;
-
-				// Schema: first erase all non-erased elements until end of group & remove all skipblocks post-iterator1 from the free_list. Then, either update preceding skipblock or create new one:
-
-				#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT // if trivially-destructible, and C++11 or higher, and no erasures in group, skip while loop below and just jump straight to the location
-					if ((std::is_trivially_destructible<element_type>::value) & (current.group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()))
-					{
-						number_of_group_erasures += static_cast<size_type>(end - current.element_pointer);
-					}
-					else
-				#endif
-				{
-					while (current.element_pointer != end)
-					{
-						if (*current.skipfield_pointer == 0)
-						{
-							#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-								if PLF_COLONY_CONSTEXPR (!(std::is_trivially_destructible<element_type>::value))
-							#endif
-							{
-								PLF_COLONY_DESTROY(element_allocator_type, (*this), reinterpret_cast<pointer>(current.element_pointer)); // Destruct element
-							}
-
-							++number_of_group_erasures;
-							++current.element_pointer;
-							++current.skipfield_pointer;
-						}
-						else // remove skipblock from group:
-						{
-							const skipfield_type prev_free_list_index = *(reinterpret_cast<skipfield_pointer_type>(current.element_pointer));
-							const skipfield_type next_free_list_index = *(reinterpret_cast<skipfield_pointer_type>(current.element_pointer) + 1);
-
-							current.element_pointer += *(current.skipfield_pointer);
-							current.skipfield_pointer += *(current.skipfield_pointer);
-
-							if (next_free_list_index == std::numeric_limits<skipfield_type>::max() && prev_free_list_index == std::numeric_limits<skipfield_type>::max()) // if this is the last skipblock in the free list
-							{
-								remove_from_groups_with_erasures_list(iterator1.group_pointer); // remove group from list of free-list groups - will be added back in down below, but not worth optimizing for
-								iterator1.group_pointer->free_list_head = std::numeric_limits<skipfield_type>::max();
-								number_of_group_erasures += static_cast<size_type>(end - current.element_pointer);
-
-								#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-									if PLF_COLONY_CONSTEXPR (!(std::is_trivially_destructible<element_type>::value))
-								#endif
-								{
-									while (current.element_pointer != end) // miniloop - avoid checking skipfield for rest of elements in group, as there are no more skipped elements now
-									{
-										PLF_COLONY_DESTROY(element_allocator_type, (*this), reinterpret_cast<pointer>(current.element_pointer++)); // Destruct element
-									}
-								}
-
-								break; // end overall while loop
-							}
-							else if (next_free_list_index == std::numeric_limits<skipfield_type>::max()) // if this is the head of the free list
-							{
-								current.group_pointer->free_list_head = prev_free_list_index; // make free list head equal to next free list node
-								*(reinterpret_cast<skipfield_pointer_type>(current.group_pointer->elements + prev_free_list_index) + 1) = std::numeric_limits<skipfield_type>::max();
-							}
-							else // either a tail or middle free list node
-							{
-								*(reinterpret_cast<skipfield_pointer_type>(current.group_pointer->elements + next_free_list_index)) = prev_free_list_index;
-
-								if (prev_free_list_index != std::numeric_limits<skipfield_type>::max()) // ie. not the tail free list node
-								{
-									*(reinterpret_cast<skipfield_pointer_type>(current.group_pointer->elements + prev_free_list_index) + 1) = next_free_list_index;
-								}
-							}
-						}
-					}
-				}
-
-
-				const skipfield_type previous_node_value = *(iterator1.skipfield_pointer - 1);
-				const skipfield_type distance_to_end = static_cast<skipfield_type>(end - iterator1.element_pointer);
-
-				if (previous_node_value == 0) // no previous skipblock
-				{
-					*iterator1.skipfield_pointer = distance_to_end;
-					*(iterator1.skipfield_pointer + distance_to_end - 1) = distance_to_end;
-
-					const skipfield_type index = static_cast<skipfield_type>(iterator1.element_pointer - iterator1.group_pointer->elements);
-
-					if (iterator1.group_pointer->free_list_head != std::numeric_limits<skipfield_type>::max()) // ie. if this group already has some erased elements
-					{
-						*(reinterpret_cast<skipfield_pointer_type>(iterator1.group_pointer->elements + iterator1.group_pointer->free_list_head) + 1) = index; // set prev free list head's 'next index' number to the index of the iterator1 element
-					}
-					else
-					{
-						iterator1.group_pointer->erasures_list_next_group = groups_with_erasures_list_head; // add it to the groups-with-erasures free list
-						groups_with_erasures_list_head = iterator1.group_pointer;
-					}
-
-					*(reinterpret_cast<skipfield_pointer_type>(iterator1.element_pointer)) = iterator1.group_pointer->free_list_head;
-					*(reinterpret_cast<skipfield_pointer_type>(iterator1.element_pointer) + 1) = std::numeric_limits<skipfield_type>::max();
-					iterator1.group_pointer->free_list_head = index;
-				}
-				else
-				{ // update previous skipblock, no need to update free list:
-					*(iterator1.skipfield_pointer - previous_node_value) = *(iterator1.skipfield_pointer + distance_to_end - 1) = previous_node_value + distance_to_end;
-				}
-
-				iterator1.group_pointer->number_of_elements -= static_cast<skipfield_type>(number_of_group_erasures);
-				total_number_of_elements -= number_of_group_erasures;
-
+				partially_erase_group(iterator1, to_aligned_pointer(iterator1.group_pointer->skipfield));
 				current.group_pointer = current.group_pointer->next_group;
 			}
 
 
-			// Intermediate groups:
+			// Section 2: remove all intermediate blocks before final block (including first block if it's a full block erasure rather than partial)
+			// ====================================================================================================================================
 			const group_pointer_type previous_group = current.group_pointer->previous_group;
 
 			while (current.group_pointer != iterator2.group_pointer)
 			{
-				#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-					if PLF_COLONY_CONSTEXPR (!(std::is_trivially_destructible<element_type>::value))
+				#ifdef PLF_TYPE_TRAITS_SUPPORT
+					if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
 				#endif
 				{
-					current.element_pointer = current.group_pointer->elements + *(current.group_pointer->skipfield);
+					current.element_pointer = to_aligned_pointer(current.group_pointer->elements) + *(current.group_pointer->skipfield);
 					current.skipfield_pointer = current.group_pointer->skipfield + *(current.group_pointer->skipfield);
-					const aligned_pointer_type end = current.group_pointer->last_endpoint;
 
-					do
-					{
-						PLF_COLONY_DESTROY(element_allocator_type, (*this), reinterpret_cast<pointer>(current.element_pointer)); // Destruct element
-						++current.skipfield_pointer;
-						current.element_pointer += *current.skipfield_pointer + 1;
-						current.skipfield_pointer += *current.skipfield_pointer;
-					} while (current.element_pointer != end);
+					destroy_group(current, to_aligned_pointer(current.group_pointer->skipfield));
 				}
 
 				if (current.group_pointer->free_list_head != std::numeric_limits<skipfield_type>::max())
@@ -2582,18 +2877,23 @@ public:
 					remove_from_groups_with_erasures_list(current.group_pointer);
 				}
 
-				total_number_of_elements -= current.group_pointer->number_of_elements;
+				total_size -= current.group_pointer->size;
 				const group_pointer_type current_group = current.group_pointer;
 				current.group_pointer = current.group_pointer->next_group;
 
-				total_capacity -= current_group->capacity;
-				PLF_COLONY_DESTROY(group_allocator_type, group_allocator_pair, current_group);
-				PLF_COLONY_DEALLOCATE(group_allocator_type, group_allocator_pair, current_group, 1);
+				if (current_group != end_iterator.group_pointer && current_group->next_group != end_iterator.group_pointer)
+				{
+					deallocate_group_remove_capacity(current_group);
+				}
+				else
+				{
+					add_to_unused_groups_list(current_group);
+				}
 			}
 
-			current.element_pointer = current.group_pointer->elements + *(current.group_pointer->skipfield);
+			current.element_pointer = to_aligned_pointer(current.group_pointer->elements) + *(current.group_pointer->skipfield);
 			current.skipfield_pointer = current.group_pointer->skipfield + *(current.group_pointer->skipfield);
-			current.group_pointer->previous_group = previous_group;
+			current.group_pointer->previous_group = previous_group; // Join this group to the previous non-removed group
 
 			if (previous_group != NULL)
 			{
@@ -2601,199 +2901,579 @@ public:
 			}
 			else
 			{
-				begin_iterator = iterator2; // This line is included here primarily to avoid a secondary if statement within the if block below - it will not be needed in any other situation
+				begin_iterator = iterator(iterator2.group_pointer, iterator2.element_pointer, iterator2.skipfield_pointer); // This line is included primarily to avoid a secondary if statement within the if block below - it is not needed otherwise
 			}
 		}
 
-		if (current.element_pointer == iterator2.element_pointer) // in case iterator2 was at beginning of it's group - also covers empty range case (first == last)
+
+		// Section 3: final block
+		// =======================================================================
+		// Code logic:
+		// If not erasing entire final block, 1. Destruct elements (if non-trivial destructor), 2. add skipblock location to group's free list of skipblocks, and 3. update skipfield.
+		// If erasing entire block, 1. Destruct elements (if non-trivial destructor), 2. if no elements left in hive reset the group, otherwise 3. reset end_iterator and remove group from groups-with-erasures list (if prior erasures are present).
+		// Note: only way that entire block can be erased is if iterator2 == end() in this case, hence why we reset end_iterator.
+
+		if (current.element_pointer != iterator2.element_pointer) // in case iterator2 was at beginning of it's block - also covers empty range case (first == last)
 		{
+			if (iterator2.element_pointer != end_iterator.element_pointer || current.element_pointer != to_aligned_pointer(current.group_pointer->elements) + *(current.group_pointer->skipfield)) // ie. not erasing entire block. Second condition will only be false if iterator1 & iterator2 are in same block.
+			{
+				partially_erase_group(current, iterator2.element_pointer);
+
+				if (iterator1.element_pointer == begin_iterator.element_pointer)
+				{
+					begin_iterator = iterator(iterator2.group_pointer, iterator2.element_pointer, iterator2.skipfield_pointer);
+				}
+			}
+			else // ie. full block erasure
+			{
+				#ifdef PLF_TYPE_TRAITS_SUPPORT
+					if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
+				#endif
+				{
+					destroy_group(current, iterator2.element_pointer);
+				}
+
+				if ((total_size -= current.group_pointer->size) != 0) // ie. hive is not empty
+				{
+					if (current.group_pointer->free_list_head != std::numeric_limits<skipfield_type>::max())
+					{
+						remove_from_groups_with_erasures_list(current.group_pointer);
+					}
+
+					current.group_pointer->previous_group->next_group = current.group_pointer->next_group;
+
+					end_iterator.group_pointer = current.group_pointer->previous_group;
+					end_iterator.element_pointer = to_aligned_pointer(end_iterator.group_pointer->skipfield);
+					end_iterator.skipfield_pointer = end_iterator.group_pointer->skipfield + end_iterator.group_pointer->capacity;
+					add_to_unused_groups_list(current.group_pointer);
+				}
+				else // ie. hive is now empty
+				{
+					// Reset skipfield and free list rather than clearing - leads to fewer allocations/deallocations:
+					reset_only_group_left(current.group_pointer);
+				}
+
+				return end_iterator;
+			}
+		}
+
+		return iterator(iterator2.group_pointer, iterator2.element_pointer, iterator2.skipfield_pointer);
+	}
+
+
+
+private:
+
+	void prepare_groups_for_assign(const size_type size)
+	{
+		// Destroy all elements if non-trivial:
+		#ifdef PLF_TYPE_TRAITS_SUPPORT
+			if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
+		#endif
+		{
+			destroy_remainder(begin_iterator);
+		}
+
+		if (size < total_capacity && (total_capacity - size) >= min_block_capacity)
+		{
+			size_type difference = total_capacity - size;
+			end_iterator.group_pointer->next_group = unused_groups_head;
+
+			// Remove surplus groups which're under the difference limit:
+			group_pointer_type current_group = begin_iterator.group_pointer, previous_group = NULL;
+
+			do
+			{
+				const group_pointer_type next_group = current_group->next_group;
+
+				if (current_group->capacity <= difference)
+				{ // Remove group:
+					difference -= current_group->capacity;
+					deallocate_group_remove_capacity(current_group);
+
+					if (current_group == begin_iterator.group_pointer) begin_iterator.group_pointer = next_group;
+				}
+				else
+				{
+					if (previous_group != NULL)
+					{
+						previous_group->next_group = current_group;
+					}
+
+					previous_group = current_group;
+				}
+
+				current_group = next_group;
+			} while (current_group != NULL);
+
+			previous_group->next_group = NULL;
+		}
+		else
+		{
+			if (size > total_capacity) reserve(size);
+
+			// Join all unused_groups to main chain:
+			end_iterator.group_pointer->next_group = unused_groups_head;
+		}
+
+		begin_iterator.element_pointer = to_aligned_pointer(begin_iterator.group_pointer->elements);
+		begin_iterator.skipfield_pointer = begin_iterator.group_pointer->skipfield;
+		erasure_groups_head = NULL;
+		total_size = 0;
+	}
+
+
+
+public:
+
+
+	// Fill assign:
+
+	void assign(size_type size, const element_type &element)
+	{
+		if (size == 0)
+		{
+			reset();
 			return;
 		}
 
-		// Final group:
-		// Code explanation:
-		// If not erasing entire final group, 1. Destruct elements (if non-trivial destructor) and add locations to group free list. 2. process skipfield.
-		// If erasing entire group, 1. Destruct elements (if non-trivial destructor), 2. if no elements left in colony, clear() 3. otherwise reset end_iterator and remove group from groups-with-erasures list (if free list of erasures present)
-
-		if (iterator2.element_pointer != end_iterator.element_pointer || current.element_pointer != current.group_pointer->elements + *(current.group_pointer->skipfield)) // ie. not erasing entire group
-		{
-			size_type number_of_group_erasures = 0;
-			// Schema: first erased all non-erased elements until end of group & remove all skipblocks post-iterator2 from the free_list. Then, either update preceding skipblock or create new one:
-
-			const iterator current_saved = current;
-
-			#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT // if trivially-destructible, and C++11 or higher, and no erasures in group, skip while loop below and just jump straight to the location
-				if ((std::is_trivially_destructible<element_type>::value) & (current.group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()))
-				{
-					number_of_group_erasures += static_cast<size_type>(iterator2.element_pointer - current.element_pointer);
-				}
-				else
-			#endif
+		#ifdef PLF_TYPE_TRAITS_SUPPORT
+			if PLF_CONSTEXPR ((std::is_trivially_destructible<element_type>::value && std::is_trivially_constructible<element_type>::value && std::is_trivially_copy_assignable<element_type>::value) || !std::is_copy_assignable<element_type>::value) // ie. If there is no benefit nor difference to assigning vs constructing, or if we can't assign, use faster method:
 			{
-				while (current.element_pointer != iterator2.element_pointer)
+				prepare_groups_for_assign(size);
+				fill_unused_groups(size, element, 0, NULL, begin_iterator.group_pointer);
+			}
+			else
+		#endif
+		{
+			if (total_size == 0)
+			{
+				prepare_groups_for_assign(size);
+				fill_unused_groups(size, element, 0, NULL, begin_iterator.group_pointer);
+			}
+			else if (size < total_size)
+			{
+				iterator current = begin_iterator;
+
+				do
 				{
-					if (*current.skipfield_pointer == 0)
+					*current++ = element;
+				} while (--size != 0);
+
+				erase(current, end_iterator);
+			}
+			else
+			{
+				iterator current = begin_iterator;
+
+				do
+				{
+					*current = element;
+				} while (++current != end_iterator);
+
+				insert(size - total_size, element);
+			}
+		}
+	}
+
+
+
+private:
+
+
+	void reset_group_range_assign(iterator &it) PLF_NOEXCEPT
+	{
+		std::memset(void_cast(it.group_pointer->skipfield), 0, it.group_pointer->capacity * sizeof(skipfield_type));
+		it.group_pointer->size = static_cast<skipfield_type>(it.element_pointer - to_aligned_pointer(it.group_pointer->elements));
+	}
+
+
+
+	void make_back_group_range_assign(iterator &it) PLF_NOEXCEPT
+	{
+		// Add all subsequent active groups to unused_groups list:
+ 		if (it.group_pointer != end_iterator.group_pointer)
+		{
+			end_iterator.group_pointer->next_group = unused_groups_head;
+			unused_groups_head = it.group_pointer->next_group;
+		}
+
+		end_iterator = it;
+		it.group_pointer->next_group = NULL;
+	}
+
+
+
+	void finish_range_assign(iterator &it) PLF_NOEXCEPT
+	{
+		reset_group_range_assign(it);
+		make_back_group_range_assign(it);
+	}
+
+
+
+	void check_iterator_end_of_block(const_iterator &it) PLF_NOEXCEPT
+	{
+		#ifdef PLF_TYPE_TRAITS_SUPPORT
+			if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
+		#endif
+		{
+			if (it.element_pointer == to_aligned_pointer(it.group_pointer->skipfield))
+			{
+				it.group_pointer = it.group_pointer->next_group;
+				const skipfield_type skip = *(it.group_pointer->skipfield);
+				it.element_pointer = to_aligned_pointer(it.group_pointer->elements) + skip;
+				it.skipfield_pointer = it.group_pointer->skipfield + skip;
+			}
+		}
+	}
+
+
+
+	// Range assign core:
+
+	template <class iterator_type>
+	void range_assign(iterator_type it, size_type size)
+	{
+		if (size == 0)
+		{
+			reset();
+			return;
+		}
+
+		if (total_size == 0)
+		{
+			prepare_groups_for_assign(size);
+			range_fill_unused_groups(size, it, 0, NULL, begin_iterator.group_pointer);
+		}
+		else
+		{
+			erasure_groups_head = NULL;
+			total_size = 0;
+			begin_iterator.element_pointer = to_aligned_pointer(begin_iterator.group_pointer->elements);
+			begin_iterator.skipfield_pointer = begin_iterator.group_pointer->skipfield;
+
+
+			for (iterator current(begin_iterator); current.group_pointer != NULL;)
+			{
+				current.element_pointer = to_aligned_pointer(current.group_pointer->elements);
+				current.skipfield_pointer = current.group_pointer->skipfield;
+				current.group_pointer->free_list_head = std::numeric_limits<skipfield_type>::max();
+
+				for (const aligned_pointer_type end = (current.group_pointer == end_iterator.group_pointer) ? end_iterator.element_pointer : to_aligned_pointer(current.group_pointer->skipfield); current.element_pointer != end;)
+				{
+					if (*(current.skipfield_pointer) != 0)
 					{
-						#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-							if PLF_COLONY_CONSTEXPR (!(std::is_trivially_destructible<element_type>::value))
-						#endif
+						skipfield_type skipblock_length = *(current.skipfield_pointer);
+						const_iterator next_element(current.group_pointer, current.element_pointer + skipblock_length, current.skipfield_pointer + skipblock_length);
+						skipblock_length = (skipblock_length > size) ? static_cast<skipfield_type>(size) : skipblock_length;
+
+						for (const aligned_pointer_type fill_end = current.element_pointer + skipblock_length; current.element_pointer != fill_end; ++current.element_pointer, ++current.skipfield_pointer)
 						{
-							PLF_COLONY_DESTROY(element_allocator_type, (*this), reinterpret_cast<pointer>(current.element_pointer)); // Destruct element
+							#ifdef PLF_EXCEPTIONS_SUPPORT
+								#ifdef PLF_TYPE_TRAITS_SUPPORT
+									if PLF_CONSTEXPR (std::is_nothrow_copy_constructible<element_type>::value)
+									{
+										PLF_CONSTRUCT_ELEMENT(current.element_pointer, *it++);
+									}
+									else
+								#endif
+								{
+									try
+									{
+										PLF_CONSTRUCT_ELEMENT(current.element_pointer, *it++);
+									}
+									catch (...)
+									{
+										#ifdef PLF_TYPE_TRAITS_SUPPORT
+											if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
+										#endif
+										{
+											check_iterator_end_of_block(next_element);
+											destroy_remainder(next_element);
+										}
+
+										finish_range_assign(current);
+										throw;
+									}
+								}
+							#else
+								PLF_CONSTRUCT_ELEMENT(current.element_pointer, *it++);
+							#endif
+
+							++total_size;
 						}
 
-						++number_of_group_erasures;
+						if ((size -= skipblock_length) == 0)
+						{
+							#ifdef PLF_TYPE_TRAITS_SUPPORT
+								if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
+							#endif
+							{
+								check_iterator_end_of_block(next_element);
+								destroy_remainder(next_element);
+							}
+
+							finish_range_assign(current);
+							return;
+						}
+					}
+					else
+					{
+						#ifdef PLF_EXCEPTIONS_SUPPORT
+							#ifdef PLF_TYPE_TRAITS_SUPPORT
+								if PLF_CONSTEXPR (std::is_nothrow_copy_assignable<element_type>::value)
+								{
+									*pointer_cast<pointer>(current.element_pointer) = *it++;
+								}
+								else
+							#endif
+							{
+								try
+								{
+									*pointer_cast<pointer>(current.element_pointer) = *it++;
+								}
+								catch (...)
+								{
+									#ifdef PLF_TYPE_TRAITS_SUPPORT
+										if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
+									#endif
+									destroy_remainder(current);
+
+									finish_range_assign(current);
+									throw;
+								}
+							}
+						#else
+							*pointer_cast<pointer>(current.element_pointer) = *it++;
+						#endif
+
+						++total_size;
+
+						if (--size == 0)
+						{
+							#ifdef PLF_TYPE_TRAITS_SUPPORT
+								if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
+							#endif
+							destroy_remainder(++iterator(current)); // To potentially allow for skipping over a skipblock
+
+							++current.element_pointer; // As opposed to just incrementing, as we do here
+							++current.skipfield_pointer;
+							finish_range_assign(current);
+							return;
+						}
+
 						++current.element_pointer;
 						++current.skipfield_pointer;
 					}
-					else // remove skipblock from group:
-					{
-						const skipfield_type prev_free_list_index = *(reinterpret_cast<skipfield_pointer_type>(current.element_pointer));
-						const skipfield_type next_free_list_index = *(reinterpret_cast<skipfield_pointer_type>(current.element_pointer) + 1);
-
-						current.element_pointer += *(current.skipfield_pointer);
-						current.skipfield_pointer += *(current.skipfield_pointer);
-
-						if (next_free_list_index == std::numeric_limits<skipfield_type>::max() && prev_free_list_index == std::numeric_limits<skipfield_type>::max()) // if this is the last skipblock in the free list
-						{
-							remove_from_groups_with_erasures_list(iterator2.group_pointer); // remove group from list of free-list groups - will be added back in down below, but not worth optimizing for
-							iterator2.group_pointer->free_list_head = std::numeric_limits<skipfield_type>::max();
-							number_of_group_erasures += static_cast<size_type>(iterator2.element_pointer - current.element_pointer);
-
-							#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-								if PLF_COLONY_CONSTEXPR (!(std::is_trivially_destructible<element_type>::value))
-							#endif
-							{
-								while (current.element_pointer != iterator2.element_pointer)
-								{
-									PLF_COLONY_DESTROY(element_allocator_type, (*this), reinterpret_cast<pointer>(current.element_pointer++)); // Destruct element
-								}
-							}
-
-							break; // end overall while loop
-						}
-						else if (next_free_list_index == std::numeric_limits<skipfield_type>::max()) // if this is the head of the free list
-						{
-							current.group_pointer->free_list_head = prev_free_list_index;
-							*(reinterpret_cast<skipfield_pointer_type>(current.group_pointer->elements + prev_free_list_index) + 1) = std::numeric_limits<skipfield_type>::max();
-						}
-						else
-						{
-							*(reinterpret_cast<skipfield_pointer_type>(current.group_pointer->elements + next_free_list_index)) = prev_free_list_index;
-
-							if (prev_free_list_index != std::numeric_limits<skipfield_type>::max()) // ie. not the tail free list node
-							{
-								*(reinterpret_cast<skipfield_pointer_type>(current.group_pointer->elements + prev_free_list_index) + 1) = next_free_list_index;
-							}
-						}
-					}
-				}
-			}
-
-
-			const skipfield_type distance_to_iterator2 = static_cast<skipfield_type>(iterator2.element_pointer - current_saved.element_pointer);
-			const skipfield_type index = static_cast<skipfield_type>(current_saved.element_pointer - iterator2.group_pointer->elements);
-
-			if (index == 0 || *(current_saved.skipfield_pointer - 1) == 0) // element is either at start of group or previous skipfield node is 0
-			{
-				*(current_saved.skipfield_pointer) = distance_to_iterator2;
-				*(iterator2.skipfield_pointer - 1) = distance_to_iterator2;
-
-				if (iterator2.group_pointer->free_list_head != std::numeric_limits<skipfield_type>::max()) // ie. if this group already has some erased elements
-				{
-					*(reinterpret_cast<skipfield_pointer_type>(iterator2.group_pointer->elements + iterator2.group_pointer->free_list_head) + 1) = index;
-				}
-				else
-				{
-					iterator2.group_pointer->erasures_list_next_group = groups_with_erasures_list_head; // add it to the groups-with-erasures free list
-					groups_with_erasures_list_head = iterator2.group_pointer;
 				}
 
-				*(reinterpret_cast<skipfield_pointer_type>(current_saved.element_pointer)) = iterator2.group_pointer->free_list_head;
-				*(reinterpret_cast<skipfield_pointer_type>(current_saved.element_pointer) + 1) = std::numeric_limits<skipfield_type>::max();
-				iterator2.group_pointer->free_list_head = index;
+				reset_group_range_assign(current);
+				current.group_pointer = current.group_pointer->next_group;
 			}
-			else // If iterator 1 & 2 are in same group, but iterator 1 was not at start of group, and previous skipfield node is an end node in a skipblock:
+
+			// Use up any remaining space at end of end block (would not be correctly identified above because the skipfield in unused nodes is 0)
+			for (const aligned_pointer_type end = to_aligned_pointer(end_iterator.group_pointer->skipfield); end_iterator.element_pointer != end;)
 			{
-				// Just update existing skipblock, no need to create new free list node:
-				const skipfield_type prev_node_value = *(current_saved.skipfield_pointer - 1);
-				*(current_saved.skipfield_pointer - prev_node_value) = prev_node_value + distance_to_iterator2;
-				*(iterator2.skipfield_pointer - 1) = prev_node_value + distance_to_iterator2;
+				PLF_CONSTRUCT_ELEMENT(end_iterator.element_pointer, *it++);
+				++total_size;
+				++end_iterator.group_pointer->size;
+				++end_iterator.element_pointer;
+				++end_iterator.skipfield_pointer;
+
+				if (--size == 0) return;
 			}
 
-
-			if (iterator1.element_pointer == begin_iterator.element_pointer)
-			{
-				begin_iterator = iterator2;
-			}
-
-			iterator2.group_pointer->number_of_elements -= static_cast<skipfield_type>(number_of_group_erasures);
-			total_number_of_elements -= number_of_group_erasures;
+			// Indicates we've reached the end of existing groups with elements, now can only reused unused groups or create new ones:
+			range_insert(it, size);
 		}
-		else // ie. full group erasure
+	}
+
+
+
+public:
+
+	// Range assign:
+
+	template <class iterator_type>
+	void assign(const typename plf::enable_if<!std::numeric_limits<iterator_type>::is_integer, iterator_type>::type &first, const iterator_type &last)
+	{
+		range_assign(first, static_cast<size_type>(std::distance(first, last)));
+	}
+
+
+
+	// Overloads for colony iterators, since std::distance overloads for these are not possible without C++20 concepts and we must stick with ADL:
+	template <class iterator_type>
+	void assign(const iterator &first, const iterator &last)
+	{
+		range_assign(first, static_cast<size_type>(first.distance(last)));
+	}
+
+
+
+	template <class iterator_type>
+	void assign(const const_iterator &first, const const_iterator &last)
+	{
+		range_assign(first, static_cast<size_type>(first.distance(last)));
+	}
+
+
+
+	template <class iterator_type>
+	void assign(const reverse_iterator &first, const reverse_iterator &last)
+	{
+		range_assign(first, static_cast<size_type>(first.distance(last)));
+	}
+
+
+
+	template <class iterator_type>
+	void assign(const const_reverse_iterator &first, const const_reverse_iterator &last)
+	{
+		range_assign(first, static_cast<size_type>(first.distance(last)));
+	}
+
+
+
+	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+		// Range assign, move_iterator overload:
+
+		template <class iterator_type>
+		void assign (const std::move_iterator<iterator_type> &first, const std::move_iterator<iterator_type> &last)
 		{
-			#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-				if PLF_COLONY_CONSTEXPR (!(std::is_trivially_destructible<element_type>::value))
-			#endif
-			{
-				while(current.element_pointer != iterator2.element_pointer)
-				{
-					PLF_COLONY_DESTROY(element_allocator_type, (*this), reinterpret_cast<pointer>(current.element_pointer));
-					++current.skipfield_pointer;
-					current.element_pointer += 1 + *current.skipfield_pointer;
-					current.skipfield_pointer += *current.skipfield_pointer;
-				}
-			}
-
-
-			if ((total_number_of_elements -= current.group_pointer->number_of_elements) != 0) // ie. previous_group != NULL
-			{
-				current.group_pointer->previous_group->next_group = current.group_pointer->next_group;
-				end_iterator.group_pointer = current.group_pointer->previous_group;
-				end_iterator.element_pointer = current.group_pointer->previous_group->last_endpoint;
-				end_iterator.skipfield_pointer = current.group_pointer->previous_group->skipfield + current.group_pointer->previous_group->capacity;
-				total_capacity -= current.group_pointer->capacity;
-
-				if (current.group_pointer->free_list_head != std::numeric_limits<skipfield_type>::max())
-				{
-					remove_from_groups_with_erasures_list(current.group_pointer);
-				}
-			}
-			else // ie. colony is now empty
-			{
-				blank();
-			}
-
-			PLF_COLONY_DESTROY(group_allocator_type, group_allocator_pair, current.group_pointer);
-			PLF_COLONY_DEALLOCATE(group_allocator_type, group_allocator_pair, current.group_pointer, 1);
+			range_assign(first, static_cast<size_type>(std::distance(first.base(), last.base())));
 		}
+	#endif
+
+
+
+	#ifdef PLF_INITIALIZER_LIST_SUPPORT
+		// Initializer-list assign:
+
+		void assign(const std::initializer_list<element_type> &element_list)
+		{
+			range_assign(element_list.begin(), static_cast<size_type>(element_list.size()));
+		}
+	#endif
+
+
+
+	#ifdef PLF_CPP20_SUPPORT
+		template<compatible_range<element_type> range_type>
+		void assign_range(range_type &&the_range)
+		{
+			range_assign(std::ranges::begin(the_range), static_cast<size_type>(std::ranges::distance(the_range)));
+		}
+
+
+
+		[[nodiscard]]
+	#endif
+	bool empty() const PLF_NOEXCEPT
+	{
+		return total_size == 0;
 	}
 
 
 
-	inline PLF_COLONY_FORCE_INLINE bool empty() const PLF_COLONY_NOEXCEPT
+	size_type size() const PLF_NOEXCEPT
 	{
-		return total_number_of_elements == 0;
+		return total_size;
 	}
 
 
 
-	inline size_type size() const PLF_COLONY_NOEXCEPT
+	PLF_CONSTFUNC size_type max_size() const PLF_NOEXCEPT
 	{
-		return total_number_of_elements;
+		#ifdef PLF_ALLOCATOR_TRAITS_SUPPORT
+			return std::allocator_traits<allocator_type>::max_size(*this);
+		#else
+			return allocator_type::max_size();
+		#endif
+	}
+
+
+
+	size_type capacity() const PLF_NOEXCEPT
+	{
+		return total_capacity;
+	}
+
+
+
+	size_type memory() const PLF_NOEXCEPT
+	{
+		size_type memory_use = sizeof(*this); // sizeof colony structure
+		end_iterator.group_pointer->next_group = unused_groups_head; // temporarily link the active & reserved (unused) groups in order to only have one loop below instead of two
+
+		for(group_pointer_type current = begin_iterator.group_pointer; current != NULL; current = current->next_group)
+		{
+			memory_use += sizeof(group) + (get_aligned_block_capacity(current->capacity) * sizeof(aligned_allocation_struct)); // add element/skipfield memory block sizes + size of the group struct
+		}
+
+		end_iterator.group_pointer->next_group = NULL; // unlink active & reserved groups
+		return memory_use;
+	}
+
+
+
+	static PLF_CONSTFUNC size_type block_metadata_memory(const size_type block_capacity) PLF_NOEXCEPT
+	{
+		return sizeof(group) + ((get_aligned_block_capacity(static_cast<skipfield_type>(block_capacity)) - block_capacity) * sizeof(aligned_allocation_struct));
+	}
+
+
+
+	static PLF_CONSTFUNC size_type block_allocation_amount(size_type block_capacity) PLF_NOEXCEPT
+	{
+		if (block_capacity > std::numeric_limits<skipfield_type>::max()) block_capacity = std::numeric_limits<skipfield_type>::max();
+
+		return sizeof(aligned_allocation_struct) * get_aligned_block_capacity(static_cast<skipfield_type>(block_capacity));
+	}
+
+
+
+	static PLF_CONSTFUNC size_type max_elements_per_allocation(const size_type allocation_amount) PLF_NOEXCEPT
+	{
+		// Get a rough approximation of the number of elements + skipfield units we can fit in the amount expressed:
+		PLF_CONSTFUNC size_type num_units = allocation_amount / (sizeof(aligned_element_struct) + sizeof(skipfield_type));
+		PLF_CONSTFUNC plf::limits hard_capacities = block_capacity_hard_limits();
+
+		// Truncate the amount to the implementation's hard block capacity max limit:
+		if (num_units > hard_capacities.max) num_units = hard_capacities.max;
+
+		// Adjust num_units downward based on (a) the additional skipfield node necessary per-block in this implementation and
+		// (b) any additional memory waste required in order to allocate the skipfield in multiples of the element type's alignof:
+		if ((	/* Explanation: elements and skipfield are allocated in a single allocation to save performance.
+				In order for the elements to be correctly aligned in memory, this single allocation is aligned to the alignof
+				the element type, so the first line below is the allocation amount in bytes required for the skipfield
+				when allocated in multiples of the element type's alignof. The + sizeof(skipfield_type) adds the additional skipfield node
+				as mentioned, and the (num_units + 1) minus 1 byte rounds up the integer division: */
+			(((((num_units + 1) * sizeof(aligned_allocation_struct)) - 1) + sizeof(skipfield_type)) / sizeof(aligned_allocation_struct))
+				/* the second line is the amount of memory in bytes necessary for the elements themselves: */
+			+ (num_units * sizeof(aligned_element_struct)))
+				/* then we compare against the desired allocation amount: */
+			> allocation_amount)
+		{
+			--num_units; // In this implementation it is not possible for the necessary adjustment to be greater than 1 element+skipfield sizeof
+		}
+
+		if (num_units < hard_capacities.min) num_units = 0;
+
+		return num_units;
 	}
 
 
 
 	#ifdef PLF_COLONY_TEST_DEBUG // used for debugging during internal testing only:
-		inline size_type group_size_sum() const
+		size_type group_size_sum() const PLF_NOEXCEPT
 		{
-			group_pointer_type current = begin_iterator.group_pointer;
 			size_type temp = 0;
 
-			while(current != NULL)
+			for (group_pointer_type current = begin_iterator.group_pointer; current != NULL; current = current->next_group)
 			{
-				temp += current->number_of_elements;
-				current = current->next_group;
+				temp += current->size;
 			}
 
 			return temp;
@@ -2801,117 +3481,200 @@ public:
 	#endif
 
 
-	inline size_type max_size() const PLF_COLONY_NOEXCEPT
+
+private:
+
+	// get all elements contiguous in memory and shrink to fit, remove erasures and free lists. Invalidates all iterators and pointers to elements.
+	void consolidate(const skipfield_type new_min, const skipfield_type new_max)
 	{
-		#ifdef PLF_COLONY_ALLOCATOR_TRAITS_SUPPORT
-      	return std::allocator_traits<element_allocator_type>::max_size(*this);
-		#else
-      	return element_allocator_type::max_size();
-      #endif
-	}
+		colony temp(plf::limits(new_min, new_max));
+		temp.reserve(total_size);
+		temp.end_iterator.group_pointer->next_group = temp.unused_groups_head;
 
-
-
-	inline size_type capacity() const PLF_COLONY_NOEXCEPT
-	{
-		return total_capacity;
-	}
-
-
-
-	inline size_type approximate_memory_use() const PLF_COLONY_NOEXCEPT
-	{
-		return
-			sizeof(*this) + // sizeof colony basic structure
-			(total_capacity * (sizeof(aligned_element_type) + sizeof(skipfield_type))) + // sizeof current colony data capacity + skipfields
-			((end_iterator.group_pointer == NULL) ? 0 : ((end_iterator.group_pointer->group_number + 1) * (sizeof(group) + sizeof(skipfield_type)))); // if colony not empty, add the memory usage of the group structures themselves, adding the extra skipfield node
-	}
-
-
-
-	void change_group_sizes(const skipfield_type min_allocation_amount, const skipfield_type max_allocation_amount)
-	{
-		assert((min_allocation_amount > 2) & (min_allocation_amount <= max_allocation_amount));
-
-		pointer_allocator_pair.min_elements_per_group = min_allocation_amount;
-		group_allocator_pair.max_elements_per_group = max_allocation_amount;
-
-		if (begin_iterator.group_pointer != NULL && (begin_iterator.group_pointer->capacity < min_allocation_amount || end_iterator.group_pointer->capacity > max_allocation_amount))
+		#if defined(PLF_MOVE_SEMANTICS_SUPPORT) && defined(PLF_TYPE_TRAITS_SUPPORT)
+			if PLF_CONSTEXPR (!std::is_trivially_copyable<element_type>::value && std::is_nothrow_move_constructible<element_type>::value)
+			{
+				temp.range_fill_unused_groups(total_size, plf::make_move_iterator(begin_iterator), 0, NULL, temp.begin_iterator.group_pointer);
+			}
+			else
+		#endif
 		{
-			consolidate();
+			temp.range_fill_unused_groups(total_size, begin_iterator, 0, NULL, temp.begin_iterator.group_pointer);
 		}
-	}
 
-
-
-	inline void change_minimum_group_size(const skipfield_type min_allocation_amount)
-	{
-		change_group_sizes(min_allocation_amount, group_allocator_pair.max_elements_per_group);
-	}
-
-
-
-	inline void change_maximum_group_size(const skipfield_type max_allocation_amount)
-	{
-		change_group_sizes(pointer_allocator_pair.min_elements_per_group, max_allocation_amount);
-	}
-
-
-
-	inline void get_group_sizes(skipfield_type &minimum_group_size, skipfield_type &maximum_group_size) const PLF_COLONY_NOEXCEPT
-	{
-		minimum_group_size = pointer_allocator_pair.min_elements_per_group;
-		maximum_group_size = group_allocator_pair.max_elements_per_group;
-	}
-
-
-
-	inline void reinitialize(const skipfield_type min_allocation_amount, const skipfield_type max_allocation_amount) PLF_COLONY_NOEXCEPT
-	{
-		assert((min_allocation_amount > 2) & (min_allocation_amount <= max_allocation_amount));
-		clear();
-		pointer_allocator_pair.min_elements_per_group = min_allocation_amount;
-		group_allocator_pair.max_elements_per_group = max_allocation_amount;
-	}
-
-
-
-	inline PLF_COLONY_FORCE_INLINE void clear() PLF_COLONY_NOEXCEPT
-	{
-		destroy_all_data();
-		blank();
-	}
-
-
-
-	inline colony & operator = (const colony &source)
-	{
-		assert (&source != this);
-
-		#ifdef PLF_COLONY_MOVE_SEMANTICS_SUPPORT
-			destroy_all_data();
-			colony temp(source);
+		#ifdef PLF_MOVE_SEMANTICS_SUPPORT
 			*this = std::move(temp); // Avoid generating 2nd temporary
 		#else
-			clear();
-			colony temp(source);
 			swap(temp);
 		#endif
+	}
 
+
+
+public:
+
+
+	void reshape(const plf::limits block_limits)
+	{
+		check_capacities_conformance(block_limits);
+		const skipfield_type new_min = static_cast<skipfield_type>(block_limits.min), new_max = static_cast<skipfield_type>(block_limits.max);
+
+		if (total_capacity != 0)
+		{
+			if (total_size != 0)
+			{
+				if (min_block_capacity > new_max || max_block_capacity < new_min) // If none of the original blocks could potentially fit within the new limits, skip checking of blocks and just consolidate:
+				{
+					consolidate(new_min, new_max);
+					return;
+				}
+
+				if (min_block_capacity < new_min || max_block_capacity > new_max) // ie. If existing blocks could be outside of the new limits
+				{
+					// Otherwise need to check all group sizes here (not just back one, which is most likely largest), because splice might append smaller blocks after a larger block:
+					for (group_pointer_type current_group = begin_iterator.group_pointer; current_group != NULL; current_group = current_group->next_group)
+					{
+						if (current_group->capacity < new_min || current_group->capacity > new_max)
+						{
+							consolidate(new_min, new_max);
+							return;
+						}
+					}
+				}
+			}
+			else // include first group to be checked in the loop below
+			{
+				begin_iterator.group_pointer->next_group = unused_groups_head;
+				unused_groups_head = begin_iterator.group_pointer;
+			}
+
+			// If a consolidation or throw has not occured, process reserved/unused groups and deallocate where they don't fit the new limits:
+
+			for (group_pointer_type current_group = unused_groups_head, previous_group = NULL; current_group != NULL;)
+			{
+				const group_pointer_type next_group = current_group->next_group;
+
+				if (current_group->capacity < new_min || current_group->capacity > new_max)
+				{
+					deallocate_group_remove_capacity(current_group);
+
+					if (previous_group == NULL)
+					{
+						unused_groups_head = next_group;
+					}
+					else
+					{
+						previous_group->next_group = next_group;
+					}
+				}
+				else
+				{
+					previous_group = current_group;
+				}
+
+				current_group = next_group;
+			}
+
+			if (total_size == 0)
+			{
+				if (unused_groups_head == NULL)
+				{
+					blank();
+				}
+				else
+				{
+					begin_iterator.group_pointer = unused_groups_head;
+					unused_groups_head = begin_iterator.group_pointer->next_group;
+					begin_iterator.group_pointer->next_group = NULL;
+				}
+			}
+		}
+
+		min_block_capacity = new_min;
+		max_block_capacity = new_max;
+	}
+
+
+
+	PLF_CONSTFUNC plf::limits block_capacity_limits() const PLF_NOEXCEPT
+	{
+		return plf::limits(static_cast<size_t>(min_block_capacity), static_cast<size_t>(max_block_capacity));
+	}
+
+
+
+	static PLF_CONSTFUNC plf::limits block_capacity_hard_limits() PLF_NOEXCEPT
+	{
+		return plf::limits(3, std::min(static_cast<size_t>(std::numeric_limits<skipfield_type>::max()), max_size_static()));
+	}
+
+
+
+	void clear() PLF_NOEXCEPT
+	{
+		if (total_size == 0) return;
+
+		// Destroy all elements if element type is non-trivial:
+		#ifdef PLF_TYPE_TRAITS_SUPPORT
+			if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
+		#endif
+		{
+			destroy_remainder(begin_iterator);
+		}
+
+		if (begin_iterator.group_pointer != end_iterator.group_pointer)
+		{ // Move all other groups onto the unused_groups list
+			end_iterator.group_pointer->next_group = unused_groups_head;
+			unused_groups_head = begin_iterator.group_pointer->next_group;
+			end_iterator.group_pointer = begin_iterator.group_pointer; // other parts of iterator reset in the function below
+		}
+
+		reset_only_group_left(begin_iterator.group_pointer);
+		erasure_groups_head = NULL;
+		total_size = 0;
+	}
+
+
+
+	colony & operator = (const colony &source)
+	{
+		assert(&source != this);
+
+		#ifdef PLF_ALLOCATOR_TRAITS_SUPPORT
+			if PLF_CONSTEXPR (std::allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value)
+		#endif
+		{
+			#ifdef PLF_IS_ALWAYS_EQUAL_SUPPORT
+				if PLF_CONSTEXPR (!std::allocator_traits<allocator_type>::is_always_equal::value)
+			#endif
+			{
+				if (static_cast<allocator_type &>(*this) != static_cast<const allocator_type &>(source))
+				{ // Deallocate existing blocks as source allocator is not necessarily able to do so
+					reset();
+				}
+			}
+
+			static_cast<allocator_type &>(*this) = static_cast<const allocator_type &>(source);
+			// Reconstruct rebinds:
+			group_allocator = group_allocator_type(*this);
+			aligned_struct_allocator = aligned_struct_allocator_type(*this);
+			skipfield_allocator = skipfield_allocator_type(*this);
+			tuple_allocator = tuple_allocator_type(*this);
+		}
+
+		range_assign(source.begin_iterator, source.total_size);
 		return *this;
 	}
 
 
 
-	#ifdef PLF_COLONY_MOVE_SEMANTICS_SUPPORT
-		// Move assignment
-		colony & operator = (colony &&source) PLF_COLONY_NOEXCEPT_MOVE_ASSIGNMENT(allocator_type)
-		{
-			assert (&source != this);
-			destroy_all_data();
+	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+	private:
 
-			#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-				if PLF_COLONY_CONSTEXPR (std::is_trivial<group_pointer_type>::value && std::is_trivial<aligned_pointer_type>::value && std::is_trivial<skipfield_pointer_type>::value)
+		void move_assign(colony &&source) PLF_NOEXCEPT
+		{
+			#ifdef PLF_IS_ALWAYS_EQUAL_SUPPORT
+				if PLF_CONSTEXPR ((std::is_trivially_copyable<allocator_type>::value || std::allocator_traits<allocator_type>::is_always_equal::value) && std::is_trivially_copyable<group_pointer_type>::value)
 				{
 					std::memcpy(static_cast<void *>(this), &source, sizeof(colony));
 				}
@@ -2920,11 +3683,66 @@ public:
 			{
 				end_iterator = std::move(source.end_iterator);
 				begin_iterator = std::move(source.begin_iterator);
-				groups_with_erasures_list_head = source.groups_with_erasures_list_head;
-				total_number_of_elements = source.total_number_of_elements;
+				erasure_groups_head = std::move(source.erasure_groups_head);
+				unused_groups_head =  std::move(source.unused_groups_head);
+				total_size = source.total_size;
 				total_capacity = source.total_capacity;
-				pointer_allocator_pair.min_elements_per_group = source.pointer_allocator_pair.min_elements_per_group;
-				group_allocator_pair.max_elements_per_group = source.group_allocator_pair.max_elements_per_group;
+				min_block_capacity = source.min_block_capacity;
+				max_block_capacity = source.max_block_capacity;
+
+				#ifdef PLF_ALLOCATOR_TRAITS_SUPPORT
+					if PLF_CONSTEXPR(std::allocator_traits<allocator_type>::propagate_on_container_move_assignment::value)
+				#endif
+				{
+					static_cast<allocator_type &>(*this) = static_cast<allocator_type &>(source);
+					// Reconstruct rebinds:
+					group_allocator = group_allocator_type(*this);
+					aligned_struct_allocator = aligned_struct_allocator_type(*this);
+					skipfield_allocator = skipfield_allocator_type(*this);
+					tuple_allocator = tuple_allocator_type(*this);
+				}
+			}
+		}
+
+
+
+	public:
+
+		// Move assignment
+		#ifdef PLF_IS_ALWAYS_EQUAL_SUPPORT
+			colony & operator = (colony &&source) PLF_NOEXCEPT(std::allocator_traits<allocator_type>::propagate_on_container_move_assignment::value || std::allocator_traits<allocator_type>::is_always_equal::value)
+		#else
+			colony & operator = (colony &&source)
+		#endif
+		{
+			assert(&source != this);
+			destroy_all_data();
+
+			#ifdef PLF_IS_ALWAYS_EQUAL_SUPPORT
+				if PLF_CONSTEXPR (std::allocator_traits<allocator_type>::propagate_on_container_move_assignment::value || std::allocator_traits<allocator_type>::is_always_equal::value)
+				{ // Note: we need this to be constexpr to avoid warning errors on the potentially-throwing section below
+					move_assign(std::move(source));
+				}
+				else
+			#endif
+			if (static_cast<allocator_type &>(*this) == static_cast<allocator_type &>(source))
+			{
+				move_assign(std::move(source));
+			}
+			else // Allocator isn't propagatable so move elements from source and deallocate the source's blocks. Could throw here:
+			{
+				#ifdef PLF_TYPE_TRAITS_SUPPORT
+					if PLF_CONSTEXPR (!(std::is_move_constructible<element_type>::value && std::is_move_assignable<element_type>::value))
+					{
+						range_assign(source.begin_iterator, source.total_size);
+					}
+					else
+				#endif
+				{
+					range_assign(plf::make_move_iterator(source.begin_iterator), source.total_size);
+				}
+
+				source.destroy_all_data();
 			}
 
 			source.blank();
@@ -2934,21 +3752,23 @@ public:
 
 
 
-	bool operator == (const colony &rh) const PLF_COLONY_NOEXCEPT
-	{
-		assert (this != &rh);
-
-		if (total_number_of_elements != rh.total_number_of_elements)
+	#ifdef PLF_INITIALIZER_LIST_SUPPORT
+		colony & operator = (const std::initializer_list<element_type> &element_list)
 		{
-			return false;
+			range_assign(element_list.begin(), static_cast<size_type>(element_list.size()));
+			return *this;
 		}
+	#endif
 
-		for (iterator lh_iterator = begin_iterator, rh_iterator = rh.begin_iterator; lh_iterator != end_iterator;)
+
+
+	friend bool operator == (const colony &lh, const colony &rh) PLF_NOEXCEPT
+	{
+		if (lh.total_size != rh.total_size) return false;
+
+		for (const_iterator lh_iterator = lh.begin_iterator, rh_iterator = rh.begin_iterator; lh_iterator != lh.end_iterator; ++lh_iterator, ++rh_iterator)
 		{
-			if (*rh_iterator++ != *lh_iterator++)
-			{
-				return false;
-			}
+			if (*lh_iterator != *rh_iterator) return false;
 		}
 
 		return true;
@@ -2956,716 +3776,305 @@ public:
 
 
 
-	inline bool operator != (const colony &rh) const PLF_COLONY_NOEXCEPT
+	friend bool operator != (const colony &lh, const colony &rh) PLF_NOEXCEPT
 	{
-		return !(*this == rh);
+		return !(lh == rh);
 	}
+
+
+
+	#ifdef PLF_CPP20_SUPPORT
+		friend constexpr std::strong_ordering operator <=> (const colony &lh, const colony &rh)
+		{
+			return std::lexicographical_compare_three_way(lh.begin(), lh.end(), rh.begin(), rh.end());
+		}
+	#endif
 
 
 
 	void shrink_to_fit()
 	{
-		if (total_number_of_elements == total_capacity)
+		if (total_size == total_capacity)
 		{
 			return;
 		}
-		else if (total_number_of_elements == 0) // Edge case
+		else if (total_size == 0)
 		{
-			clear();
+			reset();
 			return;
 		}
 
-		consolidate();
+		consolidate(min_block_capacity, max_block_capacity);
 	}
 
 
 
-	void reserve(const size_type original_reserve_amount)
+	void trim_capacity() PLF_NOEXCEPT
 	{
-		if (original_reserve_amount == 0 || original_reserve_amount <= total_capacity) // Already have enough space allocated
+		if (end_iterator.element_pointer == NULL) return; // empty colony
+
+		while(unused_groups_head != NULL)
 		{
-			return;
+			const group_pointer_type next_group = unused_groups_head->next_group;
+			deallocate_group_remove_capacity(unused_groups_head);
+			unused_groups_head = next_group;
 		}
 
-		skipfield_type reserve_amount;
+		if (begin_iterator.element_pointer == end_iterator.element_pointer) // ie. clear() has been called prior
+		{
+			deallocate_group(begin_iterator.group_pointer);
+			blank();
+		}
+	}
 
-		if (original_reserve_amount > static_cast<size_type>(group_allocator_pair.max_elements_per_group))
+
+
+	void trim_capacity(const size_type capacity_retain) PLF_NOEXCEPT
+	{
+		const size_type capacity_difference = total_capacity - capacity_retain;
+
+		if (end_iterator.element_pointer == NULL || total_capacity <= capacity_retain || total_size >= capacity_retain || capacity_difference < min_block_capacity) return;
+
+		size_type number_of_elements_to_remove = capacity_difference;
+
+		for (group_pointer_type current_group = unused_groups_head, previous_group = NULL; current_group != NULL;)
 		{
-			reserve_amount = group_allocator_pair.max_elements_per_group;
+			const group_pointer_type next_group = current_group->next_group;
+
+			if (number_of_elements_to_remove >= current_group->capacity)
+			{
+				number_of_elements_to_remove -= current_group->capacity;
+				deallocate_group(current_group);
+
+				if (previous_group == NULL)
+				{
+					unused_groups_head = next_group;
+				}
+				else
+				{
+					previous_group->next_group = next_group;
+				}
+
+				if (number_of_elements_to_remove < min_block_capacity) break;
+			}
+			else
+			{
+				previous_group = current_group;
+			}
+
+			current_group = next_group;
 		}
-		else if (original_reserve_amount < static_cast<size_type>(pointer_allocator_pair.min_elements_per_group))
+
+
+		if (begin_iterator.element_pointer == end_iterator.element_pointer) // ie. clear() has been called prior
 		{
-			reserve_amount = pointer_allocator_pair.min_elements_per_group;
+			if (number_of_elements_to_remove >= begin_iterator.group_pointer->capacity)
+			{
+				number_of_elements_to_remove -= begin_iterator.group_pointer->capacity;
+				deallocate_group(begin_iterator.group_pointer);
+
+				if (unused_groups_head != NULL) // some of the reserved blocks were not removed as they were too large, so use one of these to make the new begin group
+				{
+					begin_iterator.group_pointer = unused_groups_head;
+					begin_iterator.element_pointer = to_aligned_pointer(unused_groups_head->elements);
+					begin_iterator.skipfield_pointer = unused_groups_head->skipfield;
+					end_iterator = begin_iterator;
+
+					unused_groups_head = unused_groups_head->next_group;
+					begin_iterator.group_pointer->next_group = NULL;
+				}
+				else
+				{
+					blank();
+					return;
+				}
+			}
 		}
-		else if (original_reserve_amount > max_size())
+
+		total_capacity -= capacity_difference - number_of_elements_to_remove;
+	}
+
+
+
+	void reserve(size_type new_capacity)
+	{
+		if (new_capacity == 0 || new_capacity <= total_capacity) return; // ie. We already have enough space allocated
+
+		if (new_capacity > max_size())
 		{
-			reserve_amount = static_cast<skipfield_type>(max_size());
+			#ifdef PLF_EXCEPTIONS_SUPPORT
+				throw std::length_error("Capacity requested via reserve() greater than max_size()");
+			#else
+				std::terminate();
+			#endif
+		}
+
+		new_capacity -= total_capacity;
+
+		size_type number_of_max_groups = new_capacity / max_block_capacity;
+		skipfield_type remainder = static_cast<skipfield_type>(new_capacity - (number_of_max_groups * max_block_capacity)), negative_remainder = 0;
+		group_pointer_type deallocatable_group = NULL;
+
+		if (remainder == 0)
+		{
+			remainder = max_block_capacity;
+			--number_of_max_groups;
 		}
 		else
 		{
-			reserve_amount = static_cast<skipfield_type>(original_reserve_amount);
-		}
+			// Here we try to increase iteration performance by deallocating a small unused group and allocating one larger group.
+			// This also means that if remainder < min_block_capacity we don't have to allocate a min capacity group and spread the difference over subsequent groups (see subsequent if block).
+			// The smaller group is not deallocated immediately so that, in the event that an exception is triggered when allocating the larger group, we don't end up with lower capacity than before reserve().
 
-		if (total_number_of_elements == 0) // Most common scenario - empty colony
-		{
-			if (begin_iterator.group_pointer != NULL) // Edge case - empty colony but first group is initialized ie. had some insertions but all elements got subsequently erased
+			if (unused_groups_head != NULL && max_block_capacity - remainder >= min_block_capacity)
 			{
-				PLF_COLONY_DESTROY(group_allocator_type, group_allocator_pair, begin_iterator.group_pointer);
-				PLF_COLONY_DEALLOCATE(group_allocator_type, group_allocator_pair, begin_iterator.group_pointer, 1);
-			} // else: Empty colony, no insertions yet, time to allocate
-
-			initialize(reserve_amount);
-			begin_iterator.group_pointer->last_endpoint = begin_iterator.group_pointer->elements; // last_endpoint initially == elements + 1 via default constructor
-			begin_iterator.group_pointer->number_of_elements = 0; // 1 by default
-		}
-		else // Non-empty colony, don't have enough space allocated
-		{
-			const skipfield_type original_min_elements = pointer_allocator_pair.min_elements_per_group;
-			pointer_allocator_pair.min_elements_per_group = static_cast<skipfield_type>(reserve_amount); // Make sure all groups are at maximum appropriate capacity (this amount already rounded down to a skipfield type earlier in function)
-			consolidate();
-			pointer_allocator_pair.min_elements_per_group = original_min_elements;
-		}
-	}
-
-
-
-	// Advance implementation for iterator and const_iterator:
-	template <bool is_const>
-	void advance(colony_iterator<is_const> &it, difference_type distance) const // Cannot be noexcept due to the possibility of an uninitialized iterator
-	{
-		// For code simplicity - should hopefully be optimized out by compiler:
-		group_pointer_type &group_pointer = it.group_pointer;
-		aligned_pointer_type &element_pointer = it.element_pointer;
-		skipfield_pointer_type &skipfield_pointer = it.skipfield_pointer;
-
-		assert(group_pointer != NULL); // covers uninitialized colony_iterator && empty group
-
-		// Now, run code based on the nature of the distance type - negative, positive or zero:
-		if (distance > 0) // ie. +=
-		{
-			// Code explanation:
-			// For the initial state of the iterator, we don't know how what elements have been erased before that element in that group.
-			// So for the first group, we follow the following logic:
-			// 1. If no elements have been erased in the group, we do simple addition to progress either to within the group (if the distance is small enough) or the end of the group and subtract from distance accordingly.
-			// 2. If any of the first group elements have been erased, we manually iterate, as we don't know whether the erased elements occur before or after the initial iterator position, and we subtract 1 from the distance amount each time. Iteration continues until either distance becomes zero, or we reach the end of the group.
-
-			// For all subsequent groups, we follow this logic:
-			// 1. If distance is larger than the total number of non-erased elements in a group, we skip that group and subtract the number of elements in that group from distance
-			// 2. If distance is smaller than the total number of non-erased elements in a group, then:
-			//	  a. if there're no erased elements in the group we simply add distance to group->elements to find the new location for the iterator
-			//	  b. if there are erased elements in the group, we manually iterate and subtract 1 from distance on each iteration, until the new iterator location is found ie. distance = 0
-
-			// Note: incrementing element_pointer is avoided until necessary to avoid needless calculations
-
-			assert (!(element_pointer == group_pointer->last_endpoint && group_pointer->next_group == NULL)); // Check that we're not already at end()
-
-			// Special case for initial element pointer and initial group (we don't know how far into the group the element pointer is)
-			if (element_pointer != group_pointer->elements + *(group_pointer->skipfield)) // ie. != first non-erased element in group
-			{
-				const difference_type distance_from_end = static_cast<difference_type>(group_pointer->last_endpoint - element_pointer);
-
-				if (group_pointer->number_of_elements == static_cast<skipfield_type>(distance_from_end)) // ie. if there are no erasures in the group (using endpoint - elements_start to determine number of elements in group just in case this is the last group of the colony, in which case group->last_endpoint != group->elements + group->capacity)
-				{
-					if (distance < distance_from_end)
-					{
-						element_pointer += distance;
-						skipfield_pointer += distance;
-						return;
-					}
-					else if (group_pointer->next_group == NULL) // either we've reached end() or gone beyond it, so bound to end()
-					{
-						element_pointer = group_pointer->last_endpoint;
-						skipfield_pointer += distance_from_end;
-						return;
-					}
-					else
-					{
-						distance -= distance_from_end;
-					}
-				}
-				else
-				{
-					const skipfield_pointer_type endpoint = skipfield_pointer + distance_from_end;
-
-					while(true)
-					{
-						++skipfield_pointer;
-						skipfield_pointer += *skipfield_pointer;
-						--distance;
-
-						if (skipfield_pointer == endpoint)
-						{
-							break;
-						}
-						else if (distance == 0)
-						{
-							element_pointer = group_pointer->elements + (skipfield_pointer - group_pointer->skipfield);
-							return;
-						}
-					}
-
-					if (group_pointer->next_group == NULL) // either we've reached end() or gone beyond it, so bound to end()
-					{
-						element_pointer = group_pointer->last_endpoint;
-						return;
-					}
-				}
-
-				group_pointer = group_pointer->next_group;
-
-				if (distance == 0)
-				{
-					element_pointer = group_pointer->elements + *(group_pointer->skipfield);
-					skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
-					return;
-				}
-			}
-
-
-			// Intermediary groups - at the start of this code block and the subsequent block, the position of the iterator is assumed to be the first non-erased element in the current group:
-			while (static_cast<difference_type>(group_pointer->number_of_elements) <= distance)
-			{
-				if (group_pointer->next_group == NULL) // either we've reached end() or gone beyond it, so bound to end()
-				{
-					element_pointer = group_pointer->last_endpoint;
-					skipfield_pointer = group_pointer->skipfield + (group_pointer->last_endpoint - group_pointer->elements);
-					return;
-				}
-				else if ((distance -= group_pointer->number_of_elements) == 0)
-				{
-					group_pointer = group_pointer->next_group;
-					element_pointer = group_pointer->elements + *(group_pointer->skipfield);
-					skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
-					return;
-				}
-				else
-				{
-					group_pointer = group_pointer->next_group;
-				}
-			}
-
-
-			// Final group (if not already reached):
-			if (group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()) // No erasures in this group, use straight pointer addition
-			{
-				element_pointer = group_pointer->elements + distance;
-				skipfield_pointer = group_pointer->skipfield + distance;
-				return;
-			}
-			else	 // ie. number_of_elements > distance - safe to ignore endpoint check condition while incrementing:
-			{
-				skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
+				deallocatable_group = unused_groups_head;
+				group_pointer_type prev_unused_group = NULL;
 
 				do
 				{
-					++skipfield_pointer;
-					skipfield_pointer += *skipfield_pointer;
-				} while(--distance != 0);
+					const skipfield_type current_capacity = deallocatable_group->capacity;
 
-				element_pointer = group_pointer->elements + (skipfield_pointer - group_pointer->skipfield);
-				return;
-			}
-
-			return;
-		}
-		else if (distance < 0) // for negative change
-		{
-			// Code logic is very similar to += above
-			assert(!((element_pointer == group_pointer->elements + *(group_pointer->skipfield)) && group_pointer->previous_group == NULL)); // check that we're not already at begin()
-			distance = -distance;
-
-			// Special case for initial element pointer and initial group (we don't know how far into the group the element pointer is)
-			if (element_pointer != group_pointer->last_endpoint) // ie. != end()
-			{
-				if (group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()) // ie. no prior erasures have occurred in this group
-				{
-					const difference_type distance_from_beginning = static_cast<difference_type>(element_pointer - group_pointer->elements);
-
-					if (distance <= distance_from_beginning)
+					// If there exists an unused group which's of low-enough capacity, deallocate that later and add it's capacity to the remainder group:
+					if (std::numeric_limits<skipfield_type>::max() - current_capacity > remainder && /* <- to make sure we don't overflow in next line */
+						max_block_capacity >= current_capacity + remainder)
 					{
-						element_pointer -= distance;
-						skipfield_pointer -= distance;
-						return;
-					}
-					else if (group_pointer->previous_group == NULL) // ie. we've gone before begin(), so bound to begin()
-					{
-						element_pointer = group_pointer->elements;
-						skipfield_pointer = group_pointer->skipfield;
-						return;
-					}
-					else
-					{
-						distance -= distance_from_beginning;
-					}
-				}
-				else
-				{
-					const skipfield_pointer_type beginning_point = group_pointer->skipfield + *(group_pointer->skipfield);
+						remainder += current_capacity;
+						const group_pointer_type next_group = deallocatable_group->next_group;
 
-					while(skipfield_pointer != beginning_point)
-					{
-						--skipfield_pointer;
-						skipfield_pointer -= *skipfield_pointer;
-
-						if (--distance == 0)
+						if (prev_unused_group != NULL)
 						{
-							element_pointer = group_pointer->elements + (skipfield_pointer - group_pointer->skipfield);
-							return;
+							prev_unused_group->next_group = next_group;
 						}
-					}
-
-					if (group_pointer->previous_group == NULL)
-					{
-						element_pointer = group_pointer->elements + *(group_pointer->skipfield); // This is first group, so bound to begin() (just in case final decrement took us before begin())
-						skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
-						return;
-					}
-				}
-
-				group_pointer = group_pointer->previous_group;
-			}
-
-
-			// Intermediary groups - at the start of this code block and the subsequent block, the position of the iterator is assumed to be either the first non-erased element in the next group over, or end():
-			while(static_cast<difference_type>(group_pointer->number_of_elements) < distance)
-			{
-				if (group_pointer->previous_group == NULL) // we've gone beyond begin(), so bound to it
-				{
-					element_pointer = group_pointer->elements + *(group_pointer->skipfield);
-					skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
-					return;
-				}
-
-				distance -= group_pointer->number_of_elements;
-				group_pointer = group_pointer->previous_group;
-			}
-
-
-			// Final group (if not already reached):
-			if (static_cast<difference_type>(group_pointer->number_of_elements) == distance)
-			{
-				element_pointer = group_pointer->elements + *(group_pointer->skipfield);
-				skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
-				return;
-			}
-			else if (group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()) // ie. no erased elements in this group
-			{
-				element_pointer = reinterpret_cast<aligned_pointer_type>(group_pointer->skipfield) - distance;
-				skipfield_pointer = (group_pointer->skipfield + group_pointer->capacity) - distance;
-				return;
-			}
-			else // ie. no more groups to traverse but there are erased elements in this group
-			{
-				skipfield_pointer = group_pointer->skipfield + group_pointer->capacity;
-
-				do
-				{
-					--skipfield_pointer;
-					skipfield_pointer -= *skipfield_pointer;
-				} while(--distance != 0);
-
-				element_pointer = group_pointer->elements + (skipfield_pointer - group_pointer->skipfield);
-				return;
-			}
-		}
-
-		// Only distance == 0 reaches here
-	}
-
-
-
-
-	// Advance for reverse_iterator and const_reverse_iterator - this needs to be implemented slightly differently to forward-iterator's advance, as it needs to be able to reach rend() (ie. begin() - 1) and to be bounded by rbegin():
-	template <bool is_const>
-	void advance(colony_reverse_iterator<is_const> &reverse_it, difference_type distance) const // could cause exception if iterator is uninitialized
-	{
-		group_pointer_type &group_pointer = reverse_it.it.group_pointer;
-		aligned_pointer_type &element_pointer = reverse_it.it.element_pointer;
-		skipfield_pointer_type &skipfield_pointer = reverse_it.it.skipfield_pointer;
-
-		assert(element_pointer != NULL);
-
-		if (distance > 0)
-		{
-			assert (!(element_pointer == group_pointer->elements - 1 && group_pointer->previous_group == NULL)); // Check that we're not already at rend()
-			// Special case for initial element pointer and initial group (we don't know how far into the group the element pointer is)
-			// Since a reverse_iterator cannot == last_endpoint (ie. before rbegin()) we don't need to check for that like with iterator
-			if (group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max())
-			{
-				difference_type distance_from_beginning = static_cast<difference_type>(element_pointer - group_pointer->elements);
-
-				if (distance <= distance_from_beginning)
-				{
-					element_pointer -= distance;
-					skipfield_pointer -= distance;
-					return;
-				}
-				else if (group_pointer->previous_group == NULL) // Either we've reached rend() or gone beyond it, so bound to rend()
-				{
-					element_pointer = group_pointer->elements - 1;
-					skipfield_pointer = group_pointer->skipfield - 1;
-					return;
-				}
-				else
-				{
-					distance -= distance_from_beginning;
-				}
-			}
-			else
-			{
-				const skipfield_pointer_type beginning_point = group_pointer->skipfield + *(group_pointer->skipfield);
-
-				while(skipfield_pointer != beginning_point)
-				{
-					--skipfield_pointer;
-					skipfield_pointer -= *skipfield_pointer;
-
-					if (--distance == 0)
-					{
-						element_pointer = group_pointer->elements + (skipfield_pointer - group_pointer->skipfield);
-						return;
-					}
-				}
-
-				if (group_pointer->previous_group == NULL)
-				{
-					element_pointer = group_pointer->elements - 1; // If we've reached rend(), bound to that
-					skipfield_pointer = group_pointer->skipfield - 1;
-					return;
-				}
-			}
-
-			group_pointer = group_pointer->previous_group;
-
-
-			// Intermediary groups - at the start of this code block and the subsequent block, the position of the iterator is assumed to be the first non-erased element in the next group:
-			while(static_cast<difference_type>(group_pointer->number_of_elements) < distance)
-			{
-				if (group_pointer->previous_group == NULL) // bound to rend()
-				{
-					element_pointer = group_pointer->elements - 1;
-					skipfield_pointer = group_pointer->skipfield - 1;
-					return;
-				}
-
-				distance -= static_cast<difference_type>(group_pointer->number_of_elements);
-				group_pointer = group_pointer->previous_group;
-			}
-
-
-			// Final group (if not already reached)
-			if (static_cast<difference_type>(group_pointer->number_of_elements) == distance)
-			{
-				element_pointer = group_pointer->elements + *(group_pointer->skipfield);
-				skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
-				return;
-			}
-			else if (group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max())
-			{
-				element_pointer = reinterpret_cast<aligned_pointer_type>(group_pointer->skipfield) - distance;
-				skipfield_pointer = (group_pointer->skipfield + group_pointer->capacity) - distance;
-				return;
-			}
-			else
-			{
-				skipfield_pointer = group_pointer->skipfield + group_pointer->capacity;
-
-				do
-				{
-					--skipfield_pointer;
-					skipfield_pointer -= *skipfield_pointer;
-				} while(--distance != 0);
-
-				element_pointer = group_pointer->elements + (skipfield_pointer - group_pointer->skipfield);
-				return;
-			}
-		}
-		else if (distance < 0)
-		{
-			assert (!((element_pointer == (group_pointer->last_endpoint - 1) - *(group_pointer->skipfield + (group_pointer->last_endpoint - group_pointer->elements) - 1)) && group_pointer->next_group == NULL)); // Check that we're not already at rbegin()
-
-			if (element_pointer != group_pointer->elements + *(group_pointer->skipfield)) // ie. != first non-erased element in group
-			{
-				if (group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()) // ie. if there are no erasures in the group
-				{
-					const difference_type distance_from_end = static_cast<difference_type>(group_pointer->last_endpoint - element_pointer);
-
-					if (distance < distance_from_end)
-					{
-						element_pointer += distance;
-						skipfield_pointer += distance;
-						return;
-					}
-					else if (group_pointer->next_group == NULL) // bound to rbegin()
-					{
-						element_pointer = group_pointer->last_endpoint - 1; // no erasures so we don't have to subtract skipfield value as we do below
-						skipfield_pointer += distance_from_end - 1;
-						return;
-					}
-					else
-					{
-						distance -= distance_from_end;
-					}
-				}
-				else
-				{
-					const skipfield_pointer_type endpoint = skipfield_pointer + (group_pointer->last_endpoint - element_pointer);
-
-					while(true)
-					{
-						++skipfield_pointer;
-						skipfield_pointer += *skipfield_pointer;
-						--distance;
-
-						if (skipfield_pointer == endpoint)
+						else
 						{
-							break;
+						  	unused_groups_head = next_group;
 						}
-						else if (distance == 0)
-						{
-							element_pointer = group_pointer->elements + (skipfield_pointer - group_pointer->skipfield);
-							return;
-						}
+
+						break;
 					}
 
-					if (group_pointer->next_group == NULL) // bound to rbegin()
+					prev_unused_group = deallocatable_group;
+					deallocatable_group = deallocatable_group->next_group;
+				} while (deallocatable_group != NULL);
+			}
+
+
+			if (remainder < min_block_capacity) // Implies we were unable to consolidate remainder with an existing unused group, in the if-block above
+			{
+				// Note: negative_remainder is used to take the difference between the minimum block capacity limit and the actual remainder, and spread this negative difference over subsequent blocks which are in the usual case at max capacity.
+				negative_remainder = min_block_capacity - remainder;
+				remainder = min_block_capacity;
+
+	  			// This line checks to see - if we have to reduce the size of the max-capacity blocks to spread the negative_remainder out - whether even reducing the max blocks to min capacity will be enough to keep the capacity under max_size(). We add 1 for the initial (remainder) block. This guards against situations where, for example, the min/max limits are very similar so spreading the negative remainder out is less doable:
+				if (max_size() - total_capacity < ((number_of_max_groups + 1) * min_block_capacity))
+				{
+					#ifdef PLF_EXCEPTIONS_SUPPORT
+						throw std::length_error("Reserve cannot increase capacity to >= n without being > max_size() due to current capacity() and block capacity limits");
+					#else
+						std::terminate();
+					#endif
+				}
+			}
+		}
+
+
+		group_pointer_type current_group, first_unused_group;
+
+		if (begin_iterator.group_pointer == NULL) // Most common scenario - empty hive
+		{
+			initialize(remainder);
+			begin_iterator.group_pointer->size = 0; // Note: this is set to 1 by default in the initialize function (which is optimised for insert())
+
+			if (number_of_max_groups == 0) return;
+
+			// Make the first allocated unused group:
+			const skipfield_type new_block_capacity = (max_block_capacity - negative_remainder < min_block_capacity) ? min_block_capacity : max_block_capacity - negative_remainder;
+			negative_remainder -= max_block_capacity - new_block_capacity;
+			first_unused_group = current_group = allocate_new_group(new_block_capacity, begin_iterator.group_pointer);
+			--number_of_max_groups;
+		}
+		else // Non-empty hive, add first new unused group:
+		{
+			#ifdef PLF_EXCEPTIONS_SUPPORT
+				try
+				{
+					first_unused_group = current_group = allocate_new_group(remainder, end_iterator.group_pointer);
+				}
+				catch (...)
+				{
+					if (deallocatable_group != NULL) // roll back group removal
 					{
-						--skipfield_pointer;
-						element_pointer = (group_pointer->last_endpoint - 1) - *skipfield_pointer;
-						skipfield_pointer -= *skipfield_pointer;
-						return;
+						add_to_unused_groups_list(deallocatable_group);
 					}
+
+					throw;
 				}
+			#else
+				first_unused_group = current_group = allocate_new_group(remainder, end_iterator.group_pointer);
+			#endif
 
-				group_pointer = group_pointer->next_group;
-
-				if (distance == 0)
-				{
-					element_pointer = group_pointer->elements + *(group_pointer->skipfield);
-					skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
-					return;
-				}
-			}
-
-
-			// Intermediary groups - at the start of this code block and the subsequent block, the position of the iterator is assumed to be the first non-erased element in the current group, as a result of the previous code blocks:
-			while(static_cast<difference_type>(group_pointer->number_of_elements) <= distance)
-			{
-				if (group_pointer->next_group == NULL) // bound to rbegin()
-				{
-					skipfield_pointer = group_pointer->skipfield + (group_pointer->last_endpoint - group_pointer->elements) - 1;
-					--skipfield_pointer;
-					element_pointer = (group_pointer->last_endpoint - 1) - *skipfield_pointer;
-					skipfield_pointer -= *skipfield_pointer;
-					return;
-				}
-				else if ((distance -= group_pointer->number_of_elements) == 0)
-				{
-					group_pointer = group_pointer->next_group;
-					element_pointer = group_pointer->elements + *(group_pointer->skipfield);
-					skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
-					return;
-				}
-				else
-				{
-					group_pointer = group_pointer->next_group;
-				}
-			}
-
-
-			// Final group (if not already reached):
-			if (group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()) // No erasures in this group, use straight pointer addition
-			{
-				element_pointer = group_pointer->elements + distance;
-				skipfield_pointer = group_pointer->skipfield + distance;
-				return;
-			}
-			else // ie. number_of_elements > distance - safe to ignore endpoint check condition while incrementing:
-			{
-				skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
-
-				do
-				{
-					++skipfield_pointer;
-					skipfield_pointer += *skipfield_pointer;
-				} while(--distance != 0);
-
-				element_pointer = group_pointer->elements + (skipfield_pointer - group_pointer->skipfield);
-				return;
-			}
-
-			return;
+			// We've now successfully allocated another group which is guaranteed to be larger than this group, so capacity is larger than it was before reserve() was called even if the other allocations below trigger an exception, and we can deallocate the group:
+			if (deallocatable_group != NULL) deallocate_group_remove_capacity(deallocatable_group);
 		}
+
+
+		while (number_of_max_groups != 0)
+		{
+			const skipfield_type new_block_capacity = (max_block_capacity - negative_remainder < min_block_capacity) ? min_block_capacity : max_block_capacity - negative_remainder;
+			negative_remainder -= max_block_capacity - new_block_capacity;
+
+			#ifdef PLF_EXCEPTIONS_SUPPORT
+				try
+				{
+					current_group->next_group = allocate_new_group(new_block_capacity, current_group);
+				}
+				catch (...)
+				{
+					current_group->next_group = unused_groups_head;
+					unused_groups_head = first_unused_group;
+					throw;
+				}
+			#else
+				current_group->next_group = allocate_new_group(new_block_capacity, current_group);
+			#endif
+
+			current_group = current_group->next_group;
+			--number_of_max_groups;
+		}
+
+		current_group->next_group = unused_groups_head;
+		unused_groups_head = first_unused_group;
 	}
 
 
 
-
-	// Next implementations:
-	template <bool is_const>
-	inline colony_iterator<is_const> next(const colony_iterator<is_const> &it, const typename colony_iterator<is_const>::difference_type distance = 1) const
-	{
-		colony_iterator<is_const> return_iterator(it);
-		advance(return_iterator, distance);
-		return return_iterator;
-	}
-
-
+private:
 
 	template <bool is_const>
-	inline colony_reverse_iterator<is_const> next(const colony_reverse_iterator<is_const> &it, const typename colony_reverse_iterator<is_const>::difference_type distance = 1) const
+	colony_iterator<is_const> get_it(const pointer element_pointer) const PLF_NOEXCEPT
 	{
-		colony_reverse_iterator<is_const> return_iterator(it);
-		advance(return_iterator, distance);
-		return return_iterator;
-	}
-
-
-
-	// Prev implementations:
-	template <bool is_const>
-	inline colony_iterator<is_const> prev(const colony_iterator<is_const> &it, const typename colony_iterator<is_const>::difference_type distance = 1) const
-	{
-		colony_iterator<is_const> return_iterator(it);
-		advance(return_iterator, -distance);
-		return return_iterator;
-	}
-
-
-
-	template <bool is_const>
-	inline colony_reverse_iterator<is_const> prev(const colony_reverse_iterator<is_const> &it, const typename colony_reverse_iterator<is_const>::difference_type distance = 1) const
-	{
-		colony_reverse_iterator<is_const> return_iterator(it);
-		advance(return_iterator, -distance);
-		return return_iterator;
-	}
-
-
-
-	// distance implementation:
-
-	template <bool is_const>
-	typename colony_iterator<is_const>::difference_type distance(const colony_iterator<is_const> &first, const colony_iterator<is_const> &last) const
-	{
-		// Code logic:
-		// If iterators are the same, return 0
-		// Otherwise, find which iterator is later in colony, copy that to iterator2. Copy the lower to iterator1.
-		// If they are not pointing to elements in the same group, process the intermediate groups and add distances,
-		// skipping manual incrementation in all but the initial and final groups.
-		// In the initial and final groups, manual incrementation must be used to calculate distance, if there have been no prior erasures in those groups.
-		// If there are no prior erasures in either of those groups, we can use pointer arithmetic to calculate the distances for those groups.
-
-		assert(!(first.group_pointer == NULL) && !(last.group_pointer == NULL));  // Check that they are initialized
-
-		if (last.element_pointer == first.element_pointer)
+		if (end_iterator.group_pointer != NULL)
 		{
-			return 0;
-		}
+			const aligned_pointer_type aligned_element_pointer = to_aligned_pointer(element_pointer);
+			// Note: we start with checking the back group first, as it will be the largest group in most cases, so there's a statistically-higher chance of the element being within it.
 
-		typedef colony_iterator<is_const> iterator_type;
-		typedef typename iterator_type::difference_type diff_type;
-		diff_type distance = 0;
-
-		iterator_type iterator1 = first, iterator2 = last;
-		const bool swap = first > last;
-
-		if (swap) // Less common case
-		{
-			iterator1 = last;
-			iterator2 = first;
-		}
-
-		if (iterator1.group_pointer != iterator2.group_pointer) // if not in same group, process intermediate groups
-		{
-			// Process initial group:
-			if (iterator1.group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()) // If no prior erasures have occured in this group we can do simple addition
+			// Special case for back group in case the element was in a group which became empty and got moved to the unused_groups list or was deallocated, and then that memory was re-used (ie. it became the current back group). The following prevents the function from mistakenly returning an iterator which is beyond the back element of the colony:
+			if (aligned_element_pointer >= to_aligned_pointer(end_iterator.group_pointer->elements) && aligned_element_pointer < end_iterator.element_pointer)
 			{
-				distance += static_cast<diff_type>(iterator1.group_pointer->last_endpoint - iterator1.element_pointer);
+				const skipfield_pointer_type skipfield_pointer = end_iterator.group_pointer->skipfield + (aligned_element_pointer - to_aligned_pointer(end_iterator.group_pointer->elements));
+				return (*skipfield_pointer == 0) ? colony_iterator<is_const>(end_iterator.group_pointer, aligned_element_pointer, skipfield_pointer) : colony_iterator<is_const>(end_iterator);
 			}
-			else if (iterator1.element_pointer == iterator1.group_pointer->elements) // ie. element is at start of group - rare case
-			{
-				distance += static_cast<diff_type>(iterator1.group_pointer->number_of_elements);
-			}
-			else
-			{
-				const skipfield_pointer_type endpoint = iterator1.skipfield_pointer + (iterator1.group_pointer->last_endpoint - iterator1.element_pointer);
 
-				while (iterator1.skipfield_pointer != endpoint)
+			// All other groups, if any exist:
+			for (group_pointer_type current_group = end_iterator.group_pointer->previous_group; current_group != NULL; current_group = current_group->previous_group)
+			{
+				if (aligned_element_pointer >= to_aligned_pointer(current_group->elements) && aligned_element_pointer < to_aligned_pointer(current_group->skipfield))
 				{
-					iterator1.skipfield_pointer += *(++iterator1.skipfield_pointer);
-					++distance;
+					const skipfield_pointer_type skipfield_pointer = current_group->skipfield + (aligned_element_pointer - to_aligned_pointer(current_group->elements));
+					return (*skipfield_pointer == 0) ? colony_iterator<is_const>(current_group, aligned_element_pointer, skipfield_pointer) : colony_iterator<is_const>(end_iterator);
 				}
 			}
-
-			// Process all other intermediate groups:
-			iterator1.group_pointer = iterator1.group_pointer->next_group;
-
-			while (iterator1.group_pointer != iterator2.group_pointer)
-			{
-				distance += static_cast<diff_type>(iterator1.group_pointer->number_of_elements);
-				iterator1.group_pointer = iterator1.group_pointer->next_group;
-			}
-
-			iterator1.skipfield_pointer = iterator1.group_pointer->skipfield;
-		}
-
-
-		if (iterator1.group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()) // ie. no erasures in this group, direct subtraction is possible
-		{
-			distance += static_cast<diff_type>(iterator2.skipfield_pointer - iterator1.skipfield_pointer);
-		}
-		else if (iterator1.group_pointer->last_endpoint - 1 >= iterator2.element_pointer) // ie. if iterator2 is .end() or 1 before
-		{
-			distance += static_cast<diff_type>(iterator1.group_pointer->number_of_elements - (iterator1.group_pointer->last_endpoint - iterator2.element_pointer));
-		}
-		else
-		{
-			while (iterator1.skipfield_pointer != iterator2.skipfield_pointer)
-			{
-				iterator1.skipfield_pointer += *(++iterator1.skipfield_pointer);
-				++distance;
-			}
-		}
-
-
-		if (swap)
-		{
-			distance = -distance;
-		}
-
-		return distance;
-	}
-
-
-
-	template <bool is_const>
-	inline typename colony_reverse_iterator<is_const>::difference_type distance(const colony_reverse_iterator<is_const> &first, const colony_reverse_iterator<is_const> &last) const
-	{
-		return distance(last.it, first.it);
-	}
-
-
-
-
-	// Type-changing functions:
-
-	iterator get_iterator_from_pointer(const pointer element_pointer) const // Cannot be noexcept as colony could be empty or pointer invalid
-	{
-		assert(!empty());
-		assert(element_pointer != NULL);
-
-		group_pointer_type current_group = end_iterator.group_pointer; // Start with last group first, as will be the largest group
-
-		while (current_group != NULL)
-		{
-			if (reinterpret_cast<aligned_pointer_type>(element_pointer) >= current_group->elements && reinterpret_cast<aligned_pointer_type>(element_pointer) < reinterpret_cast<aligned_pointer_type>(current_group->skipfield))
-			{
-				const skipfield_pointer_type skipfield_pointer = current_group->skipfield + (reinterpret_cast<aligned_pointer_type>(element_pointer) - current_group->elements);
-				return (*skipfield_pointer == 0) ? iterator(current_group, reinterpret_cast<aligned_pointer_type>(element_pointer), skipfield_pointer) : end_iterator; // If element has been erased, return end()
-			}
-
-			current_group = current_group->previous_group;
 		}
 
 		return end_iterator;
@@ -3673,85 +4082,281 @@ public:
 
 
 
-	template <bool is_const>
-	size_type get_index_from_iterator(const colony_iterator<is_const> &it) const // may throw exception if iterator is invalid/uninitialized
+public:
+
+	iterator get_iterator(const pointer element_pointer) PLF_NOEXCEPT
 	{
-		assert(!empty());
-		assert(it.group_pointer != NULL);
+		return get_it<false>(element_pointer);
+	}
 
-		// This is essentially a simplified version of distance() optimized for counting from begin()
-		size_type index = 0;
-		group_pointer_type group_pointer = begin_iterator.group_pointer;
 
-		// For all prior groups, add group sizes
-		while (group_pointer != it.group_pointer)
+
+	const_iterator get_iterator(const const_pointer element_pointer) const PLF_NOEXCEPT
+	{
+		return get_it<true>(const_cast<pointer>(element_pointer));
+	}
+
+
+
+	bool is_active(const const_iterator &it) const PLF_NOEXCEPT
+	{
+		if (end_iterator.group_pointer != NULL)
 		{
-			index += static_cast<size_type>(group_pointer->number_of_elements);
-			group_pointer = group_pointer->next_group;
-		}
+			// Schema: check (a) that the group the iterator belongs to is still active and not deallocated or in the unused_groups list, then (b) that the element is not erased. (a) prevents an out-of-bounds memory access if the group is deallocated. Same reasoning as get_iterator for loop conditions
 
-		if (group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max())
-		{
-			index += static_cast<size_type>(it.element_pointer - group_pointer->elements); // If no erased elements in group exist, do straight pointer arithmetic to get distance to start for first element
-		}
-		else // Otherwise do manual ++ loop - count from beginning of group until location is reached
-		{
-			skipfield_pointer_type skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
-
-			while(skipfield_pointer != it.skipfield_pointer)
+			// Special case for back group, same reasoning as in get_it():
+			if (it.group_pointer == end_iterator.group_pointer && it.element_pointer >= to_aligned_pointer(end_iterator.group_pointer->elements) && it.element_pointer < end_iterator.element_pointer)
 			{
-				++skipfield_pointer;
-				skipfield_pointer += *skipfield_pointer;
-				++index;
+				return (*it.skipfield_pointer == 0);
+			}
+
+			for (group_pointer_type current_group = end_iterator.group_pointer->previous_group; current_group != NULL; current_group = current_group->previous_group)
+			{
+				if (it.group_pointer == current_group && it.element_pointer >= to_aligned_pointer(current_group->elements) && it.element_pointer < to_aligned_pointer(current_group->skipfield)) // 2nd 2 conditions necessary in case the group contained the element which the iterator points to, has been deallocated from the colony previously, but then the same pointer address is re-supplied via an allocator for a subsequent group allocation (in which case the group's element block memory location may be different)
+				{
+					return (*it.skipfield_pointer == 0);
+				}
 			}
 		}
 
-		return index;
+		return false;
 	}
 
 
 
-	template <bool is_const>
-	inline size_type get_index_from_reverse_iterator(const colony_reverse_iterator<is_const> &rev_iterator) const
+	allocator_type get_allocator() const PLF_NOEXCEPT
 	{
-		return get_index_from_iterator(rev_iterator.it);
+		return static_cast<allocator_type>(*this);
 	}
-
-
-
-	template <typename index_type>
-	iterator get_iterator_from_index(const index_type index) const // Cannot be noexcept as colony could be empty
-	{
-		assert(!empty());
-		assert(std::numeric_limits<index_type>::is_integer);
-
-		iterator it(begin_iterator);
-		advance(it, static_cast<difference_type>(index));
-		return it;
-	}
-
-
-
-    inline allocator_type get_allocator() const PLF_COLONY_NOEXCEPT
-    {
-		return element_allocator_type();
-	}
-
 
 
 
 private:
 
-	struct less
+	void source_blocks_incompatible()
 	{
-		bool operator() (const element_type &a, const element_type &b) const PLF_COLONY_NOEXCEPT
+		#ifdef PLF_EXCEPTIONS_SUPPORT
+			throw std::length_error("A source memory block capacity is outside of the destination's minimum or maximum memory block capacity limits - please change either the source or the destination's min/max block capacity limits using reshape() before calling splice() in this case");
+		#else
+			std::terminate();
+		#endif
+	}
+
+
+
+public:
+
+	void splice(colony &source)
+	{
+		// Process: if there are unused memory spaces at the end of the current back group of the chain, convert them
+		// to skipped elements and add the locations to the group's free list.
+		// Then link the destination's groups to the source's groups and nullify the source.
+		// If the source has more unused memory spaces in the back group than the destination, swap them before processing to reduce the number of locations added to a free list and also subsequent jumps during iteration.
+
+		assert(&source != this);
+
+		if (source.total_size == 0) return;
+
+		// Throw if incompatible block capacities found in source:
+		if (source.min_block_capacity > max_block_capacity || source.max_block_capacity < min_block_capacity) // ie. source blocks cannot possibly fit within *this's block capacity limits
 		{
-			return a < b;
+			source_blocks_incompatible();
 		}
+		else if (source.min_block_capacity < min_block_capacity || source.max_block_capacity > max_block_capacity) // ie. source blocks may or may not fit
+		{
+			for (group_pointer_type current_group = source.begin_iterator.group_pointer; current_group != NULL; current_group = current_group->next_group)
+			{
+				if (current_group->capacity < min_block_capacity || current_group->capacity > max_block_capacity)
+				{
+					source_blocks_incompatible();
+				}
+			}
+		}
+
+
+		if (total_size != 0)
+		{
+			// If there's more unused element locations in back memory block of destination than in back memory block of source, swap with source to reduce number of skipped elements during iteration:
+			if ((to_aligned_pointer(end_iterator.group_pointer->skipfield) - end_iterator.element_pointer) > (to_aligned_pointer(source.end_iterator.group_pointer->skipfield) - source.end_iterator.element_pointer))
+			{
+				swap(source);
+				// Swap back unused groups list and block capacity limits so that source and *this retain their original ones:
+				std::swap(source.unused_groups_head, unused_groups_head);
+				std::swap(source.min_block_capacity, min_block_capacity);
+				std::swap(source.max_block_capacity, max_block_capacity);
+			}
+
+
+			// Add source list of groups-with-erasures to destination list of groups-with-erasures:
+			if (source.erasure_groups_head != NULL)
+			{
+				if (erasure_groups_head != NULL)
+				{
+					group_pointer_type tail_group = erasure_groups_head;
+
+					while (tail_group->erasures_list_next_group != NULL)
+					{
+						tail_group = tail_group->erasures_list_next_group;
+					}
+
+					tail_group->erasures_list_next_group = source.erasure_groups_head;
+					source.erasure_groups_head->erasures_list_previous_group = tail_group;
+				}
+				else
+				{
+					erasure_groups_head = source.erasure_groups_head;
+				}
+			}
+
+
+			const skipfield_type distance_to_end = static_cast<skipfield_type>(to_aligned_pointer(end_iterator.group_pointer->skipfield) - end_iterator.element_pointer);
+
+			if (distance_to_end != 0) // 0 == edge case
+			{	 // Mark unused element memory locations from back group as skipped/erased:
+				// Update skipfield:
+				const skipfield_type previous_node_value = *(end_iterator.skipfield_pointer - 1);
+
+				if (previous_node_value == 0) // no previous skipblock
+				{
+					*end_iterator.skipfield_pointer = distance_to_end;
+					*(end_iterator.skipfield_pointer + distance_to_end - 1) = distance_to_end;
+
+					if (distance_to_end > 2) // make erased middle nodes non-zero for get_iterator and is_active
+					{
+						std::memset(void_cast(end_iterator.skipfield_pointer + 1), 1, sizeof(skipfield_type) * (distance_to_end - 2));
+					}
+
+					const skipfield_type index = static_cast<skipfield_type>(end_iterator.element_pointer - to_aligned_pointer(end_iterator.group_pointer->elements));
+
+					if (end_iterator.group_pointer->free_list_head != std::numeric_limits<skipfield_type>::max()) // ie. if this group already has some erased elements
+					{
+						edit_free_list_next(to_aligned_pointer(end_iterator.group_pointer->elements) + end_iterator.group_pointer->free_list_head, index); // set prev free list head's 'next index' number to the index of the current element
+					}
+					else
+					{
+						add_to_groups_with_erasures_list(end_iterator.group_pointer);
+					}
+
+					edit_free_list_head(end_iterator.element_pointer, end_iterator.group_pointer->free_list_head);
+					end_iterator.group_pointer->free_list_head = index;
+				}
+				else
+				{ // update previous skipblock, no need to update free list:
+					*(end_iterator.skipfield_pointer - previous_node_value) = *(end_iterator.skipfield_pointer + distance_to_end - 1) = static_cast<skipfield_type>(previous_node_value + distance_to_end);
+
+					if (distance_to_end > 1) // make erased middle nodes non-zero for get_iterator and is_active
+					{
+						std::memset(void_cast(end_iterator.skipfield_pointer), 1, sizeof(skipfield_type) * (distance_to_end - 1));
+					}
+				}
+			}
+
+
+			// Join the destination and source group chains:
+			end_iterator.group_pointer->next_group = source.begin_iterator.group_pointer;
+			source.begin_iterator.group_pointer->previous_group = end_iterator.group_pointer;
+
+			// Update group numbers if necessary:
+			if (source.begin_iterator.group_pointer->group_number <= end_iterator.group_pointer->group_number)
+			{
+				size_type source_group_count = 0;
+
+				for (group_pointer_type current_group = source.begin_iterator.group_pointer; current_group != NULL; current_group = current_group->next_group, ++source_group_count) {}
+
+				if ((std::numeric_limits<size_type>::max() - end_iterator.group_pointer->group_number) >= source_group_count)
+				{
+					update_subsequent_group_numbers(end_iterator.group_pointer->group_number + 1u, source.begin_iterator.group_pointer);
+				}
+				else
+				#ifdef PLF_CPP20_SUPPORT
+					[[unlikely]]
+				#endif
+				{
+					reset_group_numbers();
+				}
+			}
+
+			end_iterator = source.end_iterator;
+			total_size += source.total_size;
+			total_capacity += source.total_capacity;
+		}
+		else // If *this is empty():
+		{
+			// Preserve unused_groups_head and de-link so that destroy_all_data doesn't remove them:
+			const group_pointer_type original_unused_groups = unused_groups_head;
+			unused_groups_head = NULL;
+			destroy_all_data();
+			unused_groups_head = original_unused_groups;
+
+			// Move source data to *this:
+			end_iterator = source.end_iterator;
+			begin_iterator = source.begin_iterator;
+			erasure_groups_head = source.erasure_groups_head;
+			total_size = source.total_size;
+			total_capacity = source.total_capacity;
+
+			// Add capacity for unused groups back into *this:
+			for (group_pointer_type current = original_unused_groups; current != NULL; current = current->next_group)
+			{
+				total_capacity += current->capacity;
+			}
+		}
+
+
+		// Reset source values:
+		const group_pointer_type original_unused_groups_head = source.unused_groups_head; // grab value before it gets wiped
+		source.blank(); // blank source before adding capacity from unused groups back in
+
+		if (original_unused_groups_head != NULL) // If there were unused groups in source, re-link them and remove their capacity count from *this while adding it to source:
+		{
+			size_type source_unused_groups_capacity = 0;
+
+			// Count capacity in source unused_groups:
+			for (group_pointer_type current = original_unused_groups_head; current != NULL; current = current->next_group)
+			{
+				source_unused_groups_capacity += current->capacity;
+			}
+
+			total_capacity -= source_unused_groups_capacity;
+			source.total_capacity = source_unused_groups_capacity;
+
+			// Establish first group from source unused_groups as first active group in source, link rest as reserved groups:
+			source.unused_groups_head = original_unused_groups_head->next_group;
+			source.begin_iterator.group_pointer = original_unused_groups_head;
+			source.begin_iterator.element_pointer = to_aligned_pointer(original_unused_groups_head->elements);
+			source.begin_iterator.skipfield_pointer = original_unused_groups_head->skipfield;
+			source.end_iterator = source.begin_iterator;
+			original_unused_groups_head->reset(0, NULL, NULL, 0);
+		}
+	}
+
+
+
+	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+		void splice(colony &&source)
+		{
+			splice(source);
+		}
+	#endif
+
+
+
+private:
+
+
+	struct item_index_tuple
+	{
+		pointer original_location;
+		size_type original_index;
+
+		item_index_tuple(const pointer _item, const size_type _index) PLF_NOEXCEPT:
+			original_location(_item),
+			original_index(_index)
+		{}
 	};
 
 
-	// Function-object, used to redirect the sort function to compare element pointers by the elements they point to, and sort the element pointers instead of the elements:
+
 	template <class comparison_function>
 	struct sort_dereferencer
 	{
@@ -3761,296 +4366,1606 @@ private:
 			stored_instance(function_instance)
 		{}
 
-		sort_dereferencer() PLF_COLONY_NOEXCEPT
-		{}
-
-		bool operator() (const pointer first, const pointer second)
+		bool operator() (const item_index_tuple first, const item_index_tuple second)
 		{
-			return stored_instance(*first, *second);
+			return stored_instance(*(first.original_location), *(second.original_location));
 		}
 	};
 
 
-public:
 
+
+	// Try and find space in the unused blocks or the back block instead of allocating for sort:
+	template <class the_type>
+	aligned_pointer_type get_free_space() const PLF_NOEXCEPT
+	{
+		const size_type number_of_elements_needed = ((total_size * sizeof(the_type)) + sizeof(aligned_element_struct) - 1) / sizeof(aligned_element_struct); // rounding up
+
+		if (number_of_elements_needed < max_block_capacity)
+		{
+			if (static_cast<size_type>(to_aligned_pointer(end_iterator.group_pointer->skipfield) - end_iterator.element_pointer) >= number_of_elements_needed)
+			{ // there is enough space at the back of the back block
+				return end_iterator.element_pointer;
+			}
+
+			for (group_pointer_type current = unused_groups_head; current != NULL; current = current->next_group)
+			{
+				if (current->capacity >= number_of_elements_needed) return to_aligned_pointer(current->elements); // ie. there is enough space in one of the unused blocks
+			}
+		}
+
+		return NULL;
+	}
+
+
+
+public:
 
 	template <class comparison_function>
 	void sort(comparison_function compare)
 	{
-		if (total_number_of_elements < 2)
-		{
-			return;
-		}
+		if (total_size < 2) return;
 
-		pointer * const element_pointers = PLF_COLONY_ALLOCATE(pointer_allocator_type, pointer_allocator_pair, total_number_of_elements, NULL);
-		pointer *element_pointer = element_pointers;
-
-		// Construct pointers to all elements in the colony in sequence:
-		for (iterator current_element = begin_iterator; current_element != end_iterator; ++current_element)
-		{
-			PLF_COLONY_CONSTRUCT(pointer_allocator_type, pointer_allocator_pair, element_pointer++, &*current_element);
-		}
-
-		// Now, sort the pointers by the values they point to:
-		#ifdef GFX_TIMSORT_HPP
-			gfx::timsort(element_pointers, element_pointers + total_number_of_elements, sort_dereferencer<comparison_function>(compare));
+  		#ifdef PLF_TYPE_TRAITS_SUPPORT
+			if PLF_CONSTEXPR ((std::is_trivially_copyable<element_type>::value || std::is_move_assignable<element_type>::value) && sizeof(element_type) <= sizeof(element_type *) * 2) // If element is <= 2 pointers, just copy to an array and sort that then copy back - consumes less memory
 		#else
-			std::sort(element_pointers, element_pointers + total_number_of_elements, sort_dereferencer<comparison_function>(compare));
+			if PLF_CONSTEXPR (sizeof(element_type) <= sizeof(element_type *) * 2)
 		#endif
-
-
-		// Create a new colony and copy the elements from the old one to the new one in the order of the sorted pointers:
-		colony new_location;
-		new_location.change_group_sizes(pointer_allocator_pair.min_elements_per_group, group_allocator_pair.max_elements_per_group);
-
-
-		try
 		{
-			new_location.reserve(static_cast<skipfield_type>((total_number_of_elements > std::numeric_limits<skipfield_type>::max()) ? std::numeric_limits<skipfield_type>::max() : total_number_of_elements));
+			pointer sort_array = pointer_cast<pointer>(get_free_space<element_type>());
+			const bool need_to_allocate = (sort_array == NULL);
 
-			#if defined(PLF_COLONY_TYPE_TRAITS_SUPPORT) && defined(PLF_COLONY_MOVE_SEMANTICS_SUPPORT)
-				if PLF_COLONY_CONSTEXPR (std::is_move_constructible<element_type>::value)
+			if (need_to_allocate)
+			{
+				sort_array = PLF_ALLOCATE(allocator_type, *this, total_size, end_iterator.skipfield_pointer);
+			}
+
+			const pointer end = sort_array + total_size;
+
+			#if defined(PLF_TYPE_TRAITS_SUPPORT) && defined(PLF_MOVE_SEMANTICS_SUPPORT)
+				if PLF_CONSTEXPR (!std::is_trivially_copy_constructible<element_type>::value && std::is_nothrow_move_assignable<element_type>::value)
 				{
-					for (pointer *current_element_pointer = element_pointers; current_element_pointer != element_pointer; ++current_element_pointer)
+					std::uninitialized_copy(plf::make_move_iterator(begin_iterator), plf::make_move_iterator(end_iterator), sort_array);
+				}
+				else
+			#endif
+			{
+				std::uninitialized_copy(begin_iterator, end_iterator, sort_array);
+			}
+
+			PLF_SORT_FUNCTION(sort_array, end, compare);
+
+			#if defined(PLF_TYPE_TRAITS_SUPPORT) && defined(PLF_MOVE_SEMANTICS_SUPPORT)
+				if PLF_CONSTEXPR ((!std::is_trivially_copy_constructible<element_type>::value || !std::is_trivially_destructible<element_type>::value) && std::is_move_assignable<element_type>::value)
+				{
+					std::copy(plf::make_move_iterator(sort_array), plf::make_move_iterator(end), begin_iterator);
+				}
+				else
+			#endif
+			{
+				std::copy(sort_array, end, begin_iterator);
+
+				#ifdef PLF_TYPE_TRAITS_SUPPORT
+					if (!std::is_trivially_destructible<element_type>::value)
+				#endif
+				{
+					for (element_type *current = sort_array; current != end; ++current)
 					{
-						new_location.insert(std::move(*reinterpret_cast<pointer>(*current_element_pointer)));
+						PLF_DESTROY(allocator_type, *this, current);
 					}
 				}
-				else
-			#endif
+			}
+
+			if (need_to_allocate)
 			{
-				for (pointer *current_element_pointer = element_pointers; current_element_pointer != element_pointer; ++current_element_pointer)
+				PLF_DEALLOCATE(allocator_type, *this, sort_array, total_size);
+			}
+		}
+ 		else
+ 		{
+			tuple_pointer_type sort_array = pointer_cast<tuple_pointer_type>(get_free_space<item_index_tuple>());
+			const bool need_to_allocate = (sort_array == NULL);
+
+			if (need_to_allocate)
+			{
+				sort_array = PLF_ALLOCATE(tuple_allocator_type, tuple_allocator, total_size, end_iterator.skipfield_pointer);
+			}
+
+			tuple_pointer_type tuple_pointer = sort_array;
+
+			// Construct pointers to all elements in the sequence:
+			size_type index = 0;
+
+			for (iterator current_element = begin_iterator; current_element != end_iterator; ++current_element, ++tuple_pointer, ++index)
+			{
+				#ifdef PLF_VARIADICS_SUPPORT
+					PLF_CONSTRUCT(tuple_allocator_type, tuple_allocator, tuple_pointer, &*current_element, index);
+				#else
+					PLF_CONSTRUCT(tuple_allocator_type, tuple_allocator, tuple_pointer, item_index_tuple(&*current_element, index));
+				#endif
+			}
+
+			// Now, sort the pointers by the values they point to:
+			PLF_SORT_FUNCTION(sort_array, tuple_pointer, sort_dereferencer<comparison_function>(compare));
+
+			// Sort the actual elements via the tuple array:
+			index = 0;
+
+			for (tuple_pointer_type current_tuple = sort_array; current_tuple != tuple_pointer; ++current_tuple, ++index)
+			{
+				if (current_tuple->original_index != index)
 				{
-					new_location.insert(*reinterpret_cast<pointer>(*current_element_pointer));
+					#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+						element_type end_value = std::move(*(current_tuple->original_location));
+					#else
+						element_type end_value = *(current_tuple->original_location);
+					#endif
+					size_type destination_index = index;
+					size_type source_index = current_tuple->original_index;
+
+					do
+					{
+						#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+							*(sort_array[destination_index].original_location) = std::move(*(sort_array[source_index].original_location));
+						#else
+							*(sort_array[destination_index].original_location) = *(sort_array[source_index].original_location);
+						#endif
+						destination_index = source_index;
+						source_index = sort_array[destination_index].original_index;
+						sort_array[destination_index].original_index = destination_index;
+					} while (source_index != index);
+
+					#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+						*(sort_array[destination_index].original_location) = std::move(end_value);
+					#else
+						*(sort_array[destination_index].original_location) = end_value;
+					#endif
 				}
 			}
-		}
-		catch (...)
-		{
-			#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-				if PLF_COLONY_CONSTEXPR (!std::is_trivially_destructible<pointer>::value)
-			#endif
+
+			if (need_to_allocate)
 			{
-				for (pointer *current_element_pointer = element_pointers; current_element_pointer != element_pointer; ++current_element_pointer)
-				{
-					PLF_COLONY_DESTROY(pointer_allocator_type, pointer_allocator_pair, current_element_pointer);
-				}
-			}
-
-			PLF_COLONY_DEALLOCATE(pointer_allocator_type, pointer_allocator_pair, element_pointers, total_number_of_elements);
-			throw;
-		}
-
-
-		// Make the old colony the new one, destroy the old one's data/sequence:
-		#ifdef PLF_COLONY_MOVE_SEMANTICS_SUPPORT
-			*this = std::move(new_location); // avoid generating temporary
-		#else
-			swap(new_location);
-		#endif
-
-
-		#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-			if PLF_COLONY_CONSTEXPR (!std::is_trivially_destructible<pointer>::value)
-		#endif
-		{
-			for (pointer *current_element_pointer = element_pointers; current_element_pointer != element_pointer; ++current_element_pointer)
-			{
-				PLF_COLONY_DESTROY(pointer_allocator_type, pointer_allocator_pair, current_element_pointer);
+				PLF_DEALLOCATE(tuple_allocator_type, tuple_allocator, sort_array, total_size);
 			}
 		}
-
-		PLF_COLONY_DEALLOCATE(pointer_allocator_type, pointer_allocator_pair, element_pointers, total_number_of_elements);
 	}
 
 
 
-
-	inline void sort()
+	void sort()
 	{
-		sort(less());
+		sort(plf::less<element_type>());
 	}
 
 
 
-	void splice(colony &source) PLF_COLONY_NOEXCEPT_SWAP(allocator_type)
+	template <class comparison_function>
+	size_type unique(comparison_function compare)
 	{
-		// Process: if there are unused memory spaces at the end of the current back group of the chain, convert them
-		// to skipped elements and add the locations to the group's free list.
-		// Then link the destination's groups to the source's groups and nullify the source.
-		// If the source has more unused memory spaces in the back group than the destination, swap them before processing to reduce the number of locations added to a free list and also subsequent jumps during iteration.
+		if (total_size < 2) return 0;
 
-		assert(&source != this);
+		size_type count = 0;
+		const const_iterator end = end_iterator;
 
-		if (source.total_number_of_elements == 0)
+		for(const_iterator current = begin_iterator, previous = begin_iterator; ++current != end; previous = current)
 		{
-			return;
-		}
-		else if (total_number_of_elements == 0)
-		{
-			#ifdef PLF_COLONY_MOVE_SEMANTICS_SUPPORT
-				*this = std::move(source);
-			#else
-				clear();
-				swap(source);
-			#endif
-
-			return;
-		}
-
-		// If there's more unused element locations at end of destination than source, swap with source to reduce number of skipped elements and size of free-list:
-		if ((reinterpret_cast<aligned_pointer_type>(end_iterator.group_pointer->skipfield) - end_iterator.element_pointer) > (reinterpret_cast<aligned_pointer_type>(source.end_iterator.group_pointer->skipfield) - source.end_iterator.element_pointer))
-		{
-			swap(source);
-		}
-
-
-		// Correct group sizes if necessary:
-		if (source.pointer_allocator_pair.min_elements_per_group < pointer_allocator_pair.min_elements_per_group)
-		{
-			pointer_allocator_pair.min_elements_per_group = source.pointer_allocator_pair.min_elements_per_group;
-		}
-
-		if (source.group_allocator_pair.max_elements_per_group > group_allocator_pair.max_elements_per_group)
-		{
-			group_allocator_pair.max_elements_per_group = source.group_allocator_pair.max_elements_per_group;
-		}
-
-		// Add source list of groups-with-erasures to destination list of groups-with-erasures:
-		if (source.groups_with_erasures_list_head != NULL)
-		{
-			if (groups_with_erasures_list_head != NULL)
+			if (compare(*current, *previous))
 			{
-				group_pointer_type tail_group = groups_with_erasures_list_head;
+				const size_type original_count = ++count;
+				const_iterator last = current;
 
-				while (tail_group->erasures_list_next_group != NULL)
+				while(++last != end && compare(*last, *previous))
 				{
-					tail_group = tail_group->erasures_list_next_group;
+					++count;
 				}
 
-				tail_group->erasures_list_next_group = source.groups_with_erasures_list_head;
-			}
-			else
-			{
-				groups_with_erasures_list_head = source.groups_with_erasures_list_head;
-			}
-		}
-
-
-		const skipfield_type distance_to_end = static_cast<skipfield_type>(reinterpret_cast<aligned_pointer_type>(end_iterator.group_pointer->skipfield) - end_iterator.element_pointer);
-
-		if (distance_to_end != 0) // 0 == edge case
-		{   // Mark unused element memory locations from back group as skipped/erased:
-
-			// Update skipfield:
-			const skipfield_type previous_node_value = *(end_iterator.skipfield_pointer - 1);
-			end_iterator.group_pointer->last_endpoint = reinterpret_cast<aligned_pointer_type>(end_iterator.group_pointer->skipfield);
-
-			if (previous_node_value == 0) // no previous skipblock
-			{
-				*end_iterator.skipfield_pointer = distance_to_end;
-				*(end_iterator.skipfield_pointer + distance_to_end - 1) = distance_to_end;
-
-				const skipfield_type index = static_cast<skipfield_type>(end_iterator.element_pointer - end_iterator.group_pointer->elements);
-
-				if (end_iterator.group_pointer->free_list_head != std::numeric_limits<skipfield_type>::max()) // ie. if this group already has some erased elements
+				if (count != original_count)
 				{
-					*(reinterpret_cast<skipfield_pointer_type>(end_iterator.group_pointer->elements + end_iterator.group_pointer->free_list_head) + 1) = index; // set prev free list head's 'next index' number to the index of the current element
+					current = erase(current, last); // optimised range-erase
 				}
 				else
 				{
-					end_iterator.group_pointer->erasures_list_next_group = groups_with_erasures_list_head; // add it to the groups-with-erasures free list
-					groups_with_erasures_list_head = end_iterator.group_pointer;
+					current = erase(current);
 				}
 
-				*(reinterpret_cast<skipfield_pointer_type>(end_iterator.element_pointer)) = end_iterator.group_pointer->free_list_head;
-				*(reinterpret_cast<skipfield_pointer_type>(end_iterator.element_pointer) + 1) = std::numeric_limits<skipfield_type>::max();
-				end_iterator.group_pointer->free_list_head = index;
-			}
-			else
-			{ // update previous skipblock, no need to update free list:
-				*(end_iterator.skipfield_pointer - previous_node_value) = *(end_iterator.skipfield_pointer + distance_to_end - 1) = previous_node_value + distance_to_end;
+				if (last == end) break;
 			}
 		}
 
-
-		// Update subsequent group numbers:
-		group_pointer_type current_group = source.begin_iterator.group_pointer;
-		size_type current_group_number = end_iterator.group_pointer->group_number;
-
-		do
-		{
-			current_group->group_number = ++current_group_number;
-			current_group = current_group->next_group;
-		} while (current_group != NULL);
-
-
-		// Join the destination and source group chains:
-		end_iterator.group_pointer->next_group = source.begin_iterator.group_pointer;
-		source.begin_iterator.group_pointer->previous_group = end_iterator.group_pointer;
-		end_iterator = source.end_iterator;
-		total_number_of_elements += source.total_number_of_elements;
-		source.blank();
+		return count;
 	}
 
 
 
-	void swap(colony &source) PLF_COLONY_NOEXCEPT_SWAP(allocator_type)
+	size_type unique()
+	{
+		return unique(std::equal_to<element_type>());
+	}
+
+
+
+	void swap(colony &source) PLF_NOEXCEPT_SWAP(allocator_type)
 	{
 		assert(&source != this);
 
-		#ifdef PLF_COLONY_TYPE_TRAITS_SUPPORT
-			if PLF_COLONY_CONSTEXPR (std::is_trivial<group_pointer_type>::value && std::is_trivial<aligned_pointer_type>::value && std::is_trivial<skipfield_pointer_type>::value) // if all pointer types are trivial we can just copy using memcpy - avoids constructors/destructors etc and is faster
+		#ifdef PLF_IS_ALWAYS_EQUAL_SUPPORT
+			if PLF_CONSTEXPR (std::allocator_traits<allocator_type>::is_always_equal::value && std::is_trivially_copyable<group_pointer_type>::value) // if all pointer types are trivial we can just copy using memcpy - avoids constructors/destructors etc and is faster
 			{
 				char temp[sizeof(colony)];
 				std::memcpy(&temp, static_cast<void *>(this), sizeof(colony));
 				std::memcpy(static_cast<void *>(this), static_cast<void *>(&source), sizeof(colony));
 				std::memcpy(static_cast<void *>(&source), &temp, sizeof(colony));
 			}
-			#ifdef PLF_COLONY_MOVE_SEMANTICS_SUPPORT // If pointer types are not trivial, moving them is probably going to be more efficient than copying them below
-				else if PLF_COLONY_CONSTEXPR (std::is_move_assignable<group_pointer_type>::value && std::is_move_assignable<aligned_pointer_type>::value && std::is_move_assignable<skipfield_pointer_type>::value && std::is_move_constructible<group_pointer_type>::value && std::is_move_constructible<aligned_pointer_type>::value && std::is_move_constructible<skipfield_pointer_type>::value)
+			#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+				else if PLF_CONSTEXPR (std::is_move_assignable<group_pointer_type>::value && std::is_move_constructible<group_pointer_type>::value)
 				{
 					colony temp(std::move(source));
 					source = std::move(*this);
 					*this = std::move(temp);
 				}
+				else
 			#endif
-			else
 		#endif
 		{
-			const iterator						swap_end_iterator = end_iterator, swap_begin_iterator = begin_iterator;
-			const group_pointer_type		swap_groups_with_erasures_list_head = groups_with_erasures_list_head;
-			const size_type					swap_total_number_of_elements = total_number_of_elements, swap_total_capacity = total_capacity;
-			const skipfield_type 			swap_min_elements_per_group = pointer_allocator_pair.min_elements_per_group, swap_max_elements_per_group = group_allocator_pair.max_elements_per_group;
+			// Otherwise, make the reads/writes as contiguous in memory as-possible (yes, it is faster than using std::swap with the individual variables):
+			const iterator 				swap_end_iterator = end_iterator, swap_begin_iterator = begin_iterator;
+			const group_pointer_type	swap_erasure_groups_head = erasure_groups_head, swap_unused_groups_head = unused_groups_head;
+			const size_type				swap_total_size = total_size, swap_total_capacity = total_capacity;
+			const skipfield_type 		swap_min_block_capacity = min_block_capacity, swap_max_block_capacity = max_block_capacity;
 
 			end_iterator = source.end_iterator;
 			begin_iterator = source.begin_iterator;
-			groups_with_erasures_list_head = source.groups_with_erasures_list_head;
-			total_number_of_elements = source.total_number_of_elements;
+			erasure_groups_head = source.erasure_groups_head;
+			unused_groups_head = source.unused_groups_head;
+			total_size = source.total_size;
 			total_capacity = source.total_capacity;
-			pointer_allocator_pair.min_elements_per_group = source.pointer_allocator_pair.min_elements_per_group;
-			group_allocator_pair.max_elements_per_group = source.group_allocator_pair.max_elements_per_group;
+			min_block_capacity = source.min_block_capacity;
+			max_block_capacity = source.max_block_capacity;
 
 			source.end_iterator = swap_end_iterator;
 			source.begin_iterator = swap_begin_iterator;
-			source.groups_with_erasures_list_head = swap_groups_with_erasures_list_head;
-			source.total_number_of_elements = swap_total_number_of_elements;
+			source.erasure_groups_head = swap_erasure_groups_head;
+			source.unused_groups_head = swap_unused_groups_head;
+			source.total_size = swap_total_size;
 			source.total_capacity = swap_total_capacity;
-			source.pointer_allocator_pair.min_elements_per_group = swap_min_elements_per_group;
-			source.group_allocator_pair.max_elements_per_group = swap_max_elements_per_group;
+			source.min_block_capacity = swap_min_block_capacity;
+			source.max_block_capacity = swap_max_block_capacity;
+
+			#ifdef PLF_IS_ALWAYS_EQUAL_SUPPORT
+				if PLF_CONSTEXPR (std::allocator_traits<allocator_type>::propagate_on_container_swap::value && !std::allocator_traits<allocator_type>::is_always_equal::value)
+			#endif
+			{
+				std::swap(static_cast<allocator_type &>(source), static_cast<allocator_type &>(*this));
+
+				// Reconstruct rebinds for swapped allocators:
+				group_allocator = group_allocator_type(*this);
+				aligned_struct_allocator = aligned_struct_allocator_type(*this);
+				skipfield_allocator = skipfield_allocator_type(*this);
+				tuple_allocator = tuple_allocator_type(*this);
+				source.group_allocator = group_allocator_type(source);
+				source.aligned_struct_allocator = aligned_struct_allocator_type(source);
+				source.skipfield_allocator = skipfield_allocator_type(source);
+				source.tuple_allocator = tuple_allocator_type(source);
+			} // else: undefined behaviour, as per standard
 		}
 	}
 
-};	// colony
+
+
+	// Because it's going to take a lot of defining of very specific allocator and pointer types to make this work with smart pointers - this class and functions associated with it will not work if the allocator supplied to the container returns smart pointers.
+	struct colony_data : public uchar_allocator_type
+	{
+		aligned_pointer_type * const block_pointers; 	// array of pointers to element memory blocks
+		unsigned char * * const bitfield_pointers;		// array of pointers to bitfields in the form of unsigned char arrays representing whether an element is erased or not (0 for erased).
+		size_t * const block_capacities; 				// array of the number of elements in each memory block
+		const size_t number_of_blocks;					// size of each of the arrays above
+
+
+		colony_data(const colony::size_type size) :
+			block_pointers(pointer_cast<aligned_pointer_type *>(PLF_ALLOCATE(uchar_allocator_type, *this, size * sizeof(aligned_pointer_type), NULL))),
+			bitfield_pointers(pointer_cast<unsigned char **>(PLF_ALLOCATE(uchar_allocator_type, *this, size * sizeof(unsigned char *), NULL))),
+			block_capacities(pointer_cast<size_t *>(PLF_ALLOCATE(uchar_allocator_type, *this, size * sizeof(size_t), NULL))),
+			number_of_blocks(size)
+		{}
+
+
+		~colony_data()
+		{
+			for (size_t index = 0; index != number_of_blocks; ++index)
+			{
+				PLF_DEALLOCATE(uchar_allocator_type, *this, bitfield_pointers[index], (block_capacities[index] + 7) / 8);
+			}
+
+			PLF_DEALLOCATE(uchar_allocator_type, *this, pointer_cast<unsigned char *>(block_pointers), number_of_blocks * sizeof(aligned_pointer_type));
+			PLF_DEALLOCATE(uchar_allocator_type, *this, pointer_cast<unsigned char *>(bitfield_pointers), number_of_blocks * sizeof(unsigned char *));
+			PLF_DEALLOCATE(uchar_allocator_type, *this, pointer_cast<unsigned char *>(block_capacities), number_of_blocks * sizeof(size_t));
+		}
+	};
+
+
+
+private:
+
+	void setup_data_cell(colony_data *data, const group_pointer_type current_group, const size_t capacity, const size_t group_number)
+	{
+		const size_t bitfield_capacity = (capacity + 7) / 8; // round up
+
+		data->block_pointers[group_number] = to_aligned_pointer(current_group->elements);
+		unsigned char *bitfield_location = data->bitfield_pointers[group_number] = PLF_ALLOCATE(uchar_allocator_type, (*data), bitfield_capacity, NULL);
+		data->block_capacities[group_number] = capacity;
+		std::memset(bitfield_location, 0, bitfield_capacity);
+
+		skipfield_pointer_type skipfield_pointer = current_group->skipfield;
+		const unsigned char * const end = bitfield_location + bitfield_capacity;
+
+		for (size_t index = 0; bitfield_location != end; ++bitfield_location)
+		{
+			for (unsigned char offset = 0; offset != 8 && index != capacity; ++index, ++offset, ++skipfield_pointer)
+			{
+				*bitfield_location |= static_cast<unsigned char>(static_cast<int>(!*skipfield_pointer) << offset);
+			}
+		}
+	}
+
+
+
+public:
+
+	colony_data * data()
+	{
+		colony_data *data = new colony_data(end_iterator.group_pointer->group_number + 1);
+		size_t group_number = 0;
+
+		for (group_pointer_type current_group = begin_iterator.group_pointer; current_group != end_iterator.group_pointer; current_group = current_group->next_group, ++group_number)
+		{
+			setup_data_cell(data, current_group, current_group->capacity, group_number);
+		}
+
+		// Special case for end group:
+		setup_data_cell(data, end_iterator.group_pointer, static_cast<size_t>(end_iterator.element_pointer - to_aligned_pointer(end_iterator.group_pointer->elements)), group_number);
+
+		return data;
+	}
 
 
 
 
-template <class element_type, class element_allocator_type, typename element_skipfield_type>
-inline void swap (colony<element_type, element_allocator_type, element_skipfield_type> &a, colony<element_type, element_allocator_type, element_skipfield_type> &b) PLF_COLONY_NOEXCEPT_SWAP(element_allocator_type)
-{
-	a.swap(b);
-}
+	// Iterators:
+	template <bool is_const>
+	class colony_iterator
+	{
+	private:
+		typedef typename colony::group_pointer_type 		group_pointer_type;
+		typedef typename colony::aligned_pointer_type 	aligned_pointer_type;
+		typedef typename colony::skipfield_pointer_type skipfield_pointer_type;
+
+		#ifdef PLF_DEFAULT_SUPPORT
+			group_pointer_type		group_pointer{NULL};
+			aligned_pointer_type 	element_pointer{NULL};
+			skipfield_pointer_type	skipfield_pointer{NULL};
+		#else
+			group_pointer_type		group_pointer;
+			aligned_pointer_type 	element_pointer;
+			skipfield_pointer_type	skipfield_pointer;
+		#endif
+
+
+	public:
+		struct colony_iterator_tag {};
+		typedef std::bidirectional_iterator_tag	iterator_category;
+		typedef std::bidirectional_iterator_tag	iterator_concept;
+		typedef typename colony::value_type 			value_type;
+		typedef typename colony::difference_type		difference_type;
+		typedef colony_reverse_iterator<is_const> 	reverse_type;
+		typedef typename plf::conditional<is_const, typename colony::const_pointer, typename colony::pointer>::type		pointer;
+		typedef typename plf::conditional<is_const, typename colony::const_reference, typename colony::reference>::type	reference;
+
+		friend class colony;
+		friend class colony_reverse_iterator<false>;
+		friend class colony_reverse_iterator<true>;
+
+		// Friend functions:
+
+		template <class distance_type>
+		friend void advance(colony_iterator &it, distance_type distance)
+		{
+			it.advance(static_cast<difference_type>(distance));
+		}
+
+
+
+		friend colony_iterator next(const colony_iterator &it, const difference_type distance)
+		{
+			colony_iterator return_iterator(it);
+			return_iterator.advance(static_cast<difference_type>(distance));
+			return return_iterator;
+		}
+
+
+
+		friend colony_iterator prev(const colony_iterator &it, const difference_type distance)
+		{
+			colony_iterator return_iterator(it);
+			return_iterator.advance(-(static_cast<difference_type>(distance)));
+			return return_iterator;
+		}
+
+
+
+		friend typename colony_iterator::difference_type distance(const colony_iterator &first, const colony_iterator &last)
+		{
+			return first.distance(last);
+		}
+
+
+
+		colony_iterator() PLF_NOEXCEPT
+		#ifdef PLF_DEFAULT_SUPPORT
+			= default;
+		#else
+			: group_pointer(NULL),
+			element_pointer(NULL),
+			skipfield_pointer(NULL)
+			{}
+		#endif
+
+
+
+		colony_iterator (const colony_iterator &source) PLF_NOEXCEPT
+		#ifdef PLF_DEFAULT_SUPPORT
+			= default;
+		#else
+			: group_pointer(source.group_pointer),
+			element_pointer(source.element_pointer),
+			skipfield_pointer(source.skipfield_pointer)
+			{}
+		#endif
+
+
+
+		#ifdef PLF_DEFAULT_SUPPORT
+			template <bool is_const_it = is_const, class = typename plf::enable_if<is_const_it>::type >
+			colony_iterator(const colony_iterator<false> &source) PLF_NOEXCEPT:
+		#else
+			colony_iterator(const colony_iterator<!is_const> &source) PLF_NOEXCEPT:
+		#endif
+			group_pointer(source.group_pointer),
+			element_pointer(source.element_pointer),
+			skipfield_pointer(source.skipfield_pointer)
+		{}
+
+
+
+		#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+			colony_iterator(colony_iterator &&source) PLF_NOEXCEPT
+			#ifdef PLF_DEFAULT_SUPPORT
+				= default;
+			#else
+				: group_pointer(std::move(source.group_pointer)),
+				element_pointer(std::move(source.element_pointer)),
+				skipfield_pointer(std::move(source.skipfield_pointer))
+				{}
+			#endif
+
+
+
+			#ifdef PLF_DEFAULT_SUPPORT
+				template <bool is_const_it = is_const, class = typename plf::enable_if<is_const_it>::type >
+				colony_iterator(colony_iterator<false> &&source) PLF_NOEXCEPT:
+			#else
+				colony_iterator(colony_iterator<!is_const> &&source) PLF_NOEXCEPT:
+			#endif
+				group_pointer(std::move(source.group_pointer)),
+				element_pointer(std::move(source.element_pointer)),
+				skipfield_pointer(std::move(source.skipfield_pointer))
+			{}
+		#endif
+
+
+
+		colony_iterator & operator = (const colony_iterator &source) PLF_NOEXCEPT
+		#ifdef PLF_DEFAULT_SUPPORT
+			= default;
+		#else
+			{
+				group_pointer = source.group_pointer;
+				element_pointer = source.element_pointer;
+				skipfield_pointer = source.skipfield_pointer;
+				return *this;
+			}
+		#endif
+
+
+
+		#ifdef PLF_DEFAULT_SUPPORT
+			template <bool is_const_it = is_const, class = typename plf::enable_if<is_const_it>::type >
+			colony_iterator & operator = (const colony_iterator<false> &source) PLF_NOEXCEPT
+		#else
+			colony_iterator & operator = (const colony_iterator<!is_const> &source) PLF_NOEXCEPT
+		#endif
+		{
+			group_pointer = source.group_pointer;
+			element_pointer = source.element_pointer;
+			skipfield_pointer = source.skipfield_pointer;
+			return *this;
+		}
+
+
+
+		#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+			colony_iterator & operator = (colony_iterator &&source) PLF_NOEXCEPT
+			#ifdef PLF_DEFAULT_SUPPORT
+				= default;
+			#else
+				{
+					assert(&source != this);
+					group_pointer = std::move(source.group_pointer);
+					element_pointer = std::move(source.element_pointer);
+					skipfield_pointer = std::move(source.skipfield_pointer);
+					return *this;
+				}
+			#endif
+
+
+
+			#ifdef PLF_DEFAULT_SUPPORT
+				template <bool is_const_it = is_const, class = typename plf::enable_if<is_const_it>::type >
+				colony_iterator & operator = (colony_iterator<false> &&source) PLF_NOEXCEPT
+			#else
+				colony_iterator & operator = (colony_iterator<!is_const> &&source) PLF_NOEXCEPT
+			#endif
+			{
+				group_pointer = std::move(source.group_pointer);
+				element_pointer = std::move(source.element_pointer);
+				skipfield_pointer = std::move(source.skipfield_pointer);
+				return *this;
+			}
+		#endif
+
+
+
+		bool operator == (const colony_iterator &rh) const PLF_NOEXCEPT
+		{
+			return (element_pointer == rh.element_pointer);
+		}
+
+
+
+		bool operator == (const colony_iterator<!is_const> &rh) const PLF_NOEXCEPT
+		{
+			return (element_pointer == rh.element_pointer);
+		}
+
+
+
+		bool operator != (const colony_iterator &rh) const PLF_NOEXCEPT
+		{
+			return (element_pointer != rh.element_pointer);
+		}
+
+
+
+		bool operator != (const colony_iterator<!is_const> &rh) const PLF_NOEXCEPT
+		{
+			return (element_pointer != rh.element_pointer);
+		}
+
+
+
+		reference operator * () const // may cause exception with uninitialized iterator
+		{
+			return *pointer_cast<pointer>(element_pointer);
+		}
+
+
+
+		pointer operator -> () const
+		{
+			return pointer_cast<pointer>(element_pointer);
+		}
+
+
+
+		colony_iterator & operator ++ ()
+		{
+			assert(group_pointer != NULL); // covers uninitialised colony_iterator
+			skipfield_type skip = *(++skipfield_pointer);
+
+			if ((element_pointer += static_cast<size_type>(skip) + 1u) == to_aligned_pointer(group_pointer->skipfield) && group_pointer->next_group != NULL) // ie. beyond end of current memory block. Second condition allows iterator to reach end(), which may be 1 past end of block, if block has been fully used and another block is not allocated
+			{
+				group_pointer = group_pointer->next_group;
+				const aligned_pointer_type elements = to_aligned_pointer(group_pointer->elements);
+				const skipfield_pointer_type skipfield = group_pointer->skipfield;
+				skip = *skipfield;
+				element_pointer = elements + skip;
+				skipfield_pointer = skipfield;
+			}
+
+			skipfield_pointer += skip;
+			return *this;
+		}
+
+
+
+		colony_iterator operator ++(int)
+		{
+			const colony_iterator copy(*this);
+			++*this;
+			return copy;
+		}
+
+
+
+		colony_iterator & operator -- ()
+		{
+			assert(group_pointer != NULL);
+
+			if (--skipfield_pointer >= group_pointer->skipfield) // ie. not already at beginning of group prior to decrementation
+			{
+				element_pointer -= static_cast<size_type>(*skipfield_pointer) + 1u;
+				if ((skipfield_pointer -= *skipfield_pointer) >= group_pointer->skipfield) return *this; // ie. skipfield jump value does not takes us beyond beginning of group
+			}
+
+			group_pointer = group_pointer->previous_group;
+			const skipfield_pointer_type skipfield = group_pointer->skipfield + group_pointer->capacity - 1;
+			const skipfield_type skip = *skipfield;
+			element_pointer = (to_aligned_pointer(group_pointer->skipfield) - 1) - skip;
+			skipfield_pointer = skipfield - skip;
+			return *this;
+		}
+
+
+
+		colony_iterator operator -- (int)
+		{
+			const colony_iterator copy(*this);
+			--*this;
+			return copy;
+		}
+
+
+
+		// Less-than etc operators retained as GCC codegen synthesis from <=> is slower and bulkier for same operations:
+		template <bool is_const_it>
+		bool operator > (const colony_iterator<is_const_it> &rh) const PLF_NOEXCEPT
+		{
+			return ((group_pointer == rh.group_pointer) & (element_pointer > rh.element_pointer)) ||
+				(group_pointer != rh.group_pointer && group_pointer->group_number > rh.group_pointer->group_number);
+		}
+
+
+
+		template <bool is_const_it>
+		bool operator < (const colony_iterator<is_const_it> &rh) const PLF_NOEXCEPT
+		{
+			return rh > *this;
+		}
+
+
+
+		template <bool is_const_it>
+		bool operator >= (const colony_iterator<is_const_it> &rh) const PLF_NOEXCEPT
+		{
+			return !(rh > *this);
+		}
+
+
+
+		template <bool is_const_it>
+		bool operator <= (const colony_iterator<is_const_it> &rh) const PLF_NOEXCEPT
+		{
+			return !(*this > rh);
+		}
+
+
+
+		#ifdef PLF_CPP20_SUPPORT
+			template <bool is_const_it>
+			std::strong_ordering operator <=> (const colony_iterator<is_const_it> &rh) const noexcept
+			{
+				return (element_pointer == rh.element_pointer) ? std::strong_ordering::equal : ((*this > rh) ? std::strong_ordering::greater : std::strong_ordering::less);
+			}
+		#endif
+
+
+
+	private:
+		// Used by cend(), erase() etc:
+		colony_iterator(const group_pointer_type group_p, const aligned_pointer_type element_p, const skipfield_pointer_type skipfield_p) PLF_NOEXCEPT:
+			group_pointer(group_p),
+			element_pointer(element_p),
+			skipfield_pointer(skipfield_p)
+		{}
+
+
+
+		// Advance implementation:
+
+		void advance(difference_type distance) // Cannot be noexcept due to the possibility of an uninitialized iterator
+		{
+			assert(group_pointer != NULL); // covers uninitialized colony_iterator && empty group
+
+			// Now, run code based on the nature of the distance type - negative, positive or zero:
+			if (distance > 0) // ie. +=
+			{
+				// Code explanation:
+				// For the initial state of the iterator, we don't know which elements have been erased before that element in that group.
+				// So for the first group, we follow the following logic:
+				// 1. If no elements have been erased in the group, we do simple pointer addition to progress, either to within the group (if the distance is small enough) or the end of the group and subtract from distance accordingly.
+				// 2. If any of the first group's elements have been erased, we manually iterate, as we don't know whether the erased elements occur before or after the initial iterator position, and we subtract 1 from the distance amount each time we iterate. Iteration continues until either distance becomes zero, or we reach the end of the group.
+
+				// For all subsequent groups, we follow this logic:
+				// 1. If distance is larger than the total number of non-erased elements in a group, we skip that group and subtract the number of elements in that group from distance.
+				// 2. If distance is smaller than the total number of non-erased elements in a group, then:
+				//   a. If there are no erased elements in the group we simply add distance to group->elements to find the new location for the iterator.
+				//   b. If there are erased elements in the group, we manually iterate and subtract 1 from distance on each iteration, until the new iterator location is found ie. distance = 0.
+
+				// Note: incrementing element_pointer is avoided until necessary to avoid needless calculations.
+
+				if (group_pointer->next_group == NULL && element_pointer == to_aligned_pointer(group_pointer->skipfield)) return; // Check if we're already beyond back of final block
+
+				// Special case for initial element pointer and initial group (we don't know how far into the group the element pointer is)
+				if (element_pointer != to_aligned_pointer(group_pointer->elements) + *(group_pointer->skipfield)) // ie. != first non-erased element in group - otherwise we skip this section and just treat the first block as we would an intermediary block
+				{
+					const difference_type distance_from_end = to_aligned_pointer(group_pointer->skipfield) - element_pointer;
+
+					if (group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()) // ie. if there are no erasures in the group
+					{
+						if (distance < distance_from_end)
+						{
+							element_pointer += distance;
+							skipfield_pointer += distance;
+							return;
+						}
+						else if (group_pointer->next_group == NULL) // either we've reached end() or gone beyond it, so bound to back of block
+						{
+							element_pointer += distance_from_end;
+							skipfield_pointer += distance_from_end;
+							return;
+						}
+						else
+						{
+							distance -= distance_from_end;
+						}
+					}
+					else
+					{
+						const skipfield_pointer_type endpoint = skipfield_pointer + distance_from_end;
+
+						while(true)
+						{
+							++skipfield_pointer;
+							skipfield_pointer += *skipfield_pointer;
+							--distance;
+
+							if (skipfield_pointer == endpoint)
+							{
+								break;
+							}
+							else if (distance == 0)
+							{
+								element_pointer = to_aligned_pointer(group_pointer->elements) + (skipfield_pointer - group_pointer->skipfield);
+								return;
+							}
+						}
+
+						if (group_pointer->next_group == NULL) // either we've reached end() or gone beyond it, so bound to end of block
+						{
+							element_pointer = to_aligned_pointer(group_pointer->skipfield);
+							return;
+						}
+					}
+
+					group_pointer = group_pointer->next_group;
+
+					if (distance == 0)
+					{
+						element_pointer = to_aligned_pointer(group_pointer->elements) + *(group_pointer->skipfield);
+						skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
+						return;
+					}
+				}
+
+
+				// Intermediary groups - at the start of this code block and the subsequent block, the position of the iterator is assumed to be the first non-erased element in the current group:
+				while (static_cast<difference_type>(group_pointer->size) <= distance)
+				{
+					if (group_pointer->next_group == NULL) // either we've reached end() or gone beyond it, so bound to end of block
+					{
+						element_pointer = to_aligned_pointer(group_pointer->skipfield);
+						skipfield_pointer = group_pointer->skipfield + group_pointer->capacity;
+						return;
+					}
+					else if ((distance -= group_pointer->size) == 0)
+					{
+						group_pointer = group_pointer->next_group;
+						element_pointer = to_aligned_pointer(group_pointer->elements) + *(group_pointer->skipfield);
+						skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
+						return;
+					}
+					else
+					{
+						group_pointer = group_pointer->next_group;
+					}
+				}
+
+
+				// Final group (if not already reached):
+				if (group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()) // No erasures in this group, use straight pointer addition
+				{
+					element_pointer = to_aligned_pointer(group_pointer->elements) + distance;
+					skipfield_pointer = group_pointer->skipfield + distance;
+				}
+				else	 // We already know size > distance due to the intermediary group checks above - safe to ignore endpoint check condition while incrementing here:
+				{
+					skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
+
+					do
+					{
+						++skipfield_pointer;
+						skipfield_pointer += *skipfield_pointer;
+					} while(--distance != 0);
+
+					element_pointer = to_aligned_pointer(group_pointer->elements) + (skipfield_pointer - group_pointer->skipfield);
+				}
+			}
+			else if (distance < 0)
+			{
+				// Code logic is very similar to += above
+				if(group_pointer->previous_group == NULL && element_pointer == to_aligned_pointer(group_pointer->elements) + *(group_pointer->skipfield)) return; // check if we're already at begin()
+
+				distance = -distance;
+
+				// Special case for initial element pointer and initial group (we don't know how far into the group the element pointer is)
+				if (element_pointer != to_aligned_pointer(group_pointer->skipfield)) // not currently at the back of a block
+				{
+					if (group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()) // ie. no prior erasures have occurred in this group
+					{
+						const difference_type distance_from_beginning = static_cast<difference_type>(element_pointer - to_aligned_pointer(group_pointer->elements));
+
+						if (distance <= distance_from_beginning)
+						{
+							element_pointer -= distance;
+							skipfield_pointer -= distance;
+							return;
+						}
+						else if (group_pointer->previous_group == NULL) // ie. we've gone before begin(), so bound to begin()
+						{
+							element_pointer = to_aligned_pointer(group_pointer->elements);
+							skipfield_pointer = group_pointer->skipfield;
+							return;
+						}
+						else
+						{
+							distance -= distance_from_beginning;
+						}
+					}
+					else
+					{
+						for (const skipfield_pointer_type begin = group_pointer->skipfield + *(group_pointer->skipfield); skipfield_pointer != begin;)
+						{
+							--skipfield_pointer;
+							skipfield_pointer -= *skipfield_pointer;
+
+							if (--distance == 0)
+							{
+								element_pointer = to_aligned_pointer(group_pointer->elements) + (skipfield_pointer - group_pointer->skipfield);
+								return;
+							}
+						}
+
+						if (group_pointer->previous_group == NULL)
+						{
+							element_pointer = to_aligned_pointer(group_pointer->elements) + *(group_pointer->skipfield); // This is first group, so bound to begin() (just in case final decrement took us before begin())
+							skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
+							return;
+						}
+					}
+
+					group_pointer = group_pointer->previous_group;
+				}
+
+
+				// Intermediary groups - at the start of this code block and the subsequent block, the position of the iterator is assumed to be either the first non-erased element in the next group over, or end():
+				while(static_cast<difference_type>(group_pointer->size) < distance)
+				{
+					if (group_pointer->previous_group == NULL) // we've gone beyond begin(), so bound to it
+					{
+						element_pointer = to_aligned_pointer(group_pointer->elements) + *(group_pointer->skipfield);
+						skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
+						return;
+					}
+
+					distance -= group_pointer->size;
+					group_pointer = group_pointer->previous_group;
+				}
+
+
+				// Final group (if not already reached):
+				if (static_cast<difference_type>(group_pointer->size) == distance) // go to front of group
+				{
+					element_pointer = to_aligned_pointer(group_pointer->elements) + *(group_pointer->skipfield);
+					skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
+				}
+				else if (group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()) // ie. no erased elements in this group
+				{
+					element_pointer = to_aligned_pointer(group_pointer->skipfield) - distance;
+					skipfield_pointer = (group_pointer->skipfield + group_pointer->size) - distance;
+				}
+				else // ie. no more groups to traverse but there are erased elements in this group
+				{
+					skipfield_pointer = group_pointer->skipfield + (to_aligned_pointer(group_pointer->skipfield) - to_aligned_pointer(group_pointer->elements));
+
+					do
+					{
+						--skipfield_pointer;
+						skipfield_pointer -= *skipfield_pointer;
+					} while(--distance != 0);
+
+					element_pointer = to_aligned_pointer(group_pointer->elements) + (skipfield_pointer - group_pointer->skipfield);
+				}
+			}
+		}
+
+
+
+		// distance implementation:
+
+		difference_type distance(const colony_iterator &last) const
+		{
+			// Code logic:
+			// If iterators are the same, return 0
+			// Otherwise, find which iterator is later in colony, copy that to iterator2. Copy the lower to iterator1.
+			// If they are not pointing to elements in the same group, process the intermediate groups and add distances,
+			// skipping manual incrementation in all but the initial and final groups.
+			// In the initial and final groups, manual incrementation must be used to calculate distance, if there have been no prior erasures in those groups.
+			// If there are no prior erasures in either of those groups, we can use pointer arithmetic to calculate the distances for those groups.
+
+			assert(!(group_pointer == NULL) && !(last.group_pointer == NULL));  // Check that they are both initialized
+
+			if (last.element_pointer == element_pointer) return 0;
+
+			difference_type distance = 0;
+			colony_iterator iterator1 = *this, iterator2 = last;
+			const bool swap_iterators = iterator1 > iterator2;
+
+			if (swap_iterators)
+			{
+				iterator1 = last;
+				iterator2 = *this;
+			}
+
+			if (iterator1.group_pointer != iterator2.group_pointer) // if not in same group, process intermediate groups
+			{
+				// Process initial group:
+				if (iterator1.group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()) // If no prior erasures have occured in this group we can do simple addition
+				{
+					distance += static_cast<difference_type>(to_aligned_pointer(iterator1.group_pointer->skipfield) - iterator1.element_pointer);
+				}
+				else if (iterator1.element_pointer == to_aligned_pointer(iterator1.group_pointer->elements) + *(iterator1.group_pointer->skipfield)) // ie. element is at start of group - rare case
+				{
+					distance += static_cast<difference_type>(iterator1.group_pointer->size);
+				}
+				else // Manually iterate to find distance to end of group:
+				{
+					for (const skipfield_pointer_type end = iterator1.skipfield_pointer + (to_aligned_pointer(iterator1.group_pointer->skipfield) - iterator1.element_pointer); iterator1.skipfield_pointer != end;)
+					{
+						++iterator1.skipfield_pointer;
+						iterator1.skipfield_pointer += *iterator1.skipfield_pointer;
+						++distance;
+					}
+				}
+
+				// Process all other intermediate groups:
+				iterator1.group_pointer = iterator1.group_pointer->next_group;
+
+				while (iterator1.group_pointer != iterator2.group_pointer)
+				{
+					distance += static_cast<difference_type>(iterator1.group_pointer->size);
+					iterator1.group_pointer = iterator1.group_pointer->next_group;
+				}
+
+				iterator1.skipfield_pointer = iterator1.group_pointer->skipfield + *(iterator1.group_pointer->skipfield);
+			}
+
+
+			if (iterator2.group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()) // ie. no erasures in this group, direct subtraction is possible
+			{
+				distance += iterator2.skipfield_pointer - iterator1.skipfield_pointer;
+			}
+ 			else if (iterator1.element_pointer == to_aligned_pointer(iterator2.group_pointer->elements) + *(iterator2.group_pointer->skipfield) && iterator2.element_pointer + 1 + *(iterator2.skipfield_pointer + 1) == to_aligned_pointer(iterator2.group_pointer->skipfield)) // ie. if iterator1 is at beginning of block (have to check this in case first and last are in the same block to begin with) and iterator2 is last element in the block
+			{
+				distance += static_cast<difference_type>(iterator2.group_pointer->size) - 1;
+			}
+			else
+			{
+				while (iterator1.skipfield_pointer != iterator2.skipfield_pointer)
+				{
+					++iterator1.skipfield_pointer;
+					iterator1.skipfield_pointer += *iterator1.skipfield_pointer;
+					++distance;
+				}
+			}
+
+
+			if (swap_iterators) distance = -distance;
+
+			return distance;
+		}
+	}; // colony_iterator
+
+
+
+
+
+	// Reverse iterators:
+
+	template <bool is_const_r>
+	class colony_reverse_iterator
+	{
+	private:
+		typedef typename colony::group_pointer_type 	group_pointer_type;
+		typedef typename colony::aligned_pointer_type 	aligned_pointer_type;
+		typedef typename colony::skipfield_pointer_type skipfield_pointer_type;
+
+	protected:
+		iterator current;
+
+	public:
+		struct colony_iterator_tag {};
+		typedef std::bidirectional_iterator_tag 	iterator_category;
+		typedef std::bidirectional_iterator_tag 	iterator_concept;
+		typedef iterator 									iterator_type;
+		typedef typename colony::value_type 		value_type;
+		typedef typename colony::difference_type	difference_type;
+		typedef typename plf::conditional<is_const_r, typename colony::const_pointer, typename colony::pointer>::type		pointer;
+		typedef typename plf::conditional<is_const_r, typename colony::const_reference, typename colony::reference>::type	reference;
+
+		friend class colony;
+
+
+		template <class distance_type>
+		friend void advance(colony_reverse_iterator &it, distance_type distance)
+		{
+			it.advance(static_cast<difference_type>(distance));
+		}
+
+
+
+		friend colony_reverse_iterator next(const colony_reverse_iterator &it, const difference_type distance)
+		{
+			colony_reverse_iterator return_iterator(it);
+			return_iterator.advance(static_cast<difference_type>(distance));
+			return return_iterator;
+		}
+
+
+
+		template <class distance_type>
+		friend colony_reverse_iterator prev(const colony_reverse_iterator &it, const difference_type distance)
+		{
+			colony_reverse_iterator return_iterator(it);
+			return_iterator.advance(-(static_cast<difference_type>(distance)));
+			return return_iterator;
+		}
+
+
+
+		friend typename colony_reverse_iterator::difference_type distance(const colony_reverse_iterator &first, const colony_reverse_iterator &last)
+		{
+			return first.distance(last);
+		}
+
+
+
+		colony_reverse_iterator (const colony_reverse_iterator &source) PLF_NOEXCEPT
+		#ifdef PLF_DEFAULT_SUPPORT
+			= default;
+		#else
+			: current(source.current) {}
+		#endif
+
+
+		#ifdef PLF_DEFAULT_SUPPORT
+			template <bool is_const_rit = is_const_r, class = typename plf::enable_if<is_const_rit>::type >
+			colony_reverse_iterator (const colony_reverse_iterator<false> &source) PLF_NOEXCEPT:
+		#else
+			colony_reverse_iterator (const colony_reverse_iterator<!is_const_r> &source) PLF_NOEXCEPT:
+		#endif
+			current(source.current)
+		{}
+
+
+		colony_reverse_iterator (const colony_iterator<is_const_r> &source) PLF_NOEXCEPT:
+			current(source)
+		{
+			++(*this);
+		}
+
+
+		#ifdef PLF_DEFAULT_SUPPORT
+			template <bool is_const_rit = is_const_r, class = typename plf::enable_if<is_const_rit>::type >
+			colony_reverse_iterator (const colony_iterator<false> &source) PLF_NOEXCEPT:
+		#else
+			colony_reverse_iterator (const colony_iterator<!is_const_r> &source) PLF_NOEXCEPT:
+		#endif
+			current(source)
+		{
+			++(*this);
+		}
+
+
+		#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+			colony_reverse_iterator (colony_reverse_iterator &&source) PLF_NOEXCEPT
+			#ifdef PLF_DEFAULT_SUPPORT
+				= default;
+			#else
+				: current(std::move(source.current)) {}
+			#endif
+
+
+			#ifdef PLF_DEFAULT_SUPPORT
+				template <bool is_const_rit = is_const_r, class = typename plf::enable_if<is_const_rit>::type >
+				colony_reverse_iterator (colony_reverse_iterator<false> &&source) PLF_NOEXCEPT:
+			#else
+				colony_reverse_iterator (colony_iterator<!is_const_r> &&source) PLF_NOEXCEPT:
+			#endif
+				current(std::move(source.current))
+			{}
+		#endif
+
+
+		colony_reverse_iterator& operator = (const colony_iterator<is_const_r> &source) PLF_NOEXCEPT
+		{
+			current = source;
+			++current;
+			return *this;
+		}
+
+
+		#ifdef PLF_DEFAULT_SUPPORT
+			template <bool is_const_rit = is_const_r, class = typename plf::enable_if<is_const_rit>::type >
+			colony_reverse_iterator& operator = (const colony_iterator<false> &source) PLF_NOEXCEPT
+		#else
+			colony_reverse_iterator& operator = (const colony_iterator<!is_const_r> &source) PLF_NOEXCEPT
+		#endif
+		{
+			current = source;
+			++current;
+			return *this;
+		}
+
+
+		colony_reverse_iterator& operator = (const colony_reverse_iterator &source) PLF_NOEXCEPT
+		#ifdef PLF_DEFAULT_SUPPORT
+			= default;
+		#else
+			{
+				current = source.current;
+				return *this;
+			}
+		#endif
+
+
+		#ifdef PLF_DEFAULT_SUPPORT
+			template <bool is_const_rit = is_const_r, class = typename plf::enable_if<is_const_rit>::type >
+			colony_reverse_iterator& operator = (const colony_reverse_iterator<false> &source) PLF_NOEXCEPT
+		#else
+			colony_reverse_iterator& operator = (const colony_reverse_iterator<!is_const_r> &source) PLF_NOEXCEPT
+		#endif
+		{
+			current = source.current;
+			return *this;
+		}
+
+
+		#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+			colony_reverse_iterator& operator = (colony_reverse_iterator &&source) PLF_NOEXCEPT
+			#ifdef PLF_DEFAULT_SUPPORT
+				= default;
+			#else
+				{
+					assert(&source != this);
+					current = std::move(source.current);
+					return *this;
+				}
+			#endif
+
+
+			#ifdef PLF_DEFAULT_SUPPORT
+				template <bool is_const_rit = is_const_r, class = typename plf::enable_if<is_const_rit>::type >
+				colony_reverse_iterator& operator = (colony_reverse_iterator<false> &&source) PLF_NOEXCEPT
+			#else
+				colony_reverse_iterator& operator = (colony_reverse_iterator<!is_const_r> &&source) PLF_NOEXCEPT
+			#endif
+			{
+				assert(&source != this);
+				current = std::move(source.current);
+				return *this;
+			}
+		#endif
+
+
+
+		bool operator == (const colony_reverse_iterator &rh) const PLF_NOEXCEPT
+		{
+			return (current == rh.current);
+		}
+
+
+
+		bool operator == (const colony_reverse_iterator<!is_const_r> &rh) const PLF_NOEXCEPT
+		{
+			return (current == rh.current);
+		}
+
+
+
+		bool operator != (const colony_reverse_iterator &rh) const PLF_NOEXCEPT
+		{
+			return (current != rh.current);
+		}
+
+
+
+		bool operator != (const colony_reverse_iterator<!is_const_r> &rh) const PLF_NOEXCEPT
+		{
+			return (current != rh.current);
+		}
+
+
+
+		reference operator * () const PLF_NOEXCEPT
+		{
+			return *pointer_cast<pointer>(current.element_pointer);
+		}
+
+
+
+		pointer operator -> () const PLF_NOEXCEPT
+		{
+			return pointer_cast<pointer>(current.element_pointer);
+		}
+
+
+
+		// In this case we have to redefine the algorithm, rather than using the internal iterator's -- operator, in order for the reverse_iterator to be allowed to reach rend() ie. begin_iterator - 1
+		colony_reverse_iterator & operator ++ ()
+		{
+			group_pointer_type &group_pointer = current.group_pointer;
+			aligned_pointer_type &element_pointer = current.element_pointer;
+			skipfield_pointer_type &skipfield_pointer = current.skipfield_pointer;
+
+			assert(group_pointer != NULL);
+
+			if (--skipfield_pointer >= group_pointer->skipfield)
+			{
+				element_pointer -= static_cast<size_type>(*skipfield_pointer) + 1u;
+				if ((skipfield_pointer -= *skipfield_pointer) >= group_pointer->skipfield) return *this;
+			}
+
+			if (group_pointer->previous_group != NULL)
+			{
+				group_pointer = group_pointer->previous_group;
+				const skipfield_pointer_type skipfield = group_pointer->skipfield + group_pointer->capacity - 1;
+				const skipfield_type skip = *skipfield;
+				element_pointer = (to_aligned_pointer(group_pointer->skipfield) - 1) - skip;
+				skipfield_pointer = skipfield - skip;
+			}
+			else // bound to rend()
+			{
+				--element_pointer;
+			}
+
+			return *this;
+		}
+
+
+
+		colony_reverse_iterator operator ++ (int)
+		{
+			const colony_reverse_iterator copy(*this);
+			++*this;
+			return copy;
+		}
+
+
+
+		colony_reverse_iterator & operator -- ()
+		{
+			++current;
+			return *this;
+		}
+
+
+
+		colony_reverse_iterator operator -- (int)
+		{
+			const colony_reverse_iterator copy(*this);
+			++current;
+			return copy;
+		}
+
+
+
+		colony_iterator<is_const_r> base() const PLF_NOEXCEPT
+		{
+			return (current.group_pointer != NULL) ? ++(colony_iterator<is_const_r>(current)) : colony_iterator<is_const_r>(NULL, NULL, NULL);
+		}
+
+
+
+		template <bool is_const_it>
+		bool operator > (const colony_reverse_iterator<is_const_it> &rh) const PLF_NOEXCEPT
+		{
+			return (rh.current > current);
+		}
+
+
+
+		template <bool is_const_it>
+		bool operator < (const colony_reverse_iterator<is_const_it> &rh) const PLF_NOEXCEPT
+		{
+			return (current > rh.current);
+		}
+
+
+
+		template <bool is_const_it>
+		bool operator >= (const colony_reverse_iterator<is_const_it> &rh) const PLF_NOEXCEPT
+		{
+			return !(current > rh.current);
+		}
+
+
+
+		template <bool is_const_it>
+		bool operator <= (const colony_reverse_iterator<is_const_it> &rh) const PLF_NOEXCEPT
+		{
+			return !(rh.current > current);
+		}
+
+
+
+		#ifdef PLF_CPP20_SUPPORT
+			template <bool is_const_it>
+			std::strong_ordering operator <=> (const colony_reverse_iterator<is_const_it> &rh) const noexcept
+			{
+				return (rh.current <=> current);
+			}
+		#endif
+
+
+
+	private:
+		// Used by rend(), etc:
+		colony_reverse_iterator(const group_pointer_type group_p, const aligned_pointer_type element_p, const skipfield_pointer_type skipfield_p) PLF_NOEXCEPT: current(group_p, element_p, skipfield_p) {}
+
+
+
+		// distance implementation:
+
+ 		difference_type distance(const colony_reverse_iterator &last) const
+ 		{
+ 			return last.current.distance(current);
+ 		}
+
+
+
+		// Advance for reverse_iterator and const_reverse_iterator - this needs to be implemented slightly differently to forward-iterator's advance, as current needs to be able to reach rend() (ie. begin() - 1) and to be bounded by rbegin():
+		void advance(difference_type distance)
+		{
+			group_pointer_type &group_pointer = current.group_pointer;
+			aligned_pointer_type &element_pointer = current.element_pointer;
+			skipfield_pointer_type &skipfield_pointer = current.skipfield_pointer;
+
+			assert(element_pointer != NULL);
+
+			if (distance > 0)
+			{
+				if (group_pointer->previous_group == NULL && element_pointer == to_aligned_pointer(group_pointer->elements) - 1) return; // Check if we're already at rend()
+
+				if (group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max())
+				{
+					const difference_type distance_from_beginning = element_pointer - to_aligned_pointer(group_pointer->elements);
+
+					if (distance <= distance_from_beginning)
+					{
+						element_pointer -= distance;
+						skipfield_pointer -= distance;
+						return;
+					}
+					else if (group_pointer->previous_group == NULL) // Either we've reached rend() or gone beyond it, so bound to rend()
+					{
+						element_pointer = to_aligned_pointer(group_pointer->elements) - 1;
+						skipfield_pointer = group_pointer->skipfield - 1;
+						return;
+					}
+					else
+					{
+						distance -= distance_from_beginning;
+					}
+				}
+				else
+				{
+					for(const skipfield_pointer_type begin = group_pointer->skipfield + *(group_pointer->skipfield); skipfield_pointer != begin;)
+					{
+						--skipfield_pointer;
+						skipfield_pointer -= *skipfield_pointer;
+
+						if (--distance == 0)
+						{
+							element_pointer = to_aligned_pointer(group_pointer->elements) + (skipfield_pointer - group_pointer->skipfield);
+							return;
+						}
+					}
+
+					if (group_pointer->previous_group == NULL)
+					{
+						element_pointer = to_aligned_pointer(group_pointer->elements) - 1; // If we've reached rend(), bound to that
+						skipfield_pointer = group_pointer->skipfield - 1;
+						return;
+					}
+				}
+
+				group_pointer = group_pointer->previous_group;
+
+
+				// Intermediary groups - at the start of this code block and the subsequent block, the position of the iterator is assumed to be the first non-erased element in the next group:
+				while(static_cast<difference_type>(group_pointer->size) < distance)
+				{
+					if (group_pointer->previous_group == NULL) // bound to rend()
+					{
+						element_pointer = to_aligned_pointer(group_pointer->elements) - 1;
+						skipfield_pointer = group_pointer->skipfield - 1;
+						return;
+					}
+
+					distance -= static_cast<difference_type>(group_pointer->size);
+					group_pointer = group_pointer->previous_group;
+				}
+
+
+				// Final group (if not already reached)
+				if (static_cast<difference_type>(group_pointer->size) == distance)
+				{
+					element_pointer = to_aligned_pointer(group_pointer->elements) + *(group_pointer->skipfield);
+					skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
+					return;
+				}
+				else if (group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max())
+				{
+					element_pointer = (to_aligned_pointer(group_pointer->elements) + group_pointer->size) - distance;
+					skipfield_pointer = (group_pointer->skipfield + group_pointer->size) - distance;
+					return;
+				}
+				else
+				{
+					skipfield_pointer = group_pointer->skipfield + group_pointer->capacity;
+
+					do
+					{
+						--skipfield_pointer;
+						skipfield_pointer -= *skipfield_pointer;
+					} while(--distance != 0);
+
+					element_pointer = to_aligned_pointer(group_pointer->elements) + (skipfield_pointer - group_pointer->skipfield);
+					return;
+				}
+			}
+			else if (distance < 0)
+			{
+				if (group_pointer->next_group == NULL && (element_pointer == (to_aligned_pointer(group_pointer->skipfield) - 1) - *(group_pointer->skipfield + (to_aligned_pointer(group_pointer->skipfield) - to_aligned_pointer(group_pointer->elements)) - 1))) return; // Check if we're already at rbegin()
+
+				if (element_pointer != to_aligned_pointer(group_pointer->elements) + *(group_pointer->skipfield)) // ie. != first non-erased element in group
+				{
+					if (group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max()) // ie. if there are no erasures in the group
+					{
+						const difference_type distance_from_end = to_aligned_pointer(group_pointer->skipfield) - element_pointer;
+
+						if (distance < distance_from_end)
+						{
+							element_pointer += distance;
+							skipfield_pointer += distance;
+							return;
+						}
+						else if (group_pointer->next_group == NULL) // either we've reached end() or gone beyond it, so bound to back of block
+						{
+							element_pointer += distance_from_end - 1;
+							skipfield_pointer += distance_from_end - 1;
+							return;
+						}
+						else
+						{
+							distance -= distance_from_end;
+						}
+					}
+					else
+					{
+						for (const skipfield_pointer_type end = skipfield_pointer + (to_aligned_pointer(group_pointer->skipfield) - element_pointer);;)
+						{
+							++skipfield_pointer;
+							skipfield_pointer += *skipfield_pointer;
+							--distance;
+
+							if (skipfield_pointer == end)
+							{
+								break;
+							}
+							else if (distance == 0)
+							{
+								element_pointer = to_aligned_pointer(group_pointer->elements) + (skipfield_pointer - group_pointer->skipfield);
+								return;
+							}
+						}
+
+						if (group_pointer->next_group == NULL) return;
+					}
+
+					group_pointer = group_pointer->next_group;
+
+					if (distance == 0)
+					{
+						element_pointer = to_aligned_pointer(group_pointer->elements) + *(group_pointer->skipfield);
+						skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
+						return;
+					}
+				}
+
+
+				// Intermediary groups:
+				while(static_cast<difference_type>(group_pointer->size) <= distance)
+				{
+					if (group_pointer->next_group == NULL) // bound to last element slot in block
+					{
+						skipfield_pointer = group_pointer->skipfield + group_pointer->capacity - 1;
+						element_pointer = (to_aligned_pointer(group_pointer->skipfield) - 1) - *skipfield_pointer;
+						skipfield_pointer -= *skipfield_pointer;
+						return;
+					}
+					else if ((distance -= group_pointer->size) == 0)
+					{
+						group_pointer = group_pointer->next_group;
+						element_pointer = to_aligned_pointer(group_pointer->elements) + *(group_pointer->skipfield);
+						skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
+						return;
+					}
+					else
+					{
+						group_pointer = group_pointer->next_group;
+					}
+				}
+
+
+				// Final group (if not already reached):
+				if (group_pointer->free_list_head == std::numeric_limits<skipfield_type>::max())
+				{
+					element_pointer = to_aligned_pointer(group_pointer->elements) + distance;
+					skipfield_pointer = group_pointer->skipfield + distance;
+					return;
+				}
+				else // we already know size > distance from previous loop - so it's safe to ignore endpoint check condition while incrementing:
+				{
+					skipfield_pointer = group_pointer->skipfield + *(group_pointer->skipfield);
+
+					do
+					{
+						++skipfield_pointer;
+						skipfield_pointer += *skipfield_pointer;
+					} while(--distance != 0);
+
+					element_pointer = to_aligned_pointer(group_pointer->elements) + (skipfield_pointer - group_pointer->skipfield);
+					return;
+				}
+
+				return;
+			}
+		}
+
+	}; // colony_reverse_iterator
+
+
+}; // colony
 
 
 
@@ -4059,24 +5974,109 @@ inline void swap (colony<element_type, element_allocator_type, element_skipfield
 
 
 
-#undef PLF_COLONY_FORCE_INLINE
+namespace std
+{
 
-#undef PLF_COLONY_ALIGNMENT_SUPPORT
-#undef PLF_COLONY_INITIALIZER_LIST_SUPPORT
-#undef PLF_COLONY_TYPE_TRAITS_SUPPORT
-#undef PLF_COLONY_ALLOCATOR_TRAITS_SUPPORT
-#undef PLF_COLONY_VARIADICS_SUPPORT
-#undef PLF_COLONY_MOVE_SEMANTICS_SUPPORT
-#undef PLF_COLONY_NOEXCEPT
-#undef PLF_COLONY_NOEXCEPT_SWAP
-#undef PLF_COLONY_NOEXCEPT_MOVE_ASSIGNMENT
-#undef PLF_COLONY_CONSTEXPR
 
-#undef PLF_COLONY_CONSTRUCT
-#undef PLF_COLONY_DESTROY
-#undef PLF_COLONY_ALLOCATE
-#undef PLF_COLONY_ALLOCATE_INITIALIZATION
-#undef PLF_COLONY_DEALLOCATE
+template <class element_type, class allocator_type>
+void swap (plf::colony<element_type, allocator_type> &a, plf::colony<element_type, allocator_type> &b) PLF_NOEXCEPT_SWAP(allocator_type)
+{
+	a.swap(b);
+}
 
+
+
+template <class element_type, class allocator_type, class predicate_function>
+typename plf::colony<element_type, allocator_type>::size_type erase_if(plf::colony<element_type, allocator_type> &container, predicate_function predicate)
+{
+	typedef typename plf::colony<element_type, allocator_type> colony;
+	typedef typename colony::const_iterator 	const_iterator;
+	typedef typename colony::size_type 			size_type;
+	size_type count = 0;
+	const const_iterator end = container.cend();
+
+	for (const_iterator current = container.cbegin(); current != end; ++current)
+	{
+		if (predicate(*current))
+		{
+			const size_type original_count = ++count;
+			const_iterator last = current;
+
+			while(++last != end && predicate(*last))
+			{
+				++count;
+			}
+
+			if (count != original_count)
+			{
+				current = container.erase(current, last); // optimised range-erase
+			}
+			else
+			{
+				current = container.erase(current);
+			}
+
+			if (last == end) break;
+		}
+	}
+
+	return count;
+}
+
+
+
+template <class element_type, class allocator_type>
+typename plf::colony<element_type, allocator_type>::size_type erase(plf::colony<element_type, allocator_type> &container, const element_type &value)
+{
+	return erase_if(container, plf::equal_to<element_type>(value));
+}
+
+
+
+#ifdef PLF_CPP20_SUPPORT
+	// std::reverse_iterator overload, to allow use of colony with ranges and make_reverse_iterator primarily:
+	template <plf::colony_iterator_concept it_type>
+	class reverse_iterator<it_type> : public it_type::reverse_type
+	{
+	public:
+		typedef typename it_type::reverse_type rit;
+		using rit::rit;
+	};
+#endif
+
+} // namespace std
+
+
+#undef PLF_CONSTRUCT_ELEMENT
+#undef PLF_DEFAULT_SUPPORT
+#undef PLF_ALIGNMENT_SUPPORT
+#undef PLF_INITIALIZER_LIST_SUPPORT
+#undef PLF_TYPE_TRAITS_SUPPORT
+#undef PLF_IS_ALWAYS_EQUAL_SUPPORT
+#undef PLF_ALLOCATOR_TRAITS_SUPPORT
+#undef PLF_VARIADICS_SUPPORT
+#undef PLF_MOVE_SEMANTICS_SUPPORT
+#undef PLF_NOEXCEPT
+#undef PLF_NOEXCEPT_ALLOCATOR
+#undef PLF_NOEXCEPT_SWAP
+#undef PLF_NOEXCEPT_MOVE_ASSIGN
+#undef PLF_CONSTEXPR
+#undef PLF_CONSTFUNC
+#undef PLF_CPP20_SUPPORT
+#undef PLF_EXCEPTIONS_SUPPORT
+
+#undef PLF_CONSTRUCT
+#undef PLF_DESTROY
+#undef PLF_ALLOCATE
+#undef PLF_DEALLOCATE
+
+#if defined(_MSC_VER) && !defined(__clang__) && !defined(__GNUC__)
+	#pragma warning ( pop )
+#endif
+
+#ifdef PLF_SORT_FUNCTION_DEFINED
+	#undef PLF_SORT_FUNCTION
+	#undef PLF_SORT_FUNCTION_DEFINED
+#endif
 
 #endif // PLF_COLONY_H

--- a/src/third-party/plf/list.h
+++ b/src/third-party/plf/list.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Matthew Bentley (mattreecebentley@gmail.com) www.plflib.org
+// Copyright (c) 2026, Matthew Bentley (mattreecebentley@gmail.com) www.plflib.org
 
 // zLib license (https://www.zlib.net/zlib_license.html):
 // This software is provided 'as-is', without any express or implied
@@ -10,11 +10,11 @@
 // freely, subject to the following restrictions:
 //
 // 1. The origin of this software must not be misrepresented; you must not
-//    claim that you wrote the original software. If you use this software
-//    in a product, an acknowledgement in the product documentation would be
-//    appreciated but is not required.
+// 	claim that you wrote the original software. If you use this software
+// 	in a product, an acknowledgement in the product documentation would be
+// 	appreciated but is not required.
 // 2. Altered source versions must be plainly marked as such, and must not be
-//    misrepresented as being the original software.
+// 	misrepresented as being the original software.
 // 3. This notice may not be removed or altered from any source distribution.
 
 
@@ -22,217 +22,255 @@
 #define PLF_LIST_H
 
 
-#define PLF_LIST_BLOCK_MIN static_cast<group_size_type>((sizeof(node) * 8 > (sizeof(*this) + sizeof(group)) * 2) ? 8 : (((sizeof(*this) + sizeof(group)) * 2) / sizeof(node)) + 1)
-#define PLF_LIST_BLOCK_MAX 2048
+// Compiler-specific defines:
+
+// Define default cases before possibly redefining:
+#define PLF_NOEXCEPT throw()
+#define PLF_NOEXCEPT_ALLOCATOR
+#define PLF_CONSTEXPR
+#define PLF_CONSTFUNC
+
+#define PLF_EXCEPTIONS_SUPPORT
+
+#if ((defined(__clang__) || defined(__GNUC__)) && !defined(__EXCEPTIONS)) || (defined(_MSC_VER) && !defined(_CPPUNWIND))
+	#undef PLF_EXCEPTIONS_SUPPORT
+	#include <exception> // std::terminate
+#endif
 
 
+#if defined(_MSC_VER) && !defined(__clang__) && !defined(__GNUC__)
+	 // Suppress incorrect (unfixed MSVC bug) warnings re: constant expressions in constexpr-if statements
+	#pragma warning ( push )
+	#pragma warning ( disable : 4127 )
 
-// Compiler-specific defines used by list:
-
-#if defined(_MSC_VER)
-	#define PLF_LIST_FORCE_INLINE __forceinline
-
-	#if _MSC_VER < 1600
-		#define PLF_LIST_NOEXCEPT throw()
-		#define PLF_LIST_NOEXCEPT_SWAP(the_allocator)
-		#define PLF_LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) throw()
-	#elif _MSC_VER == 1600
-		#define PLF_LIST_MOVE_SEMANTICS_SUPPORT
-		#define PLF_LIST_NOEXCEPT throw()
-		#define PLF_LIST_NOEXCEPT_SWAP(the_allocator)
-		#define PLF_LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) throw()
-	#elif _MSC_VER == 1700
-		#define PLF_LIST_TYPE_TRAITS_SUPPORT
-		#define PLF_LIST_ALLOCATOR_TRAITS_SUPPORT
-		#define PLF_LIST_MOVE_SEMANTICS_SUPPORT
-		#define PLF_LIST_NOEXCEPT throw()
-		#define PLF_LIST_NOEXCEPT_SWAP(the_allocator)
-		#define PLF_LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) throw()
-	#elif _MSC_VER == 1800
-		#define PLF_LIST_TYPE_TRAITS_SUPPORT
-		#define PLF_LIST_ALLOCATOR_TRAITS_SUPPORT
-		#define PLF_LIST_VARIADICS_SUPPORT // Variadics, in this context, means both variadic templates and variadic macros are supported
-		#define PLF_LIST_MOVE_SEMANTICS_SUPPORT
-		#define PLF_LIST_NOEXCEPT throw()
-		#define PLF_LIST_NOEXCEPT_SWAP(the_allocator)
-		#define PLF_LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) throw()
-		#define PLF_LIST_INITIALIZER_LIST_SUPPORT
-	#elif _MSC_VER >= 1900
-		#define PLF_LIST_ALIGNMENT_SUPPORT
-		#define PLF_LIST_TYPE_TRAITS_SUPPORT
-		#define PLF_LIST_ALLOCATOR_TRAITS_SUPPORT
-		#define PLF_LIST_VARIADICS_SUPPORT
-		#define PLF_LIST_MOVE_SEMANTICS_SUPPORT
-		#define PLF_LIST_NOEXCEPT noexcept
-		#define PLF_LIST_NOEXCEPT_SWAP(the_allocator) noexcept(std::allocator_traits<the_allocator>::propagate_on_container_swap::value)
-		#define PLF_LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept(std::allocator_traits<the_allocator>::is_always_equal::value)
-		#define PLF_LIST_INITIALIZER_LIST_SUPPORT
+	#if _MSC_VER >= 1600
+		#define PLF_MOVE_SEMANTICS_SUPPORT
+	#endif
+	#if _MSC_VER >= 1700
+		#define PLF_TYPE_TRAITS_SUPPORT
+		#define PLF_ALLOCATOR_TRAITS_SUPPORT
+	#endif
+	#if _MSC_VER >= 1800
+		#define PLF_VARIADICS_SUPPORT // Variadics, in this context, means both variadic templates and variadic macros are supported
+		#define PLF_DEFAULT_SUPPORT // Both support for default template arguments and defaulted class functions
+		#define PLF_INITIALIZER_LIST_SUPPORT
+	#endif
+	#if _MSC_VER >= 1900
+		#define PLF_ALIGNMENT_SUPPORT
+		#undef PLF_NOEXCEPT
+		#undef PLF_NOEXCEPT_ALLOCATOR
+		#define PLF_NOEXCEPT noexcept
+		#define PLF_NOEXCEPT_ALLOCATOR noexcept(noexcept(allocator_type()))
+		#define PLF_IS_ALWAYS_EQUAL_SUPPORT
 	#endif
 
 	#if defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L)
-		#define PLF_LIST_CONSTEXPR constexpr
-	#else
-		#define PLF_LIST_CONSTEXPR
+		#undef PLF_CONSTEXPR
+		#define PLF_CONSTEXPR constexpr
 	#endif
 
+	#if defined(_MSVC_LANG) && (_MSVC_LANG >= 202002L) && _MSC_VER >= 1929
+		#define PLF_CPP20_SUPPORT
+		#undef PLF_CONSTFUNC
+		#define PLF_CONSTFUNC constexpr
+	#endif
 #elif defined(__cplusplus) && __cplusplus >= 201103L // C++11 support, at least
-	#define PLF_LIST_FORCE_INLINE // note: GCC creates faster code without forcing inline
-
 	#if defined(__GNUC__) && defined(__GNUC_MINOR__) && !defined(__clang__) // If compiler is GCC/G++
-		#if (__GNUC__ == 4 && __GNUC_MINOR__ >= 3) || __GNUC__ > 4 // 4.2 and below do not support variadic templates
-			#define PLF_LIST_VARIADICS_SUPPORT
+		#if (__GNUC__ == 4 && __GNUC_MINOR__ >= 3) || __GNUC__ > 4
+			#define PLF_MOVE_SEMANTICS_SUPPORT
+			#define PLF_VARIADICS_SUPPORT
 		#endif
-		#if (__GNUC__ == 4 && __GNUC_MINOR__ >= 4) || __GNUC__ > 4 // 4.3 and below do not support initializer lists
-			#define PLF_LIST_INITIALIZER_LIST_SUPPORT
+		#if (__GNUC__ == 4 && __GNUC_MINOR__ >= 4) || __GNUC__ > 4
+			#define PLF_DEFAULT_SUPPORT
+			#define PLF_INITIALIZER_LIST_SUPPORT
 		#endif
-		#if (__GNUC__ == 4 && __GNUC_MINOR__ < 6) || __GNUC__ < 4
-			#define PLF_LIST_NOEXCEPT throw()
-			#define PLF_LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator)
-			#define PLF_LIST_NOEXCEPT_SWAP(the_allocator)
-		#elif __GNUC__ < 6
-			#define PLF_LIST_NOEXCEPT noexcept
-			#define PLF_LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept
-			#define PLF_LIST_NOEXCEPT_SWAP(the_allocator) noexcept
-		#else // C++17 support
-			#define PLF_LIST_NOEXCEPT noexcept
-			#define PLF_LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept(std::allocator_traits<the_allocator>::is_always_equal::value)
-			#define PLF_LIST_NOEXCEPT_SWAP(the_allocator) noexcept(std::allocator_traits<the_allocator>::propagate_on_container_swap::value)
+		#if (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || __GNUC__ > 4
+			#undef PLF_NOEXCEPT
+			#undef PLF_NOEXCEPT_ALLOCATOR
+			#define PLF_NOEXCEPT noexcept
+			#define PLF_NOEXCEPT_ALLOCATOR noexcept(noexcept(allocator_type()))
 		#endif
 		#if (__GNUC__ == 4 && __GNUC_MINOR__ >= 7) || __GNUC__ > 4
-			#define PLF_LIST_ALLOCATOR_TRAITS_SUPPORT
+			#define PLF_ALLOCATOR_TRAITS_SUPPORT
 		#endif
 		#if (__GNUC__ == 4 && __GNUC_MINOR__ >= 8) || __GNUC__ > 4
-			#define PLF_LIST_ALIGNMENT_SUPPORT
+			#define PLF_ALIGNMENT_SUPPORT
 		#endif
 		#if __GNUC__ >= 5 // GCC v4.9 and below do not support std::is_trivially_copyable
-			#define PLF_LIST_TYPE_TRAITS_SUPPORT
+			#define PLF_TYPE_TRAITS_SUPPORT
+		#endif
+		#if __GNUC__ > 6
+			#define PLF_IS_ALWAYS_EQUAL_SUPPORT
+		#endif
+	#elif defined(__clang__) && !defined(__GLIBCXX__) && !defined(_LIBCPP_CXX03_LANG) && __clang_major__ >= 3
+		#define PLF_DEFAULT_SUPPORT
+		#define PLF_ALLOCATOR_TRAITS_SUPPORT
+		#define PLF_TYPE_TRAITS_SUPPORT
+
+		#if __has_feature(cxx_alignas) && __has_feature(cxx_alignof)
+			#define PLF_ALIGNMENT_SUPPORT
+		#endif
+		#if __has_feature(cxx_noexcept)
+			#undef PLF_NOEXCEPT
+			#undef PLF_NOEXCEPT_ALLOCATOR
+			#define PLF_NOEXCEPT noexcept
+			#define PLF_NOEXCEPT_ALLOCATOR noexcept(noexcept(allocator_type()))
+			#define PLF_IS_ALWAYS_EQUAL_SUPPORT
+		#endif
+		#if __has_feature(cxx_rvalue_references) && !defined(_LIBCPP_HAS_NO_RVALUE_REFERENCES)
+			#define PLF_MOVE_SEMANTICS_SUPPORT
+		#endif
+		#if __has_feature(cxx_variadic_templates) && !defined(_LIBCPP_HAS_NO_VARIADICS)
+			#define PLF_VARIADICS_SUPPORT
+		#endif
+		#if (__clang_major__ == 3 && __clang_minor__ >= 1) || __clang_major__ > 3
+			#define PLF_INITIALIZER_LIST_SUPPORT
 		#endif
 	#elif defined(__GLIBCXX__) // Using another compiler type with libstdc++ - we are assuming full c++11 compliance for compiler - which may not be true
-		#if __GLIBCXX__ >= 20080606 	// libstdc++ 4.2 and below do not support variadic templates
-			#define PLF_LIST_VARIADICS_SUPPORT
+		#define PLF_DEFAULT_SUPPORT
+
+		#if __GLIBCXX__ >= 20080606
+			#define PLF_MOVE_SEMANTICS_SUPPORT
+			#define PLF_VARIADICS_SUPPORT
 		#endif
-		#if __GLIBCXX__ >= 20090421 	// libstdc++ 4.3 and below do not support initializer lists
-			#define PLF_LIST_INITIALIZER_LIST_SUPPORT
+		#if __GLIBCXX__ >= 20090421
+			#define PLF_INITIALIZER_LIST_SUPPORT
 		#endif
-		#if __GLIBCXX__ >= 20160111
-			#define PLF_LIST_ALLOCATOR_TRAITS_SUPPORT
-			#define PLF_LIST_NOEXCEPT noexcept
-			#define PLF_LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept(std::allocator_traits<the_allocator>::is_always_equal::value)
-			#define PLF_LIST_NOEXCEPT_SWAP(the_allocator) noexcept(std::allocator_traits<the_allocator>::propagate_on_container_swap::value)
-		#elif __GLIBCXX__ >= 20120322
-			#define PLF_LIST_ALLOCATOR_TRAITS_SUPPORT
-			#define PLF_LIST_NOEXCEPT noexcept
-			#define PLF_LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept
-			#define PLF_LIST_NOEXCEPT_SWAP(the_allocator) noexcept
-		#else
-			#define PLF_LIST_NOEXCEPT throw()
-			#define PLF_LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator)
-			#define PLF_LIST_NOEXCEPT_SWAP(the_allocator)
+		#if __GLIBCXX__ >= 20120322
+			#define PLF_ALLOCATOR_TRAITS_SUPPORT
+			#undef PLF_NOEXCEPT
+			#undef PLF_NOEXCEPT_ALLOCATOR
+			#define PLF_NOEXCEPT noexcept
+			#define PLF_NOEXCEPT_ALLOCATOR noexcept(noexcept(allocator_type()))
 		#endif
 		#if __GLIBCXX__ >= 20130322
-			#define PLF_LIST_ALIGNMENT_SUPPORT
+			#define PLF_ALIGNMENT_SUPPORT
 		#endif
 		#if __GLIBCXX__ >= 20150422 // libstdc++ v4.9 and below do not support std::is_trivially_copyable
-			#define PLF_LIST_TYPE_TRAITS_SUPPORT
+			#define PLF_TYPE_TRAITS_SUPPORT
 		#endif
-	#elif defined(_LIBCPP_VERSION)
-		#define PLF_LIST_ALLOCATOR_TRAITS_SUPPORT
-		#define PLF_LIST_VARIADICS_SUPPORT
-		#define PLF_LIST_INITIALIZER_LIST_SUPPORT
-		#define PLF_LIST_ALIGNMENT_SUPPORT
-		#define PLF_LIST_NOEXCEPT noexcept
-		#define PLF_LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept(std::allocator_traits<the_allocator>::is_always_equal::value)
-		#define PLF_LIST_NOEXCEPT_SWAP(the_allocator) noexcept
-
-		#if !(defined(_LIBCPP_CXX03_LANG) || defined(_LIBCPP_HAS_NO_RVALUE_REFERENCES))
-			#define PLF_LIST_TYPE_TRAITS_SUPPORT
+		#if __GLIBCXX__ >= 20160111
+			#define PLF_IS_ALWAYS_EQUAL_SUPPORT
 		#endif
-	#else // Assume type traits and initializer support for other compilers and standard libraries
-		#define PLF_LIST_ALLOCATOR_TRAITS_SUPPORT
-		#define PLF_LIST_ALIGNMENT_SUPPORT
-		#define PLF_LIST_VARIADICS_SUPPORT
-		#define PLF_LIST_INITIALIZER_LIST_SUPPORT
-		#define PLF_LIST_TYPE_TRAITS_SUPPORT
-		#define PLF_LIST_NOEXCEPT noexcept
-		#define PLF_LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator) noexcept(std::allocator_traits<the_allocator>::is_always_equal::value)
-		#define PLF_LIST_NOEXCEPT_SWAP(the_allocator) noexcept
+	#elif defined(_LIBCPP_CXX03_LANG) || defined(_LIBCPP_HAS_NO_RVALUE_REFERENCES) // Special case for checking C++11 support with libCPP
+		#if !defined(_LIBCPP_HAS_NO_VARIADICS)
+			#define PLF_VARIADICS_SUPPORT
+		#endif
+	#else // Assume type traits and initializer support for other compilers and standard library implementations
+		#define PLF_DEFAULT_SUPPORT
+		#define PLF_MOVE_SEMANTICS_SUPPORT
+		#define PLF_VARIADICS_SUPPORT
+		#define PLF_TYPE_TRAITS_SUPPORT
+		#define PLF_ALLOCATOR_TRAITS_SUPPORT
+		#define PLF_ALIGNMENT_SUPPORT
+		#define PLF_INITIALIZER_LIST_SUPPORT
+		#undef PLF_NOEXCEPT
+		#undef PLF_NOEXCEPT_ALLOCATOR
+		#define PLF_NOEXCEPT noexcept
+		#define PLF_NOEXCEPT_ALLOCATOR noexcept(noexcept(allocator_type()))
+		#define PLF_IS_ALWAYS_EQUAL_SUPPORT
 	#endif
 
-	#if __cplusplus >= 201703L
-		#if defined(__clang__) && ((__clang_major__ == 3 && __clang_minor__ == 9) || __clang_major__ > 3)
-			#define PLF_LIST_CONSTEXPR constexpr
-		#elif defined(__GNUC__) && __GNUC__ >= 7
-			#define PLF_LIST_CONSTEXPR constexpr
-		#elif !defined(__clang__) && !defined(__GNUC__)
-			#define PLF_LIST_CONSTEXPR constexpr // assume correct C++17 implementation for other compilers
-		#else
-			#define PLF_LIST_CONSTEXPR
-		#endif
-	#else
-		#define PLF_LIST_CONSTEXPR
+	#if __cplusplus >= 201703L && ((defined(__clang__) && ((__clang_major__ == 3 && __clang_minor__ == 9) || __clang_major__ > 3)) || (defined(__GNUC__) && __GNUC__ >= 7) || (!defined(__clang__) && !defined(__GNUC__))) // assume correct C++17 implementation for non-gcc/clang compilers
+		#undef PLF_CONSTEXPR
+		#define PLF_CONSTEXPR constexpr
 	#endif
 
-	#define PLF_LIST_MOVE_SEMANTICS_SUPPORT
+	#if __cplusplus > 201704L && ((((defined(__clang__) && !defined(__APPLE_CC__) && __clang_major__ >= 14) || (defined(__GNUC__) && (__GNUC__ > 11 || (__GNUC__ == 11 && __GNUC_MINOR__ > 0)))) && ((defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 14) || (defined(__GLIBCXX__) && __GLIBCXX__ >= 201806L))) || (!defined(__clang__) && !defined(__GNUC__)))
+		#define PLF_CPP20_SUPPORT
+		#undef PLF_CONSTFUNC
+		#define PLF_CONSTFUNC constexpr
+	#endif
+#endif
+
+#if defined(PLF_IS_ALWAYS_EQUAL_SUPPORT) && defined(PLF_MOVE_SEMANTICS_SUPPORT) && defined(PLF_ALLOCATOR_TRAITS_SUPPORT) && (__cplusplus >= 201703L || (defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L)))
+	#define PLF_NOEXCEPT_MOVE_ASSIGN(the_allocator) noexcept(std::allocator_traits<the_allocator>::propagate_on_container_move_assignment::value || std::allocator_traits<the_allocator>::is_always_equal::value)
+	#define PLF_NOEXCEPT_SWAP(the_allocator) noexcept(std::allocator_traits<the_allocator>::propagate_on_container_swap::value || std::allocator_traits<the_allocator>::is_always_equal::value)
 #else
-	#define PLF_LIST_FORCE_INLINE
-	#define PLF_LIST_NOEXCEPT throw()
-	#define PLF_LIST_NOEXCEPT_SWAP(the_allocator)
-	#define PLF_LIST_NOEXCEPT_MOVE_ASSIGNMENT(the_allocator)
-	#define PLF_LIST_CONSTEXPR
+	#define PLF_NOEXCEPT_MOVE_ASSIGN(the_allocator)
+	#define PLF_NOEXCEPT_SWAP(the_allocator)
 #endif
 
-
-
-#ifdef PLF_LIST_ALLOCATOR_TRAITS_SUPPORT
-	#ifdef PLF_LIST_VARIADICS_SUPPORT
-		#define PLF_LIST_CONSTRUCT(the_allocator, allocator_instance, location, ...)	std::allocator_traits<the_allocator>::construct(allocator_instance, location, __VA_ARGS__)
+#ifdef PLF_ALLOCATOR_TRAITS_SUPPORT
+	#ifdef PLF_VARIADICS_SUPPORT
+		#define PLF_CONSTRUCT(the_allocator, allocator_instance, location, ...) std::allocator_traits<the_allocator>::construct(allocator_instance, location, __VA_ARGS__)
 	#else
-		#define PLF_LIST_CONSTRUCT(the_allocator, allocator_instance, location, data) 	std::allocator_traits<the_allocator>::construct(allocator_instance, location, data)
+		#define PLF_CONSTRUCT(the_allocator, allocator_instance, location, data)	std::allocator_traits<the_allocator>::construct(allocator_instance, location, data)
 	#endif
 
-	#define PLF_LIST_DESTROY(the_allocator, allocator_instance, location) 				std::allocator_traits<the_allocator>::destroy(allocator_instance, location)
-	#define PLF_LIST_ALLOCATE(the_allocator, allocator_instance, size, hint) 			std::allocator_traits<the_allocator>::allocate(allocator_instance, size, hint)
- 	#define PLF_LIST_ALLOCATE_INITIALIZATION(the_allocator, size, hint) 				std::allocator_traits<the_allocator>::allocate(*this, size, hint)
-	#define PLF_LIST_DEALLOCATE(the_allocator, allocator_instance, location, size) 		std::allocator_traits<the_allocator>::deallocate(allocator_instance, location, size)
+	#define PLF_DESTROY(the_allocator, allocator_instance, location)				std::allocator_traits<the_allocator>::destroy(allocator_instance, location)
+	#define PLF_ALLOCATE(the_allocator, allocator_instance, size, hint)			std::allocator_traits<the_allocator>::allocate(allocator_instance, size, hint)
+	#define PLF_DEALLOCATE(the_allocator, allocator_instance, location, size)	std::allocator_traits<the_allocator>::deallocate(allocator_instance, location, size)
 #else
-	#ifdef PLF_LIST_VARIADICS_SUPPORT
-		#define PLF_LIST_CONSTRUCT(the_allocator, allocator_instance, location, ...)	allocator_instance.construct(location, __VA_ARGS__)
+	#ifdef PLF_VARIADICS_SUPPORT
+		#define PLF_CONSTRUCT(the_allocator, allocator_instance, location, ...) 	(allocator_instance).construct(location, __VA_ARGS__)
 	#else
-		#define PLF_LIST_CONSTRUCT(the_allocator, allocator_instance, location, data) 	allocator_instance.construct(location, data)
+		#define PLF_CONSTRUCT(the_allocator, allocator_instance, location, data)	(allocator_instance).construct(location, data)
 	#endif
 
-	#define PLF_LIST_DESTROY(the_allocator, allocator_instance, location) 				allocator_instance.destroy(location)
-	#define PLF_LIST_ALLOCATE(the_allocator, allocator_instance, size, hint)	 		allocator_instance.allocate(size, hint)
-	#define PLF_LIST_ALLOCATE_INITIALIZATION(the_allocator, size, hint) 				the_allocator::allocate(size, hint)
-	#define PLF_LIST_DEALLOCATE(the_allocator, allocator_instance, location, size) 		allocator_instance.deallocate(location, size)
+	#define PLF_DESTROY(the_allocator, allocator_instance, location)				(allocator_instance).destroy(location)
+	#define PLF_ALLOCATE(the_allocator, allocator_instance, size, hint)			(allocator_instance).allocate(size, hint)
+	#define PLF_DEALLOCATE(the_allocator, allocator_instance, location, size)	(allocator_instance).deallocate(location, size)
+#endif
+
+
+#ifdef PLF_VARIADICS_SUPPORT
+	#define PLF_CONSTRUCT_NODE(location, next, prev, element)	PLF_CONSTRUCT(node_allocator_type, node_allocator_pair, location, next, prev, element)
+#else
+	#define PLF_CONSTRUCT_NODE(location, next, prev, element)	PLF_CONSTRUCT(node_allocator_type, node_allocator_pair, location, node(next, prev, element))
 #endif
 
 
 
+#include <cstring> // memmove, memcpy
+#include <cassert> // assert
+#include <limits>   // std::numeric_limits
+#include <memory>  // std::uninitialized_copy, std::allocator, std::to_address
+#include <iterator>	// std::bidirectional_iterator_tag, iterator_traits, std::move_iterator, std::distance
+#include <stdexcept> // std::length_error
+#include <utility> // std::move, std::swap
 
-#include <cstring>	// memmove, memcpy
-#include <cassert>	// assert
-#include <limits>  	// std::numeric_limits
-#include <memory>	// std::uninitialized_copy, std::allocator
-#include <iterator> 	// std::bidirectional_iterator_tag
 
-
-#ifndef GFX_TIMSORT_HPP
-	#include <algorithm> // std::sort
+#if !defined(PLF_SORT_FUNCTION) || defined(PLF_CPP20_SUPPORT)
+	#include <algorithm> // std::sort, lexicographical_three_way_compare (C++20)
 #endif
 
-#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
+#ifdef PLF_TYPE_TRAITS_SUPPORT
 	#include <type_traits> // std::is_trivially_destructible, etc
 #endif
 
-#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-	#include <utility> // std::move
-#endif
 
-#ifdef PLF_LIST_INITIALIZER_LIST_SUPPORT
+#ifdef PLF_INITIALIZER_LIST_SUPPORT
 	#include <initializer_list>
 #endif
 
+#ifdef PLF_CPP20_SUPPORT
+	#include <concepts>
+	#include <compare> // std::strong_ordering
+	#include <ranges>
+
+	namespace plf
+	{
+		// For getting std:: overload for reverse_iterator to match plf::list iterators specifically (see bottom of header):
+		template <class T>
+		concept list_iterator_concept = requires { typename T::list_iterator_tag; };
+
+		#ifndef PLF_RANGES
+			#define PLF_RANGES
+
+			// For matching ranges which return input_iterator's and match the container's element type:
+			template <typename range_type, class element_type>
+			concept compatible_range = std::ranges::input_range<range_type> && std::convertible_to<std::ranges::range_reference_t<range_type>, element_type>;
+
+			// Until such point as standard libraries include std::ranges::from_range_t, including this so the rangesv3 constructor overloads will work unambiguously:
+			namespace ranges
+			{
+				struct from_range_t {};
+				constexpr from_range_t from_range;
+			}
+		#endif
+	}
+#endif
 
 
 
@@ -240,42 +278,126 @@ namespace plf
 {
 
 
+#ifndef PLF_TOOLS
+	#define PLF_TOOLS
 
-template <class element_type, class element_allocator_type = std::allocator<element_type> > class list : private element_allocator_type
+	// std:: tool replacements for C++03/98/11 support:
+	template <bool condition, class T = void>
+	struct enable_if
+	{
+		typedef T type;
+	};
+
+	template <class T>
+	struct enable_if<false, T>
+	{};
+
+
+
+	template <bool flag, class is_true, class is_false> struct conditional;
+
+	template <class is_true, class is_false> struct conditional<true, is_true, is_false>
+	{
+		typedef is_true type;
+	};
+
+	template <class is_true, class is_false> struct conditional<false, is_true, is_false>
+	{
+		typedef is_false type;
+	};
+
+
+
+	template <class element_type>
+	struct less
+	{
+		bool operator() (const element_type &a, const element_type &b) const PLF_NOEXCEPT
+		{
+			return a < b;
+		}
+	};
+
+
+
+	template<class element_type>
+	struct equal_to
+	{
+		const element_type &value;
+
+		explicit equal_to(const element_type &store_value) PLF_NOEXCEPT:
+			value(store_value)
+		{}
+
+		bool operator() (const element_type &compare_value) const PLF_NOEXCEPT
+		{
+			return value == compare_value;
+		}
+	};
+
+
+
+	// To enable conversion to void * when allocator supplies non-raw pointers:
+	template <class source_pointer_type>
+	static PLF_CONSTFUNC void * void_cast(const source_pointer_type source_pointer) PLF_NOEXCEPT
+	{
+		#ifdef PLF_CPP20_SUPPORT
+			return static_cast<void *>(std::to_address(source_pointer));
+		#else
+			return static_cast<void *>(&*source_pointer);
+		#endif
+	}
+
+
+	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+		template <class iterator_type>
+		static PLF_CONSTFUNC std::move_iterator<iterator_type> make_move_iterator(iterator_type it)
+		{
+			return std::move_iterator<iterator_type>(std::move(it));
+		}
+	#endif
+
+
+
+	enum priority { performance = 1, memory_use = 4};
+
+#endif
+
+
+
+template <class element_type, class allocator_type = std::allocator<element_type> > class list : private allocator_type
 {
 public:
 	// Standard container typedefs:
-	typedef element_type															value_type;
-	typedef element_allocator_type													allocator_type;
-	typedef unsigned short															group_size_type;
+	typedef element_type														value_type;
+	typedef unsigned short													group_size_type;
 
-	#ifdef PLF_LIST_ALLOCATOR_TRAITS_SUPPORT // C++11
-		typedef typename std::allocator_traits<element_allocator_type>::size_type			size_type;
-		typedef typename std::allocator_traits<element_allocator_type>::difference_type 	difference_type;
-		typedef element_type &																reference;
-		typedef const element_type &														const_reference;
-		typedef typename std::allocator_traits<element_allocator_type>::pointer 			pointer;
-		typedef typename std::allocator_traits<element_allocator_type>::const_pointer		const_pointer;
+	#ifdef PLF_ALLOCATOR_TRAITS_SUPPORT
+		typedef typename std::allocator_traits<allocator_type>::size_type			size_type;
+		typedef typename std::allocator_traits<allocator_type>::difference_type difference_type;
+		typedef element_type &														reference;
+		typedef const element_type &												const_reference;
+		typedef typename std::allocator_traits<allocator_type>::pointer 			pointer;
+		typedef typename std::allocator_traits<allocator_type>::const_pointer	const_pointer;
 	#else
-		typedef typename element_allocator_type::size_type			size_type;
-		typedef typename element_allocator_type::difference_type	difference_type;
-		typedef typename element_allocator_type::reference			reference;
-		typedef typename element_allocator_type::const_reference	const_reference;
-		typedef typename element_allocator_type::pointer			pointer;
-		typedef typename element_allocator_type::const_pointer		const_pointer;
+		typedef typename allocator_type::size_type			size_type;
+		typedef typename allocator_type::difference_type	difference_type;
+		typedef typename allocator_type::reference			reference;
+		typedef typename allocator_type::const_reference	const_reference;
+		typedef typename allocator_type::pointer				pointer;
+		typedef typename allocator_type::const_pointer		const_pointer;
 	#endif
 
 
 	// Iterator declarations:
-	template <bool is_const> class list_iterator;
+	template <bool is_const> class	list_iterator;
 	typedef list_iterator<false>		iterator;
-	typedef list_iterator<true>			const_iterator;
+	typedef list_iterator<true>		const_iterator;
 	friend class list_iterator<false>; // Using 'iterator' typedef name here is illegal under C++03
 	friend class list_iterator<true>;
 
-	template <bool is_const> class list_reverse_iterator;
-	typedef list_reverse_iterator<false>		reverse_iterator;
-	typedef list_reverse_iterator<true>			const_reverse_iterator;
+	template <bool is_const> class			list_reverse_iterator;
+	typedef list_reverse_iterator<false>	reverse_iterator;
+	typedef list_reverse_iterator<true>		const_reverse_iterator;
 	friend class list_reverse_iterator<false>;
 	friend class list_reverse_iterator<true>;
 
@@ -284,18 +406,18 @@ private:
 	struct group; // forward declarations for typedefs below
 	struct node;
 
-	#ifdef PLF_LIST_ALLOCATOR_TRAITS_SUPPORT // C++11
-		typedef typename std::allocator_traits<element_allocator_type>::template rebind_alloc<group>				group_allocator_type;
-		typedef typename std::allocator_traits<element_allocator_type>::template rebind_alloc<node>					node_allocator_type;
-		typedef typename std::allocator_traits<group_allocator_type>::pointer 				group_pointer_type;
-		typedef typename std::allocator_traits<node_allocator_type>::pointer				node_pointer_type;
-		typedef typename std::allocator_traits<element_allocator_type>::template rebind_alloc<node_pointer_type>	node_pointer_allocator_type;
+	#ifdef PLF_ALLOCATOR_TRAITS_SUPPORT // >= C++11
+		typedef typename std::allocator_traits<allocator_type>::template rebind_alloc<group>				group_allocator_type;
+		typedef typename std::allocator_traits<allocator_type>::template rebind_alloc<node>					node_allocator_type;
+		typedef typename std::allocator_traits<group_allocator_type>::pointer 									group_pointer_type;
+		typedef typename std::allocator_traits<node_allocator_type>::pointer										node_pointer_type;
+		typedef typename std::allocator_traits<allocator_type>::template rebind_alloc<node_pointer_type>	node_pointer_allocator_type;
 	#else
-		typedef typename element_allocator_type::template rebind<group>::other				group_allocator_type;
-		typedef typename element_allocator_type::template rebind<node>::other				node_allocator_type;
-		typedef typename group_allocator_type::pointer 				group_pointer_type;
-		typedef typename node_allocator_type::pointer				node_pointer_type;
-		typedef typename element_allocator_type::template rebind<node_pointer_type>::other	node_pointer_allocator_type;
+		typedef typename allocator_type::template rebind<group>::other			group_allocator_type;
+		typedef typename allocator_type::template rebind<node>::other			node_allocator_type;
+		typedef typename group_allocator_type::pointer 								group_pointer_type;
+		typedef typename node_allocator_type::pointer								node_pointer_type;
+		typedef typename allocator_type::template rebind<node_pointer_type>::other	node_pointer_allocator_type;
 	#endif
 
 
@@ -304,17 +426,17 @@ private:
 	{
 		node_pointer_type next, previous;
 
-		node_base()
+		node_base() PLF_NOEXCEPT
 		{}
 
-		node_base(const node_pointer_type &n, const node_pointer_type &p):
+		node_base(const node_pointer_type &n, const node_pointer_type &p) PLF_NOEXCEPT:
 			next(n),
 			previous(p)
 		{}
 
 
-		#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-			node_base(node_pointer_type &&n, node_pointer_type &&p) PLF_LIST_NOEXCEPT:
+		#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+			node_base(node_pointer_type &&n, node_pointer_type &&p) PLF_NOEXCEPT:
 				next(std::move(n)),
 				previous(std::move(p))
 			{}
@@ -333,17 +455,17 @@ private:
 		{}
 
 
-		#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-			node(node_pointer_type &&next, node_pointer_type &&previous, element_type &&source) PLF_LIST_NOEXCEPT:
+		#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+			node(node_pointer_type &&next, node_pointer_type &&previous, element_type &&source) PLF_NOEXCEPT:
 				node_base(std::move(next), std::move(previous)),
 				element(std::move(source))
 			{}
 		#endif
 
 
-		#ifdef PLF_LIST_VARIADICS_SUPPORT
+		#ifdef PLF_VARIADICS_SUPPORT
 			template<typename... arguments>
-			node(node_pointer_type const next, node_pointer_type const previous, arguments&&... parameters):
+			node(const node_pointer_type next, const node_pointer_type previous, arguments&&... parameters):
 				node_base(next, previous),
 				element(std::forward<arguments>(parameters) ...)
 			{}
@@ -352,7 +474,7 @@ private:
 
 
 
-	struct group : public node_allocator_type
+	struct group : public node_allocator_type // Node memory block + metadata
 	{
 		node_pointer_type nodes;
 		node_pointer_type free_list_head;
@@ -360,7 +482,7 @@ private:
 		group_size_type number_of_elements;
 
 
-		group() PLF_LIST_NOEXCEPT:
+		group() PLF_NOEXCEPT:
 			nodes(NULL),
 			free_list_head(NULL),
 			beyond_end(NULL),
@@ -368,16 +490,16 @@ private:
 		{}
 
 
-		#if defined(PLF_LIST_VARIADICS_SUPPORT) || defined(PLF_LIST_MOVE_SEMANTICS_SUPPORT)
-			group(const group_size_type group_size, node_pointer_type const previous = NULL):
-				nodes(PLF_LIST_ALLOCATE_INITIALIZATION(node_allocator_type, group_size, previous)),
+		#if defined(PLF_VARIADICS_SUPPORT) || defined(PLF_MOVE_SEMANTICS_SUPPORT)
+			group(const group_size_type group_size, const node_pointer_type previous = NULL):
+				nodes(PLF_ALLOCATE(node_allocator_type, *this, group_size, previous)),
 				free_list_head(NULL),
 				beyond_end(nodes + group_size),
 				number_of_elements(0)
 			{}
 		#else
 			// This is a hack around the fact that allocator_type::construct only supports copy construction in C++03 and copy elision does not occur on the vast majority of compilers in this circumstance. And to avoid running out of memory (and performance loss) from allocating the same block twice, we're allocating in this constructor and moving data in the copy constructor.
-			group(const group_size_type group_size, node_pointer_type const previous = NULL) PLF_LIST_NOEXCEPT:
+			group(const group_size_type group_size, const node_pointer_type previous = NULL) PLF_NOEXCEPT:
 				nodes(NULL),
 				free_list_head(previous),
 				beyond_end(NULL),
@@ -387,7 +509,7 @@ private:
 			// Not a real copy constructor ie. actually a move constructor. Only used for allocator.construct in C++03 for reasons stated above:
 			group(const group &source):
 				node_allocator_type(source),
-				nodes(PLF_LIST_ALLOCATE_INITIALIZATION(node_allocator_type, source.number_of_elements, source.free_list_head)),
+				nodes(PLF_ALLOCATE(node_allocator_type, *this, source.number_of_elements, source.free_list_head)),
 				free_list_head(NULL),
 				beyond_end(nodes + source.number_of_elements),
 				number_of_elements(0)
@@ -395,7 +517,7 @@ private:
 		#endif
 
 
-		group & operator = (const group &source) PLF_LIST_NOEXCEPT // Actually a move operator, used by c++03 in group_vector's remove, expand_capacity and append
+		group & operator = (const group &source) PLF_NOEXCEPT // Actually a move operator, used by c++03 in group_vector's remove, expand_capacity and append functions
 		{
 			nodes = source.nodes;
 			free_list_head = source.free_list_head;
@@ -405,8 +527,8 @@ private:
 		}
 
 
-		#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-			group(group &&source) PLF_LIST_NOEXCEPT:
+		#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+			group(group &&source) PLF_NOEXCEPT:
 				node_allocator_type(source),
 				nodes(std::move(source.nodes)),
 				free_list_head(std::move(source.free_list_head)),
@@ -418,7 +540,7 @@ private:
 			}
 
 
-			group & operator = (group &&source) PLF_LIST_NOEXCEPT
+			group & operator = (group &&source) PLF_NOEXCEPT
 			{
 				nodes = std::move(source.nodes);
 				free_list_head = std::move(source.free_list_head);
@@ -431,52 +553,57 @@ private:
 		#endif
 
 
-		~group() PLF_LIST_NOEXCEPT
+		~group() PLF_NOEXCEPT
 		{
-			PLF_LIST_DEALLOCATE(node_allocator_type, (*this), nodes, static_cast<size_type>(beyond_end - nodes));
+			PLF_DEALLOCATE(node_allocator_type, *this, nodes, static_cast<size_type>(beyond_end - nodes));
 		}
 	};
 
 
 
 
-	class group_vector : private node_pointer_allocator_type
+	class group_vector : private allocator_type // Simple vector of groups + associated functions
 	{
 	public:
 		group_pointer_type last_endpoint_group, block_pointer, last_searched_group; // last_endpoint_group is the last -active- group in the block. Other -inactive- (previously used, now empty of elements) groups may be stored after this group for future usage (to reduce deallocation/reallocation of nodes). block_pointer + size - 1 == the last group in the block, regardless of whether or not the group is active.
 		size_type size;
 
-
-		struct ebco_pair2 : allocator_type // empty-base-class optimisation
+		struct ebco_pair2 : node_pointer_allocator_type // empty-base-class optimisation
 		{
 			size_type capacity; // Total element capacity of all initialized groups
-			explicit ebco_pair2(const size_type number_of_elements) PLF_LIST_NOEXCEPT: capacity(number_of_elements) {};
-		}		element_allocator_pair;
+			ebco_pair2(const size_type number_of_elements, const allocator_type &alloc) PLF_NOEXCEPT:
+				node_pointer_allocator_type(alloc),
+				capacity(number_of_elements)
+			{};
+		} node_pointer_allocator_pair;
 
 		struct ebco_pair : group_allocator_type
 		{
-			size_type capacity; // Total group capacity
-			explicit ebco_pair(const size_type number_of_groups) PLF_LIST_NOEXCEPT: capacity(number_of_groups) {};
-		}		group_allocator_pair;
+			size_type capacity; // Total number of groups
+			ebco_pair(const size_type number_of_groups, const allocator_type &alloc) PLF_NOEXCEPT:
+				group_allocator_type(alloc),
+				capacity(number_of_groups)
+			{};
+		} group_allocator_pair;
 
 
 
-		group_vector() PLF_LIST_NOEXCEPT:
-			node_pointer_allocator_type(node_pointer_allocator_type()),
+		group_vector(const allocator_type &alloc) PLF_NOEXCEPT:
+			allocator_type(alloc),
 			last_endpoint_group(NULL),
 			block_pointer(NULL),
 			last_searched_group(NULL),
 			size(0),
-			element_allocator_pair(0),
-			group_allocator_pair(0)
+			node_pointer_allocator_pair(0, alloc),
+			group_allocator_pair(0, alloc)
 		{}
 
 
 
-		inline PLF_LIST_FORCE_INLINE void blank() PLF_LIST_NOEXCEPT
+		void blank() PLF_NOEXCEPT
 		{
-			#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-				if PLF_LIST_CONSTEXPR (std::is_trivial<group_pointer_type>::value)
+			#ifdef PLF_IS_ALWAYS_EQUAL_SUPPORT // allocator_traits and type_traits always available when is_always_equal is available
+				if PLF_CONSTEXPR (std::is_standard_layout<group_vector>::value && std::allocator_traits<allocator_type>::is_always_equal::value && std::is_trivially_destructible<group_pointer_type>::value)
 				{
 					std::memset(static_cast<void *>(this), 0, sizeof(group_vector));
 				}
@@ -487,30 +614,32 @@ private:
 				block_pointer = NULL;
 				last_searched_group = NULL;
 				size = 0;
-				element_allocator_pair.capacity = 0;
+				node_pointer_allocator_pair.capacity = 0;
 				group_allocator_pair.capacity = 0;
 			}
 		}
 
 
 
-		#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-			group_vector(group_vector &&source) PLF_LIST_NOEXCEPT:
+		#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+			group_vector(group_vector &&source) PLF_NOEXCEPT:
+				allocator_type(source),
 				last_endpoint_group(std::move(source.last_endpoint_group)),
 				block_pointer(std::move(source.block_pointer)),
 				last_searched_group(std::move(source.last_searched_group)),
 				size(source.size),
-				element_allocator_pair(source.element_allocator_pair.capacity),
-				group_allocator_pair(source.group_allocator_pair.capacity)
+				node_pointer_allocator_pair(source.node_pointer_allocator_pair.capacity, source),
+				group_allocator_pair(source.group_allocator_pair.capacity, source)
 			{
 				source.blank();
 			}
 
 
-			group_vector & operator = (group_vector &&source) PLF_LIST_NOEXCEPT
+
+			group_vector & operator = (group_vector &&source) PLF_NOEXCEPT
 			{
-				#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-					if PLF_LIST_CONSTEXPR (std::is_trivial<group_pointer_type>::value)
+				#ifdef PLF_IS_ALWAYS_EQUAL_SUPPORT
+					if PLF_CONSTEXPR ((std::is_trivially_copyable<allocator_type>::value || std::allocator_traits<allocator_type>::is_always_equal::value) && std::is_trivially_copyable<group_pointer_type>::value)
 					{
 						std::memcpy(static_cast<void *>(this), &source, sizeof(group_vector));
 					}
@@ -521,8 +650,18 @@ private:
 					block_pointer = std::move(source.block_pointer);
 					last_searched_group = std::move(source.last_searched_group);
 					size = source.size;
-					element_allocator_pair.capacity = source.element_allocator_pair.capacity;
+					node_pointer_allocator_pair.capacity = source.node_pointer_allocator_pair.capacity;
 					group_allocator_pair.capacity = source.group_allocator_pair.capacity;
+
+					#ifdef PLF_ALLOCATOR_TRAITS_SUPPORT
+						if PLF_CONSTEXPR(std::allocator_traits<allocator_type>::propagate_on_container_move_assignment::value)
+					#endif
+					{
+						static_cast<allocator_type &>(*this) = static_cast<allocator_type &>(source);
+						// Reconstruct rebinds:
+		  				static_cast<node_pointer_allocator_type &>(node_pointer_allocator_pair) = node_allocator_type(*this);
+						static_cast<group_allocator_type &>(group_allocator_pair) = group_allocator_type(*this);
+					}
 				}
 
 				source.blank();
@@ -532,147 +671,94 @@ private:
 
 
 
-		~group_vector() PLF_LIST_NOEXCEPT
-		{}
-
-
-
-		void destroy_all_data(const node_pointer_type last_endpoint_node) PLF_LIST_NOEXCEPT
+		void destroy_all_data(const node_pointer_type last_endpoint_node) PLF_NOEXCEPT
 		{
-			if (block_pointer == NULL)
-			{
-				return;
-			}
+			if (block_pointer == NULL) return;
 
-			#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-				if PLF_LIST_CONSTEXPR (!std::is_trivially_destructible<element_type>::value || !std::is_trivially_destructible<node_pointer_type>::value)
+			#ifdef PLF_TYPE_TRAITS_SUPPORT
+				if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value || !std::is_trivially_destructible<node_pointer_type>::value)
 			#endif
 			{
-				clear(last_endpoint_node); // If clear has already been called, last_endpoint_node will already be == block_pointer->nodes, so no work will occur
+				if (last_endpoint_node != NULL) clear(last_endpoint_node);
 			}
 
-			const group_pointer_type end_group = block_pointer + size;
-			for (group_pointer_type current_group = block_pointer; current_group != end_group; ++current_group)
+			const group_pointer_type end = block_pointer + size;
+			for (group_pointer_type current_group = block_pointer; current_group != end; ++current_group)
 			{
-				PLF_LIST_DESTROY(group_allocator_type, group_allocator_pair, current_group);
+				PLF_DESTROY(group_allocator_type, group_allocator_pair, current_group);
 			}
 
-			PLF_LIST_DEALLOCATE(group_allocator_type, group_allocator_pair, block_pointer, group_allocator_pair.capacity);
+			PLF_DEALLOCATE(group_allocator_type, group_allocator_pair, block_pointer, group_allocator_pair.capacity);
 			blank();
 		}
 
 
 
-		void clear(const node_pointer_type last_endpoint_node) PLF_LIST_NOEXCEPT
+		void destroy_group(const group_pointer_type current_group, const node_pointer_type end_node) PLF_NOEXCEPT
 		{
-			for (group_pointer_type current_group = block_pointer; current_group != last_endpoint_group; ++current_group)
-			{
-				#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-					if PLF_LIST_CONSTEXPR (!std::is_trivially_destructible<element_type>::value || !std::is_trivially_destructible<node_pointer_type>::value)
-				#endif
-				{
-					const node_pointer_type end = current_group->beyond_end;
-
-					if ((end - current_group->nodes) != current_group->number_of_elements) // If there are erased nodes present in the group
-					{
-						for (node_pointer_type current_node = current_group->nodes; current_node != end; ++current_node)
-						{
-							#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-								if PLF_LIST_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
-							#endif
-							{
-								if (current_node->next != NULL) // ie. is not part of free list
-								{
-									PLF_LIST_DESTROY(element_allocator_type, element_allocator_pair, &(current_node->element));
-								}
-							}
-
-							#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-								if PLF_LIST_CONSTEXPR (!std::is_trivially_destructible<node_pointer_type>::value)
-							#endif
-							{
-								PLF_LIST_DESTROY(node_pointer_allocator_type, (*this), &(current_node->next));
-								PLF_LIST_DESTROY(node_pointer_allocator_type, (*this), &(current_node->previous));
-							}
-						}
-					}
-					else
-					{
-						for (node_pointer_type current_node = current_group->nodes; current_node != end; ++current_node)
-						{
-							#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-								if PLF_LIST_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
-							#endif
-							{
-								PLF_LIST_DESTROY(element_allocator_type, element_allocator_pair, &(current_node->element));
-							}
-
-							#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-								if PLF_LIST_CONSTEXPR (!std::is_trivially_destructible<node_pointer_type>::value)
-							#endif
-							{
-								PLF_LIST_DESTROY(node_pointer_allocator_type, (*this), &(current_node->next));
-								PLF_LIST_DESTROY(node_pointer_allocator_type, (*this), &(current_node->previous));
-							}
-						}
-					}
-				}
-
-				current_group->free_list_head = NULL;
-				current_group->number_of_elements = 0;
-			}
-
-			#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-				if PLF_LIST_CONSTEXPR (!std::is_trivially_destructible<element_type>::value || !std::is_trivially_destructible<node_pointer_type>::value)
+			#ifdef PLF_TYPE_TRAITS_SUPPORT
+				if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value || !std::is_trivially_destructible<node_pointer_type>::value)
 			#endif
 			{
-				if ((last_endpoint_node - last_endpoint_group->nodes) != last_endpoint_group->number_of_elements) // If there are erased nodes present in the group
+				if ((end_node - current_group->nodes) != current_group->number_of_elements) // If there are erased nodes present in the group
 				{
-					for (node_pointer_type current_node = last_endpoint_group->nodes; current_node != last_endpoint_node; ++current_node)
+					for (node_pointer_type current_node = current_group->nodes; current_node != end_node; ++current_node)
 					{
-						#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-							if PLF_LIST_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
+						#ifdef PLF_TYPE_TRAITS_SUPPORT
+							if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
 						#endif
 						{
 							if (current_node->next != NULL) // is not part of free list ie. element has not already had it's destructor called
 							{
-								PLF_LIST_DESTROY(element_allocator_type, element_allocator_pair, &(current_node->element));
+								PLF_DESTROY(allocator_type, *this, &(current_node->element));
 							}
 						}
 
-						#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-							if PLF_LIST_CONSTEXPR (!std::is_trivially_destructible<node_pointer_type>::value)
+						#ifdef PLF_TYPE_TRAITS_SUPPORT
+							if PLF_CONSTEXPR (!std::is_trivially_destructible<node_pointer_type>::value)
 						#endif
 						{
-							PLF_LIST_DESTROY(node_pointer_allocator_type, (*this), &(current_node->next));
-							PLF_LIST_DESTROY(node_pointer_allocator_type, (*this), &(current_node->previous));
+							PLF_DESTROY(node_pointer_allocator_type, node_pointer_allocator_pair, &(current_node->next));
+							PLF_DESTROY(node_pointer_allocator_type, node_pointer_allocator_pair, &(current_node->previous));
 						}
 					}
 				}
 				else
 				{
-					for (node_pointer_type current_node = last_endpoint_group->nodes; current_node != last_endpoint_node; ++current_node)
+					for (node_pointer_type current_node = current_group->nodes; current_node != end_node; ++current_node)
 					{
-						#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-							if PLF_LIST_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
+						#ifdef PLF_TYPE_TRAITS_SUPPORT
+							if PLF_CONSTEXPR (!std::is_trivially_destructible<element_type>::value)
 						#endif
 						{
-							PLF_LIST_DESTROY(element_allocator_type, element_allocator_pair, &(current_node->element));
+							PLF_DESTROY(allocator_type, *this, &(current_node->element));
 						}
 
-						#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-							if PLF_LIST_CONSTEXPR (!std::is_trivially_destructible<node_pointer_type>::value)
+						#ifdef PLF_TYPE_TRAITS_SUPPORT
+							if PLF_CONSTEXPR (!std::is_trivially_destructible<node_pointer_type>::value)
 						#endif
 						{
-							PLF_LIST_DESTROY(node_pointer_allocator_type, (*this), &(current_node->next));
-							PLF_LIST_DESTROY(node_pointer_allocator_type, (*this), &(current_node->previous));
+							PLF_DESTROY(node_pointer_allocator_type, node_pointer_allocator_pair, &(current_node->next));
+							PLF_DESTROY(node_pointer_allocator_type, node_pointer_allocator_pair, &(current_node->previous));
 						}
 					}
 				}
 			}
 
-			last_endpoint_group->free_list_head = NULL;
-			last_endpoint_group->number_of_elements = 0;
+			current_group->free_list_head = NULL;
+			current_group->number_of_elements = 0;
+		}
+
+
+
+		void clear(const node_pointer_type last_endpoint_node) PLF_NOEXCEPT
+		{
+			for (group_pointer_type current_group = block_pointer; current_group != last_endpoint_group; ++current_group)
+			{
+				destroy_group(current_group, current_group->beyond_end);
+			}
+
+			destroy_group(last_endpoint_group, last_endpoint_node);
 			last_searched_group = last_endpoint_group = block_pointer;
 		}
 
@@ -680,39 +766,38 @@ private:
 
 		void expand_capacity(const size_type new_capacity) // used by add_new and append
 		{
-			group_pointer_type const old_block = block_pointer;
-			block_pointer = PLF_LIST_ALLOCATE(group_allocator_type, group_allocator_pair, new_capacity, 0);
+			const group_pointer_type old_block = block_pointer;
+			block_pointer = PLF_ALLOCATE(group_allocator_type, group_allocator_pair, new_capacity, 0);
 
-			#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-				if PLF_LIST_CONSTEXPR (std::is_trivially_copyable<node_pointer_type>::value && std::is_trivially_destructible<node_pointer_type>::value)
-				{ // Dereferencing here in order to deal with smart pointer situations ie. obtaining the raw pointer from the smart pointer
-					std::memcpy(static_cast<void *>(&*block_pointer), static_cast<void *>(&*old_block), sizeof(group) * size); // reinterpret_cast necessary to deal with GCC 8 warnings
+			#ifdef PLF_TYPE_TRAITS_SUPPORT
+				if PLF_CONSTEXPR (std::is_trivially_copyable<node_pointer_type>::value && std::is_trivially_destructible<node_pointer_type>::value)
+				{
+					std::memcpy(plf::void_cast(block_pointer), plf::void_cast(old_block), sizeof(group) * size);
 				}
-				#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-					else if PLF_LIST_CONSTEXPR (std::is_move_constructible<node_pointer_type>::value)
+				#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+					else if PLF_CONSTEXPR (std::is_move_constructible<node_pointer_type>::value)
 					{
-						std::uninitialized_copy(std::make_move_iterator(old_block), std::make_move_iterator(old_block + size), block_pointer);
+						std::uninitialized_copy(plf::make_move_iterator(old_block), plf::make_move_iterator(old_block + size), block_pointer);
 					}
 				#endif
 				else
 			#endif
 			{
 				// If allocator supplies non-trivial pointers it becomes necessary to destroy the group. uninitialized_copy will not work in this context as the copy constructor for "group" is overriden in C++03/98. The = operator for "group" has been overriden to make the following work:
-				const group_pointer_type beyond_end = old_block + size;
-				group_pointer_type current_new_group = block_pointer;
+				const group_pointer_type end = old_block + size;
 
-				for (group_pointer_type current_group = old_block; current_group != beyond_end; ++current_group)
+				for (group_pointer_type current_group = old_block, current_new_group = block_pointer; current_group != end; ++current_group)
 				{
-					*(current_new_group++) = *(current_group);
+					*current_new_group++ = *current_group;
 
 					current_group->nodes = NULL;
 					current_group->beyond_end = NULL;
-					PLF_LIST_DESTROY(group_allocator_type, group_allocator_pair, current_group);
+					PLF_DESTROY(group_allocator_type, group_allocator_pair, current_group);
 				}
 			}
 
 			last_searched_group = block_pointer + (last_searched_group - old_block); // correct pointer post-reallocation
-			PLF_LIST_DEALLOCATE(group_allocator_type, group_allocator_pair, old_block, group_allocator_pair.capacity);
+			PLF_DEALLOCATE(group_allocator_type, group_allocator_pair, old_block, group_allocator_pair.capacity);
 			group_allocator_pair.capacity = new_capacity;
 		}
 
@@ -720,61 +805,63 @@ private:
 
 		void add_new(const group_size_type group_size)
 		{
-			if (group_allocator_pair.capacity == size)
-			{
-				expand_capacity(group_allocator_pair.capacity * 2);
-			}
+			if (group_allocator_pair.capacity == size) expand_capacity(group_allocator_pair.capacity * 2);
 
 			last_endpoint_group = block_pointer + size - 1;
 
-			#ifdef PLF_LIST_VARIADICS_SUPPORT
-				PLF_LIST_CONSTRUCT(group_allocator_type, group_allocator_pair, last_endpoint_group + 1, group_size, last_endpoint_group->nodes);
+			#ifdef PLF_VARIADICS_SUPPORT
+				PLF_CONSTRUCT(group_allocator_type, group_allocator_pair, last_endpoint_group + 1, group_size, last_endpoint_group->nodes);
 			#else
-				PLF_LIST_CONSTRUCT(group_allocator_type, group_allocator_pair, last_endpoint_group + 1, group(group_size, last_endpoint_group->nodes));
+				PLF_CONSTRUCT(group_allocator_type, group_allocator_pair, last_endpoint_group + 1, group(group_size, last_endpoint_group->nodes));
 			#endif
 
 			++last_endpoint_group; // Doing this here instead of pre-construct to avoid need for a try-catch block
-			element_allocator_pair.capacity += group_size;
+			node_pointer_allocator_pair.capacity += group_size;
 			++size;
 		}
 
 
 
-		void initialize(const group_size_type group_size) // For adding first group *only* when group vector is completely empty and block_pointer is NULL
+		void initialize(const group_size_type first_group_capacity) // For adding first group *only* when group vector is completely empty and block_pointer is NULL
 		{
-			last_endpoint_group = block_pointer = last_searched_group = PLF_LIST_ALLOCATE(group_allocator_type, group_allocator_pair, 1, 0);
+			last_endpoint_group = block_pointer = last_searched_group = PLF_ALLOCATE(group_allocator_type, group_allocator_pair, 1, 0);
 			group_allocator_pair.capacity = 1;
 
-			#ifdef PLF_LIST_VARIADICS_SUPPORT
-				PLF_LIST_CONSTRUCT(group_allocator_type, group_allocator_pair, last_endpoint_group, group_size);
+			#ifdef PLF_VARIADICS_SUPPORT
+				PLF_CONSTRUCT(group_allocator_type, group_allocator_pair, last_endpoint_group, first_group_capacity);
 			#else
-				PLF_LIST_CONSTRUCT(group_allocator_type, group_allocator_pair, last_endpoint_group, group(group_size));
+				PLF_CONSTRUCT(group_allocator_type, group_allocator_pair, last_endpoint_group, group(first_group_capacity));
 			#endif
 
 			size = 1; // Doing these here instead of pre-construct to avoid need for a try-catch block
-			element_allocator_pair.capacity = group_size;
+			node_pointer_allocator_pair.capacity = first_group_capacity;
 		}
 
 
 
-		void remove(group_pointer_type const group_to_erase) PLF_LIST_NOEXCEPT
+		#ifdef PLF_CPP20_SUPPORT
+			#define PLF_TO_ADDRESS(pointer) std::to_address(pointer)
+		#else
+			#define PLF_TO_ADDRESS(pointer) &*(pointer)
+		#endif
+
+
+
+		void remove(const group_pointer_type group_to_erase) PLF_NOEXCEPT
 		{
-			if (last_searched_group >= group_to_erase && last_searched_group != block_pointer)
-			{
-				--last_searched_group;
-			}
+			if (last_searched_group >= group_to_erase && last_searched_group != block_pointer) --last_searched_group;
 
-			element_allocator_pair.capacity -= static_cast<size_type>(group_to_erase->beyond_end - group_to_erase->nodes);
+			node_pointer_allocator_pair.capacity -= static_cast<size_type>(group_to_erase->beyond_end - group_to_erase->nodes);
 
-			PLF_LIST_DESTROY(group_allocator_type, group_allocator_pair, group_to_erase);
+			PLF_DESTROY(group_allocator_type, group_allocator_pair, group_to_erase);
 
-			#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-				if PLF_LIST_CONSTEXPR (std::is_trivially_copyable<node_pointer_type>::value && std::is_trivially_destructible<node_pointer_type>::value)
-				{ // Dereferencing here in order to deal with smart pointer situations ie. obtaining the raw pointer from the smart pointer
-					std::memmove(static_cast<void *>(&*group_to_erase), static_cast<void *>(&*group_to_erase + 1), sizeof(group) * (--size - static_cast<size_type>(&*group_to_erase - &*block_pointer)));
+			#ifdef PLF_TYPE_TRAITS_SUPPORT
+				if PLF_CONSTEXPR (std::is_trivially_copyable<node_pointer_type>::value && std::is_trivially_destructible<node_pointer_type>::value)
+				{
+					std::memmove(plf::void_cast(group_to_erase), plf::void_cast(group_to_erase + 1), sizeof(group) * (--size - static_cast<size_type>(PLF_TO_ADDRESS(group_to_erase) - PLF_TO_ADDRESS(block_pointer))));
 				}
-				#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-					else if PLF_LIST_CONSTEXPR (std::is_move_constructible<node_pointer_type>::value)
+				#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+					else if PLF_CONSTEXPR (std::is_move_constructible<node_pointer_type>::value)
 					{
 						std::move(group_to_erase + 1, block_pointer + size--, group_to_erase);
 					}
@@ -787,206 +874,161 @@ private:
 
 				back->nodes = NULL;
 				back->beyond_end = NULL;
-				PLF_LIST_DESTROY(group_allocator_type, group_allocator_pair, back);
+				PLF_DESTROY(group_allocator_type, group_allocator_pair, back);
 			}
 		}
 
 
 
-		void move_to_back(group_pointer_type const group_to_erase)
+		void move_to_back(const group_pointer_type group_to_erase)
 		{
-			if (last_searched_group >= group_to_erase && last_searched_group != block_pointer)
-			{
-				--last_searched_group;
-			}
+			if (last_searched_group >= group_to_erase && last_searched_group != block_pointer) --last_searched_group;
 
-			group *temp_group = PLF_LIST_ALLOCATE(group_allocator_type, group_allocator_pair, 1, NULL);
+			group *temp_group = PLF_ALLOCATE(group_allocator_type, group_allocator_pair, 1, NULL);
 
-			#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-				if PLF_LIST_CONSTEXPR (std::is_trivially_copyable<node_pointer_type>::value && std::is_trivially_destructible<node_pointer_type>::value)
+			#ifdef PLF_TYPE_TRAITS_SUPPORT
+				if PLF_CONSTEXPR (std::is_trivially_copyable<node_pointer_type>::value && std::is_trivially_destructible<node_pointer_type>::value)
 				{
-					std::memcpy(static_cast<void *>(&*temp_group), static_cast<void *>(&*group_to_erase), sizeof(group));
-					std::memmove(static_cast<void *>(&*group_to_erase), static_cast<void *>(&*group_to_erase + 1), sizeof(group) * ((size - 1) - static_cast<size_type>(&*group_to_erase - &*block_pointer)));
-					std::memcpy(static_cast<void *>(&*(block_pointer + size - 1)), static_cast<void *>(&*temp_group), sizeof(group));
+					std::memcpy(plf::void_cast(temp_group), plf::void_cast(group_to_erase), sizeof(group));
+					std::memmove(plf::void_cast(group_to_erase), plf::void_cast(group_to_erase + 1), sizeof(group) * ((size - 1) - static_cast<size_type>(PLF_TO_ADDRESS(group_to_erase) - PLF_TO_ADDRESS(block_pointer))));
+					std::memcpy(plf::void_cast(block_pointer + size - 1), plf::void_cast(temp_group), sizeof(group));
 				}
-				#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-					else if PLF_LIST_CONSTEXPR (std::is_move_constructible<node_pointer_type>::value)
+				#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+					else if PLF_CONSTEXPR (std::is_move_constructible<node_pointer_type>::value)
 					{
-						PLF_LIST_CONSTRUCT(group_allocator_type, group_allocator_pair, temp_group, std::move(*group_to_erase));
+						PLF_CONSTRUCT(group_allocator_type, group_allocator_pair, temp_group, std::move(*group_to_erase));
 						std::move(group_to_erase + 1, block_pointer + size, group_to_erase);
 						*(block_pointer + size - 1) = std::move(*temp_group);
 
-						if PLF_LIST_CONSTEXPR (!std::is_trivially_destructible<node_pointer_type>::value)
+						if PLF_CONSTEXPR (!std::is_trivially_destructible<node_pointer_type>::value)
 						{
-							PLF_LIST_DESTROY(group_allocator_type, group_allocator_pair, temp_group);
+							PLF_DESTROY(group_allocator_type, group_allocator_pair, temp_group);
 						}
 					}
 				#endif
 				else
 			#endif
 			{
-				PLF_LIST_CONSTRUCT(group_allocator_type, group_allocator_pair, temp_group, group());
+				PLF_CONSTRUCT(group_allocator_type, group_allocator_pair, temp_group, group());
 
 				*temp_group = *group_to_erase;
 				std::copy(group_to_erase + 1, block_pointer + size, group_to_erase);
 				*(block_pointer + --size) = *temp_group;
 
 				temp_group->nodes = NULL;
-				PLF_LIST_DESTROY(group_allocator_type, group_allocator_pair, temp_group);
+				PLF_DESTROY(group_allocator_type, group_allocator_pair, temp_group);
 			}
 
-			PLF_LIST_DEALLOCATE(group_allocator_type, group_allocator_pair, temp_group, 1);
+			PLF_DEALLOCATE(group_allocator_type, group_allocator_pair, temp_group, 1);
 		}
 
 
 
-		group_pointer_type get_nearest_freelist_group(const node_pointer_type location_node) PLF_LIST_NOEXCEPT // In working implementation this cannot throw
+		group_pointer_type get_nearest_freelist_group(const node_pointer_type location_node) PLF_NOEXCEPT // In working implementation this cannot throw
 		{
 			const group_pointer_type beyond_end_group = last_endpoint_group + 1;
 			group_pointer_type left = last_searched_group - 1, right = last_searched_group + 1, freelist_group = NULL;
-			bool right_not_beyond_back = (right < beyond_end_group);
-			bool left_not_beyond_front = (left >= block_pointer);
+			bool right_not_beyond_back = right < beyond_end_group;
+			bool left_not_beyond_front = left >= block_pointer;
 
 
 			if (location_node >= last_searched_group->nodes && location_node < last_searched_group->beyond_end) // ie. location is within last_search_group
 			{
-				if (last_searched_group->free_list_head != NULL) // if last_searched_group has previously-erased nodes
-				{
-					return last_searched_group;
-				}
+				if (last_searched_group->free_list_head != NULL) return last_searched_group; // if last_searched_group has previously-erased nodes
+				// Else: search outwards using loop below this if/else block
 			}
 			else // search for the node group which location_node is located within, using last_searched_group as a starting point and searching left and right. Try and find the closest node group with reusable erased-element locations along the way:
 			{
-				group_pointer_type closest_freelist_left = (last_searched_group->free_list_head == NULL) ? NULL : last_searched_group, closest_freelist_right = (last_searched_group->free_list_head == NULL) ? NULL : last_searched_group;
+				group_pointer_type closest_freelist_left = (last_searched_group->free_list_head == NULL) ? NULL : last_searched_group;
+				group_pointer_type closest_freelist_right = closest_freelist_left;
 
 				while (true)
 				{
 					if (right_not_beyond_back)
 					{
-						if ((location_node < right->beyond_end) && (location_node >= right->nodes)) // location_node's group is found
+						if (location_node < right->beyond_end && location_node >= right->nodes) // location_node's group is found
 						{
-							if (right->free_list_head != NULL) // group has erased nodes, reuse them:
-							{
-								last_searched_group = right;
-								return right;
-							}
-
+							last_searched_group = right;
+							if (right->free_list_head != NULL) return right; // group has erased nodes, reuse them:
 							difference_type left_distance;
 
 							if (closest_freelist_right != NULL)
 							{
-								last_searched_group = right;
 								left_distance = right - closest_freelist_right;
-
-								if (left_distance <= 2) // ie. this group is close enough to location_node's group
-								{
-									return closest_freelist_right;
-								}
-
+								if (left_distance <= 2) return closest_freelist_right; // ie. this group is close enough to location_node's group
 								freelist_group = closest_freelist_right;
 							}
 							else
 							{
-								last_searched_group = right;
 								left_distance = right - left;
 							}
 
 
 							// Otherwise find closest group with freelist - check an equal distance on the right to the distance we've checked on the left:
-							const group_pointer_type end_group = (((right + left_distance) > beyond_end_group) ? beyond_end_group : (right + left_distance - 1));
+							const group_pointer_type right_plus_distance = right + left_distance;
+							const group_pointer_type end_group = (right_plus_distance > beyond_end_group) ? beyond_end_group : right_plus_distance - 1;
 
 							while (++right != end_group)
 							{
-								if (right->free_list_head != NULL)
-								{
-									return right;
-								}
+								if (right->free_list_head != NULL) return right;
 							}
 
-							if (freelist_group != NULL)
-							{
-								return freelist_group;
-							}
+							if (freelist_group != NULL) return freelist_group;
 
-							right_not_beyond_back = (right < beyond_end_group);
+							right_not_beyond_back = right < beyond_end_group;
 							break; // group with reusable erased nodes not found yet, continue searching in loop below
 						}
 
 						if (right->free_list_head != NULL) // location_node's group not found, but a reusable location found
 						{
-							if ((closest_freelist_right == NULL) & (closest_freelist_left == NULL))
-							{
-								closest_freelist_left = right;
-							}
-
+							if ((closest_freelist_right == NULL) & (closest_freelist_left == NULL)) closest_freelist_left = right;
 							closest_freelist_right = right;
 						}
 
-						right_not_beyond_back = (++right < beyond_end_group);
+						right_not_beyond_back = ++right < beyond_end_group;
 					}
 
 
 					if (left_not_beyond_front)
 					{
-						if ((location_node >= left->nodes) && (location_node < left->beyond_end))
+						if (location_node >= left->nodes && location_node < left->beyond_end)
 						{
-							if (left->free_list_head != NULL)
-							{
-								last_searched_group = left;
-								return left;
-							}
-
+							last_searched_group = left;
+							if (left->free_list_head != NULL) return left;
 							difference_type right_distance;
 
 							if (closest_freelist_left != NULL)
 							{
-								last_searched_group = left;
 								right_distance = closest_freelist_left - left;
-
-								if (right_distance <= 2)
-								{
-									return closest_freelist_left;
-								}
-
+								if (right_distance <= 2) return closest_freelist_left;
 								freelist_group = closest_freelist_left;
 							}
 							else
 							{
-								last_searched_group = left;
 								right_distance = right - left;
 							}
 
 							// Otherwise find closest group with freelist:
-							const group_pointer_type end_group = (((left - right_distance) < block_pointer) ? block_pointer - 1 : (left - right_distance) + 1);
+							const group_pointer_type left_minus_distance = left - right_distance;
+							const group_pointer_type end_group = (left_minus_distance < block_pointer) ? block_pointer - 1 : left_minus_distance + 1;
 
 							while (--left != end_group)
 							{
-								if (left->free_list_head != NULL)
-								{
-									return left;
-								}
+								if (left->free_list_head != NULL) return left;
 							}
 
-							if (freelist_group != NULL)
-							{
-								return freelist_group;
-							}
-
-							left_not_beyond_front = (left >= block_pointer);
+							if (freelist_group != NULL) return freelist_group;
+							left_not_beyond_front = left >= block_pointer;
 							break;
 						}
 
 						if (left->free_list_head != NULL)
 						{
-							if ((closest_freelist_left == NULL) & (closest_freelist_right == NULL))
-							{
-								closest_freelist_right = left;
-							}
-
+							if ((closest_freelist_left == NULL) & (closest_freelist_right == NULL)) closest_freelist_right = left;
 							closest_freelist_left = left;
 						}
 
-						left_not_beyond_front = (--left >= block_pointer);
+						left_not_beyond_front = --left >= block_pointer;
 					}
 				}
 			}
@@ -997,34 +1039,26 @@ private:
 			{
 				if (right_not_beyond_back)
 				{
-					if (right->free_list_head != NULL)
-					{
-						return right;
-					}
-
-					right_not_beyond_back = (++right < beyond_end_group);
+					if (right->free_list_head != NULL) return right;
+					right_not_beyond_back = ++right < beyond_end_group;
 				}
 
 				if (left_not_beyond_front)
 				{
-					if (left->free_list_head != NULL)
-					{
-						return left;
-					}
-
-					left_not_beyond_front = (--left >= block_pointer);
+					if (left->free_list_head != NULL) return left;
+					left_not_beyond_front = --left >= block_pointer;
 				}
 			}
 
-			// Will never reach here on functioning implementations
+			// Will never reach here
 		}
 
 
 
-		void swap(group_vector &source) PLF_LIST_NOEXCEPT_SWAP(group_allocator_type)
+		void swap(group_vector &source) PLF_NOEXCEPT_SWAP(group_allocator_type)
 		{
-			#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-				if PLF_LIST_CONSTEXPR (std::is_trivial<group_pointer_type>::value) // if all pointer types are trivial we can just copy using memcpy - faster - avoids constructors/destructors etc
+			#ifdef PLF_IS_ALWAYS_EQUAL_SUPPORT
+				if PLF_CONSTEXPR (std::allocator_traits<allocator_type>::is_always_equal::value && std::is_trivially_copyable<group_pointer_type>::value) // if all pointer types are trivial we can just copy using memcpy - avoids constructors/destructors etc and is faster
 				{
 					char temp[sizeof(group_vector)];
 					std::memcpy(static_cast<void *>(&temp), static_cast<void *>(this), sizeof(group_vector));
@@ -1034,430 +1068,120 @@ private:
 				else
 			#endif
 			{
+				// Otherwise, make the reads/writes as contiguous in memory as-possible (yes, it is faster than using std::swap with the individual variables):
 				const group_pointer_type swap_last_endpoint_group = last_endpoint_group, swap_block_pointer = block_pointer, swap_last_searched_group = last_searched_group;
-				const size_type swap_size = size, swap_element_capacity = element_allocator_pair.capacity, swap_capacity = group_allocator_pair.capacity;
+				const size_type swap_size = size, swap_element_capacity = node_pointer_allocator_pair.capacity, swap_capacity = group_allocator_pair.capacity;
 
 				last_endpoint_group = source.last_endpoint_group;
 				block_pointer = source.block_pointer;
 				last_searched_group = source.last_searched_group;
 				size = source.size;
-				element_allocator_pair.capacity = source.element_allocator_pair.capacity;
+				node_pointer_allocator_pair.capacity = source.node_pointer_allocator_pair.capacity;
 				group_allocator_pair.capacity = source.group_allocator_pair.capacity;
 
 				source.last_endpoint_group = swap_last_endpoint_group;
 				source.block_pointer = swap_block_pointer;
 				source.last_searched_group = swap_last_searched_group;
 				source.size = swap_size;
-				source.element_allocator_pair.capacity = swap_element_capacity;
+				source.node_pointer_allocator_pair.capacity = swap_element_capacity;
 				source.group_allocator_pair.capacity = swap_capacity;
+
+				#ifdef PLF_IS_ALWAYS_EQUAL_SUPPORT
+					if PLF_CONSTEXPR (std::allocator_traits<allocator_type>::propagate_on_container_swap::value && !std::allocator_traits<allocator_type>::is_always_equal::value)
+				#endif
+				{
+					std::swap(static_cast<allocator_type &>(source), static_cast<allocator_type &>(*this));
+
+					// Reconstruct rebinds for swapped allocators:
+					static_cast<node_pointer_allocator_type &>(node_pointer_allocator_pair) = node_pointer_allocator_type(*this);
+					static_cast<group_allocator_type &>(group_allocator_pair) = group_allocator_type(*this);
+					static_cast<node_pointer_allocator_type &>(source.node_pointer_allocator_pair) = node_pointer_allocator_type(source);
+					static_cast<group_allocator_type &>(source.group_allocator_pair) = group_allocator_type(source);
+				} // else: undefined behaviour, as per standard
 			}
 		}
 
 
 
-		void trim_trailing_groups() PLF_LIST_NOEXCEPT
+		void trim_unused_groups() PLF_NOEXCEPT // trim trailing groups previously allocated by reserve() or retained via erase()
 		{
-			const group_pointer_type beyond_last = block_pointer + size;
+			const group_pointer_type end = block_pointer + size;
 
-			for (group_pointer_type current_group = last_endpoint_group + 1; current_group != beyond_last; ++current_group)
+			for (group_pointer_type current_group = last_endpoint_group + 1; current_group != end; ++current_group)
 			{
-				element_allocator_pair.capacity -= static_cast<size_type>(current_group->beyond_end - current_group->nodes);
-				PLF_LIST_DESTROY(group_allocator_type, group_allocator_pair, current_group);
+				node_pointer_allocator_pair.capacity -= static_cast<size_type>(current_group->beyond_end - current_group->nodes);
+				PLF_DESTROY(group_allocator_type, group_allocator_pair, current_group);
 			}
 
-			size -= static_cast<size_type>(beyond_last - (last_endpoint_group + 1));
+			size -= static_cast<size_type>(end - (last_endpoint_group + 1));
 		}
 
 
 
 		void append(group_vector &source)
 		{
-			source.trim_trailing_groups();
-			trim_trailing_groups();
+			source.trim_unused_groups();
+			trim_unused_groups();
 
-			if (size + source.size > group_allocator_pair.capacity)
-			{
-				expand_capacity(size + source.size);
-			}
+			if (size + source.size > group_allocator_pair.capacity) expand_capacity(size + source.size);
 
-			#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-				if PLF_LIST_CONSTEXPR (std::is_trivially_copyable<node_pointer_type>::value && std::is_trivially_destructible<node_pointer_type>::value)
-				{ // &* in order to deal with smart pointer situations ie. obtaining the raw pointer from the smart pointer
-					std::memcpy(static_cast<void *>(&*block_pointer + size), static_cast<void *>(&*source.block_pointer), sizeof(group) * source.size);
+			#ifdef PLF_TYPE_TRAITS_SUPPORT
+				if PLF_CONSTEXPR (std::is_trivially_copyable<node_pointer_type>::value && std::is_trivially_destructible<node_pointer_type>::value)
+				{
+					std::memcpy(plf::void_cast(block_pointer + size), plf::void_cast(source.block_pointer), sizeof(group) * source.size);
 				}
-				#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-					else if PLF_LIST_CONSTEXPR (std::is_move_constructible<node_pointer_type>::value)
+				#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+					else if PLF_CONSTEXPR (std::is_move_constructible<node_pointer_type>::value)
 					{
-						std::uninitialized_copy(std::make_move_iterator(source.block_pointer), std::make_move_iterator(source.block_pointer + source.size), block_pointer + size);
+						std::uninitialized_copy(plf::make_move_iterator(source.block_pointer), plf::make_move_iterator(source.block_pointer + source.size), block_pointer + size);
 					}
 				#endif
 				else
 			#endif
 			{
-				group_pointer_type current_new_group = block_pointer + size;
-				const group_pointer_type beyond_end_source = source.block_pointer + source.size;
+				const group_pointer_type end = source.block_pointer + source.size;
 
-				for (group_pointer_type current_group = source.block_pointer; current_group != beyond_end_source; ++current_group)
+				for (group_pointer_type current_group = source.block_pointer, current_new_group = block_pointer + size; current_group != end; ++current_group)
 				{
-					*(current_new_group++) = *(current_group);
+					*current_new_group++ = *current_group;
 
 					current_group->nodes = NULL;
 					current_group->beyond_end = NULL;
-					PLF_LIST_DESTROY(group_allocator_type, source.group_allocator_pair, current_group);
+					PLF_DESTROY(group_allocator_type, source.group_allocator_pair, current_group);
 				}
 			}
 
-			PLF_LIST_DEALLOCATE(group_allocator_type, source.group_allocator_pair, source.block_pointer, source.group_allocator_pair.capacity);
+			PLF_DEALLOCATE(group_allocator_type, source.group_allocator_pair, source.block_pointer, source.group_allocator_pair.capacity);
 			size += source.size;
 			last_endpoint_group = block_pointer + size - 1;
-			element_allocator_pair.capacity += source.element_allocator_pair.capacity;
+			node_pointer_allocator_pair.capacity += source.node_pointer_allocator_pair.capacity;
 			source.blank();
 		}
 	};
 
 
 
-	// Implement const/non-const iterator switching pattern:
-	template <bool flag, class IsTrue, class IsFalse> struct choose;
-
-	template <class IsTrue, class IsFalse> struct choose<true, IsTrue, IsFalse>
-	{
-		typedef IsTrue type;
-	};
-
-	template <class IsTrue, class IsFalse> struct choose<false, IsTrue, IsFalse>
-	{
-		typedef IsFalse type;
-	};
-
-
-public:
-
-	template <bool is_const> class list_iterator
-	{
-	private:
-		node_pointer_type node_pointer;
-
-	public:
-		typedef std::bidirectional_iterator_tag 	iterator_category;
-		typedef typename list::value_type 			value_type;
-		typedef typename list::difference_type 		difference_type;
-		typedef typename choose<is_const, typename list::const_pointer, typename list::pointer>::type		pointer;
-		typedef typename choose<is_const, typename list::const_reference, typename list::reference>::type	reference;
-
-		friend class list;
-
-
-
-		inline PLF_LIST_FORCE_INLINE bool operator == (const list_iterator rh) const PLF_LIST_NOEXCEPT
-		{
-			return (node_pointer == rh.node_pointer);
-		}
-
-
-
-		inline PLF_LIST_FORCE_INLINE bool operator == (const list_iterator<!is_const> rh) const PLF_LIST_NOEXCEPT
-		{
-			return (node_pointer == rh.node_pointer);
-		}
-
-
-
-		inline PLF_LIST_FORCE_INLINE bool operator != (const list_iterator rh) const PLF_LIST_NOEXCEPT
-		{
-			return (node_pointer != rh.node_pointer);
-		}
-
-
-
-		inline PLF_LIST_FORCE_INLINE bool operator != (const list_iterator<!is_const> rh) const PLF_LIST_NOEXCEPT
-		{
-			return (node_pointer != rh.node_pointer);
-		}
-
-
-
-		inline PLF_LIST_FORCE_INLINE reference operator * () const
-		{
-			return node_pointer->element;
-		}
-
-
-
-		inline PLF_LIST_FORCE_INLINE pointer operator -> () const
-		{
-			return &(node_pointer->element);
-		}
-
-
-
-		inline PLF_LIST_FORCE_INLINE list_iterator & operator ++ () PLF_LIST_NOEXCEPT
-		{
-			assert(node_pointer != NULL); // covers uninitialised list_iterator
-			node_pointer = node_pointer->next;
-			return *this;
-		}
-
-
-
-		inline list_iterator operator ++(int) PLF_LIST_NOEXCEPT
-		{
-			const list_iterator copy(*this);
-			++*this;
-			return copy;
-		}
-
-
-
-		inline PLF_LIST_FORCE_INLINE list_iterator & operator -- () PLF_LIST_NOEXCEPT
-		{
-			assert(node_pointer != NULL); // covers uninitialised list_iterator
-			node_pointer = node_pointer->previous;
-			return *this;
-		}
-
-
-
-		inline list_iterator operator -- (int) PLF_LIST_NOEXCEPT
-		{
-			const list_iterator copy(*this);
-			--*this;
-			return copy;
-		}
-
-
-
-		inline list_iterator & operator = (const list_iterator &rh) PLF_LIST_NOEXCEPT
-		{
-			node_pointer = rh.node_pointer;
-			return *this;
-		}
-
-
-
-		inline list_iterator & operator = (const list_iterator<!is_const> &rh) PLF_LIST_NOEXCEPT
-		{
-			node_pointer = rh.node_pointer;
-			return *this;
-		}
-
-
-
-		#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-			inline list_iterator & operator = (const list_iterator &&rh) PLF_LIST_NOEXCEPT
-			{
-				node_pointer = std::move(rh.node_pointer);
-				return *this;
-			}
-
-
-			inline list_iterator & operator = (const list_iterator<!is_const> &&rh) PLF_LIST_NOEXCEPT
-			{
-				node_pointer = std::move(rh.node_pointer);
-				return *this;
-			}
-		#endif
-
-
-
-		list_iterator() PLF_LIST_NOEXCEPT: node_pointer(NULL) {}
-
-		list_iterator(const list_iterator &source) PLF_LIST_NOEXCEPT: node_pointer(source.node_pointer) {}
-
-		list_iterator(const list_iterator<!is_const> &source) PLF_LIST_NOEXCEPT: node_pointer(source.node_pointer) {}
-
-		#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-			list_iterator (const list_iterator &&source) PLF_LIST_NOEXCEPT: node_pointer(std::move(source.node_pointer)) {}
-
-			list_iterator(const list_iterator<!is_const> &&source) PLF_LIST_NOEXCEPT: node_pointer(std::move(source.node_pointer)) {}
-		#endif
-
-	private:
-
-		list_iterator (const node_pointer_type node_p) PLF_LIST_NOEXCEPT: node_pointer(node_p) {}
-	};
-
-
-
-
-	template <bool is_const> class list_reverse_iterator
-	{
-	private:
-		node_pointer_type node_pointer;
-
-	public:
-		typedef std::bidirectional_iterator_tag 	iterator_category;
-		typedef typename list::value_type 		value_type;
-		typedef typename list::difference_type 		difference_type;
-		typedef typename choose<is_const, typename list::const_pointer, typename list::pointer>::type		pointer;
-		typedef typename choose<is_const, typename list::const_reference, typename list::reference>::type	reference;
-
-		friend class list;
-
-
-		inline PLF_LIST_FORCE_INLINE bool operator == (const list_reverse_iterator rh) const PLF_LIST_NOEXCEPT
-		{
-			return (node_pointer == rh.node_pointer);
-		}
-
-
-
-		inline PLF_LIST_FORCE_INLINE bool operator == (const list_reverse_iterator<!is_const> rh) const PLF_LIST_NOEXCEPT
-		{
-			return (node_pointer == rh.node_pointer);
-		}
-
-
-
-		inline PLF_LIST_FORCE_INLINE bool operator != (const list_reverse_iterator rh) const PLF_LIST_NOEXCEPT
-		{
-			return (node_pointer != rh.node_pointer);
-		}
-
-
-
-		inline PLF_LIST_FORCE_INLINE bool operator != (const list_reverse_iterator<!is_const> rh) const PLF_LIST_NOEXCEPT
-		{
-			return (node_pointer != rh.node_pointer);
-		}
-
-
-
-		inline PLF_LIST_FORCE_INLINE reference operator * () const
-		{
-			return node_pointer->element;
-		}
-
-
-
-		inline PLF_LIST_FORCE_INLINE pointer operator -> () const
-		{
-			return &(node_pointer->element);
-		}
-
-
-
-		inline PLF_LIST_FORCE_INLINE list_reverse_iterator & operator ++ () PLF_LIST_NOEXCEPT
-		{
-			assert(node_pointer != NULL); // covers uninitialised list_reverse_iterator
-			node_pointer = node_pointer->previous;
-			return *this;
-		}
-
-
-
-		inline list_reverse_iterator operator ++(int) PLF_LIST_NOEXCEPT
-		{
-			const list_reverse_iterator copy(*this);
-			++*this;
-			return copy;
-		}
-
-
-
-		inline PLF_LIST_FORCE_INLINE list_reverse_iterator & operator -- () PLF_LIST_NOEXCEPT
-		{
-			assert(node_pointer != NULL);
-			node_pointer = node_pointer->next;
-			return *this;
-		}
-
-
-
-		inline list_reverse_iterator operator -- (int) PLF_LIST_NOEXCEPT
-		{
-			const list_reverse_iterator copy(*this);
-			--*this;
-			return copy;
-		}
-
-
-
-		inline list_reverse_iterator & operator = (const list_reverse_iterator &rh) PLF_LIST_NOEXCEPT
-		{
-			node_pointer = rh.node_pointer;
-			return *this;
-		}
-
-
-
-		inline list_reverse_iterator & operator = (const list_reverse_iterator<!is_const> &rh) PLF_LIST_NOEXCEPT
-		{
-			node_pointer = rh.node_pointer;
-			return *this;
-		}
-
-
-
-		#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-			inline list_reverse_iterator & operator = (const list_reverse_iterator &&rh) PLF_LIST_NOEXCEPT
-			{
-				node_pointer = std::move(rh.node_pointer);
-				return *this;
-			}
-
-
-			inline list_reverse_iterator & operator = (const list_reverse_iterator<!is_const> &&rh) PLF_LIST_NOEXCEPT
-			{
-				node_pointer = std::move(rh.node_pointer);
-				return *this;
-			}
-		#endif
-
-
-
-		inline typename list::iterator base() const PLF_LIST_NOEXCEPT
-		{
-			return typename list::iterator(node_pointer->next);
-		}
-
-
-
-		list_reverse_iterator() PLF_LIST_NOEXCEPT: node_pointer(NULL) {}
-
-		list_reverse_iterator(const list_reverse_iterator &source) PLF_LIST_NOEXCEPT: node_pointer(source.node_pointer) {}
-
-		#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-			list_reverse_iterator (const list_reverse_iterator &&source) PLF_LIST_NOEXCEPT: node_pointer(std::move(source.node_pointer)) {}
-		#endif
-
-	private:
-
-		list_reverse_iterator (const node_pointer_type node_p) PLF_LIST_NOEXCEPT: node_pointer(node_p) {}
-	};
-
-
-
 private:
 
-	// Used by range-insert and range-constructor to prevent fill-insert and fill-constructor function calls mistakenly resolving to the range insert/constructor
-	template <bool condition, class T = void>
-	struct plf_enable_if_c
-	{
-		typedef T type;
-	};
+	group_vector groups; // Structure which contains all groups (structures containing node memory blocks + block metadata)
+	node_base end_node; // The independent, content-less node which is returned by end()
+	// When the list is empty, the previous and next pointers of end_node both point to end_node.
+	node_pointer_type last_endpoint; // The node location which is one-past the last inserted element in the last group of the list. Is not affected by erasures to prior elements (these are handled using the group's freelist).
+	// If last_endpoint is beyond the end of a memory block it means a new group must be created upon the next insertion if prior erased nodes are not available for re-use.
+	// last_endpoint == NULL means total_size is zero, but there may still be groups available due to calling clear(), reserve() on an empty list, or having erased all elements in the list
+	// groups.block_pointer == NULL means an uninitialized container ie. no groups or elements yet
+	iterator end_iterator, begin_iterator; // Returned by begin() and end().
+	// end_iterator always points to end_node. It is a convenience/optimization variable to save generating many temporary iterators from end_node during functions and during end().
+	// When the list is empty of elements, begin_iterator == end_iterator so that program loops iterating from begin() to end() will function as expected.
+	size_type total_size;
 
-	template <class T>
-	struct plf_enable_if_c<false, T>
-	{};
-
-
-
-	group_vector groups;
-	node_base end_node;
-	node_pointer_type last_endpoint; // last_endpoint being NULL means no elements have been constructed, but there may still be groups available due to clear() or reservee()
-	iterator end_iterator, begin_iterator; // end_iterator is always the last entry point in last group in list (or one past the end of group)
-
-	struct ebco_pair1 : node_pointer_allocator_type // Packaging the group allocator with least-used member variables, for empty-base-class optimisation
-	{
-		size_type total_number_of_elements;
-		explicit ebco_pair1(const size_type total_num_elements) PLF_LIST_NOEXCEPT: total_number_of_elements(total_num_elements) {}
-	}		node_pointer_allocator_pair;
-
-	struct ebco_pair2 : node_allocator_type
+	struct ebco_pair3 : node_allocator_type
 	{
 		size_type number_of_erased_nodes;
-		explicit ebco_pair2(const size_type num_erased_nodes) PLF_LIST_NOEXCEPT: number_of_erased_nodes(num_erased_nodes) {}
+		ebco_pair3(const size_type num_nodes, const allocator_type &alloc) PLF_NOEXCEPT:
+			node_allocator_type(alloc),
+			number_of_erased_nodes(num_nodes)
+		{};
 	}		node_allocator_pair;
 
 
@@ -1466,28 +1190,29 @@ public:
 
 	// Default constructor:
 
-	list() PLF_LIST_NOEXCEPT:
-		element_allocator_type(element_allocator_type()),
-		end_node(reinterpret_cast<node_pointer_type>(&end_node), reinterpret_cast<node_pointer_type>(&end_node)),
+	PLF_CONSTFUNC list() PLF_NOEXCEPT_ALLOCATOR:
+		groups(*this),
+		end_node(static_cast<node_pointer_type>(&end_node), static_cast<node_pointer_type>(&end_node)),
 		last_endpoint(NULL),
-		end_iterator(reinterpret_cast<node_pointer_type>(&end_node)),
-		begin_iterator(reinterpret_cast<node_pointer_type>(&end_node)),
-		node_pointer_allocator_pair(0),
-		node_allocator_pair(0)
+		end_iterator(static_cast<node_pointer_type>(&end_node)),
+		begin_iterator(static_cast<node_pointer_type>(&end_node)),
+		total_size(0),
+		node_allocator_pair(0, *this)
 	{}
 
 
 
 	// Allocator-extended constructor:
 
-	explicit list(const element_allocator_type &alloc):
-		element_allocator_type(alloc),
-		end_node(reinterpret_cast<node_pointer_type>(&end_node), reinterpret_cast<node_pointer_type>(&end_node)),
+	explicit list(const allocator_type &alloc):
+		allocator_type(alloc),
+		groups(alloc),
+		end_node(static_cast<node_pointer_type>(&end_node), static_cast<node_pointer_type>(&end_node)),
 		last_endpoint(NULL),
-		end_iterator(reinterpret_cast<node_pointer_type>(&end_node)),
-		begin_iterator(reinterpret_cast<node_pointer_type>(&end_node)),
-		node_pointer_allocator_pair(0),
-		node_allocator_pair(0)
+		end_iterator(static_cast<node_pointer_type>(&end_node)),
+		begin_iterator(static_cast<node_pointer_type>(&end_node)),
+		total_size(0),
+		node_allocator_pair(0, alloc)
 	{}
 
 
@@ -1495,72 +1220,120 @@ public:
 	// Copy constructor:
 
 	list(const list &source):
-		element_allocator_type(source),
-		end_node(reinterpret_cast<node_pointer_type>(&end_node), reinterpret_cast<node_pointer_type>(&end_node)),
+		#if (defined(__cplusplus) && __cplusplus >= 201103L) || _MSC_VER >= 1700
+			allocator_type(std::allocator_traits<allocator_type>::select_on_container_copy_construction(source)),
+		#else
+			allocator_type(source),
+		#endif
+		groups(*this),
+		end_node(static_cast<node_pointer_type>(&end_node), static_cast<node_pointer_type>(&end_node)),
 		last_endpoint(NULL),
-		end_iterator(reinterpret_cast<node_pointer_type>(&end_node)),
-		begin_iterator(reinterpret_cast<node_pointer_type>(&end_node)),
-		node_pointer_allocator_pair(0),
-		node_allocator_pair(0)
+		end_iterator(static_cast<node_pointer_type>(&end_node)),
+		begin_iterator(static_cast<node_pointer_type>(&end_node)),
+		total_size(0),
+		node_allocator_pair(0, *this)
 	{
-	 	reserve(source.node_pointer_allocator_pair.total_number_of_elements);
-		insert(end_iterator, source.begin_iterator, source.end_iterator);
+		range_insert(end_iterator, source.total_size, source.begin_iterator);
 	}
 
 
 
 	// Allocator-extended copy constructor:
 
-	list(const list &source, const allocator_type &alloc):
-		element_allocator_type(alloc),
-		end_node(reinterpret_cast<node_pointer_type>(&end_node), reinterpret_cast<node_pointer_type>(&end_node)),
+	#ifdef PLF_CPP20_SUPPORT
+		list(const list &source, const std::type_identity_t<allocator_type> &alloc):
+	#else
+		list(const list &source, const allocator_type &alloc):
+	#endif
+		allocator_type(alloc),
+		groups(alloc),
+		end_node(static_cast<node_pointer_type>(&end_node), static_cast<node_pointer_type>(&end_node)),
 		last_endpoint(NULL),
-		end_iterator(reinterpret_cast<node_pointer_type>(&end_node)),
-		begin_iterator(reinterpret_cast<node_pointer_type>(&end_node)),
-		node_pointer_allocator_pair(0),
-		node_allocator_pair(0)
+		end_iterator(static_cast<node_pointer_type>(&end_node)),
+		begin_iterator(static_cast<node_pointer_type>(&end_node)),
+		total_size(0),
+		node_allocator_pair(0, alloc)
 	{
-	 	reserve(source.node_pointer_allocator_pair.total_number_of_elements);
-		insert(end_iterator, source.begin_iterator, source.end_iterator);
+		range_insert(end_iterator, source.total_size, source.begin_iterator);
 	}
 
 
 
-	#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
+private:
+
+	void blank() PLF_NOEXCEPT
+	{
+		end_node.next = static_cast<node_pointer_type>(&end_node);
+		end_node.previous = static_cast<node_pointer_type>(&end_node);
+		last_endpoint = NULL;
+		begin_iterator.node_pointer = end_iterator.node_pointer;
+		total_size = 0;
+		node_allocator_pair.number_of_erased_nodes = 0;
+	}
+
+
+
+	void reset() PLF_NOEXCEPT
+	{
+		groups.destroy_all_data(last_endpoint);
+		blank();
+	}
+
+
+
+public:
+
+	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
 		// Move constructor:
 
-		list(list &&source) PLF_LIST_NOEXCEPT:
-			element_allocator_type(source),
+		list(list &&source) PLF_NOEXCEPT:
+			allocator_type(static_cast<allocator_type &>(source)),
 			groups(std::move(source.groups)),
 			end_node(std::move(source.end_node)),
 			last_endpoint(std::move(source.last_endpoint)),
-			end_iterator(reinterpret_cast<node_pointer_type>(&end_node)),
-			begin_iterator((source.begin_iterator.node_pointer == source.end_iterator.node_pointer) ? reinterpret_cast<node_pointer_type>(&end_node) : std::move(source.begin_iterator)),
-			node_pointer_allocator_pair(source.node_pointer_allocator_pair.total_number_of_elements),
-			node_allocator_pair(source.node_allocator_pair.number_of_erased_nodes)
+			end_iterator(static_cast<node_pointer_type>(&end_node)),
+			begin_iterator((source.begin_iterator.node_pointer == source.end_iterator.node_pointer) ? static_cast<node_pointer_type>(&end_node) : std::move(source.begin_iterator)),
+			total_size(source.total_size),
+			node_allocator_pair(source.node_allocator_pair.number_of_erased_nodes, source)
 		{
 			end_node.previous->next = begin_iterator.node_pointer->previous = end_iterator.node_pointer;
 			source.groups.blank();
-			source.reset();
+			source.blank();
 		}
 
 
 
 		// Allocator-extended move constructor:
 
-		list(list &&source, const allocator_type &alloc):
-			element_allocator_type(alloc),
+		#ifdef PLF_CPP20_SUPPORT
+			list(list &&source, const std::type_identity_t<allocator_type> &alloc):
+		#else
+			list(list &&source, const allocator_type &alloc):
+		#endif
+			allocator_type(alloc),
 			groups(std::move(source.groups)),
 			end_node(std::move(source.end_node)),
 			last_endpoint(std::move(source.last_endpoint)),
-			end_iterator(reinterpret_cast<node_pointer_type>(&end_node)),
-			begin_iterator((source.begin_iterator.node_pointer == source.end_iterator.node_pointer) ? reinterpret_cast<node_pointer_type>(&end_node) : std::move(source.begin_iterator)),
-			node_pointer_allocator_pair(source.node_pointer_allocator_pair.total_number_of_elements),
-			node_allocator_pair(source.node_allocator_pair.number_of_erased_nodes)
+			end_iterator(static_cast<node_pointer_type>(&end_node)),
+			begin_iterator((source.begin_iterator.node_pointer == source.end_iterator.node_pointer) ? static_cast<node_pointer_type>(&end_node) : std::move(source.begin_iterator)),
+			total_size(source.total_size),
+			node_allocator_pair(source.node_allocator_pair.number_of_erased_nodes, alloc)
 		{
+			#ifdef PLF_IS_ALWAYS_EQUAL_SUPPORT
+				if PLF_CONSTEXPR (!std::allocator_traits<allocator_type>::is_always_equal::value)
+			#endif
+			{
+				if (alloc != static_cast<allocator_type &>(source))
+				{
+					blank();
+					range_insert(end_iterator, source.total_size, source.begin_iterator);
+					source.~list();
+				}
+			}
+
 			end_node.previous->next = begin_iterator.node_pointer->previous = end_iterator.node_pointer;
 			source.groups.blank();
-			source.reset();
+			source.blank();
 		}
 	#endif
 
@@ -1568,17 +1341,34 @@ public:
 
 	// Fill constructor:
 
-	list(const size_type fill_number, const element_type &element, const element_allocator_type &alloc = element_allocator_type()):
-		element_allocator_type(alloc),
-		end_node(reinterpret_cast<node_pointer_type>(&end_node), reinterpret_cast<node_pointer_type>(&end_node)),
+	list(const size_type fill_number, const element_type &element, const allocator_type &alloc = allocator_type()):
+		allocator_type(alloc),
+		groups(alloc),
+		end_node(static_cast<node_pointer_type>(&end_node), static_cast<node_pointer_type>(&end_node)),
 		last_endpoint(NULL),
-		end_iterator(reinterpret_cast<node_pointer_type>(&end_node)),
-		begin_iterator(reinterpret_cast<node_pointer_type>(&end_node)),
-		node_pointer_allocator_pair(0),
-		node_allocator_pair(0)
+		end_iterator(static_cast<node_pointer_type>(&end_node)),
+		begin_iterator(static_cast<node_pointer_type>(&end_node)),
+		total_size(0),
+		node_allocator_pair(0, alloc)
 	{
-		reserve(fill_number);
 		insert(end_iterator, fill_number, element);
+	}
+
+
+
+	// Default element value fill constructor:
+
+	list(const size_type fill_number, const allocator_type &alloc = allocator_type()):
+		allocator_type(alloc),
+		groups(alloc),
+		end_node(static_cast<node_pointer_type>(&end_node), static_cast<node_pointer_type>(&end_node)),
+		last_endpoint(NULL),
+		end_iterator(static_cast<node_pointer_type>(&end_node)),
+		begin_iterator(static_cast<node_pointer_type>(&end_node)),
+		total_size(0),
+		node_allocator_pair(0, alloc)
+	{
+		insert(end_iterator, fill_number, element_type());
 	}
 
 
@@ -1586,14 +1376,15 @@ public:
 	// Range constructor:
 
 	template<typename iterator_type>
-	list(const typename plf_enable_if_c<!std::numeric_limits<iterator_type>::is_integer, iterator_type>::type &first, const iterator_type &last, const element_allocator_type &alloc = element_allocator_type()):
-		element_allocator_type(alloc),
-		end_node(reinterpret_cast<node_pointer_type>(&end_node), reinterpret_cast<node_pointer_type>(&end_node)),
+	list(const typename plf::enable_if<!std::numeric_limits<iterator_type>::is_integer, iterator_type>::type &first, const iterator_type &last, const allocator_type &alloc = allocator_type()):
+		allocator_type(alloc),
+		groups(alloc),
+		end_node(static_cast<node_pointer_type>(&end_node), static_cast<node_pointer_type>(&end_node)),
 		last_endpoint(NULL),
-		end_iterator(reinterpret_cast<node_pointer_type>(&end_node)),
-		begin_iterator(reinterpret_cast<node_pointer_type>(&end_node)),
-		node_pointer_allocator_pair(0),
-		node_allocator_pair(0)
+		end_iterator(static_cast<node_pointer_type>(&end_node)),
+		begin_iterator(static_cast<node_pointer_type>(&end_node)),
+		total_size(0),
+		node_allocator_pair(0, alloc)
 	{
 		insert<iterator_type>(end_iterator, first, last);
 	}
@@ -1602,151 +1393,171 @@ public:
 
 	// Initializer-list constructor:
 
-	#ifdef PLF_LIST_INITIALIZER_LIST_SUPPORT
-		list(const std::initializer_list<element_type> &element_list, const element_allocator_type &alloc = element_allocator_type()):
-			element_allocator_type(alloc),
-			end_node(reinterpret_cast<node_pointer_type>(&end_node), reinterpret_cast<node_pointer_type>(&end_node)),
+	#ifdef PLF_INITIALIZER_LIST_SUPPORT
+		list(const std::initializer_list<element_type> &element_list, const allocator_type &alloc = allocator_type()):
+			allocator_type(alloc),
+			groups(alloc),
+			end_node(static_cast<node_pointer_type>(&end_node), static_cast<node_pointer_type>(&end_node)),
 			last_endpoint(NULL),
-			end_iterator(reinterpret_cast<node_pointer_type>(&end_node)),
-			begin_iterator(reinterpret_cast<node_pointer_type>(&end_node)),
-			node_pointer_allocator_pair(0),
-			node_allocator_pair(0)
+			end_iterator(static_cast<node_pointer_type>(&end_node)),
+			begin_iterator(static_cast<node_pointer_type>(&end_node)),
+			total_size(0),
+			node_allocator_pair(0, alloc)
 		{
-			reserve(element_list.size());
-			insert(end_iterator, element_list);
+			range_insert(end_iterator, static_cast<size_type>(element_list.size()), element_list.begin());
 		}
 
 	#endif
 
 
 
-	~list() PLF_LIST_NOEXCEPT
+	#ifdef PLF_CPP20_SUPPORT
+		// Ranges v3 constructor:
+
+		template<compatible_range<element_type> range_type>
+		list(plf::ranges::from_range_t, range_type &&rg, const allocator_type &alloc = allocator_type()):
+			allocator_type(alloc),
+			end_node(static_cast<node_pointer_type>(&end_node), static_cast<node_pointer_type>(&end_node)),
+			last_endpoint(NULL),
+			end_iterator(static_cast<node_pointer_type>(&end_node)),
+			begin_iterator(static_cast<node_pointer_type>(&end_node)),
+			total_size(0),
+			node_allocator_pair(0, alloc)
+		{
+			range_insert(end_iterator, static_cast<size_type>(std::ranges::distance(rg)), std::ranges::begin(rg));
+		}
+	#endif
+
+
+
+	~list() PLF_NOEXCEPT
 	{
 		groups.destroy_all_data(last_endpoint);
 	}
 
 
 
-	inline iterator begin() PLF_LIST_NOEXCEPT
+	iterator begin() PLF_NOEXCEPT
 	{
 		return begin_iterator;
 	}
 
 
 
-	inline const_iterator begin() const PLF_LIST_NOEXCEPT
+	const_iterator begin() const PLF_NOEXCEPT
 	{
 		return begin_iterator;
 	}
 
 
 
-	inline iterator end() PLF_LIST_NOEXCEPT
+	iterator end() PLF_NOEXCEPT
 	{
 		return end_iterator;
 	}
 
 
 
-	inline const_iterator end() const PLF_LIST_NOEXCEPT
+	const_iterator end() const PLF_NOEXCEPT
 	{
 		return end_iterator;
 	}
 
 
 
-	inline const_iterator cbegin() const PLF_LIST_NOEXCEPT
+	const_iterator cbegin() const PLF_NOEXCEPT
 	{
 		return const_iterator(begin_iterator.node_pointer);
 	}
 
 
 
-	inline const_iterator cend() const PLF_LIST_NOEXCEPT
+	const_iterator cend() const PLF_NOEXCEPT
 	{
 		return const_iterator(end_iterator.node_pointer);
 	}
 
 
 
- 	inline reverse_iterator rbegin() const PLF_LIST_NOEXCEPT
+ 	reverse_iterator rbegin() PLF_NOEXCEPT
  	{
  		return reverse_iterator(end_node.previous);
  	}
 
 
 
- 	inline reverse_iterator rend() const PLF_LIST_NOEXCEPT
- 	{
- 		return reverse_iterator(end_iterator.node_pointer);
- 	}
-
-
-
- 	inline const_reverse_iterator crbegin() const PLF_LIST_NOEXCEPT
+ 	const_reverse_iterator rbegin() const PLF_NOEXCEPT
  	{
  		return const_reverse_iterator(end_node.previous);
  	}
 
 
 
- 	inline const_reverse_iterator crend() const PLF_LIST_NOEXCEPT
+ 	reverse_iterator rend() PLF_NOEXCEPT
+ 	{
+ 		return reverse_iterator(end_iterator.node_pointer);
+ 	}
+
+
+
+ 	const_reverse_iterator rend() const PLF_NOEXCEPT
  	{
  		return const_reverse_iterator(end_iterator.node_pointer);
  	}
 
 
 
-	inline reference front()
+ 	const_reverse_iterator crbegin() const PLF_NOEXCEPT
+ 	{
+ 		return const_reverse_iterator(end_node.previous);
+ 	}
+
+
+
+ 	const_reverse_iterator crend() const PLF_NOEXCEPT
+ 	{
+ 		return const_reverse_iterator(end_iterator.node_pointer);
+ 	}
+
+
+
+	reference front()
 	{
-		assert(begin_iterator.node_pointer != &end_node);
+		assert(total_size != 0);
 		return begin_iterator.node_pointer->element;
 	}
 
 
 
-	inline const_reference front() const
+	const_reference front() const
 	{
-		assert(begin_iterator.node_pointer != &end_node);
+		assert(total_size != 0);
 		return begin_iterator.node_pointer->element;
 	}
 
 
 
-	inline reference back()
+	reference back()
 	{
-		assert(end_node.previous != &end_node);
+		assert(total_size != 0);
 		return end_node.previous->element;
 	}
 
 
 
-	inline const_reference back() const
+	const_reference back() const
 	{
-		assert(end_node.previous != &end_node);
+		assert(total_size != 0);
 		return end_node.previous->element;
 	}
 
 
 
-	void clear() PLF_LIST_NOEXCEPT
+	void clear() PLF_NOEXCEPT
 	{
-		if (last_endpoint == NULL)
-		{
-			return;
-		}
-
-		if (node_pointer_allocator_pair.total_number_of_elements != 0)
-		{
-			groups.clear(last_endpoint);
-		}
-
-		end_node.next = reinterpret_cast<node_pointer_type>(&end_node);
-		end_node.previous = reinterpret_cast<node_pointer_type>(&end_node);
-		last_endpoint = groups.block_pointer->nodes;
-		begin_iterator.node_pointer = end_iterator.node_pointer;
-		node_pointer_allocator_pair.total_number_of_elements = 0;
-		node_allocator_pair.number_of_erased_nodes = 0;
+		if (last_endpoint == NULL) return; // already clear'ed or uninitialized
+		if (total_size != 0) groups.clear(last_endpoint);
+		blank();
 	}
 
 
@@ -1754,246 +1565,113 @@ public:
 private:
 
 
-	void reset() PLF_LIST_NOEXCEPT
+
+	void add_group_if_necessary()
 	{
-		groups.destroy_all_data(last_endpoint);
-		last_endpoint = NULL;
-		end_node.next = reinterpret_cast<node_pointer_type>(&end_node);
-		end_node.previous = reinterpret_cast<node_pointer_type>(&end_node);
-		begin_iterator.node_pointer = end_iterator.node_pointer;
-		node_pointer_allocator_pair.total_number_of_elements = 0;
-		node_allocator_pair.number_of_erased_nodes = 0;
+		if (last_endpoint == groups.last_endpoint_group->beyond_end) // last_endpoint is beyond the end of a group
+		{
+			if (static_cast<size_type>(groups.last_endpoint_group - groups.block_pointer) == groups.size - 1) // ie. there are no reusable groups available at the back of group vector
+			{
+				groups.add_new((total_size < list_max_block_capacity()) ? static_cast<group_size_type>(total_size) : list_max_block_capacity());
+			}
+			else
+			{
+				++groups.last_endpoint_group;
+			}
+
+			last_endpoint = groups.last_endpoint_group->nodes;
+		}
 	}
 
+
+
+	void update_sizes_and_iterators(const const_iterator it)
+	{
+		++(groups.last_endpoint_group->number_of_elements);
+		++total_size;
+		if (it.node_pointer == begin_iterator.node_pointer) begin_iterator.node_pointer = last_endpoint;
+		it.node_pointer->previous->next = last_endpoint;
+		it.node_pointer->previous = last_endpoint;
+	}
+
+
+
+	static PLF_CONSTFUNC group_size_type list_min_block_capacity() PLF_NOEXCEPT
+	{
+		return static_cast<group_size_type>((sizeof(node) * 8 > (sizeof(list) + sizeof(group)) * 2) ? 8 : (((sizeof(list) + sizeof(group)) * 2) / sizeof(node)) + 1);
+	}
+
+
+
+	static PLF_CONSTFUNC group_size_type list_max_block_capacity() PLF_NOEXCEPT
+	{
+		return 2048u;
+	}
+
+
+
+	void insert_initialize()
+	{
+		if (groups.block_pointer == NULL) groups.initialize(list_min_block_capacity()); // In case of prior reserve/clear call as opposed to being uninitialized
+
+		groups.last_endpoint_group->number_of_elements = 1;
+		end_node.next = end_node.previous = last_endpoint = begin_iterator.node_pointer = groups.last_endpoint_group->nodes;
+		total_size = 1;
+	}
 
 
 
 public:
 
 
-	iterator insert(const iterator it, const element_type &element)
+	iterator insert(const const_iterator it, const element_type &element)
 	{
 		if (last_endpoint != NULL) // ie. list is not empty
 		{
 			if (node_allocator_pair.number_of_erased_nodes == 0) // No erased nodes available for reuse
 			{
-				if (last_endpoint == groups.last_endpoint_group->beyond_end) // last_endpoint is beyond the end of a group
-				{
-					if (static_cast<size_type>(groups.last_endpoint_group - groups.block_pointer) == groups.size - 1) // ie. there are no reusable groups available at the back of group vector
-					{
-						groups.add_new((node_pointer_allocator_pair.total_number_of_elements < PLF_LIST_BLOCK_MAX) ? static_cast<group_size_type>(node_pointer_allocator_pair.total_number_of_elements) : PLF_LIST_BLOCK_MAX);
-					}
-					else
-					{
-						++groups.last_endpoint_group;
-					}
-
-					last_endpoint = groups.last_endpoint_group->nodes;
-				}
-
-				#ifdef PLF_LIST_VARIADICS_SUPPORT
-					PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint, it.node_pointer, it.node_pointer->previous, element);
-				#else
-					PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint, node(it.node_pointer, it.node_pointer->previous, element));
-				#endif
-
-				++(groups.last_endpoint_group->number_of_elements);
-				++node_pointer_allocator_pair.total_number_of_elements;
-
-				if (it.node_pointer == begin_iterator.node_pointer)
-				{
-					begin_iterator.node_pointer = last_endpoint;
-				}
-
-				it.node_pointer->previous->next = last_endpoint;
-				it.node_pointer->previous = last_endpoint;
-
+				add_group_if_necessary();
+				PLF_CONSTRUCT_NODE(last_endpoint, it.node_pointer, it.node_pointer->previous, element);
+				update_sizes_and_iterators(it);
 				return iterator(last_endpoint++);
 			}
 			else
 			{
-				group_pointer_type const node_group = groups.get_nearest_freelist_group((it.node_pointer != end_iterator.node_pointer) ? it.node_pointer : end_node.previous);
-				node_pointer_type const selected_node = node_group->free_list_head;
+				const group_pointer_type node_group = groups.get_nearest_freelist_group((it.node_pointer != end_iterator.node_pointer) ? it.node_pointer : end_node.previous);
+				const node_pointer_type selected_node = node_group->free_list_head;
 				const node_pointer_type previous = node_group->free_list_head->previous;
-
-				#ifdef PLF_LIST_VARIADICS_SUPPORT
-					PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, selected_node, it.node_pointer, it.node_pointer->previous, element);
-				#else
-					PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, selected_node, node(it.node_pointer, it.node_pointer->previous, element));
-				#endif
+				PLF_CONSTRUCT_NODE(selected_node, it.node_pointer, it.node_pointer->previous, element);
 
 				node_group->free_list_head = previous;
 				++(node_group->number_of_elements);
-				++node_pointer_allocator_pair.total_number_of_elements;
+				++total_size;
 				--node_allocator_pair.number_of_erased_nodes;
 
 				it.node_pointer->previous->next = selected_node;
 				it.node_pointer->previous = selected_node;
 
-				if (it.node_pointer == begin_iterator.node_pointer)
-				{
-					begin_iterator.node_pointer = selected_node;
-				}
-
+				if (it.node_pointer == begin_iterator.node_pointer) begin_iterator.node_pointer = selected_node;
 				return iterator(selected_node);
 			}
 		}
 		else // list is empty
 		{
-			if (groups.block_pointer == NULL) // In case of prior reserve/clear call as opposed to being uninitialized
-			{
-				groups.initialize(PLF_LIST_BLOCK_MIN);
-			}
+			insert_initialize();
 
-			groups.last_endpoint_group->number_of_elements = 1;
-			end_node.next = end_node.previous = last_endpoint = begin_iterator.node_pointer = groups.last_endpoint_group->nodes;
-			node_pointer_allocator_pair.total_number_of_elements = 1;
-
-			#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-				if PLF_LIST_CONSTEXPR (std::is_nothrow_copy_constructible<node>::value) // Avoid try-catch code generation
-				{
-					#ifdef PLF_LIST_VARIADICS_SUPPORT
-						PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint++, end_iterator.node_pointer, end_iterator.node_pointer, element);
-					#else
-						PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint++, node(end_iterator.node_pointer, end_iterator.node_pointer, element));
-					#endif
-				}
-				else
-			#endif
-			{
-				try
-				{
-					#ifdef PLF_LIST_VARIADICS_SUPPORT
-						PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint++, end_iterator.node_pointer, end_iterator.node_pointer, element);
-					#else
-						PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint++, node(end_iterator.node_pointer, end_iterator.node_pointer, element));
-					#endif
-				}
-				catch (...)
-				{
-					reset();
-					throw;
-				}
-			}
-
-			return begin_iterator;
-		}
-	}
-
-
-
-	inline PLF_LIST_FORCE_INLINE void push_back(const element_type &element)
-	{
-		insert(end_iterator, element);
-	}
-
-
-
-	inline PLF_LIST_FORCE_INLINE void push_front(const element_type &element)
-	{
-		insert(begin_iterator, element);
-	}
-
-
-
-	#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-		iterator insert(const iterator it, element_type &&element) // This is almost identical to the insert implementation above with the only change being std::move of the element
-		{
-			if (last_endpoint != NULL)
-			{
-				if (node_allocator_pair.number_of_erased_nodes == 0)
-				{
-					if (last_endpoint == groups.last_endpoint_group->beyond_end)
+			#ifndef PLF_EXCEPTIONS_SUPPORT
+				PLF_CONSTRUCT_NODE(last_endpoint++, end_iterator.node_pointer, end_iterator.node_pointer, element);
+	 		#else
+				#ifdef PLF_TYPE_TRAITS_SUPPORT
+					if PLF_CONSTEXPR (std::is_nothrow_copy_constructible<node>::value) // Avoid try-catch code generation
 					{
-						if (static_cast<size_type>(groups.last_endpoint_group - groups.block_pointer) == groups.size - 1)
-						{
-							groups.add_new((node_pointer_allocator_pair.total_number_of_elements < PLF_LIST_BLOCK_MAX) ? static_cast<group_size_type>(node_pointer_allocator_pair.total_number_of_elements) : PLF_LIST_BLOCK_MAX);
-						}
-						else
-						{
-							++groups.last_endpoint_group;
-						}
-
-						last_endpoint = groups.last_endpoint_group->nodes;
-					}
-
-					#ifdef PLF_LIST_VARIADICS_SUPPORT
-						PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint, it.node_pointer, it.node_pointer->previous, std::move(element));
-					#else
-						PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint, node(it.node_pointer, it.node_pointer->previous, std::move(element)));
-					#endif
-
-					++(groups.last_endpoint_group->number_of_elements);
-					++node_pointer_allocator_pair.total_number_of_elements;
-
-					if (it.node_pointer == begin_iterator.node_pointer)
-					{
-						begin_iterator.node_pointer = last_endpoint;
-					}
-
-					it.node_pointer->previous->next = last_endpoint;
-					it.node_pointer->previous = last_endpoint;
-
-					return iterator(last_endpoint++);
-				}
-				else
-				{
-					group_pointer_type const node_group = groups.get_nearest_freelist_group((it.node_pointer != end_iterator.node_pointer) ? it.node_pointer : end_node.previous);
-					node_pointer_type const selected_node = node_group->free_list_head;
-					const node_pointer_type previous = node_group->free_list_head->previous;
-
-					#ifdef PLF_LIST_VARIADICS_SUPPORT
-						PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, selected_node, it.node_pointer, it.node_pointer->previous, std::move(element));
-					#else
-						PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, selected_node, node(it.node_pointer, it.node_pointer->previous, std::move(element)));
-					#endif
-
-					node_group->free_list_head = previous;
-					++(node_group->number_of_elements);
-					++node_pointer_allocator_pair.total_number_of_elements;
-					--node_allocator_pair.number_of_erased_nodes;
-
-					it.node_pointer->previous->next = selected_node;
-					it.node_pointer->previous = selected_node;
-
-					if (it.node_pointer == begin_iterator.node_pointer)
-					{
-						begin_iterator.node_pointer = selected_node;
-					}
-
-					return iterator(selected_node);
-				}
-			}
-			else
-			{
-				if (groups.block_pointer == NULL)
-				{
-					groups.initialize(PLF_LIST_BLOCK_MIN);
-				}
-
-				groups.last_endpoint_group->number_of_elements = 1;
-				end_node.next = end_node.previous = last_endpoint = begin_iterator.node_pointer = groups.last_endpoint_group->nodes;
-				node_pointer_allocator_pair.total_number_of_elements = 1;
-
-				#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-					if PLF_LIST_CONSTEXPR (std::is_nothrow_move_constructible<node>::value)
-					{
-						#ifdef PLF_LIST_VARIADICS_SUPPORT
-							PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint++, end_iterator.node_pointer, end_iterator.node_pointer, std::move(element));
-						#else
-							PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint++, node(end_iterator.node_pointer, end_iterator.node_pointer, std::move(element)));
-						#endif
+						PLF_CONSTRUCT_NODE(last_endpoint++, end_iterator.node_pointer, end_iterator.node_pointer, element);
 					}
 					else
 				#endif
 				{
 					try
 					{
-						#ifdef PLF_LIST_VARIADICS_SUPPORT
-							PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint++, end_iterator.node_pointer, end_iterator.node_pointer, std::move(element));
-						#else
-							PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint++, node(end_iterator.node_pointer, end_iterator.node_pointer, std::move(element)));
-						#endif
+						PLF_CONSTRUCT_NODE(last_endpoint++, end_iterator.node_pointer, end_iterator.node_pointer, element);
 					}
 					catch (...)
 					{
@@ -2001,6 +1679,85 @@ public:
 						throw;
 					}
 				}
+			#endif
+
+			return begin_iterator;
+		}
+	}
+
+
+
+	void push_back(const element_type &element)
+	{
+		insert(end_iterator, element);
+	}
+
+
+
+	void push_front(const element_type &element)
+	{
+		insert(begin_iterator, element);
+	}
+
+
+
+	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+		iterator insert(const const_iterator it, element_type &&element) // This is almost identical to the insert implementation above with the only change being std::move of the element and the is_nothrow test
+		{
+			if (last_endpoint != NULL)
+			{
+				if (node_allocator_pair.number_of_erased_nodes == 0)
+				{
+					add_group_if_necessary();
+					PLF_CONSTRUCT_NODE(last_endpoint, it.node_pointer, it.node_pointer->previous, std::move(element));
+					update_sizes_and_iterators(it);
+					return iterator(last_endpoint++);
+				}
+				else
+				{
+					const group_pointer_type node_group = groups.get_nearest_freelist_group((it.node_pointer != end_iterator.node_pointer) ? it.node_pointer : end_node.previous);
+					const node_pointer_type selected_node = node_group->free_list_head;
+					const node_pointer_type previous = node_group->free_list_head->previous;
+					PLF_CONSTRUCT_NODE(selected_node, it.node_pointer, it.node_pointer->previous, std::move(element));
+
+					node_group->free_list_head = previous;
+					++(node_group->number_of_elements);
+					++total_size;
+					--node_allocator_pair.number_of_erased_nodes;
+
+					it.node_pointer->previous->next = selected_node;
+					it.node_pointer->previous = selected_node;
+
+					if (it.node_pointer == begin_iterator.node_pointer) begin_iterator.node_pointer = selected_node;
+					return iterator(selected_node);
+				}
+			}
+			else
+			{
+				insert_initialize();
+
+				#ifndef PLF_EXCEPTIONS_SUPPORT
+					PLF_CONSTRUCT_NODE(last_endpoint++, end_iterator.node_pointer, end_iterator.node_pointer, std::move(element));
+		 		#else
+					#ifdef PLF_TYPE_TRAITS_SUPPORT
+						if PLF_CONSTEXPR (std::is_nothrow_move_constructible<node>::value)
+						{
+							PLF_CONSTRUCT_NODE(last_endpoint++, end_iterator.node_pointer, end_iterator.node_pointer, std::move(element));
+						}
+						else
+					#endif
+					{
+						try
+						{
+							PLF_CONSTRUCT_NODE(last_endpoint++, end_iterator.node_pointer, end_iterator.node_pointer, std::move(element));
+						}
+						catch (...)
+						{
+							reset();
+							throw;
+						}
+					}
+				#endif
 
 				return begin_iterator;
 			}
@@ -2008,14 +1765,14 @@ public:
 
 
 
-		inline PLF_LIST_FORCE_INLINE void push_back(element_type &&element)
+		void push_back(element_type &&element)
 		{
 			insert(end_iterator, std::move(element));
 		}
 
 
 
-		inline PLF_LIST_FORCE_INLINE void push_front(element_type &&element)
+		void push_front(element_type &&element)
 		{
 			insert(begin_iterator, std::move(element));
 		}
@@ -2024,96 +1781,64 @@ public:
 
 
 
-	#ifdef PLF_LIST_VARIADICS_SUPPORT
+	#ifdef PLF_VARIADICS_SUPPORT
 		template<typename... arguments>
-		iterator emplace(const iterator it, arguments &&... parameters) // This is almost identical to the insert implementations above with the only changes being std::forward of element parameters and removal of VARIADICS support checking
+		iterator emplace(const const_iterator it, arguments &&... parameters) // This is almost identical to the insert implementations above with the only changes being std::forward of element parameters, removal of VARIADICS support checking, and is_nothrow_contructible
 		{
 			if (last_endpoint != NULL)
 			{
 				if (node_allocator_pair.number_of_erased_nodes == 0)
 				{
-					if (last_endpoint == groups.last_endpoint_group->beyond_end)
-					{
-						if (static_cast<size_type>(groups.last_endpoint_group - groups.block_pointer) == groups.size - 1)
-						{
-							groups.add_new((node_pointer_allocator_pair.total_number_of_elements < PLF_LIST_BLOCK_MAX) ? static_cast<group_size_type>(node_pointer_allocator_pair.total_number_of_elements) : PLF_LIST_BLOCK_MAX);
-						}
-						else
-						{
-							++groups.last_endpoint_group;
-						}
-
-						last_endpoint = groups.last_endpoint_group->nodes;
-					}
-
-					PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint, it.node_pointer, it.node_pointer->previous, std::forward<arguments>(parameters)...);
-
-					++(groups.last_endpoint_group->number_of_elements);
-					++node_pointer_allocator_pair.total_number_of_elements;
-
-					if (it.node_pointer == begin_iterator.node_pointer)
-					{
-						begin_iterator.node_pointer = last_endpoint;
-					}
-
-					it.node_pointer->previous->next = last_endpoint;
-					it.node_pointer->previous = last_endpoint;
-
+					add_group_if_necessary();
+					PLF_CONSTRUCT_NODE(last_endpoint, it.node_pointer, it.node_pointer->previous, std::forward<arguments>(parameters)...);
+					update_sizes_and_iterators(it);
 					return iterator(last_endpoint++);
 				}
 				else
 				{
-					group_pointer_type const node_group = groups.get_nearest_freelist_group((it.node_pointer != end_iterator.node_pointer) ? it.node_pointer : end_node.previous);
-					node_pointer_type const selected_node = node_group->free_list_head;
+					const group_pointer_type node_group = groups.get_nearest_freelist_group((it.node_pointer != end_iterator.node_pointer) ? it.node_pointer : end_node.previous);
+					const node_pointer_type selected_node = node_group->free_list_head;
 					const node_pointer_type previous = node_group->free_list_head->previous;
-
-					PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, selected_node, it.node_pointer, it.node_pointer->previous, std::forward<arguments>(parameters)...);
+					PLF_CONSTRUCT_NODE(selected_node, it.node_pointer, it.node_pointer->previous, std::forward<arguments>(parameters)...);
 
 					node_group->free_list_head = previous;
 					++(node_group->number_of_elements);
-					++node_pointer_allocator_pair.total_number_of_elements;
+					++total_size;
 					--node_allocator_pair.number_of_erased_nodes;
 
 					it.node_pointer->previous->next = selected_node;
 					it.node_pointer->previous = selected_node;
 
-					if (it.node_pointer == begin_iterator.node_pointer)
-					{
-						begin_iterator.node_pointer = selected_node;
-					}
-
+					if (it.node_pointer == begin_iterator.node_pointer) begin_iterator.node_pointer = selected_node;
 					return iterator(selected_node);
 				}
 			}
 			else
 			{
-				if (groups.block_pointer == NULL)
-				{
-					groups.initialize(PLF_LIST_BLOCK_MIN);
-				}
+			  	insert_initialize();
 
-				groups.last_endpoint_group->number_of_elements = 1;
-				end_node.next = end_node.previous = last_endpoint = begin_iterator.node_pointer = groups.last_endpoint_group->nodes;
-				node_pointer_allocator_pair.total_number_of_elements = 1;
-
-				#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-					if PLF_LIST_CONSTEXPR (std::is_nothrow_constructible<element_type, arguments ...>::value)
+				#ifndef PLF_EXCEPTIONS_SUPPORT
+					PLF_CONSTRUCT_NODE(last_endpoint++, end_iterator.node_pointer, end_iterator.node_pointer, std::forward<arguments>(parameters)...);
+		 		#else
+					#ifdef PLF_TYPE_TRAITS_SUPPORT
+						if PLF_CONSTEXPR (std::is_nothrow_constructible<node>::value)
+						{
+							PLF_CONSTRUCT_NODE(last_endpoint++, end_iterator.node_pointer, end_iterator.node_pointer, std::forward<arguments>(parameters)...);
+						}
+						else
+					#endif
 					{
-						PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint++, end_iterator.node_pointer, end_iterator.node_pointer, std::forward<arguments>(parameters)...);
+						try
+						{
+							PLF_CONSTRUCT_NODE(last_endpoint++, end_iterator.node_pointer, end_iterator.node_pointer, std::forward<arguments>(parameters)...);
+						}
+						catch (...)
+						{
+							reset();
+							throw;
+						}
 					}
-					else
 				#endif
-				{
-					try
-					{
-						PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint++, end_iterator.node_pointer, end_iterator.node_pointer, std::forward<arguments>(parameters)...);
-					}
-					catch (...)
-					{
-						reset();
-						throw;
-					}
-				}
 
 				return begin_iterator;
 			}
@@ -2122,7 +1847,7 @@ public:
 
 
 		template<typename... arguments>
-		inline PLF_LIST_FORCE_INLINE reference emplace_back(arguments &&... parameters)
+		reference emplace_back(arguments &&... parameters)
 		{
 			return (emplace(end_iterator, std::forward<arguments>(parameters)...)).node_pointer->element;
 		}
@@ -2130,7 +1855,7 @@ public:
 
 
 		template<typename... arguments>
-		inline PLF_LIST_FORCE_INLINE reference emplace_front(arguments &&... parameters)
+		reference emplace_front(arguments &&... parameters)
 		{
 			return (emplace(begin_iterator, std::forward<arguments>(parameters)...)).node_pointer->element;
 		}
@@ -2140,43 +1865,40 @@ public:
 
 
 
+
 private:
 
-	void group_fill_position(const element_type &element, group_size_type number_of_elements, node_pointer_type const position)
+	void fill(const element_type &element, group_size_type number_of_elements, const node_pointer_type position)
 	{
 		position->previous->next = last_endpoint;
-		groups.last_endpoint_group->number_of_elements += number_of_elements;
+		groups.last_endpoint_group->number_of_elements = static_cast<group_size_type>(groups.last_endpoint_group->number_of_elements + number_of_elements);
 		node_pointer_type previous = position->previous;
 
 		do
 		{
-			#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-				if PLF_LIST_CONSTEXPR (std::is_nothrow_copy_constructible<element_type>::value)
+			#ifdef PLF_TYPE_TRAITS_SUPPORT
+				if PLF_CONSTEXPR (std::is_nothrow_copy_constructible<element_type>::value)
 				{
-					#ifdef PLF_LIST_VARIADICS_SUPPORT
-						PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint, last_endpoint + 1, previous, element);
-					#else
-						PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint, node(last_endpoint + 1, previous, element));
-					#endif
+					PLF_CONSTRUCT_NODE(last_endpoint, last_endpoint + 1, previous, element);
 				}
 				else
 			#endif
 			{
-				try
-				{
-					#ifdef PLF_LIST_VARIADICS_SUPPORT
-						PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint, last_endpoint + 1, previous, element);
-					#else
-						PLF_LIST_CONSTRUCT(node_allocator_type, node_allocator_pair, last_endpoint, node(last_endpoint + 1, previous, element));
-					#endif
-				}
-				catch (...)
-				{
-					previous->next = position;
-					position->previous = --previous;
-					groups.last_endpoint_group->number_of_elements -= static_cast<group_size_type>(number_of_elements - (last_endpoint - position));
-					throw;
-				}
+				#ifdef PLF_EXCEPTIONS_SUPPORT
+					try
+					{
+						PLF_CONSTRUCT_NODE(last_endpoint, last_endpoint + 1, previous, element);
+					}
+					catch (...)
+					{
+						previous->next = position;
+						position->previous = --previous;
+						groups.last_endpoint_group->number_of_elements = static_cast<group_size_type>(groups.last_endpoint_group->number_of_elements - (number_of_elements - (last_endpoint - position)));
+						throw;
+					}
+				#else
+					PLF_CONSTRUCT_NODE(last_endpoint, last_endpoint + 1, previous, element);
+				#endif
 			}
 
 			previous = last_endpoint++;
@@ -2188,11 +1910,124 @@ private:
 
 
 
+
+	template <class iterator_type>
+	void range_fill(iterator_type &it, group_size_type number_of_elements, const node_pointer_type position)
+	{
+		position->previous->next = last_endpoint;
+		groups.last_endpoint_group->number_of_elements = static_cast<group_size_type>(groups.last_endpoint_group->number_of_elements + number_of_elements);
+		node_pointer_type previous = position->previous;
+
+		do
+		{
+			#ifdef PLF_TYPE_TRAITS_SUPPORT
+				if PLF_CONSTEXPR (std::is_nothrow_copy_constructible<element_type>::value)
+				{
+					PLF_CONSTRUCT_NODE(last_endpoint, last_endpoint + 1, previous, *it++);
+				}
+				else
+			#endif
+			{
+				#ifdef PLF_EXCEPTIONS_SUPPORT
+					try
+					{
+						PLF_CONSTRUCT_NODE(last_endpoint, last_endpoint + 1, previous, *it++);
+					}
+					catch (...)
+					{
+						previous->next = position;
+						position->previous = --previous;
+						groups.last_endpoint_group->number_of_elements = static_cast<group_size_type>(groups.last_endpoint_group->number_of_elements - (number_of_elements - (last_endpoint - position)));
+						throw;
+					}
+				#else
+					PLF_CONSTRUCT_NODE(last_endpoint, last_endpoint + 1, previous, *it++);
+				#endif
+			}
+
+			previous = last_endpoint++;
+		} while (--number_of_elements != 0);
+
+		previous->next = position;
+		position->previous = previous;
+	}
+
+
+
+	// This function is near-identical to fill-insert, the only difference is it uses and iterates over an iterator:
+	template <class iterator_type>
+	iterator range_insert(const const_iterator position, const size_type number_of_elements, iterator_type it)
+	{
+		if (number_of_elements == 0)
+		{
+			return end_iterator;
+		}
+		else if (number_of_elements == 1)
+		{
+			return insert(position, *it);
+		}
+
+		reserve(total_size + number_of_elements);
+
+		// Insert first element, then use up any erased nodes:
+		size_type remainder = number_of_elements - 1;
+		const iterator return_iterator = insert(position, *it++);
+
+		while (node_allocator_pair.number_of_erased_nodes != 0)
+		{
+			insert(position, *it++);
+			if (--remainder == 0) return return_iterator;
+		}
+
+		total_size += remainder;
+
+		// then use up remainder of last_endpoint_group:
+		const group_size_type remaining_nodes_in_group = static_cast<group_size_type>(groups.last_endpoint_group->beyond_end - last_endpoint);
+
+		if (remaining_nodes_in_group != 0)
+		{
+			if (remaining_nodes_in_group < remainder)
+			{
+				range_fill(it, remaining_nodes_in_group, position.node_pointer);
+				remainder -= remaining_nodes_in_group;
+			}
+			else
+			{
+				range_fill(it, static_cast<group_size_type>(remainder), position.node_pointer);
+				return return_iterator;
+			}
+		}
+
+
+		// Then start using trailing (reserved) groups:
+		while (true)
+		{
+			last_endpoint = (++groups.last_endpoint_group)->nodes;
+			const group_size_type group_size = static_cast<group_size_type>(groups.last_endpoint_group->beyond_end - groups.last_endpoint_group->nodes);
+
+			if (group_size < remainder)
+			{
+				range_fill(it, group_size, position.node_pointer);
+				remainder -= group_size;
+			}
+			else
+			{
+				range_fill(it, static_cast<group_size_type>(remainder), position.node_pointer);
+				break;
+			}
+		}
+
+		return return_iterator;
+	}
+
+
+
+
 public:
 
 	// Fill insert
 
-	iterator insert(iterator position, const size_type number_of_elements, const element_type &element)
+	iterator insert(const const_iterator position, const size_type number_of_elements, const element_type &element)
 	{
 		if (number_of_elements == 0)
 		{
@@ -2203,160 +2038,54 @@ public:
 			return insert(position, element);
 		}
 
+		reserve(total_size + number_of_elements);
 
-		if (node_pointer_allocator_pair.total_number_of_elements == 0 && last_endpoint != NULL && (static_cast<size_type>(groups.block_pointer->beyond_end - groups.block_pointer->nodes) < number_of_elements) && (static_cast<size_type>(groups.block_pointer->beyond_end - groups.block_pointer->nodes) < PLF_LIST_BLOCK_MAX))
+		// Insert first element, then use up any erased nodes:
+		size_type remainder = number_of_elements - 1;
+		const iterator return_iterator = insert(position, element);
+
+		while (node_allocator_pair.number_of_erased_nodes != 0)
 		{
-			reset();
+			insert(position, element);
+			if (--remainder == 0) return return_iterator;
 		}
 
+		total_size += remainder;
 
-		if (groups.block_pointer == NULL) // ie. Uninitialized list
+		// then use up remainder of last_endpoint_group:
+		const group_size_type remaining_nodes_in_group = static_cast<group_size_type>(groups.last_endpoint_group->beyond_end - last_endpoint);
+
+		if (remaining_nodes_in_group != 0)
 		{
-			if (number_of_elements > PLF_LIST_BLOCK_MAX)
+			if (remaining_nodes_in_group < remainder)
 			{
-				size_type multiples = number_of_elements / PLF_LIST_BLOCK_MAX;
-				const group_size_type remainder = static_cast<group_size_type>(number_of_elements - (multiples++ * PLF_LIST_BLOCK_MAX)); // ++ to aid while loop below
-
-				// Create and fill first group:
-				if (remainder != 0) // make sure smallest block is first
-				{
-					if (remainder >= PLF_LIST_BLOCK_MIN)
-					{
-						groups.initialize(remainder);
-						end_node.next = end_node.previous = last_endpoint = begin_iterator.node_pointer = groups.last_endpoint_group->nodes;
-						group_fill_position(element, remainder, end_iterator.node_pointer);
-					}
-					else
-					{ // Create first group as BLOCK_MIN size then subtract difference between BLOCK_MIN and remainder from next group:
-						groups.initialize(PLF_LIST_BLOCK_MIN);
-						end_node.next = end_node.previous = last_endpoint = begin_iterator.node_pointer = groups.last_endpoint_group->nodes;
-						group_fill_position(element, PLF_LIST_BLOCK_MIN, end_iterator.node_pointer);
-
-						groups.add_new(PLF_LIST_BLOCK_MAX - (PLF_LIST_BLOCK_MIN - remainder));
-						end_node.previous = last_endpoint = groups.last_endpoint_group->nodes;
-						group_fill_position(element, PLF_LIST_BLOCK_MAX - (PLF_LIST_BLOCK_MIN - remainder), end_iterator.node_pointer);
-						--multiples;
-					}
-				}
-				else
-				{
-					groups.initialize(PLF_LIST_BLOCK_MAX);
-					end_node.next = end_node.previous = last_endpoint = begin_iterator.node_pointer = groups.last_endpoint_group->nodes;
-					group_fill_position(element, PLF_LIST_BLOCK_MAX, end_iterator.node_pointer);
-					--multiples;
-				}
-
-				while (--multiples != 0)
-				{
-					groups.add_new(PLF_LIST_BLOCK_MAX);
-					end_node.previous = last_endpoint = groups.last_endpoint_group->nodes;
-					group_fill_position(element, PLF_LIST_BLOCK_MAX, end_iterator.node_pointer);
-				}
-
+				fill(element, remaining_nodes_in_group, position.node_pointer);
+				remainder -= remaining_nodes_in_group;
 			}
 			else
 			{
-				groups.initialize((number_of_elements < PLF_LIST_BLOCK_MIN) ? PLF_LIST_BLOCK_MIN : static_cast<group_size_type>(number_of_elements)); // Construct first group
-				end_node.next = end_node.previous = last_endpoint = begin_iterator.node_pointer = groups.last_endpoint_group->nodes;
-				group_fill_position(element, static_cast<group_size_type>(number_of_elements), end_iterator.node_pointer);
+				fill(element, static_cast<group_size_type>(remainder), position.node_pointer);
+				return return_iterator;
 			}
-
-			node_pointer_allocator_pair.total_number_of_elements = number_of_elements;
-			return begin_iterator;
-		}
-		else
-		{
-			// Insert first element, then use up any erased nodes:
-			size_type remainder = number_of_elements - 1;
-			const iterator return_iterator = insert(position, element);
-
-			while (node_allocator_pair.number_of_erased_nodes != 0)
-			{
-				insert(position, element);
-				--node_allocator_pair.number_of_erased_nodes;
-
-				if (--remainder == 0)
-				{
-					return return_iterator;
-				}
-			}
-
-			node_pointer_allocator_pair.total_number_of_elements += remainder;
-
-			// then use up remainder of last_endpoint_group:
-			const group_size_type remaining_nodes_in_group = static_cast<group_size_type>(groups.last_endpoint_group->beyond_end - last_endpoint);
-
-			if (remaining_nodes_in_group != 0)
-			{
-				if (remaining_nodes_in_group < remainder)
-				{
-					group_fill_position(element, remaining_nodes_in_group, position.node_pointer);
-					remainder -= remaining_nodes_in_group;
-				}
-				else
-				{
-					group_fill_position(element, static_cast<group_size_type>(remainder), position.node_pointer);
-					return return_iterator;
-				}
-			}
-
-
-			// use up trailing groups:
-			while ((groups.last_endpoint_group != (groups.block_pointer + groups.size - 1)) & (remainder != 0))
-			{
-				last_endpoint = (++groups.last_endpoint_group)->nodes;
-				const group_size_type group_size = static_cast<group_size_type>(groups.last_endpoint_group->beyond_end - groups.last_endpoint_group->nodes);
-
-				if (group_size < remainder)
-				{
-					group_fill_position(element, group_size, position.node_pointer);
-					remainder -= group_size;
-				}
-				else
-				{
-					group_fill_position(element, static_cast<group_size_type>(remainder), position.node_pointer);
-					return return_iterator;
-				}
-			}
-
-			size_type multiples = remainder / static_cast<size_type>(PLF_LIST_BLOCK_MAX);
-			remainder -= multiples * PLF_LIST_BLOCK_MAX;
-
-			while (multiples-- != 0)
-			{
-				groups.add_new(PLF_LIST_BLOCK_MAX);
-				last_endpoint = groups.last_endpoint_group->nodes;
-				group_fill_position(element, PLF_LIST_BLOCK_MAX, position.node_pointer);
-			}
-
-			if (remainder != 0) // Bit annoying to create a large block to house a lower number of elements, but beats the alternatives
-			{
-				groups.add_new(PLF_LIST_BLOCK_MAX);
-				last_endpoint = groups.last_endpoint_group->nodes;
-				group_fill_position(element, static_cast<group_size_type>(remainder), position.node_pointer);
-			}
-
-			return return_iterator;
-		}
-	}
-
-
-
-	// Range insert
-
-	template <class iterator_type>
-	iterator insert(const iterator it, typename plf_enable_if_c<!std::numeric_limits<iterator_type>::is_integer, iterator_type>::type first, const iterator_type last)
-	{
-		if (first == last)
-		{
-			return end_iterator;
 		}
 
-		const iterator return_iterator = insert(it, *first);
 
-		while(++first != last)
+		// Then start using trailing (reserved) groups:
+		while (true)
 		{
-			insert(it, *first);
+			last_endpoint = (++groups.last_endpoint_group)->nodes;
+			const group_size_type group_size = static_cast<group_size_type>(groups.last_endpoint_group->beyond_end - groups.last_endpoint_group->nodes);
+
+			if (group_size < remainder)
+			{
+				fill(element, group_size, position.node_pointer);
+				remainder -= group_size;
+			}
+			else
+			{
+				fill(element, static_cast<group_size_type>(remainder), position.node_pointer);
+				break;
+			}
 		}
 
 		return return_iterator;
@@ -2364,12 +2093,44 @@ public:
 
 
 
+	// Range insert
+
+	template <class iterator_type>
+	iterator insert(const const_iterator position, typename plf::enable_if<!std::numeric_limits<iterator_type>::is_integer, iterator_type>::type first, const iterator_type last)
+	{
+		return range_insert(position, static_cast<size_type>(std::distance(first, last)), first);
+	}
+
+
+
+	// Range insert, move_iterator overload
+
+	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+		template <class iterator_type>
+		iterator insert (const const_iterator position, const std::move_iterator<iterator_type> first, const std::move_iterator<iterator_type> last)
+		{
+			return range_insert(position, static_cast<size_type>(std::distance(first.base(),last.base())), first);
+		}
+	#endif
+
+
+
 	// Initializer-list insert
 
-	#ifdef PLF_LIST_INITIALIZER_LIST_SUPPORT
-		inline iterator insert(const iterator it, const std::initializer_list<element_type> &element_list)
-		{ // use range insert:
-			return insert(it, element_list.begin(), element_list.end());
+	#ifdef PLF_INITIALIZER_LIST_SUPPORT
+		iterator insert(const const_iterator it, const std::initializer_list<element_type> &element_list)
+		{
+			return range_insert(it, static_cast<size_type>(element_list.size()), element_list.begin());
+		}
+	#endif
+
+
+
+	#ifdef PLF_CPP20_SUPPORT
+		template<compatible_range<element_type> range_type>
+		iterator insert_range(const const_iterator it, range_type &&the_range)
+		{
+			return range_insert(it, static_cast<size_type>(std::ranges::distance(the_range)), std::ranges::begin(the_range));
 		}
 	#endif
 
@@ -2377,12 +2138,12 @@ public:
 
 private:
 
-	inline PLF_LIST_FORCE_INLINE void destroy_all_node_pointers(group_pointer_type const group_to_process, const node_pointer_type beyond_end_node) PLF_LIST_NOEXCEPT
+	void destroy_all_node_pointers(const group_pointer_type group_to_process, const node_pointer_type beyond_end_node) PLF_NOEXCEPT
 	{
 		for (node_pointer_type current_node = group_to_process->nodes; current_node != beyond_end_node; ++current_node)
 		{
-			PLF_LIST_DESTROY(node_pointer_allocator_type, node_pointer_allocator_pair, &(current_node->next)); // Destruct element
-			PLF_LIST_DESTROY(node_pointer_allocator_type, node_pointer_allocator_pair, &(current_node->previous)); // Destruct element
+			PLF_DESTROY(node_pointer_allocator_type, groups.node_pointer_allocator_pair, &(current_node->next));
+			PLF_DESTROY(node_pointer_allocator_type, groups.node_pointer_allocator_pair, &(current_node->previous));
 		}
 	}
 
@@ -2395,73 +2156,69 @@ public:
 
 	iterator erase(const const_iterator it) // if uninitialized/invalid iterator supplied, function could generate an exception, hence no noexcept
 	{
-		assert(node_pointer_allocator_pair.total_number_of_elements != 0);
-		assert(it.node_pointer != NULL);
-		assert(it.node_pointer != end_iterator.node_pointer);
+		assert(total_size != 0);
+		assert(it.node_pointer != NULL); // uninitialized iterator
+		assert(it.node_pointer != end_iterator.node_pointer); // iterator points to end()
 
-		#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-			if PLF_LIST_CONSTEXPR (!(std::is_trivially_destructible<element_type>::value))
+		#ifdef PLF_TYPE_TRAITS_SUPPORT
+			if PLF_CONSTEXPR (!(std::is_trivially_destructible<element_type>::value))
 		#endif
 		{
-			PLF_LIST_DESTROY(element_allocator_type, (*this), &(it.node_pointer->element)); // Destruct element
+			PLF_DESTROY(allocator_type, *this, &(it.node_pointer->element)); // Destruct element
 		}
 
-		--node_pointer_allocator_pair.total_number_of_elements;
+		--total_size;
 		++node_allocator_pair.number_of_erased_nodes;
 
 
+		// find the group this element is in, starting from the last group an element to-be-erased was found in (as erasures are, for most programs, likely to be closer in proximity to previous erasures):
 		group_pointer_type node_group = groups.last_searched_group;
 
-		// find nearest group with reusable (erased element) memory location:
-		if ((it.node_pointer < node_group->nodes) || (it.node_pointer >= node_group->beyond_end))
+		if (it.node_pointer < node_group->nodes || it.node_pointer >= node_group->beyond_end)
 		{
-			// Search left and right:
+			// Search groups to the left and right of the last searched group, in the group vector:
 			const group_pointer_type beyond_end_group = groups.last_endpoint_group + 1;
 			group_pointer_type left = node_group - 1;
-			bool right_not_beyond_back = (++node_group < beyond_end_group);
-			bool left_not_beyond_front = (left >= groups.block_pointer);
+			bool right_not_beyond_back = ++node_group < beyond_end_group;
+			bool left_not_beyond_front = left >= groups.block_pointer;
 
 			while (true)
 			{
 				if (right_not_beyond_back)
 				{
-					if ((it.node_pointer < node_group->beyond_end) && (it.node_pointer >= node_group->nodes)) // usable location found
-					{
-						break;
-					}
-
-					right_not_beyond_back = (++node_group < beyond_end_group);
+					if (it.node_pointer < node_group->beyond_end && it.node_pointer >= node_group->nodes) break; // element location found
+					right_not_beyond_back = ++node_group < beyond_end_group;
 				}
 
 				if (left_not_beyond_front)
 				{
-					if ((it.node_pointer >= left->nodes) && (it.node_pointer < left->beyond_end)) // usable location found
+					if (it.node_pointer >= left->nodes && it.node_pointer < left->beyond_end) // element location found
 					{
 						node_group = left;
 						break;
 					}
 
-					left_not_beyond_front = (--left >= groups.block_pointer);
+					left_not_beyond_front = --left >= groups.block_pointer;
 				}
 			}
 
 			groups.last_searched_group = node_group;
 		}
 
-		it.node_pointer->next->previous = it.node_pointer->previous;
-		it.node_pointer->previous->next = it.node_pointer->next;
+		// To avoid pointer aliasing and increase performance:
+		const node_pointer_type previous = it.node_pointer->previous;
+		const node_pointer_type next = it.node_pointer->next;
+		next->previous = previous;
+		previous->next = next;
 
-		if (it.node_pointer == begin_iterator.node_pointer)
-		{
-			begin_iterator.node_pointer = it.node_pointer->next;
-		}
+		if (it.node_pointer == begin_iterator.node_pointer) begin_iterator.node_pointer = next;
 
 
-		const iterator return_iterator(it.node_pointer->next);
+		const iterator return_iterator(next);
 
 		if (--(node_group->number_of_elements) != 0) // ie. group is not empty yet, add node to free list
 		{
-			it.node_pointer->next = NULL; // next == NULL so that destructor can detect the free list item as opposed to non-free-list item
+			it.node_pointer->next = NULL; // next == NULL so that destructor and other functions which linearly iterate over node memory chunks can detect this as a free list node, ie an erased node
 			it.node_pointer->previous = node_group->free_list_head;
 			node_group->free_list_head = it.node_pointer;
 			return return_iterator;
@@ -2471,8 +2228,8 @@ public:
 			const group_size_type group_size = static_cast<group_size_type>(node_group->beyond_end - node_group->nodes);
 			node_allocator_pair.number_of_erased_nodes -= group_size;
 
-			#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-				if PLF_LIST_CONSTEXPR (!(std::is_trivially_destructible<node_pointer_type>::value))
+			#ifdef PLF_TYPE_TRAITS_SUPPORT
+				if PLF_CONSTEXPR (!std::is_trivially_destructible<node_pointer_type>::value)
 			#endif
 			{
 				destroy_all_node_pointers(node_group, node_group->beyond_end);
@@ -2480,7 +2237,7 @@ public:
 
 			node_group->free_list_head = NULL;
 
-			if ((group_size == PLF_LIST_BLOCK_MAX) | (node_group >= groups.last_endpoint_group - 1)) // Preserve only last (active) group or second/third-to-last group - seems to be best for performance under high-modification benchmarks
+			if ((group_size == list_max_block_capacity()) | (node_group >= groups.last_endpoint_group - 1)) // Preserve only groups which are at the maximum possible size, or first/second/third-to-last active groups - seems to be best for performance under high-modification benchmarks
 			{
 				groups.move_to_back(node_group);
 			}
@@ -2493,8 +2250,8 @@ public:
 		}
 		else // clear back group, leave trailing
 		{
-			#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-				if PLF_LIST_CONSTEXPR (!(std::is_trivially_destructible<node_pointer_type>::value))
+			#ifdef PLF_TYPE_TRAITS_SUPPORT
+				if PLF_CONSTEXPR (!std::is_trivially_destructible<node_pointer_type>::value)
 			#endif
 			{
 				destroy_all_node_pointers(node_group, last_endpoint);
@@ -2502,17 +2259,16 @@ public:
 
 			node_group->free_list_head = NULL;
 
-			if (node_pointer_allocator_pair.total_number_of_elements != 0)
+			if (total_size != 0)
 			{
 				node_allocator_pair.number_of_erased_nodes -= static_cast<group_size_type>(last_endpoint - node_group->nodes);
 	  			last_endpoint = groups.last_endpoint_group->beyond_end;
 			}
 			else
 			{
-				groups.last_endpoint_group = groups.block_pointer; // If number of elements is zero, it indicates that this was the first group in the vector. In which case the last_endpoint_group would be invalid at this point due to the decrement in the above else-if statement. So it needs to be reset, as it will not be reset in the function call below.
-				clear();
+				groups.last_endpoint_group = groups.block_pointer; // If number of elements is zero, it indicates that this was the only group in the vector. In which case the last_endpoint_group would be invalid at this point due to the decrement in the above else-if statement. So it needs to be reset, as it will not be reset in the function call below.
+				blank();
 			}
-
 
 			return return_iterator;
 		}
@@ -2522,86 +2278,159 @@ public:
 
 	// Range-erase:
 
-	inline void erase(const const_iterator iterator1, const const_iterator iterator2)  // if uninitialized/invalid iterator supplied, function could generate an exception
+	iterator erase(const_iterator iterator1, const const_iterator iterator2)
 	{
-		for (const_iterator current = iterator1; current != iterator2;)
+		while (iterator1 != iterator2)
 		{
-			current = erase(current);
+			iterator1 = erase(iterator1);
 		}
+
+		return iterator(iterator2.node_pointer);
 	}
 
 
 
-	inline void pop_back() // Exception will occur on empty list
+	void pop_back() // Exception will occur on empty list
 	{
 		erase(iterator(end_node.previous));
 	}
 
 
 
-	inline void pop_front() // Exception will occur on empty list
+	void pop_front()
 	{
 		erase(begin_iterator);
 	}
 
 
 
-	inline list & operator = (const list &source)
+	list & operator = (const list &source)
 	{
 		assert (&source != this);
 
-		clear();
-	 	reserve(source.node_pointer_allocator_pair.total_number_of_elements);
-		insert(end_iterator, source.begin_iterator, source.end_iterator);
+		#ifdef PLF_ALLOCATOR_TRAITS_SUPPORT
+			if PLF_CONSTEXPR (std::allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value)
+		#endif
+		{
+			#ifdef PLF_IS_ALWAYS_EQUAL_SUPPORT
+				if PLF_CONSTEXPR (!std::allocator_traits<allocator_type>::is_always_equal::value)
+			#endif
+			{
+				if(static_cast<allocator_type &>(*this) != static_cast<const allocator_type &>(source))
+				{ // Deallocate existing blocks as source allocator is not necessarily able to do so
+					reset();
+				}
+			}
 
+			static_cast<allocator_type &>(*this) = static_cast<const allocator_type &>(source);
+
+			// Reconstruct rebinds:
+			static_cast<node_allocator_type &>(node_allocator_pair) = node_allocator_type(*this);
+		}
+
+		range_assign(source.begin_iterator, source.total_size);
 		return *this;
 	}
 
 
 
-	#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-		// Move assignment
-		list & operator = (list &&source) PLF_LIST_NOEXCEPT_MOVE_ASSIGNMENT(allocator_type)
-		{
-			assert (&source != this);
+	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+	private:
 
-			// Move source values across:
+		void move_assign(list &&source) PLF_NOEXCEPT
+		{
 			groups.destroy_all_data(last_endpoint);
 
 			groups = std::move(source.groups);
 			end_node = std::move(source.end_node);
 			last_endpoint = std::move(source.last_endpoint);
 			begin_iterator.node_pointer = (source.begin_iterator.node_pointer == source.end_iterator.node_pointer) ? end_iterator.node_pointer : std::move(source.begin_iterator.node_pointer);
-			node_pointer_allocator_pair.total_number_of_elements = source.node_pointer_allocator_pair.total_number_of_elements;
+			total_size = source.total_size;
 			node_allocator_pair.number_of_erased_nodes = source.node_allocator_pair.number_of_erased_nodes;
 
 			end_node.previous->next = begin_iterator.node_pointer->previous = end_iterator.node_pointer;
-
 			source.groups.blank();
-			source.reset();
+
+			#ifdef PLF_ALLOCATOR_TRAITS_SUPPORT
+				if PLF_CONSTEXPR(std::allocator_traits<allocator_type>::propagate_on_container_move_assignment::value)
+			#endif
+			{
+				static_cast<allocator_type &>(*this) = source;
+				static_cast<node_allocator_type &>(node_allocator_pair) = node_allocator_type(*this);
+			}
+
+			source.blank();
+		}
+
+
+
+	public:
+
+		// Move assignment
+		list & operator = (list &&source) PLF_NOEXCEPT_MOVE_ASSIGN(allocator_type)
+		{
+			assert (&source != this);
+
+			// Move source values across:
+			#ifdef PLF_IS_ALWAYS_EQUAL_SUPPORT
+				if PLF_CONSTEXPR (std::allocator_traits<allocator_type>::propagate_on_container_move_assignment::value || std::allocator_traits<allocator_type>::is_always_equal::value)
+				{
+					move_assign(std::move(source));
+				}
+				else
+			#endif
+			if (static_cast<allocator_type &>(*this) == static_cast<allocator_type &>(source))
+			{
+				move_assign(std::move(source));
+			}
+			else // Allocator isn't movable so move/copy elements from source and deallocate the source's blocks:
+			{
+				reset();
+
+				#ifdef PLF_TYPE_TRAITS_SUPPORT
+					if PLF_CONSTEXPR (!std::is_move_constructible<element_type>::value)
+					{
+						#ifdef PLF_EXCEPTIONS_SUPPORT
+							if PLF_CONSTEXPR (!std::is_copy_constructible<element_type>::value)
+							{
+								throw std::domain_error("Cannot perform move assignment, allocators are not equal and type is not copy/move-constructible.");
+							}
+						#endif
+
+						range_insert(end_iterator, source.total_size, source.begin_iterator);
+					}
+					else
+				#endif
+				{
+					range_insert(end_iterator, source.total_size, plf::make_move_iterator(source.begin_iterator));
+				}
+
+				source.reset();
+			}
+
 			return *this;
 		}
 	#endif
 
 
 
-	bool operator == (const list &rh) const PLF_LIST_NOEXCEPT
-	{
-		assert (this != &rh);
-
-		if (node_pointer_allocator_pair.total_number_of_elements != rh.node_pointer_allocator_pair.total_number_of_elements)
+	#ifdef PLF_INITIALIZER_LIST_SUPPORT
+		list & operator = (const std::initializer_list<element_type> &element_list)
 		{
-			return false;
+			range_assign(element_list.begin(), static_cast<size_type>(element_list.size()));
+			return *this;
 		}
+	#endif
 
-		iterator rh_iterator = rh.begin_iterator;
 
-		for (iterator lh_iterator = begin_iterator; lh_iterator != end_iterator;)
+
+	friend bool operator == (const list &lh, const list &rh) PLF_NOEXCEPT
+	{
+		if (lh.total_size != rh.total_size) return false;
+
+		for (const_iterator lh_iterator = lh.begin_iterator, rh_iterator = rh.begin_iterator; lh_iterator != lh.end_iterator; ++lh_iterator, ++rh_iterator)
 		{
-			if (*rh_iterator++ != *lh_iterator++)
-			{
-				return false;
-			}
+			if (*lh_iterator != *rh_iterator) return false;
 		}
 
 		return true;
@@ -2609,63 +2438,63 @@ public:
 
 
 
-	inline bool operator != (const list &rh) const PLF_LIST_NOEXCEPT
+	friend bool operator != (const list &lh, const list &rh) PLF_NOEXCEPT
 	{
-		return !(*this == rh);
+		return !(lh == rh);
 	}
 
 
 
-	inline bool empty() const PLF_LIST_NOEXCEPT
+	#ifdef PLF_CPP20_SUPPORT
+		friend constexpr std::strong_ordering operator <=> (const list &lh, const list &rh)
+		{
+			return std::lexicographical_compare_three_way(lh.begin(), lh.end(), rh.begin(), rh.end());
+		}
+
+
+
+		[[nodiscard]]
+	#endif
+	bool empty() const PLF_NOEXCEPT
 	{
-		return node_pointer_allocator_pair.total_number_of_elements == 0;
+		return total_size == 0;
 	}
 
 
 
-	inline size_type size() const PLF_LIST_NOEXCEPT
+	size_type size() const PLF_NOEXCEPT
 	{
-		return node_pointer_allocator_pair.total_number_of_elements;
+		return total_size;
 	}
 
 
 
-	inline size_type max_size() const PLF_LIST_NOEXCEPT
+	size_type max_size() const PLF_NOEXCEPT
 	{
-		#ifdef PLF_LIST_ALLOCATOR_TRAITS_SUPPORT
-      	return std::allocator_traits<element_allocator_type>::max_size(*this);
+		#ifdef PLF_ALLOCATOR_TRAITS_SUPPORT
+			return std::allocator_traits<allocator_type>::max_size(*this);
 		#else
-      	return element_allocator_type::max_size();
-      #endif
+			return allocator_type::max_size();
+		#endif
 	}
 
 
 
-	inline size_type capacity() const PLF_LIST_NOEXCEPT
+	size_type capacity() const PLF_NOEXCEPT
 	{
-		return groups.element_allocator_pair.capacity;
+		return groups.node_pointer_allocator_pair.capacity;
 	}
 
 
 
-	inline size_type approximate_memory_use() const PLF_LIST_NOEXCEPT
+	size_type memory() const PLF_NOEXCEPT
 	{
-		return static_cast<size_type>(sizeof(*this) + (groups.element_allocator_pair.capacity * sizeof(node)) + (sizeof(group) * groups.group_allocator_pair.capacity));
+		return sizeof(*this) + (groups.node_pointer_allocator_pair.capacity * sizeof(node)) + (groups.group_allocator_pair.capacity * sizeof(group));
 	}
 
 
 
 private:
-
-
-	struct less
-	{
-		inline bool operator() (const element_type &a, const element_type &b) const PLF_LIST_NOEXCEPT
-		{
-			return a < b;
-		}
-	};
-
 
 
 	// Function-object to redirect the sort function to sort pointers by the elements they point to, not the pointer value
@@ -2674,14 +2503,11 @@ private:
 	{
 		comparison_function stored_instance;
 
-		explicit sort_dereferencer(const comparison_function &function_instance):
+		explicit sort_dereferencer(const comparison_function &function_instance) PLF_NOEXCEPT:
 			stored_instance(function_instance)
 		{}
 
-		sort_dereferencer() PLF_LIST_NOEXCEPT
-		{}
-
-		inline bool operator() (const node_pointer_type first, const node_pointer_type second)
+		bool operator() (const node_pointer_type first, const node_pointer_type second)
 		{
 			return stored_instance(first->element, second->element);
 		}
@@ -2695,46 +2521,42 @@ public:
 	template <class comparison_function>
 	void sort(comparison_function compare)
 	{
-		if (node_pointer_allocator_pair.total_number_of_elements < 2)
-		{
-			return;
-		}
+		if (total_size < 2) return;
 
-		node_pointer_type * const node_pointers = PLF_LIST_ALLOCATE(node_pointer_allocator_type, node_pointer_allocator_pair, node_pointer_allocator_pair.total_number_of_elements, NULL);
+		node_pointer_type * const node_pointers = PLF_ALLOCATE(node_pointer_allocator_type, groups.node_pointer_allocator_pair, total_size, NULL);
 		node_pointer_type *node_pointer = node_pointers;
-
 
 		// According to the C++ standard, construction of a pointer (of any type) may not trigger an exception - hence, no try-catch blocks are necessary for constructing the pointers:
 		for (group_pointer_type current_group = groups.block_pointer; current_group != groups.last_endpoint_group; ++current_group)
 		{
 			const node_pointer_type end = current_group->beyond_end;
 
-			if ((end - current_group->nodes) != current_group->number_of_elements) // If there are erased nodes present in the group
+			if (end - current_group->nodes != current_group->number_of_elements) // If there are erased nodes present in the group
 			{
 				for (node_pointer_type current_node = current_group->nodes; current_node != end; ++current_node)
 				{
 					if (current_node->next != NULL) // is not free list node
 					{
-						PLF_LIST_CONSTRUCT(node_pointer_allocator_type, node_pointer_allocator_pair, node_pointer++, current_node);
+						PLF_CONSTRUCT(node_pointer_allocator_type, groups.node_pointer_allocator_pair, node_pointer++, current_node);
 					}
 				}
 			}
-			else
+			else // If no erased nodes present we can avoid the per-node testing
 			{
 				for (node_pointer_type current_node = current_group->nodes; current_node != end; ++current_node)
 				{
-					PLF_LIST_CONSTRUCT(node_pointer_allocator_type, node_pointer_allocator_pair, node_pointer++, current_node);
+					PLF_CONSTRUCT(node_pointer_allocator_type, groups.node_pointer_allocator_pair, node_pointer++, current_node);
 				}
 			}
 		}
 
-		if ((last_endpoint - groups.last_endpoint_group->nodes) != groups.last_endpoint_group->number_of_elements) // If there are erased nodes present in the group
+		if (last_endpoint - groups.last_endpoint_group->nodes != groups.last_endpoint_group->number_of_elements) // If there are erased nodes present in the group
 		{
 			for (node_pointer_type current_node = groups.last_endpoint_group->nodes; current_node != last_endpoint; ++current_node)
 			{
 				if (current_node->next != NULL)
 				{
-					PLF_LIST_CONSTRUCT(node_pointer_allocator_type, node_pointer_allocator_pair, node_pointer++, current_node);
+					PLF_CONSTRUCT(node_pointer_allocator_type, groups.node_pointer_allocator_pair, node_pointer++, current_node);
 				}
 			}
 		}
@@ -2742,221 +2564,88 @@ public:
 		{
 			for (node_pointer_type current_node = groups.last_endpoint_group->nodes; current_node != last_endpoint; ++current_node)
 			{
-				PLF_LIST_CONSTRUCT(node_pointer_allocator_type, node_pointer_allocator_pair, node_pointer++, current_node);
+				PLF_CONSTRUCT(node_pointer_allocator_type, groups.node_pointer_allocator_pair, node_pointer++, current_node);
 			}
 		}
 
 
-		#ifdef GFX_TIMSORT_HPP
-			gfx::timsort(node_pointers, node_pointers + node_pointer_allocator_pair.total_number_of_elements, sort_dereferencer<comparison_function>(compare));
+		#ifndef PLF_SORT_FUNCTION
+			std::sort(node_pointers, node_pointer, sort_dereferencer<comparison_function>(compare));
 		#else
-			std::sort(node_pointers, node_pointers + node_pointer_allocator_pair.total_number_of_elements, sort_dereferencer<comparison_function>(compare));
+			PLF_SORT_FUNCTION(node_pointers, node_pointer, sort_dereferencer<comparison_function>(compare));
 		#endif
+
 
 		begin_iterator.node_pointer = node_pointers[0];
 		begin_iterator.node_pointer->next = node_pointers[1];
 		begin_iterator.node_pointer->previous = end_iterator.node_pointer;
 
 		end_node.next = node_pointers[0];
-		end_node.previous = node_pointers[node_pointer_allocator_pair.total_number_of_elements - 1];
+		end_node.previous = node_pointers[total_size - 1];
 		end_node.previous->next = end_iterator.node_pointer;
-		end_node.previous->previous = node_pointers[node_pointer_allocator_pair.total_number_of_elements - 2];
+		end_node.previous->previous = node_pointers[total_size - 2];
 
-		node_pointer_type * const back = node_pointers + node_pointer_allocator_pair.total_number_of_elements - 1;
+		node_pointer_type * const back = node_pointers + total_size - 1;
 
 		for(node_pointer = node_pointers + 1; node_pointer != back; ++node_pointer)
 		{
 			(*node_pointer)->next = *(node_pointer + 1);
 			(*node_pointer)->previous = *(node_pointer - 1);
 
-			#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-				if PLF_LIST_CONSTEXPR (!std::is_trivially_destructible<node_pointer_type>::value)
+			#ifdef PLF_TYPE_TRAITS_SUPPORT
+				if PLF_CONSTEXPR (!std::is_trivially_destructible<node_pointer_type>::value)
 			#endif
 			{
-				PLF_LIST_DESTROY(node_pointer_allocator_type, node_pointer_allocator_pair, node_pointer - 1);
+				PLF_DESTROY(node_pointer_allocator_type, groups.node_pointer_allocator_pair, node_pointer - 1);
 			}
 		}
 
-		#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-			if PLF_LIST_CONSTEXPR (!std::is_trivially_destructible<node_pointer_type>::value)
+		#ifdef PLF_TYPE_TRAITS_SUPPORT
+			if PLF_CONSTEXPR (!std::is_trivially_destructible<node_pointer_type>::value)
 		#endif
 		{
-			PLF_LIST_DESTROY(node_pointer_allocator_type, node_pointer_allocator_pair, back);
+			PLF_DESTROY(node_pointer_allocator_type, groups.node_pointer_allocator_pair, back);
 		}
 
-		PLF_LIST_DEALLOCATE(node_pointer_allocator_type, node_pointer_allocator_pair, node_pointers, node_pointer_allocator_pair.total_number_of_elements);
+		PLF_DEALLOCATE(node_pointer_allocator_type, groups.node_pointer_allocator_pair, node_pointers, total_size);
 	}
 
 
 
-	inline void sort()
+	void sort()
 	{
-		sort(less());
+		sort(plf::less<element_type>());
 	}
 
 
 
-	void reorder(const iterator position, const iterator first, const iterator last) PLF_LIST_NOEXCEPT
+	void splice(const const_iterator position, const const_iterator first, const const_iterator last) PLF_NOEXCEPT // intra-list only splice functions - will crash if first & list are not from *this
 	{
-		last.node_pointer->next->previous = first.node_pointer->previous;
-		first.node_pointer->previous->next = last.node_pointer->next;
+		if (position == last) return;
+		if (begin_iterator == first) begin_iterator.node_pointer = last.node_pointer;
 
-		last.node_pointer->next = position.node_pointer;
-		first.node_pointer->previous = position.node_pointer->previous;
+		// To avoid pointer aliasing and subsequently increase performance via simultaneous assignments:
+		const node_pointer_type first_previous = first.node_pointer->previous;
+		const node_pointer_type last_previous = last.node_pointer->previous;
+		const node_pointer_type position_previous = position.node_pointer->previous;
 
-		position.node_pointer->previous->next = first.node_pointer;
-		position.node_pointer->previous = last.node_pointer;
+		last.node_pointer->previous = first_previous;
+		first.node_pointer->previous->next = last.node_pointer;
 
-		if (begin_iterator == position)
-		{
-			begin_iterator = first;
-		}
+ 		last_previous->next = position.node_pointer;
+		first.node_pointer->previous = position_previous;
+
+		position_previous->next = first.node_pointer;
+		position.node_pointer->previous = last_previous;
+
+		if (begin_iterator == position) begin_iterator.node_pointer = first.node_pointer;
 	}
 
 
 
-	inline void reorder(const iterator position, const iterator location) PLF_LIST_NOEXCEPT
+	void splice(const const_iterator position, const const_iterator location) PLF_NOEXCEPT
 	{
-		reorder(position, location, location);
-	}
-
-
-
-	void reserve(size_type reserve_amount)
-	{
-		if (reserve_amount == 0 || reserve_amount <= groups.element_allocator_pair.capacity)
-		{
-			return;
-		}
-		else if (reserve_amount < PLF_LIST_BLOCK_MIN)
-		{
-			reserve_amount = PLF_LIST_BLOCK_MIN;
-		}
-		else if (reserve_amount > max_size())
-		{
-			reserve_amount = max_size();
-		}
-
-
-		if (groups.block_pointer != NULL && node_pointer_allocator_pair.total_number_of_elements == 0)
-		{ // edge case: has been filled with elements then clear()'d - some groups may be smaller than would be desired, should be replaced
-			group_size_type end_group_size = static_cast<group_size_type>((groups.block_pointer + groups.size - 1)->beyond_end - (groups.block_pointer + groups.size - 1)->nodes);
-
-			if (reserve_amount > end_group_size && end_group_size != PLF_LIST_BLOCK_MAX) // if last group isn't large enough, remove all groups
-			{
-				reset();
-			}
-			else
-			{
-				size_type number_of_full_groups_needed = reserve_amount / PLF_LIST_BLOCK_MAX;
-				group_size_type remainder = static_cast<group_size_type>(reserve_amount - (number_of_full_groups_needed * PLF_LIST_BLOCK_MAX));
-
-				// Remove any max_size groups which're not needed and any groups that're smaller than remainder:
-				for (group_pointer_type current_group = groups.block_pointer; current_group < groups.block_pointer + groups.size;)
-				{
-					const group_size_type current_group_size = static_cast<group_size_type>(groups.block_pointer->beyond_end - groups.block_pointer->nodes);
-
-					if (number_of_full_groups_needed != 0 && current_group_size == PLF_LIST_BLOCK_MAX)
-					{
-						--number_of_full_groups_needed;
-						++current_group;
-					}
-					else if (remainder != 0 && current_group_size >= remainder)
-					{
-						remainder = 0;
-						++current_group;
-					}
-					else
-					{
-						groups.remove(current_group);
-					}
-				}
-
-				last_endpoint = groups.block_pointer->nodes;
-			}
-		}
-
-		reserve_amount -= groups.element_allocator_pair.capacity;
-
-		// To correct from possible reallocation caused by add_new:
-		const difference_type last_endpoint_group_number = groups.last_endpoint_group - groups.block_pointer;
-
-		size_type number_of_full_groups = (reserve_amount / PLF_LIST_BLOCK_MAX);
-		reserve_amount -= (number_of_full_groups++ * PLF_LIST_BLOCK_MAX); // ++ to aid while loop below
-
-		if (groups.block_pointer == NULL) // Previously uninitialized list or reset in above if statement; most common scenario
-		{
-			if (reserve_amount != 0)
-			{
-				groups.initialize(static_cast<group_size_type>(((reserve_amount < PLF_LIST_BLOCK_MIN) ? PLF_LIST_BLOCK_MIN : reserve_amount)));
-			}
-			else
-			{
-				groups.initialize(PLF_LIST_BLOCK_MAX);
-				--number_of_full_groups;
-			}
-		}
-		else if (reserve_amount != 0)
-		{ // Create a group at least as large as the last group - may allocate more than necessary, but better solution than creating a veyr small group in the middle of the group vector, I think:
-			const group_size_type last_endpoint_group_capacity = static_cast<group_size_type>(groups.last_endpoint_group->beyond_end - groups.last_endpoint_group->nodes);
-			groups.add_new(static_cast<group_size_type>((reserve_amount < last_endpoint_group_capacity) ? last_endpoint_group_capacity : reserve_amount));
-		}
-
-		while (--number_of_full_groups != 0)
-		{
-			groups.add_new(PLF_LIST_BLOCK_MAX);
-		}
-
-		groups.last_endpoint_group = groups.block_pointer + last_endpoint_group_number;
-	}
-
-
-
-	inline PLF_LIST_FORCE_INLINE void free_unused_memory() PLF_LIST_NOEXCEPT
-	{
-		groups.trim_trailing_groups();
-	}
-
-
-
-	void shrink_to_fit()
-	{
-		if ((last_endpoint == NULL) | (node_pointer_allocator_pair.total_number_of_elements == groups.element_allocator_pair.capacity)) // uninitialized list or full
-		{
-			return;
-		}
-		else if (node_pointer_allocator_pair.total_number_of_elements == 0) // Edge case
-		{
-			reset();
-			return;
-		}
-		else if (node_allocator_pair.number_of_erased_nodes == 0 && last_endpoint == groups.last_endpoint_group->beyond_end) //edge case - currently no waste except for possible trailing groups
-		{
-			groups.trim_trailing_groups();
-			return;
-		}
-
-		#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-			list temp;
-		 	temp.reserve(node_pointer_allocator_pair.total_number_of_elements);
-
-			#ifdef PLF_LIST_TYPE_TRAITS_SUPPORT
-				if PLF_LIST_CONSTEXPR (std::is_move_assignable<element_type>::value && std::is_move_constructible<element_type>::value) // move elements if possible, otherwise copy them
-				{
-					temp.insert(temp.end_iterator, std::make_move_iterator(begin_iterator), std::make_move_iterator(end_iterator));
-				}
-				else
-			#endif
-			{
-				temp.insert(temp.end_iterator, begin_iterator, end_iterator);
-			}
-
-			*this = std::move(temp);
-		#else
-			list temp(*this);
-			reset();
-			swap(temp);
-		#endif
+		splice(position, location, const_iterator(location.node_pointer->next));
 	}
 
 
@@ -2965,8 +2654,10 @@ private:
 
 	void append_process(list &source) // used by merge and splice
 	{
+		node_allocator_pair.number_of_erased_nodes += source.node_allocator_pair.number_of_erased_nodes;
+
 		if (last_endpoint != groups.last_endpoint_group->beyond_end)
-		{	// Add unused nodes to group's free list
+		{ // Add unused nodes to group's free list
 			const node_pointer_type back_node = last_endpoint - 1;
 			for (node_pointer_type current_node = groups.last_endpoint_group->beyond_end - 1; current_node != back_node; --current_node)
 			{
@@ -2980,8 +2671,8 @@ private:
 
 		groups.append(source.groups);
 		last_endpoint = source.last_endpoint;
-		node_pointer_allocator_pair.total_number_of_elements += source.node_pointer_allocator_pair.total_number_of_elements;
-		source.reset();
+		total_size += source.total_size;
+		source.blank();
 	}
 
 
@@ -2993,13 +2684,13 @@ public:
 	{
 		assert(&source != this);
 
-		if (source.node_pointer_allocator_pair.total_number_of_elements == 0)
+		if (source.total_size == 0)
 		{
 			return;
 		}
-		else if (node_pointer_allocator_pair.total_number_of_elements == 0)
+		else if (total_size == 0)
 		{
-			#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
+			#ifdef PLF_MOVE_SEMANTICS_SUPPORT
 				*this = std::move(source);
 			#else
 				reset();
@@ -3025,11 +2716,19 @@ public:
 
 
 
+	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+		void splice(iterator position, list &&source)
+		{
+			splice(position, source);
+		}
+	#endif
+
+
+
 	template <class comparison_function>
 	void merge(list &source, comparison_function compare)
 	{
-		assert(&source != this);
-		splice((source.node_pointer_allocator_pair.total_number_of_elements >= node_pointer_allocator_pair.total_number_of_elements) ? end_iterator : begin_iterator, source);
+		splice((source.total_size >= total_size) ? end_iterator : begin_iterator, source);
 		sort(compare);
 	}
 
@@ -3039,13 +2738,13 @@ public:
 	{
 		assert(&source != this);
 
-		if (source.node_pointer_allocator_pair.total_number_of_elements == 0)
+		if (source.total_size == 0)
 		{
 			return;
 		}
-		else if (node_pointer_allocator_pair.total_number_of_elements == 0)
+		else if (total_size == 0)
 		{
-			#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
+			#ifdef PLF_MOVE_SEMANTICS_SUPPORT
 				*this = std::move(source);
 			#else
 				reset();
@@ -3092,9 +2791,27 @@ public:
 
 
 
-	void reverse() PLF_LIST_NOEXCEPT
+	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+		template <class comparison_function>
+		void merge(list &&source, comparison_function compare)
+		{
+			merge(source, compare);
+		}
+
+
+
+		void merge(list &&source)
+		{
+			merge(source);
+		}
+	#endif
+
+
+
+	void reverse() PLF_NOEXCEPT
 	{
-		if (node_pointer_allocator_pair.total_number_of_elements > 1)
+		// Note: current_node->next has to be read during swapping in this process anyway, so including a test to figure out whether or not a given group has erased elements within it, and thus avoid per-node tests, is actually detrimental to performance according to benchmarks. This is unlike sort() where current_node->next is not used in the rest of the process and avoiding per-node tests of it's value is therefore beneficial in benchmarks.
+		if (total_size > 1)
 		{
 			for (group_pointer_type current_group = groups.block_pointer; current_group != groups.last_endpoint_group; ++current_group)
 			{
@@ -3102,29 +2819,16 @@ public:
 
 				for (node_pointer_type current_node = current_group->nodes; current_node != end; ++current_node)
 				{
-					if (current_node->next != NULL) // is not free list node
-					{ // swap the pointers:
-						const node_pointer_type temp = current_node->next;
-						current_node->next = current_node->previous;
-						current_node->previous = temp;
-					}
+					if (current_node->next != NULL) /* ie. is not free list node */ std::swap(current_node->next, current_node->previous);
 				}
 			}
 
 			for (node_pointer_type current_node = groups.last_endpoint_group->nodes; current_node != last_endpoint; ++current_node)
 			{
-				if (current_node->next != NULL)
-				{
-					const node_pointer_type temp = current_node->next;
-					current_node->next = current_node->previous;
-					current_node->previous = temp;
-				}
+				if (current_node->next != NULL) std::swap(current_node->next, current_node->previous);
 			}
 
-			const node_pointer_type temp = end_node.previous;
-			end_node.previous = begin_iterator.node_pointer;
-			begin_iterator.node_pointer = temp;
-
+			std::swap(end_node.previous, begin_iterator.node_pointer);
 			end_node.previous->next = end_iterator.node_pointer;
 			begin_iterator.node_pointer->previous = end_iterator.node_pointer;
 		}
@@ -3137,29 +2841,9 @@ private:
 	// Used by unique()
 	struct eq
 	{
-		inline bool operator() (const element_type &a, const element_type &b) const PLF_LIST_NOEXCEPT
+		bool operator() (const element_type &a, const element_type &b) const PLF_NOEXCEPT
 		{
 			return a == b;
-		}
-	};
-
-
-
-	// Used by remove()
-	struct eq_to
-	{
-		const element_type value;
-
-		explicit eq_to(const element_type store_value):
-			value(store_value)
-		{}
-
-		eq_to() PLF_LIST_NOEXCEPT
-		{}
-
-		inline bool operator() (const element_type compare_value) const PLF_LIST_NOEXCEPT
-		{
-			return value == compare_value;
 		}
 	};
 
@@ -3170,7 +2854,7 @@ public:
 	template <class comparison_function>
 	size_type unique(comparison_function compare)
 	{
-  		const size_type original_number_of_elements = node_pointer_allocator_pair.total_number_of_elements;
+  		const size_type original_number_of_elements = total_size;
 
 		if (original_number_of_elements > 1)
 		{
@@ -3188,13 +2872,13 @@ public:
 				}
 			}
 		}
-		
-		return original_number_of_elements - node_pointer_allocator_pair.total_number_of_elements;
+
+		return original_number_of_elements - total_size;
 	}
 
 
 
-	inline size_type unique()
+	size_type unique()
 	{
 		return unique(eq());
 	}
@@ -3204,7 +2888,7 @@ public:
 	template <class predicate_function>
 	size_type remove_if(predicate_function predicate)
 	{
-  		const size_type original_number_of_elements = node_pointer_allocator_pair.total_number_of_elements;
+  		const size_type original_number_of_elements = total_size;
 
 		if (original_number_of_elements != 0)
 		{
@@ -3256,11 +2940,7 @@ public:
 					if (current_node->next != NULL && predicate(current_node->element))
 					{
 						erase(current_node);
-
-						if (--num_elements == 0)
-						{
-							break;
-						}
+						if (--num_elements == 0) break;
 					}
 				}
 			}
@@ -3271,31 +2951,27 @@ public:
 					if (predicate(current_node->element))
 					{
 						erase(current_node);
-
-						if (--num_elements == 0)
-						{
-							break;
-						}
+						if (--num_elements == 0) break;
 					}
 				}
 			}
 		}
-		
-		return original_number_of_elements - node_pointer_allocator_pair.total_number_of_elements;
+
+		return original_number_of_elements - total_size;
 	}
 
 
 
-	inline size_type remove(const element_type &value)
+	size_type remove(const element_type &value)
 	{
-		return remove_if(eq_to(value));
+		return remove_if(plf::equal_to<element_type>(value));
 	}
 
 
 
 	void resize(const size_type number_of_elements, const element_type &value = element_type())
 	{
-		if (node_pointer_allocator_pair.total_number_of_elements == number_of_elements)
+		if (total_size == number_of_elements)
 		{
 			return;
 		}
@@ -3304,15 +2980,15 @@ public:
 			clear();
 			return;
 		}
-		else if (node_pointer_allocator_pair.total_number_of_elements < number_of_elements)
+		else if (total_size < number_of_elements)
 		{
-			insert(end_iterator, number_of_elements - node_pointer_allocator_pair.total_number_of_elements, value);
+			insert(end_iterator, number_of_elements - total_size, value);
 		}
-		else // ie. node_pointer_allocator_pair.total_number_of_elements > number_of_elements
+		else // ie. total_size > number_of_elements
 		{
-			iterator current(end_node.previous);
+			const_iterator current(end_node.previous);
 
-			for (size_type number_to_remove = node_pointer_allocator_pair.total_number_of_elements - number_of_elements; number_to_remove != 0; --number_to_remove)
+			for (size_type number_to_remove = total_size - number_of_elements; number_to_remove != 0; --number_to_remove)
 			{
 				const node_pointer_type temp = current.node_pointer->previous;
 				erase(current);
@@ -3323,109 +2999,1053 @@ public:
 
 
 
+	void reserve(size_type reserve_amount)
+	{
+		if (reserve_amount == 0 || reserve_amount <= groups.node_pointer_allocator_pair.capacity)
+		{
+			return;
+		}
+		else if (reserve_amount < list_min_block_capacity())
+		{
+			reserve_amount = list_min_block_capacity();
+		}
+		else if (reserve_amount > max_size())
+		{
+			#ifdef PLF_EXCEPTIONS_SUPPORT
+				throw std::length_error("Capacity requested via reserve() greater than max_size()");
+			#else
+				std::terminate();
+			#endif
+		}
+
+
+		if (groups.block_pointer != NULL && total_size == 0)
+		{ // edge case: has been filled with elements then clear()'d - some groups may be smaller than would be desired, should be replaced
+			group_size_type end_group_size = static_cast<group_size_type>((groups.block_pointer + groups.size - 1)->beyond_end - (groups.block_pointer + groups.size - 1)->nodes);
+
+			if (reserve_amount > end_group_size && end_group_size != list_max_block_capacity()) // if last group isn't large enough, remove all groups
+			{
+				reset();
+			}
+			else
+			{
+				size_type number_of_full_groups_needed = reserve_amount / list_max_block_capacity();
+				group_size_type remainder = static_cast<group_size_type>(reserve_amount - (number_of_full_groups_needed * list_max_block_capacity()));
+
+				// Remove any max_size groups which're not needed and any groups that're smaller than remainder:
+				for (group_pointer_type current_group = groups.block_pointer; current_group < groups.block_pointer + groups.size;) // note: groups.size may change during procedure so we calculate this every loop
+				{
+					const group_size_type current_group_size = static_cast<group_size_type>(groups.block_pointer->beyond_end - groups.block_pointer->nodes);
+
+					if (number_of_full_groups_needed != 0 && current_group_size == list_max_block_capacity())
+					{
+						--number_of_full_groups_needed;
+						++current_group;
+					}
+					else if (remainder != 0 && current_group_size >= remainder)
+					{
+						remainder = 0;
+						++current_group;
+					}
+					else
+					{
+						groups.remove(current_group);
+					}
+				}
+
+				last_endpoint = groups.block_pointer->nodes;
+			}
+		}
+
+		reserve_amount -= groups.node_pointer_allocator_pair.capacity;
+
+		// To correct from possible reallocation caused by add_new:
+		const difference_type last_endpoint_group_number = groups.last_endpoint_group - groups.block_pointer;
+
+		size_type number_of_full_groups = reserve_amount / list_max_block_capacity();
+		reserve_amount -= (number_of_full_groups++ * list_max_block_capacity()); // ++ to aid while loop below
+
+		if (groups.block_pointer == NULL) // Previously uninitialized list or reset in above if statement; most common scenario
+		{
+			if (reserve_amount != 0)
+			{
+				groups.initialize(static_cast<group_size_type>(((reserve_amount < list_min_block_capacity()) ? list_min_block_capacity() : reserve_amount)));
+			}
+			else
+			{
+				groups.initialize(list_max_block_capacity());
+				--number_of_full_groups;
+			}
+		}
+		else if (reserve_amount != 0)
+		{ // Create a group at least as large as the last group - may allocate more than necessary, but better solution than creating a very small group in the middle of the group vector, I think:
+			const group_size_type last_endpoint_group_capacity = static_cast<group_size_type>(groups.last_endpoint_group->beyond_end - groups.last_endpoint_group->nodes);
+			groups.add_new(static_cast<group_size_type>((reserve_amount < last_endpoint_group_capacity) ? last_endpoint_group_capacity : reserve_amount));
+		}
+
+		while (--number_of_full_groups != 0)
+		{
+			groups.add_new(list_max_block_capacity());
+		}
+
+		groups.last_endpoint_group = groups.block_pointer + last_endpoint_group_number;
+	}
+
+
+
+	void trim_capacity() PLF_NOEXCEPT
+	{
+		groups.trim_unused_groups();
+	}
+
+
+
+	void shrink_to_fit()
+	{
+		if ((groups.block_pointer == NULL) | (total_size == groups.node_pointer_allocator_pair.capacity)) // if list is uninitialized or full
+		{
+			return;
+		}
+		else if (total_size == 0) // Edge case
+		{
+			reset();
+			return;
+		}
+		else if (node_allocator_pair.number_of_erased_nodes == 0 && last_endpoint == groups.last_endpoint_group->beyond_end) //edge case - currently no wasted space except for possible trailing groups
+		{
+			groups.trim_unused_groups();
+			return;
+		}
+
+		#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+			list temp;
+
+			#ifdef PLF_TYPE_TRAITS_SUPPORT
+				if PLF_CONSTEXPR (std::is_move_assignable<element_type>::value && std::is_move_constructible<element_type>::value) // move elements if possible, otherwise copy them
+				{
+					temp.range_insert(temp.end_iterator, total_size, plf::make_move_iterator(begin_iterator));
+				}
+				else
+			#endif
+			{
+				temp.range_insert(temp.end_iterator, total_size, begin_iterator);
+			}
+
+			*this = std::move(temp);
+		#else
+			list temp(*this);
+			reset();
+			swap(temp);
+		#endif
+	}
+
+
+
 	// Range assign:
+
+private:
+
+
  	template <class iterator_type>
- 	inline void assign(const typename plf_enable_if_c<!std::numeric_limits<iterator_type>::is_integer, iterator_type>::type first, const iterator_type last)
+ 	void range_assign(iterator_type it, size_type range_size)
 	{
-		clear();
-		insert(end_iterator, first, last);
-		groups.trim_trailing_groups();
-	}
-
-
-
-	// Fill assign:
-	inline void assign(const size_type number_of_elements, const element_type &value)
-	{
-		clear();
-		reserve(number_of_elements); // Will return anyway if capacity already > number_of_elements
-		insert(end_iterator, number_of_elements, value);
-	}
-
-
-
-	#ifdef PLF_LIST_INITIALIZER_LIST_SUPPORT
-		// Initializer-list assign:
-		inline void assign(const std::initializer_list<element_type> &element_list)
+		if (range_size == 0)
 		{
 			clear();
-			reserve(element_list.size());
-			insert(end_iterator, element_list);
+			return;
+		}
+
+		#ifdef PLF_TYPE_TRAITS_SUPPORT
+			if PLF_CONSTEXPR ((std::is_trivially_destructible<element_type>::value && std::is_trivially_constructible<element_type>::value && std::is_trivially_copy_assignable<element_type>::value) || !std::is_copy_assignable<element_type>::value) // ie. If there is no benefit nor difference to assigning vs constructing, or if we can't assign
+			{
+				clear();
+				range_insert(end_iterator, range_size, it);
+			}
+			else
+		#endif
+		{
+			if (total_size == 0)
+			{
+				range_insert(end_iterator, range_size, it);
+			}
+			else if (range_size < total_size)
+			{
+				iterator current = begin_iterator;
+
+				do
+				{
+					*current++ = *it++;
+				} while (--range_size != 0);
+
+				erase(current, end_iterator);
+			}
+			else
+			{
+				iterator current = begin_iterator;
+
+				do
+				{
+					*current = *it++;
+				} while (++current != end_iterator);
+
+				range_insert(end_iterator, range_size - total_size, it);
+			}
+		}
+
+		groups.trim_unused_groups();
+	}
+
+
+
+
+public:
+
+
+ 	template <class iterator_type>
+ 	void assign(typename plf::enable_if<!std::numeric_limits<iterator_type>::is_integer, iterator_type>::type first, const iterator_type last)
+	{
+		range_assign(first, std::distance(first, last));
+	}
+
+
+
+	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+		template <class iterator_type>
+		void insert (const std::move_iterator<iterator_type> first, const std::move_iterator<iterator_type> last)
+		{
+			range_assign(first, static_cast<size_type>(std::distance(first.base(),last.base())));
 		}
 	#endif
 
 
 
-	inline allocator_type get_allocator() const PLF_LIST_NOEXCEPT
+	// Fill assign:
+
+	void assign(size_type number_of_elements, const element_type &value)
 	{
-		return element_allocator_type();
+		if (number_of_elements == 0)
+		{
+			clear();
+			return;
+		}
+
+		#ifdef PLF_TYPE_TRAITS_SUPPORT
+			if PLF_CONSTEXPR ((std::is_trivially_destructible<element_type>::value && std::is_trivially_constructible<element_type>::value && std::is_trivially_copy_assignable<element_type>::value) || !std::is_copy_assignable<element_type>::value)
+			{
+				clear();
+				insert(end_iterator, number_of_elements, value);
+			}
+		#endif
+		{
+			if (total_size == 0)
+			{
+				insert(end_iterator, number_of_elements, value);
+			}
+			else if (number_of_elements < total_size)
+			{
+				iterator current = begin_iterator;
+
+				do
+				{
+					*current++ = value;
+				} while (--number_of_elements != 0);
+
+				erase(current, end_iterator);
+			}
+			else
+			{
+				iterator current = begin_iterator;
+
+				do
+				{
+					*current = value;
+				} while (++current != end_iterator);
+
+				insert(end_iterator, number_of_elements - total_size, value);
+			}
+		}
+
+		groups.trim_unused_groups();
 	}
 
 
 
-	void swap(list &source) PLF_LIST_NOEXCEPT_SWAP(allocator_type)
+	#ifdef PLF_INITIALIZER_LIST_SUPPORT
+		// Initializer-list assign:
+
+		void assign(const std::initializer_list<element_type> &element_list)
+		{
+			range_assign(element_list.begin(), static_cast<size_type>(element_list.size()));
+		}
+	#endif
+
+
+
+	#ifdef PLF_CPP20_SUPPORT
+		template<compatible_range<element_type> range_type>
+		void assign_range(range_type &&the_range)
+		{
+			range_assign(std::ranges::begin(the_range), static_cast<size_type>(std::ranges::distance(the_range)));
+		}
+	#endif
+
+
+
+	allocator_type get_allocator() const PLF_NOEXCEPT
 	{
-		#ifdef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-			list temp(std::move(source));
-			source = std::move(*this);
-			*this = std::move(temp);
-		#else
+		return allocator_type();
+	}
+
+
+
+	template <class predicate_function>
+	iterator unordered_find_single(predicate_function predicate) const PLF_NOEXCEPT
+	{
+		if (total_size != 0)
+		{
+			for (group_pointer_type current_group = groups.block_pointer; current_group != groups.last_endpoint_group; ++current_group)
+			{
+				const node_pointer_type end = current_group->beyond_end;
+
+				if (end - current_group->nodes != current_group->number_of_elements) // If there are erased nodes present in the group
+				{
+					for (node_pointer_type current_node = current_group->nodes; current_node != end; ++current_node)
+					{
+						if (current_node->next != NULL && predicate(current_node->element)) return iterator(current_node); // is not free list node and matches element
+					}
+				}
+				else // No erased nodes in group
+				{
+					for (node_pointer_type current_node = current_group->nodes; current_node != end; ++current_node)
+					{
+						if (predicate(current_node->element)) return iterator(current_node);
+					}
+				}
+			}
+
+			if (last_endpoint - groups.last_endpoint_group->nodes != groups.last_endpoint_group->number_of_elements)
+			{
+				for (node_pointer_type current_node = groups.last_endpoint_group->nodes; current_node != last_endpoint; ++current_node)
+				{
+					if (current_node->next != NULL && predicate(current_node->element)) return iterator(current_node);
+				}
+			}
+			else
+			{
+				for (node_pointer_type current_node = groups.last_endpoint_group->nodes; current_node != last_endpoint; ++current_node)
+				{
+					if (predicate(current_node->element)) return iterator(current_node);
+				}
+			}
+		}
+
+		return end_iterator;
+	}
+
+
+
+	iterator unordered_find_single(const element_type &element_to_match) const PLF_NOEXCEPT
+	{
+		return unordered_find_single(plf::equal_to<element_type>(element_to_match));
+	}
+
+
+
+	template <class predicate_function>
+	list<iterator> unordered_find_multiple(predicate_function predicate, size_type number_to_find) const
+	{
+		list<iterator> return_list;
+
+		if (total_size != 0)
+		{
+			for (group_pointer_type current_group = groups.block_pointer; current_group != groups.last_endpoint_group; ++current_group)
+			{
+				const node_pointer_type end = current_group->beyond_end;
+
+				if (end - current_group->nodes != current_group->number_of_elements)
+				{
+					for (node_pointer_type current_node = current_group->nodes; current_node != end; ++current_node)
+					{
+						if (current_node->next != NULL && predicate(current_node->element))
+						{
+							return_list.push_back(iterator(current_node));
+							if (--number_to_find == 0) return return_list;
+						}
+					}
+				}
+				else // No erased nodes in group
+				{
+					for (node_pointer_type current_node = current_group->nodes; current_node != end; ++current_node)
+					{
+						if (predicate(current_node->element))
+						{
+							return_list.push_back(iterator(current_node));
+							if (--number_to_find == 0) return return_list;
+						}
+					}
+				}
+			}
+
+			if (last_endpoint - groups.last_endpoint_group->nodes != groups.last_endpoint_group->number_of_elements)
+			{
+				for (node_pointer_type current_node = groups.last_endpoint_group->nodes; current_node != last_endpoint; ++current_node)
+				{
+					if (current_node->next != NULL && predicate(current_node->element))
+					{
+						return_list.push_back(iterator(current_node));
+						if (--number_to_find == 0) return return_list;
+					}
+				}
+			}
+			else
+			{
+				for (node_pointer_type current_node = groups.last_endpoint_group->nodes; current_node != last_endpoint; ++current_node)
+				{
+					if (predicate(current_node->element))
+					{
+						return_list.push_back(iterator(current_node));
+						if (--number_to_find == 0) return return_list;
+					}
+				}
+			}
+		}
+
+		return return_list;
+	}
+
+
+
+	list<iterator> unordered_find_multiple(const element_type &element_to_match, size_type number_to_find) const
+	{
+		return unordered_find_multiple(plf::equal_to<element_type>(element_to_match), number_to_find);
+	}
+
+
+
+	template <class predicate_function>
+	list<iterator> unordered_find_all(predicate_function predicate) const
+	{
+		list<iterator> return_list;
+
+		if (total_size != 0)
+		{
+			for (group_pointer_type current_group = groups.block_pointer; current_group != groups.last_endpoint_group; ++current_group)
+			{
+				const node_pointer_type end = current_group->beyond_end;
+
+				if (end - current_group->nodes != current_group->number_of_elements)
+				{
+					for (node_pointer_type current_node = current_group->nodes; current_node != end; ++current_node)
+					{
+						if (current_node->next != NULL && predicate(current_node->element)) return_list.push_back(iterator(current_node));
+					}
+				}
+				else // No erased nodes in group
+				{
+					for (node_pointer_type current_node = current_group->nodes; current_node != end; ++current_node)
+					{
+						if (predicate(current_node->element)) return_list.push_back(iterator(current_node));
+					}
+				}
+			}
+
+			if (last_endpoint - groups.last_endpoint_group->nodes != groups.last_endpoint_group->number_of_elements)
+			{
+				for (node_pointer_type current_node = groups.last_endpoint_group->nodes; current_node != last_endpoint; ++current_node)
+				{
+					if (current_node->next != NULL && predicate(current_node->element)) return_list.push_back(iterator(current_node));
+				}
+			}
+			else
+			{
+				for (node_pointer_type current_node = groups.last_endpoint_group->nodes; current_node != last_endpoint; ++current_node)
+				{
+					if (predicate(current_node->element)) return_list.push_back(iterator(current_node));
+				}
+			}
+		}
+
+		return return_list;
+	}
+
+
+
+	list<iterator> unordered_find_all(const element_type &element_to_match) const
+	{
+		return unordered_find_all(plf::equal_to<element_type>(element_to_match));
+	}
+
+
+
+	void swap(list &source) PLF_NOEXCEPT_SWAP(allocator_type)
+	{
+		#if defined(PLF_TYPE_TRAITS_SUPPORT) && defined(PLF_MOVE_SEMANTICS_SUPPORT)
+			if PLF_CONSTEXPR (std::is_move_assignable<group_pointer_type>::value && std::is_move_assignable<node_pointer_type>::value && std::is_move_constructible<group_pointer_type>::value && std::is_move_constructible<node_pointer_type>::value)
+			{
+				list temp(std::move(source));
+				source = std::move(*this);
+				*this = std::move(temp);
+			}
+			else
+		#endif
+		{
 			groups.swap(source.groups);
 
 			const node_pointer_type swap_end_node_previous = end_node.previous, swap_last_endpoint = last_endpoint;
 			const iterator swap_begin_iterator = begin_iterator;
-			const size_type swap_total_number_of_elements = node_pointer_allocator_pair.total_number_of_elements, swap_number_of_erased_nodes = node_allocator_pair.number_of_erased_nodes;
+			const size_type swap_total_size = total_size, swap_number_of_erased_nodes = node_allocator_pair.number_of_erased_nodes;
 
 			last_endpoint = source.last_endpoint;
 			end_node.next = begin_iterator.node_pointer = (source.begin_iterator.node_pointer != source.end_iterator.node_pointer) ? source.begin_iterator.node_pointer : end_iterator.node_pointer;
 			end_node.previous = (source.begin_iterator.node_pointer != source.end_iterator.node_pointer) ? source.end_node.previous : end_iterator.node_pointer;
 			end_node.previous->next = begin_iterator.node_pointer->previous = end_iterator.node_pointer;
-			node_pointer_allocator_pair.total_number_of_elements = source.node_pointer_allocator_pair.total_number_of_elements;
+			total_size = source.total_size;
 			node_allocator_pair.number_of_erased_nodes = source.node_allocator_pair.number_of_erased_nodes;
 
 			source.last_endpoint = swap_last_endpoint;
 			source.end_node.next = source.begin_iterator.node_pointer = (swap_begin_iterator.node_pointer != end_iterator.node_pointer) ? swap_begin_iterator.node_pointer : source.end_iterator.node_pointer;
 			source.end_node.previous = (swap_begin_iterator.node_pointer != end_iterator.node_pointer) ? swap_end_node_previous : source.end_iterator.node_pointer;
 			source.end_node.previous->next = source.begin_iterator.node_pointer->previous = source.end_iterator.node_pointer;
-			source.node_pointer_allocator_pair.total_number_of_elements = swap_total_number_of_elements;
+			source.total_size = swap_total_size;
 			source.node_allocator_pair.number_of_erased_nodes = swap_number_of_erased_nodes;
-		#endif
+
+			#ifdef PLF_IS_ALWAYS_EQUAL_SUPPORT
+				if PLF_CONSTEXPR (std::allocator_traits<allocator_type>::propagate_on_container_swap::value && !std::allocator_traits<allocator_type>::is_always_equal::value)
+			#endif
+			{
+				std::swap(static_cast<allocator_type &>(source), static_cast<allocator_type &>(*this));
+
+				// Reconstruct rebinds for swapped allocators:
+				static_cast<node_allocator_type &>(node_allocator_pair) = node_allocator_type(*this);
+				static_cast<node_allocator_type &>(source.node_allocator_pair) = node_allocator_type(source);
+			} // else: undefined behaviour, as per standard
+		}
 	}
 
-};
+
+
+	// Iterators:
+
+	template <bool is_const> class list_iterator
+	{
+	private:
+		typedef typename list::node_pointer_type node_pointer_type;
+
+		#ifdef PLF_DEFAULT_SUPPORT
+			node_pointer_type node_pointer {NULL};
+		#else
+			node_pointer_type node_pointer;
+		#endif
+
+	public:
+		struct list_iterator_tag {};
+		typedef std::bidirectional_iterator_tag 	iterator_category;
+		typedef std::bidirectional_iterator_tag	iterator_concept;
+		typedef typename list::value_type 			value_type;
+		typedef typename list::difference_type 	difference_type;
+		typedef list_reverse_iterator<is_const> 	reverse_type;
+		typedef typename plf::conditional<is_const, typename list::const_pointer, typename list::pointer>::type		pointer;
+		typedef typename plf::conditional<is_const, typename list::const_reference, typename list::reference>::type	reference;
+
+		friend class list;
 
 
 
-template <class swap_element_type, class swap_element_allocator_type>
-inline void swap(list<swap_element_type, swap_element_allocator_type> &a, list<swap_element_type, swap_element_allocator_type> &b) PLF_LIST_NOEXCEPT_SWAP(swap_element_allocator_type)
-{
-	a.swap(b);
-}
+		bool operator == (const list_iterator rh) const PLF_NOEXCEPT
+		{
+			return (node_pointer == rh.node_pointer);
+		}
 
+
+
+		bool operator == (const list_iterator<!is_const> rh) const PLF_NOEXCEPT
+		{
+			return (node_pointer == rh.node_pointer);
+		}
+
+
+
+		bool operator != (const list_iterator rh) const PLF_NOEXCEPT
+		{
+			return (node_pointer != rh.node_pointer);
+		}
+
+
+
+		bool operator != (const list_iterator<!is_const> rh) const PLF_NOEXCEPT
+		{
+			return (node_pointer != rh.node_pointer);
+		}
+
+
+
+		reference operator * () const
+		{
+			return node_pointer->element;
+		}
+
+
+
+		pointer operator -> () const
+		{
+			return &(node_pointer->element);
+		}
+
+
+
+		list_iterator & operator ++ () PLF_NOEXCEPT
+		{
+			assert(node_pointer != NULL); // covers uninitialised list_iterator
+			node_pointer = node_pointer->next;
+			return *this;
+		}
+
+
+
+		list_iterator operator ++(int) PLF_NOEXCEPT
+		{
+			const list_iterator copy(*this);
+			++*this;
+			return copy;
+		}
+
+
+
+		list_iterator & operator -- () PLF_NOEXCEPT
+		{
+			assert(node_pointer != NULL);
+			node_pointer = node_pointer->previous;
+			return *this;
+		}
+
+
+
+		list_iterator operator -- (int) PLF_NOEXCEPT
+		{
+			const list_iterator copy(*this);
+			--*this;
+			return copy;
+		}
+
+
+
+		#ifdef PLF_DEFAULT_SUPPORT // Note: defaulting allows for treating iterators as trivially-copyable types, which enables optimizations in some functions and containers using list as back-end storage
+			list_iterator() PLF_NOEXCEPT = default;
+		#else
+			list_iterator() PLF_NOEXCEPT: node_pointer(NULL) {}
+		#endif
+
+
+
+		list_iterator(const list_iterator &source) PLF_NOEXCEPT
+		#ifdef PLF_DEFAULT_SUPPORT
+			= default;
+		#else
+			: node_pointer(source.node_pointer) {}
+		#endif
+
+
+
+		#ifdef PLF_DEFAULT_SUPPORT
+			template <bool is_const_it = is_const, class = typename plf::enable_if<is_const_it>::type >
+			list_iterator(const list_iterator<false> &source) PLF_NOEXCEPT: node_pointer(source.node_pointer) {}
+		#else
+			list_iterator(const list_iterator<!is_const> &source) PLF_NOEXCEPT: node_pointer(source.node_pointer) {}
+		#endif
+
+
+
+		list_iterator & operator = (const list_iterator &rh) PLF_NOEXCEPT
+		#ifdef PLF_DEFAULT_SUPPORT
+			= default;
+		#else
+			{
+				node_pointer = rh.node_pointer;
+				return *this;
+			}
+		#endif
+
+
+
+		#ifdef PLF_DEFAULT_SUPPORT
+			template <bool is_const_it = is_const, class = typename plf::enable_if<is_const_it>::type >
+			list_iterator & operator = (const list_iterator<false> &rh) PLF_NOEXCEPT
+		#else
+			list_iterator & operator = (const list_iterator<!is_const> &rh) PLF_NOEXCEPT
+		#endif
+		{
+			node_pointer = rh.node_pointer;
+			return *this;
+		}
+
+
+
+		#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+			list_iterator (list_iterator &&source) PLF_NOEXCEPT
+			#ifdef PLF_DEFAULT_SUPPORT
+				= default;
+			#else
+				: node_pointer(std::move(source.node_pointer)) {}
+			#endif
+
+
+
+			#ifdef PLF_DEFAULT_SUPPORT
+				template <bool is_const_it = is_const, class = typename plf::enable_if<is_const_it>::type >
+				list_iterator(list_iterator<false> &&source) PLF_NOEXCEPT: node_pointer(std::move(source.node_pointer)) {}
+			#else
+				list_iterator(list_iterator<!is_const> &&source) PLF_NOEXCEPT: node_pointer(std::move(source.node_pointer)) {}
+			#endif
+
+
+
+			list_iterator & operator = (list_iterator &&rh) PLF_NOEXCEPT
+			#ifdef PLF_DEFAULT_SUPPORT
+				= default;
+			#else
+				: node_pointer(std::move(rh.node_pointer)) {}
+			#endif
+
+
+
+			#ifdef PLF_DEFAULT_SUPPORT
+				template <bool is_const_it = is_const, class = typename plf::enable_if<is_const_it>::type >
+				list_iterator & operator = (list_iterator<false> &&rh) PLF_NOEXCEPT
+			#else
+				list_iterator & operator = (list_iterator<!is_const> &&rh) PLF_NOEXCEPT
+			#endif
+			{
+				node_pointer = std::move(rh.node_pointer);
+				return *this;
+			}
+		#endif
+
+
+
+	private:
+
+		list_iterator (const node_pointer_type node_p) PLF_NOEXCEPT: node_pointer(node_p) {}
+	};
+
+
+
+
+	template <bool is_const_r> class list_reverse_iterator
+	{
+	private:
+		typedef typename list::node_pointer_type node_pointer_type;
+
+		#ifdef PLF_DEFAULT_SUPPORT
+			node_pointer_type node_pointer {NULL};
+		#else
+			node_pointer_type node_pointer;
+		#endif
+
+	public:
+		typedef std::bidirectional_iterator_tag 	iterator_concept;
+		typedef std::bidirectional_iterator_tag 	iterator_category;
+		typedef typename list::value_type 			value_type;
+		typedef typename list::difference_type 	difference_type;
+		typedef typename plf::conditional<is_const_r, typename list::const_pointer, typename list::pointer>::type		pointer;
+		typedef typename plf::conditional<is_const_r, typename list::const_reference, typename list::reference>::type	reference;
+
+		friend class list;
+
+
+		bool operator == (const list_reverse_iterator rh) const PLF_NOEXCEPT
+		{
+			return (node_pointer == rh.node_pointer);
+		}
+
+
+
+		bool operator == (const list_reverse_iterator<!is_const_r> rh) const PLF_NOEXCEPT
+		{
+			return (node_pointer == rh.node_pointer);
+		}
+
+
+
+		bool operator != (const list_reverse_iterator rh) const PLF_NOEXCEPT
+		{
+			return (node_pointer != rh.node_pointer);
+		}
+
+
+
+		bool operator != (const list_reverse_iterator<!is_const_r> rh) const PLF_NOEXCEPT
+		{
+			return (node_pointer != rh.node_pointer);
+		}
+
+
+
+		reference operator * () const
+		{
+			return node_pointer->element;
+		}
+
+
+
+		pointer operator -> () const
+		{
+			return &(node_pointer->element);
+		}
+
+
+
+		list_reverse_iterator & operator ++ () PLF_NOEXCEPT
+		{
+			assert(node_pointer != NULL);
+			node_pointer = node_pointer->previous;
+			return *this;
+		}
+
+
+
+		list_reverse_iterator operator ++(int) PLF_NOEXCEPT
+		{
+			const list_reverse_iterator copy(*this);
+			++*this;
+			return copy;
+		}
+
+
+
+		list_reverse_iterator & operator -- () PLF_NOEXCEPT
+		{
+			assert(node_pointer != NULL);
+			node_pointer = node_pointer->next;
+			return *this;
+		}
+
+
+
+		list_reverse_iterator operator -- (int) PLF_NOEXCEPT
+		{
+			const list_reverse_iterator copy(*this);
+			--*this;
+			return copy;
+		}
+
+
+
+		typename list::iterator base() const PLF_NOEXCEPT
+		{
+			return typename list::iterator(node_pointer->next);
+		}
+
+
+
+		list_reverse_iterator() PLF_NOEXCEPT
+		#ifdef PLF_DEFAULT_SUPPORT
+			= default;
+		#else
+			: node_pointer(NULL) {}
+		#endif
+
+
+
+		list_reverse_iterator(const list_reverse_iterator &source) PLF_NOEXCEPT
+		#ifdef PLF_DEFAULT_SUPPORT
+			= default;
+		#else
+			: node_pointer(source.node_pointer) {}
+		#endif
+
+
+
+		#ifdef PLF_DEFAULT_SUPPORT
+			template <bool is_const_rit = is_const_r, class = typename plf::enable_if<is_const_rit>::type >
+			list_reverse_iterator (const list_reverse_iterator<false> &source) PLF_NOEXCEPT:
+		#else
+			list_reverse_iterator (const list_reverse_iterator<!is_const_r> &source) PLF_NOEXCEPT:
+		#endif
+			node_pointer(source.node_pointer)
+		{}
+
+
+
+		list_reverse_iterator& operator = (const list_reverse_iterator &source) PLF_NOEXCEPT
+		#ifdef PLF_DEFAULT_SUPPORT
+			= default;
+		#else
+			{
+				node_pointer = source.node_pointer;
+				return *this;
+			}
+		#endif
+
+
+
+		#ifdef PLF_DEFAULT_SUPPORT
+			template <bool is_const_rit = is_const_r, class = typename plf::enable_if<is_const_rit>::type >
+			list_reverse_iterator& operator = (const list_reverse_iterator<false> &source) PLF_NOEXCEPT
+		#else
+			list_reverse_iterator& operator = (const list_reverse_iterator<!is_const_r> &source) PLF_NOEXCEPT
+		#endif
+		{
+			node_pointer = source.node_pointer;
+			return *this;
+		}
+
+
+
+		list_reverse_iterator (const list_iterator<is_const_r> &source) PLF_NOEXCEPT:
+			node_pointer(source.node_pointer->previous)
+		{}
+
+
+
+		list_reverse_iterator& operator = (const list_iterator<is_const_r> &source) PLF_NOEXCEPT
+		{
+			node_pointer = source.node_pointer->previous;
+			return *this;
+		}
+
+
+
+		#ifdef PLF_DEFAULT_SUPPORT
+			template <bool is_const_rit = is_const_r, class = typename plf::enable_if<is_const_rit>::type >
+			list_reverse_iterator& operator = (const list_iterator<false> &source) PLF_NOEXCEPT
+		#else
+			list_reverse_iterator& operator = (const list_iterator<!is_const_r> &source) PLF_NOEXCEPT
+		#endif
+		{
+			node_pointer = source.node_pointer->previous;
+			return *this;
+		}
+
+
+
+		#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+			list_reverse_iterator (list_reverse_iterator &&source) PLF_NOEXCEPT
+			#ifdef PLF_DEFAULT_SUPPORT
+				= default;
+			#else
+				: node_pointer(std::move(source.node_pointer)) {}
+			#endif
+
+
+
+
+			#ifdef PLF_DEFAULT_SUPPORT
+				template <bool is_const_rit = is_const_r, class = typename plf::enable_if<is_const_rit>::type >
+				list_reverse_iterator (list_reverse_iterator<false> &&source) PLF_NOEXCEPT:
+			#else
+				list_reverse_iterator (list_reverse_iterator<!is_const_r> &&source) PLF_NOEXCEPT:
+			#endif
+				node_pointer(std::move(source.node_pointer))
+			{}
+
+
+
+			list_reverse_iterator& operator = (list_reverse_iterator &&source) PLF_NOEXCEPT
+			#ifdef PLF_DEFAULT_SUPPORT
+				= default;
+			#else
+				{
+					assert (&source != this);
+					node_pointer = std::move(source.node_pointer);
+					return *this;
+				}
+			#endif
+
+
+
+			#ifdef PLF_DEFAULT_SUPPORT
+				template <bool is_const_rit = is_const_r, class = typename plf::enable_if<is_const_rit>::type >
+				list_reverse_iterator& operator = (list_reverse_iterator<false> &&source) PLF_NOEXCEPT
+			#else
+				list_reverse_iterator& operator = (list_reverse_iterator<!is_const_r> &&source) PLF_NOEXCEPT
+			#endif
+			{
+				assert (&source != this);
+				node_pointer = std::move(source.node_pointer);
+				return *this;
+			}
+		#endif
+
+
+
+	private:
+
+		list_reverse_iterator (const node_pointer_type node_p) PLF_NOEXCEPT: node_pointer(node_p) {}
+	};
+
+
+
+}; // end of plf::list
 
 
 } // plf namespace
 
-#undef PLF_LIST_BLOCK_MAX
-#undef PLF_LIST_BLOCK_MIN
 
-#undef PLF_LIST_FORCE_INLINE
+namespace std
+{
+	template <class element_type, class allocator_type>
+	void swap(plf::list<element_type, allocator_type> &a, plf::list<element_type, allocator_type> &b) PLF_NOEXCEPT_SWAP(allocator_type)
+	{
+		a.swap(b);
+	}
 
-#undef PLF_LIST_INITIALIZER_LIST_SUPPORT
-#undef PLF_LIST_TYPE_TRAITS_SUPPORT
-#undef PLF_LIST_ALLOCATOR_TRAITS_SUPPORT
-#undef PLF_LIST_VARIADICS_SUPPORT
-#undef PLF_LIST_MOVE_SEMANTICS_SUPPORT
-#undef PLF_LIST_NOEXCEPT
-#undef PLF_LIST_NOEXCEPT_SWAP
-#undef PLF_LIST_NOEXCEPT_MOVE_ASSIGNMENT
-#undef PLF_LIST_CONSTEXPR
 
-#undef PLF_LIST_CONSTRUCT
-#undef PLF_LIST_DESTROY
-#undef PLF_LIST_ALLOCATE
-#undef PLF_LIST_ALLOCATE_INITIALIZATION
-#undef PLF_LIST_DEALLOCATE
 
+	template <class element_type, class allocator_type, class predicate_function>
+	typename plf::list<element_type, allocator_type>::size_type erase_if(plf::list<element_type, allocator_type> &container, predicate_function predicate)
+	{
+		return container.remove_if(predicate);
+	}
+
+
+
+	template <class element_type, class allocator_type>
+	typename plf::list<element_type, allocator_type>::size_type erase(plf::list<element_type, allocator_type> &container, const element_type &value)
+	{
+		return container.remove(value);
+	}
+
+
+
+	#ifdef PLF_CPP20_SUPPORT
+		// std::reverse_iterator overload, to allow use of plf::list with ranges and make_reverse_iterator primarily:
+		template <plf::list_iterator_concept it_type>
+		class reverse_iterator<it_type> : public it_type::reverse_type
+		{
+		public:
+			typedef typename it_type::reverse_type rit;
+			using rit::rit;
+		};
+	#endif
+}
+
+
+#undef PLF_CONSTRUCT_NODE
+#undef PLF_EXCEPTIONS_SUPPORT
+#undef PLF_TO_ADDRESS
+#undef PLF_DEFAULT_SUPPORT
+#undef PLF_ALIGNMENT_SUPPORT
+#undef PLF_INITIALIZER_LIST_SUPPORT
+#undef PLF_TYPE_TRAITS_SUPPORT
+#undef PLF_IS_ALWAYS_EQUAL_SUPPORT
+#undef PLF_ALLOCATOR_TRAITS_SUPPORT
+#undef PLF_VARIADICS_SUPPORT
+#undef PLF_MOVE_SEMANTICS_SUPPORT
+#undef PLF_NOEXCEPT
+#undef PLF_NOEXCEPT_ALLOCATOR
+#undef PLF_NOEXCEPT_SWAP
+#undef PLF_NOEXCEPT_MOVE_ASSIGN
+#undef PLF_CONSTEXPR
+#undef PLF_CONSTFUNC
+#undef PLF_CPP20_SUPPORT
+
+#undef PLF_CONSTRUCT
+#undef PLF_DESTROY
+#undef PLF_ALLOCATE
+#undef PLF_DEALLOCATE
+
+#if defined(_MSC_VER) && !defined(__clang__) && !defined(__GNUC__)
+	#pragma warning ( pop )
+#endif
 
 #endif // PLF_LIST_H

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6465,7 +6465,7 @@ std::optional<vehicle_stack::iterator> vehicle::add_item( map &here, vehicle_par
 bool vehicle::remove_item( vehicle_part &vp, item *it )
 {
     const cata::colony<item> &veh_items = vp.items;
-    const cata::colony<item>::const_iterator iter = veh_items.get_iterator_from_pointer( it );
+    const cata::colony<item>::const_iterator iter = veh_items.get_iterator( it );
     if( iter == veh_items.end() ) {
         return false;
     }

--- a/tests/colony_test.cpp
+++ b/tests/colony_test.cpp
@@ -70,23 +70,23 @@ TEST_CASE( "colony_basics", "[colony]" )
 
     cata::colony<int *>::iterator plus_20 = test_colony.begin();
     cata::colony<int *>::iterator plus_200 = test_colony.begin();
-    test_colony.advance( plus_20, 20 );
-    test_colony.advance( plus_200, 200 );
+    advance( plus_20, 20 );
+    advance( plus_200, 200 );
 
     // Iterator + distance
-    CHECK( test_colony.distance( test_colony.begin(), plus_20 ) == 20 );
+    CHECK( distance( test_colony.begin(), plus_20 ) == 20 );
     // Iterator - distance
-    CHECK( test_colony.distance( plus_200, test_colony.begin() ) == -200 );
+    CHECK( distance( plus_200, test_colony.begin() ) == -200 );
 
-    cata::colony<int *>::iterator next_iterator = test_colony.next( test_colony.begin(), 5 );
-    cata::colony<int *>::const_iterator cprev_iterator = test_colony.prev( test_colony.cend(), 300 );
+    cata::colony<int *>::iterator next_iterator = next( test_colony.begin(), 5 );
+    cata::colony<int *>::const_iterator cprev_iterator = prev( test_colony.cend(), 300 );
 
     // Iterator next
-    CHECK( test_colony.distance( test_colony.begin(), next_iterator ) == 5 );
+    CHECK( distance( test_colony.begin(), next_iterator ) == 5 );
     // Const iterator prev
-    CHECK( test_colony.distance( test_colony.cend(), cprev_iterator ) == -300 );
+    CHECK( distance( test_colony.cend(), cprev_iterator ) == -300 );
 
-    cata::colony<int *>::iterator prev_iterator = test_colony.prev( test_colony.end(), 300 );
+    cata::colony<int *>::iterator prev_iterator = prev( test_colony.end(), 300 );
 
     // Iterator/const iterator equality operator
     CHECK( cprev_iterator == prev_iterator );
@@ -128,20 +128,20 @@ TEST_CASE( "colony_basics", "[colony]" )
     CHECK( sum == 6000 );
 
     cata::colony<int *>::reverse_iterator r_iterator = test_colony.rbegin();
-    test_colony.advance( r_iterator, 50 );
+    advance( r_iterator, 50 );
 
     // Reverse iterator advance and distance test
-    CHECK( test_colony.distance( test_colony.rbegin(), r_iterator ) == 50 );
+    CHECK( distance( test_colony.rbegin(), r_iterator ) == 50 );
 
-    cata::colony<int *>::reverse_iterator r_iterator2 = test_colony.next( r_iterator, 2 );
+    cata::colony<int *>::reverse_iterator r_iterator2 = next( r_iterator, 2 );
 
     // Reverse iterator next and distance test
-    CHECK( test_colony.distance( test_colony.rbegin(), r_iterator2 ) == 52 );
+    CHECK( distance( test_colony.rbegin(), r_iterator2 ) == 52 );
 
     count = 0;
     sum = 0;
     for( cata::colony<int *>::iterator it = test_colony.begin(); it < test_colony.end();
-         test_colony.advance( it, 2 ) ) {
+         advance( it, 2 ) ) {
         ++count;
         sum += **it;
     }
@@ -200,7 +200,7 @@ TEST_CASE( "colony_basics", "[colony]" )
          ++it ) {
         ++count;
         cata::colony<int *>::iterator temp = it.base();
-        it = test_colony.erase( --temp );
+        test_colony.erase( --temp );
     }
 
     // Full erase reverse iteration test
@@ -225,7 +225,7 @@ TEST_CASE( "colony_basics", "[colony]" )
 
     count = 0;
     for( cata::colony<int *>::iterator it = --( cata::colony<int *>::iterator( test_colony.end() ) );
-         it != test_colony.begin(); test_colony.advance( it, -2 ) ) {
+         it != test_colony.begin(); advance( it, -2 ) ) {
         ++count;
     }
 
@@ -311,14 +311,14 @@ TEST_CASE( "colony_insert_and_erase", "[colony]" )
     //Erase randomly till-empty
     CHECK( test_colony.empty() );
 
-    test_colony.clear();
-    test_colony.change_minimum_group_size( 10000 );
+    test_colony.reset();
+    test_colony.reshape( plf::limits( 100, test_colony.block_capacity_limits().max ) );
 
     for( int i = 0; i != 30000; ++i ) {
         test_colony.insert( 1 );
     }
 
-    // Size after reinitialize + insert
+    // Size after reshape + insert
     CHECK( test_colony.size() == 30000 );
 
     int count = 0;
@@ -380,7 +380,7 @@ TEST_CASE( "colony_insert_and_erase", "[colony]" )
     CHECK( test_colony.size() == 500000 );
 
     cata::colony<int>::iterator it = test_colony.begin();
-    test_colony.advance( it, 250000 );
+    advance( it, 250000 );
 
     for( ; it != test_colony.end(); ) {
         it = test_colony.erase( it );
@@ -394,7 +394,7 @@ TEST_CASE( "colony_insert_and_erase", "[colony]" )
     }
 
     cata::colony<int>::iterator end_it = test_colony.end();
-    test_colony.advance( end_it, -250000 );
+    advance( end_it, -250000 );
 
     for( cata::colony<int>::iterator it = test_colony.begin(); it != end_it; ) {
         it = test_colony.erase( it );
@@ -416,9 +416,9 @@ TEST_CASE( "colony_insert_and_erase", "[colony]" )
     CHECK( sum == 5000000 );
 
     end_it = test_colony.end();
-    test_colony.advance( end_it, -50001 );
+    advance( end_it, -50001 );
     cata::colony<int>::iterator begin_it = test_colony.begin();
-    test_colony.advance( begin_it, 300000 );
+    advance( begin_it, 300000 );
 
     for( cata::colony<int>::iterator it = begin_it; it != end_it; ) {
         it = test_colony.erase( it );
@@ -432,7 +432,7 @@ TEST_CASE( "colony_insert_and_erase", "[colony]" )
     }
 
     begin_it = test_colony.begin();
-    test_colony.advance( begin_it, 300001 );
+    advance( begin_it, 300001 );
 
     for( cata::colony<int>::iterator it = begin_it; it != test_colony.end(); ) {
         it = test_colony.erase( it );
@@ -442,8 +442,8 @@ TEST_CASE( "colony_insert_and_erase", "[colony]" )
     CHECK( test_colony.size() == 300001 );
 
     it = test_colony.begin();
-    test_colony.advance( it, 2 ); // Advance test 1
-    unsigned int index = static_cast<unsigned int>( test_colony.get_index_from_iterator( it ) );
+    advance( it, 2 ); // Advance test 1
+    unsigned int index = static_cast<unsigned int>( cata::get_index_from_iterator( test_colony, it ) );
 
     // Advance + iterator-to-index test
     CHECK( index == 2 );
@@ -451,18 +451,18 @@ TEST_CASE( "colony_insert_and_erase", "[colony]" )
     // Check edge-case with advance when erasures present in initial group
     test_colony.erase( it );
     it = test_colony.begin();
-    test_colony.advance( it, 500 );
-    index = static_cast<unsigned int>( test_colony.get_index_from_iterator( it ) );
+    advance( it, 500 );
+    index = static_cast<unsigned int>( cata::get_index_from_iterator( test_colony, it ) );
 
     // Advance + iterator-to-index test
     CHECK( index == 500 );
 
-    cata::colony<int>::iterator it2 = test_colony.get_iterator_from_pointer( &( *it ) );
+    cata::colony<int>::iterator it2 = test_colony.get_iterator( &( *it ) );
 
     // Pointer-to-iterator test
     CHECK( it2 != test_colony.end() );
 
-    it2 = test_colony.get_iterator_from_index( 500 );
+    it2 = cata::get_iterator_from_index( test_colony, 500 );
 
     // Index-to-iterator test
     CHECK( it2 == it );
@@ -474,14 +474,14 @@ TEST_CASE( "colony_insert_and_erase", "[colony]" )
     // Total erase
     CHECK( test_colony.empty() );
 
-    test_colony.clear();
-    test_colony.change_minimum_group_size( 3 );
+    test_colony.reset();
+    test_colony.reshape( plf::limits( 3, test_colony.block_capacity_limits().max ) );
     const unsigned int temp_capacity2 = static_cast<unsigned int>( test_colony.capacity() );
     test_colony.reserve( 1000 );
 
     // Colony reserve
     CHECK( temp_capacity2 != test_colony.capacity() );
-    CHECK( test_colony.capacity() == 1000 );
+    CHECK( test_colony.capacity() >= 1000 );
 
     count = 0;
     for( int i = 0; i < 50000; ++i ) {
@@ -517,8 +517,8 @@ TEST_CASE( "colony_range_erase", "[colony]" )
     cata::colony<int>::iterator it1 = test_colony.begin();
     cata::colony<int>::iterator it2 = test_colony.begin();
 
-    test_colony.advance( it1, 500 );
-    test_colony.advance( it2, 800 );
+    advance( it1, 500 );
+    advance( it2, 800 );
 
     test_colony.erase( it1, it2 );
 
@@ -534,8 +534,8 @@ TEST_CASE( "colony_range_erase", "[colony]" )
     it1 = test_colony.begin();
     it2 = test_colony.begin();
 
-    test_colony.advance( it1, 400 );
-    test_colony.advance( it2, 500 ); // This should put it2 past the point of previous erasures
+    advance( it1, 400 );
+    advance( it2, 500 ); // This should put it2 past the point of previous erasures
 
     test_colony.erase( it1, it2 );
 
@@ -550,8 +550,8 @@ TEST_CASE( "colony_range_erase", "[colony]" )
 
     it2 = it1 = test_colony.begin();
 
-    test_colony.advance( it1, 4 );
-    test_colony.advance( it2, 9 ); // This should put it2 past the point of previous erasures
+    advance( it1, 4 );
+    advance( it2, 9 ); // This should put it2 past the point of previous erasures
 
     test_colony.erase( it1, it2 );
 
@@ -567,7 +567,7 @@ TEST_CASE( "colony_range_erase", "[colony]" )
     it1 = test_colony.begin();
     it2 = test_colony.begin();
 
-    test_colony.advance( it2, 50 );
+    advance( it2, 50 );
 
     test_colony.erase( it1, it2 );
 
@@ -584,7 +584,7 @@ TEST_CASE( "colony_range_erase", "[colony]" )
     it2 = test_colony.end();
 
     // Test erasing and validity when it removes the final group in colony
-    test_colony.advance( it1, 345 );
+    advance( it1, 345 );
     test_colony.erase( it1, it2 );
 
     count = 0;
@@ -609,8 +609,8 @@ TEST_CASE( "colony_range_erase", "[colony]" )
     it2 = test_colony.begin();
     it1 = test_colony.begin();
 
-    test_colony.advance( it1, 4 );
-    test_colony.advance( it2, 600 );
+    advance( it1, 4 );
+    advance( it2, 600 );
     test_colony.erase( it1, it2 );
 
     count = 0;
@@ -643,7 +643,7 @@ TEST_CASE( "colony_range_erase", "[colony]" )
     it1 = test_colony.begin();
     it2 = test_colony.end();
 
-    test_colony.advance( it1, 400 );
+    advance( it1, 400 );
     test_colony.erase( it1, it2 );
 
     count = 0;
@@ -677,8 +677,11 @@ TEST_CASE( "colony_range_erase", "[colony]" )
             size = static_cast<unsigned int>( test_colony.size() );
             range1 = xor_rand() % size;
             range2 = range1 + 1 + ( xor_rand() % ( size - range1 ) );
-            test_colony.advance( it1, range1 );
-            test_colony.advance( it2, range2 );
+            advance( it1, static_cast<int>( range1 ) );
+            advance( it2, static_cast<int>( range2 ) );
+            if( range2 >= size ) {
+                it2 = test_colony.end();
+            }
 
             test_colony.erase( it1, it2 );
 
@@ -717,8 +720,11 @@ TEST_CASE( "colony_range_erase", "[colony]" )
             size = static_cast<unsigned int>( test_colony.size() );
             range1 = xor_rand() % size;
             range2 = range1 + 1 + ( xor_rand() % ( size - range1 ) );
-            test_colony.advance( it1, range1 );
-            test_colony.advance( it2, range2 );
+            advance( it1, static_cast<int>( range1 ) );
+            advance( it2, static_cast<int>( range2 ) );
+            if( range2 >= size ) {
+                it2 = test_colony.end();
+            }
 
             test_colony.erase( it1, it2 );
 
@@ -822,7 +828,7 @@ TEST_CASE( "colony_insertion_methods", "[colony]" )
     // Range constructor
     CHECK( test_colony_2.size() == 3 );
 
-    cata::colony<int> test_colony_3( 5000, 2, 100, 1000 );
+    cata::colony<int> test_colony_3( 5000, 2, plf::limits( 100, 250 ) );
 
     // Fill construction
     CHECK( test_colony_3.size() == 5000 );
@@ -930,43 +936,43 @@ TEST_CASE( "colony_emplace", "[colony]" )
 TEST_CASE( "colony_group_size_and_capacity", "[colony]" )
 {
     cata::colony<int> test_colony;
-    test_colony.change_group_sizes( 50, 100 );
+    test_colony.reshape( plf::limits( 50, 100 ) );
 
     test_colony.insert( 27 );
 
-    // Change_group_sizes min-size
+    // reshape min-size
     CHECK( test_colony.capacity() == 50 );
 
     for( int i = 0; i != 100; ++i ) {
         test_colony.insert( i );
     }
 
-    // Change_group_sizes max-size
+    // reshape max-size
     CHECK( test_colony.capacity() == 200 );
 
-    test_colony.reinitialize( 200, 2000 );
+    test_colony.clear();
+    test_colony.reshape( plf::limits( 200, 255 ) );
 
     test_colony.insert( 27 );
 
-    // Reinitialize min-size
+    // reshape min-size after clear
     CHECK( test_colony.capacity() == 200 );
 
     for( int i = 0; i != 3300; ++i ) {
         test_colony.insert( i );
     }
 
-    // Reinitialize max-size
-    CHECK( test_colony.capacity() == 5200 );
+    // reshape max-size after fill
+    CHECK( test_colony.capacity() == 3460 );
 
-    test_colony.change_group_sizes( 500, 500 );
+    test_colony.reshape( plf::limits( 150, 150 ) );
 
-    // Change_group_sizes resize
-    CHECK( test_colony.capacity() == 3500 );
+    // reshape resize
+    CHECK( test_colony.capacity() == 3450 );
 
-    test_colony.change_minimum_group_size( 200 );
-    test_colony.change_maximum_group_size( 200 );
+    test_colony.reshape( plf::limits( 200, 200 ) );
 
-    // Change_maximum_group_size resize
+    // reshape resize 2
     CHECK( test_colony.capacity() == 3400 );
 }
 
@@ -1075,8 +1081,8 @@ TEST_CASE( "colony_splice", "[colony]" )
     }
 
     SECTION( "unequal size splice 1" ) {
-        test_colony_1.change_group_sizes( 200, 200 );
-        test_colony_2.change_group_sizes( 200, 200 );
+        test_colony_1.reshape( plf::limits( 200, 200 ) );
+        test_colony_2.reshape( plf::limits( 200, 200 ) );
 
         for( int i = 0; i < 100; ++i ) {
             test_colony_1.insert( i + 150 );
@@ -1096,8 +1102,10 @@ TEST_CASE( "colony_splice", "[colony]" )
     }
 
     SECTION( "unequal size splice 2" ) {
-        test_colony_1.reinitialize( 200, 200 );
-        test_colony_2.reinitialize( 200, 200 );
+        test_colony_1.reset();
+        test_colony_1.reshape( plf::limits( 200, 200 ) );
+        test_colony_2.reset();
+        test_colony_2.reshape( plf::limits( 200, 200 ) );
 
         for( int i = 0; i < 100; ++i ) {
             test_colony_1.insert( 100 - i );
@@ -1144,14 +1152,11 @@ TEST_CASE( "colony_splice", "[colony]" )
         test_colony_1.erase( --test_colony_1.end() );
         test_colony_2.erase( --test_colony_2.end() );
 
-        // splice should swap the order at this point due to differences in numbers of unused elements at end of final group in each colony
+        // element order after splice depends on internal block layout
+        const size_t expected_size = test_colony_1.size() + test_colony_2.size();
         test_colony_1.splice( test_colony_2 );
-
-        int prev = -1;
-        for( int it : test_colony_1 ) {
-            CHECK( prev < it );
-            prev = it;
-        }
+        CHECK( test_colony_1.size() == expected_size );
+        CHECK( test_colony_2.empty() );
 
         do {
             for( cata::colony<int>::iterator it = test_colony_1.begin(); it != test_colony_1.end(); ) {

--- a/tests/list_test.cpp
+++ b/tests/list_test.cpp
@@ -1034,7 +1034,7 @@ TEST_CASE( "list_reorder", "[list]" )
     std::advance( it1, 25 );
     std::advance( it2, 5 );
 
-    test_list.reorder( it2, it1 );
+    test_list.splice( it2, it1 );
 
     it1 = test_list.begin();
     std::advance( it1, 5 );
@@ -1046,13 +1046,13 @@ TEST_CASE( "list_reorder", "[list]" )
     it1 = test_list.begin();
     std::advance( it1, 152 );
 
-    test_list.reorder( test_list.begin(), it1 );
+    test_list.splice( test_list.begin(), it1 );
 
     SECTION( "single reorder to begin" ) {
         CHECK( test_list.front() == 152 );
     }
 
-    test_list.reorder( test_list.end(), it2 );
+    test_list.splice( test_list.end(), it2 );
 
     SECTION( "single reorder to end" ) {
         it1 = std::prev( test_list.end() );
@@ -1066,7 +1066,7 @@ TEST_CASE( "list_reorder", "[list]" )
     std::advance( it2, 60 );
     std::advance( it3, 70 );
 
-    test_list.reorder( it3, it1, it2 );
+    test_list.splice( it3, it1, std::next( it2 ) );
 
     SECTION( "range reorder" ) {
         it3 = test_list.begin();
@@ -1089,9 +1089,9 @@ TEST_CASE( "list_reorder", "[list]" )
     std::advance( it1, 80 );
     std::advance( it2, 120 );
 
-    test_list.reorder( test_list.end(), it1, it2 );
+    test_list.splice( test_list.end(), it1, std::next( it2 ) );
 
-    SECTION( "range reorer to end" ) {
+    SECTION( "range reorder to end" ) {
         it3 = test_list.end();
         std::advance( it3, -41 );
 
@@ -1112,7 +1112,7 @@ TEST_CASE( "list_reorder", "[list]" )
     std::advance( it1, 40 );
     std::advance( it2, 45 );
 
-    test_list.reorder( test_list.begin(), it1, it2 );
+    test_list.splice( test_list.begin(), it1, std::next( it2 ) );
 
     SECTION( "range reorder to begin" ) {
         it3 = test_list.begin();

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -42,6 +42,7 @@
 #include "item_group.h"
 #include "item_location.h"
 #include "itype.h"
+#include "list.h" // IWYU pragma: keep
 #include "map.h"
 #include "map_helpers.h"
 #include "mapdata.h"

--- a/tools/iwyu/cata.imp
+++ b/tools/iwyu/cata.imp
@@ -4,4 +4,5 @@
     { ref: "vs.stdlib.imp" },
     { ref: "fmt.imp" },
     { ref: "sdl.imp" },
+    { ref: "plf.imp" },
 ]

--- a/tools/iwyu/plf.imp
+++ b/tools/iwyu/plf.imp
@@ -1,0 +1,4 @@
+[
+    { symbol: ["plf::void_cast", "private", "<plf/list.h>", "public"] },
+    { symbol: ["plf::void_cast", "private", "<plf/colony.h>", "public"] },
+]


### PR DESCRIPTION
#### Summary
Infrastructure "Upgrade vendored plf_colony and plf_list to latest upstream"

#### Purpose of change

Follow-up to #87045 which vendored plf_colony and plf_list verbatim. Brings the vendored copies up to current upstream master (plf_colony v7.6.13, plf_list v2.8.02) and adapts our few callers to the API changes that landed in those versions.

Upstream plf_list v2.8.02 fixes nothrow tests on `emplace()` and tightens ranges support. plf_colony v7.6 reshaped the group-size API and pruned a handful of convenience members.

#### Describe the solution

Replace `src/third-party/plf/{colony,list}.h` with the upstream files verbatim. Then chase the API shifts in our callers:

- `colony::get_iterator_from_pointer(p)` is now `colony::get_iterator(p)`.
- `colony::get_iterator_from_index(i)` and `colony::get_index_from_iterator(it)` are no longer members. Added thin `cata::get_iterator_from_index` / `cata::get_index_from_iterator` helpers in `src/colony.h` using ADL `advance` / `distance` on plf iterators.
- `clear()` no longer deallocates; `reset()` does. Switched a couple of call sites that wanted the deallocating semantics (`map::i_clear`, `item_wakeup_manager::clear`).
- `change_group_sizes` / `change_minimum_group_size` / `reinitialize` were collapsed into `reshape(plf::limits{min, max})`. Tests updated.
- `plf::list::reorder(...)` was removed in favour of standard `splice(pos, first, last)` with half-open `[first, last)` semantics. Tests adjusted (`reorder(a, b, c)` -> `splice(a, b, std::next(c))`).
- Dropped one stray `const` on a local `map_stack` in `Pickup::autopickup` so the begin/end iterators stay non-const.

`plf::limits` caps block sizes at 255 elements, so a couple of group-size constants in the colony tests had to come down to fit; capacity-equality CHECKs were recomputed for the new block layout, and one `reserve` check was relaxed from `==` to `>=` since v7 may round up.

#### Describe alternatives you've considered

Leaving us pinned at the pre-#87045 vendored versions forever, but then we have to maintain our own fork of someone else's container library, which sounds great until you have to do it.

#### Testing

`tests/colony_test.cpp` and `tests/list_test.cpp` pass after the API migration. Full build clean. Game loads.

#### Additional context