### PR TITLE
Make varmint air rifle spawn

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -624,7 +624,8 @@
       [ "woven_anklet", 1 ],
       { "group": "tinware", "prob": 10 },
       { "group": "costume_all_clothing", "prob": 10 },
-      [ "cheongsam", 5 ]
+      [ "cheongsam", 5 ],
+      { "group": "ammo_varmint_airgun", "prob": 10 }
     ]
   },
   {
@@ -655,6 +656,7 @@
       [ "freeze_dried_meal", 20 ],
       [ "chocolate_military", 20 ],
       { "group": "infantry_knives", "prob": 14 },
+      { "item": "varmint_airgun", "prob": 2 },
       [ "knife_rm42", 1 ],
       [ "kukri", 2 ],
       [ "knife_KABAR", 6 ],

--- a/data/json/itemgroups/SUS/lodge.json
+++ b/data/json/itemgroups/SUS/lodge.json
@@ -31,6 +31,7 @@
       { "item": "win70", "prob": 20, "charges": [ 0, 3 ] },
       { "item": "henry_big_boy", "prob": 2, "charges": [ 0, 10 ] },
       { "item": "weatherby_5", "prob": 2, "charges": [ 0, 3 ] },
+      { "item": "varmint_airgun", "prob": 20, "charges": [ 0, 1 ] },
       { "item": "single_sling", "prob": 10 }
     ]
   },

--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -1332,5 +1332,14 @@
       { "group": "guns_pistol_common_display_357mag", "prob": 15, "charges": [ 0, 9 ] },
       { "group": "guns_pistol_common_display_40", "prob": 25, "charges": [ 0, 20 ] }
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "ammo_varmint_airgun",
+    "container-item": "box_small",
+    "items": [
+      { "item": "airgun_pellet_target", "charges": [ 0, 250 ], "prob": 50 },
+      { "item": "airgun_pellet_hunting", "charges": [ 0, 250 ], "prob": 50 }
+    ]
   }
 ]

--- a/data/json/itemgroups/activities_hobbies.json
+++ b/data/json/itemgroups/activities_hobbies.json
@@ -292,6 +292,8 @@
       { "group": "crossbow_bolts", "prob": 5 },
       { "group": "crossbow_bolts_makeshift", "prob": 7 },
       { "item": "bbgun", "prob": 10, "charges": [ 0, 150 ] },
+      { "item": "varmint_airgun", "prob": 20 },
+      { "group": "ammo_varmint_airgun", "prob": 20 },
       [ "crossbow", 2 ],
       [ "compcrossbow", 2 ],
       [ "mag_survival", 40 ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Closes #80359.
Wanted to get back into contributing so I am getting some low-hanging fruit on my to-do list.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Looked through itemgroups to find out where the air rifle should spawn, felt appropriate to add it to camping gear, sport supplies, and pawn stores. 
I also added a group for the ammo and spawned it in those locations as well.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Add it somewhere to gun spawns but those itemgroups scare me.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Game loads, weapon and ammo spawns in locations.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
