### PR TITLE
Fix safe in house_25

### DIFF
--- a/data/json/mapgen/house/house25.json
+++ b/data/json/mapgen/house/house25.json
@@ -23,7 +23,7 @@
         "..#|+|||+||         7o..",
         ".^#          |YéJJJ F#..",
         "..#|||||+||  ||||||||#..",
-        "..#      %|     |QY8B#..",
+        "..#      v|     |QY8B#..",
         "..o@@     ||+|| +   B#..",
         "..#@@EddDD|U q| |t8S8#..",
         "..##oo#oo######*######..",
@@ -34,9 +34,7 @@
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_landscaping_palette", "parametrized_carpets_palette" ],
       "terrain": { "~": { "param": "carpet_color_type", "fallback": "t_carpet_yellow" }, ",": "t_thconc_floor" },
       "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 1 } ],
-      "furniture": { "%": "f_safe_o" },
       "place_items": [
-        { "chance": 10, "item": "ammo_common_boxed", "x": 9, "y": 17 },
         { "chance": 20, "item": "camping", "x": 13, "y": 19 },
         { "chance": 40, "item": "tools_home", "x": 13, "y": 19 },
         { "chance": 25, "item": "book_gunref", "x": 5, "y": 4 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There was a bush spawning under the safe in `house_25`.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Replaced the symbol for the safe with the one defined in the domestic palette.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Game loads, safe spawns, items & terrain are correct.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
