### PR TITLE
Show monster difficulty rating in the look panel

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -908,6 +908,12 @@ int monster::print_info( const catacurses::window &w, int vStart, int vLines, in
                                        type->speed_desc );
     vStart += fold_and_print( w, point( column, vStart ), max_width, c_white, speed_desc );
 
+    // Difficulty indicator in the fourth line.
+    const std::string difficulty_str = debug_mode ?
+                                       _( "Difficulty " ) + std::to_string( type->get_total_difficulty() ) :
+                                       type->get_difficulty_description();
+    vStart += fold_and_print( w, point( column, vStart ), max_width, c_white, difficulty_str );
+
     // Monster description on following lines.
     std::vector<std::string> lines = foldstring( type->get_description(), max_width );
     int numlines = lines.size();

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -892,7 +892,13 @@ int monster::print_info( const catacurses::window &w, int vStart, int vLines, in
         mvwprintz( w, point( column, vStart++ ), att.second, att.first );
     }
 
-    // Awareness indicator in the third line.
+    // Difficulty indicator in the third line.
+    const std::string difficulty_str = debug_mode ?
+                                       _( "Difficulty " ) + std::to_string( type->get_total_difficulty() ) :
+                                       type->get_difficulty_description();
+    vStart += fold_and_print( w, point( column, vStart ), max_width, c_white, difficulty_str );
+
+    // Awareness indicator in the fourth line.
     std::string senses_str = sees_player ? _( "Can see to your current location" ) :
                              _( "Can't see to your current location" );
 
@@ -907,12 +913,6 @@ int monster::print_info( const catacurses::window &w, int vStart, int vLines, in
                                        has_flag( mon_flag_IMMOBILE ) || has_flag( json_flag_CANNOT_MOVE ),
                                        type->speed_desc );
     vStart += fold_and_print( w, point( column, vStart ), max_width, c_white, speed_desc );
-
-    // Difficulty indicator in the fourth line.
-    const std::string difficulty_str = debug_mode ?
-                                       _( "Difficulty " ) + std::to_string( type->get_total_difficulty() ) :
-                                       type->get_difficulty_description();
-    vStart += fold_and_print( w, point( column, vStart ), max_width, c_white, difficulty_str );
 
     // Monster description on following lines.
     std::vector<std::string> lines = foldstring( type->get_description(), max_width );


### PR DESCRIPTION
#### Summary
Interface "Show monster difficulty rating in the look panel"

#### Purpose of change
The only quick visual indicator of a creature's threat level is its name color. More specific difficulty info is available in the extended UI, but this is vital information when deciding whether to engage and shouldn't require extra menu navigation. This change surfaces it directly in the look panel.

#### Describe the solution
Show the monster difficulty rating in the look panel, just above the awareness indicator; it gives the player a better idea of the threat level without having to navigate into an extra menu.

<img width="646" height="335" alt="Screenshot 2026-05-19 190911" src="https://github.com/user-attachments/assets/0283cf4a-0e27-476f-9c66-34592821ac53" />

#### Describe alternatives you've considered
None.

#### Testing
Compiled on Windows. 
Examined creatures of various difficulty and confirmed the rating displayed correctly with appropriate colors.

#### Additional context
None.