### PR TITLE
[classic_zombies] Fix portable cassette player use action error

### DIFF
--- a/data/mods/classic_zombies/items/tools.json
+++ b/data/mods/classic_zombies/items/tools.json
@@ -16,8 +16,8 @@
     "use_action": [
       {
         "type": "mp3",
-        "transform": "You slip in a cassette, put on headphones, and start listening to music.",
-        "message": "<ddotd_portable_music_on>.",
+        "transform": "portable_music_player_on",
+        "message": "You slip in a cassette, put on headphones, and start listening to music.",
         "activate": true
       }
     ],


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Using a portable cassette player (Dark Days of the Dead) turns it into an undefined item.

#### Describe the solution

Fill correct id and message.

#### Describe alternatives you've considered

N/A

#### Testing

N/A

#### Additional context

N/A