### PR TITLE
Add gyrocopter rotor

### DIFF
--- a/data/json/items/vehicle/rotor.json
+++ b/data/json/items/vehicle/rotor.json
@@ -28,5 +28,20 @@
     "material": [ "mc_steel" ],
     "symbol": "X",
     "color": "blue"
+  },
+  {
+    "id": "small_gyrocopter_rotor",
+    "type": "ITEM",
+    "category": "veh_parts",
+    "name": { "str": "small gyrocopter rotor", "str_pl": "sets of small gyrocopter rotor" },
+    "description": "A set of four rotor blades from a gyrocopter.",
+    "price": "180 USD",
+    "price_postapoc": "1550 USD",
+    "weight": "152500 g",
+    "volume": "152500 ml",
+    "looks_like": "xl_wind_turbine",
+    "material": [ "mc_steel" ],
+    "symbol": "X",
+    "color": "yellow"
   }
 ]

--- a/data/json/recipes/other/vehicle.json
+++ b/data/json/recipes/other/vehicle.json
@@ -184,5 +184,47 @@
     "using": [ [ "welding_standard", 30 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
     "components": [ [ [ "pipe", 6 ] ], [ [ "basket", 1 ] ], [ [ "pipe_fittings", 3 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "BRISK_EXERCISE",
+    "result": "small_gyrocopter_rotor",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_VEHICLE",
+    "skill_used": "fabrication",
+    "skills_required": [ "mechanics", 4 ],
+    "difficulty": 6,
+    "time": "14 h",
+    "proficiencies": [ 
+        { "proficiency": "prof_blacksmithing" },
+        { "proficiency": "prof_metalworking" },
+        { "proficiency": "prof_welding_basic" }
+      ],
+    "autolearn": true,
+    "using": [ 
+        [ "lc_steel_standard", 40 ],
+        [ "blacksmithing_standard", 80 ],
+        [ "metal_punch", 1 ]
+      ],
+      "qualities": [ 
+        { "id": "GLARE", "level": 1 },
+        { "id": "SCREW", "level": 1 },
+        { "id": "VISE", "level": 1 },
+        { "id": "WRENCH", "level": 2 },
+        { "id": "SAW_M", "level": 2 },
+        { "id": "GRIND", "level": 2 },
+        { "id": "HAMMER", "level": 3 },
+        { "id": "ANVIL", "level": 3 }
+      ],
+     "components": [ 
+        [ [ "nuts_bolts", 48 ] ],
+        [ [ "sheet_metal", 12 ] ],
+        [ [ "wheel_mount_medium", 1 ] ]
+      ],
+    "tools": [
+        [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
+        [ [ "hotcut_any", 1, "LIST" ] ],
+        [ [ "welder", 1900 ], [ "welding_kit", 1900 ], [ "welder_crude", 3450 ], [ "integrated_welder", 1900 ], [ "oxy_torch", 750 ] ]
+      ]
   }
 ]

--- a/data/json/vehicleparts/rotor.json
+++ b/data/json/vehicleparts/rotor.json
@@ -52,5 +52,27 @@
     "name": { "str": "heavy-duty military Osprey rotors" },
     "//": "rotor diameter is in meters",
     "rotor_diameter": 11
+  },
+  {
+    "id": "small_gyrocopter_rotor",
+    "type": "vehicle_part",
+    "item": "small_gyrocopter_rotor",
+    "description": "A set of four rotor blades from a gyrocopter.",
+    "//": "rotor diameter is in meters",
+    "categories": [ "movement" ],
+    "location": "on_roof",
+    "color": "light_blue",
+    "flags": [ "ROTOR" ],
+    "variants": [ { "symbols": "X", "symbols_broken": "O" } ],
+    "rotor_diameter": 8,
+    "durability": 150,
+    "damage_modifier": 80,
+    "requirements": { 
+        "install": { "skills": [ [ "mechanics", 6 ] ], "time": "4 h", "using": [ [ "welding_standard", 400 ], [ "vehicle_bolt_install", 2 ] ] },
+        "removal": { "skills": [ [ "mechanics", 4 ] ], "time": "2 h", "using": "vehicle_weld_removal" },
+        "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "1 h", "using": [ [ "repair_welding_lc_steel", 25 ] ] } 
+      },
+    "breaks_into": [ { "item": "scrap", "count": [ 8, 15 ] }, { "item": "ch_steel_chunk", "count": [ 2, 8 ] } ],
+    "damage_reduction": { "all": 22 }
   }
 ]


### PR DESCRIPTION
#### Summary

Content "Add gyrocopter rotor"

#### Purpose of change

Provides an accessible option for aerial transport in the late game.

#### Describe the solution

Added the item, crafting recipes, and vehicle parts **"small_gyrocopter_rotor"**.

#### Describe alternatives you've considered

None

#### Testing

1. Verified the crafting recipe.

2. Verified installation on a vehicle.

3. Verified flight functionality.

#### Additional context

An alternative balance for the recipe and installation might be needed. Also, I noticed that the **"prof_helicopter_pilot"** proficiency is not required to operate a vehicle with the gyrocopter rotor; however, once you install the gyrocopter rotor on your vehicle, you will not be able to modify the vehicle without the consequences of lacking the **"prof_aircraft_mechanic"** proficiency.
