### PR TITLE
Rubik & Venn will fully cyborgify you if you're trusted enough, outside mission rewards

### DIFF
--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -108,6 +108,34 @@
         "topic": "TALK_EXODII_MERCHANT_Talk_Intro2a"
       },
       {
+        "text": "So, now that I'm a cyborg, could I get a full bionic body like yours?",
+        "condition": {
+          "and": [
+            { "u_has_trait": "CBM_Interface" },
+            { "not": { "compare_string": [ "yes", { "u_val": "Rubik_promised_cyberframe" } ] } },
+            { "not": { "u_has_trait": "EXODII_BODY_1" } },
+            { "not": { "u_has_trait": "EXODII_BODY_1b" } },
+            { "not": { "u_has_trait": "EXODII_CYBERFRAME_GENERIC" } },
+            { "math": [ "faction_trust('exodii') < 40" ] }
+          ]
+        },
+        "topic": "TALK_EXODII_MERCHANT_Cyberframe_trust_no"
+      },
+      {
+        "text": "So, I'm ready for the next step.  How do I get a full bionic body like yours?",
+        "condition": {
+          "and": [
+            { "u_has_trait": "CBM_Interface" },
+            { "not": { "compare_string": [ "yes", { "u_val": "Rubik_promised_cyberframe" } ] } },
+            { "not": { "u_has_trait": "EXODII_BODY_1" } },
+            { "not": { "u_has_trait": "EXODII_BODY_1b" } },
+            { "not": { "u_has_trait": "EXODII_CYBERFRAME_GENERIC" } },
+            { "math": [ "faction_trust('exodii') >= 40" ] }
+          ]
+        },
+        "topic": "TALK_EXODII_MERCHANT_Cyberframe_trust_yes"
+      },
+      {
         "text": "I'm ready to become a true cyborg.",
         "condition": { "compare_string": [ "yes", { "u_val": "Rubik_promised_cyberframe" } ] },
         "effect": [

--- a/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
@@ -363,7 +363,7 @@
     "type": "talk_topic",
     "dynamic_line": {
       "//~": "No, I don't think so.  Not today.",
-      "str": "&Rubik is quiet for a long moment, and is clearing sizing you up.  \"No, methinks not today.\""
+      "str": "&Rubik is quiet for a long moment, and is clearly sizing you up.  \"No, methinks not today.\""
     },
     "responses": [
       { "text": "Well, I guess I'll ask again another time.  <end_talking_leave>  <end_talking_bye>", "topic": "TALK_DONE" }
@@ -373,7 +373,7 @@
     "id": "TALK_EXODII_MERCHANT_Cyberframe_trust_yes",
     "type": "talk_topic",
     "dynamic_line": {
-      "//~": "Hm.  That's a really big ask.  You seem to be the sort of person who would ask for this kind of thing, but are you certain you want to be permenantly attached to this suitcase?  You sure you're thinking clearly?  This isn't like the CBMs I sell.  There's no going back.  And you better be able to produce enough power.  These need constant power.  Without it, you're as good as dead.  For a Cyberframe like mine, one power storage unit will last less than an hour of walking.  Less if you're fighting or running.  It's not an easy life.",
+      "//~": "Hm.  That's a really big ask.  You seem to be the sort of person who would ask for this kind of thing, but are you certain you want to be permanently attached to this suitcase?  You sure you're thinking clearly?  This isn't like the CBMs I sell.  There's no going back.  And you better be able to produce enough power.  These need constant power.  Without it, you're as good as dead.  For a Cyberframe like mine, one power storage unit will last less than an hour of walking.  Less if you're fighting or running.  It's not an easy life.",
       "str": "Hm.  A mighty ask on a mighty ask.  Ye certainly got the disposition, but you sure you wanna be cut inta' this crowded space?\"  Rubik taps their metal torso.  \"You sure ya' lump is screwed on tight?  This isn't like the bright'n'steelies on offer.  No goin' back.  And ye best be happy with the amount'a power you can generate.  This'ere needs contant power.  Without power, yer good as dead.  The power storage units?  Fer a case this'n kind, one'a the power storage units buys you a little-less'an an hour of walkin'.  Less for scrappin' and scramblin'.  Nothin's easy about it.\""
     },
     "responses": [

--- a/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
@@ -336,6 +336,67 @@
     ]
   },
   {
+    "id": "TALK_EXODII_MERCHANT_Cyberframe_trust_no",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "Not today.  That's too much to ask, and we can't spare the materials.  But, I'll give you some advice.  Keep up the working and trading, and maybe I'll change my mind one day.",
+      "str": "Not today.  Too mighty an ask, and we can't spare the steelies.  But, I'll give ye a lump'a'ice.  Keep up work'n'trade, n' mayhaps somethin' changes one'a these days."
+    },
+    "responses": [
+      {
+        "text": "I'm just really eager to shed this fleshy prison.  You sure there's nothing we can do?",
+        "topic": "TALK_EXODII_MERCHANT_Cyberframe_trust_no_weirdo",
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "decisions_blobpsychosis_u_too_eager_cyborg_body" } ] } },
+        "effect": [
+          { "u_add_var": "decisions_blobpsychosis_u_too_eager_cyborg_body", "value": "yes" },
+          { "math": [ "u_counter_exodii_exodii_psychosis_judgment += 2" ] },
+          { "u_add_faction_trust": -2 }
+        ]
+      },
+      { "text": "I guess I'll ask again another time.  <done_conversation_section>", "topic": "TALK_NONE" },
+      { "text": "I guess I'll ask again another time.  <end_talking_leave>  <end_talking_bye>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_Cyberframe_trust_no_weirdo",
+    "//": "Rubik is skeptical of you if you are over-eager to get dissected down to your guts.",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "No, I don't think so.  Not today.",
+      "str": "&Rubik is quiet for a long moment, and is clearing sizing you up.  \"No, methinks not today.\""
+    },
+    "responses": [
+      { "text": "Well, I guess I'll ask again another time.  <end_talking_leave>  <end_talking_bye>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_Cyberframe_trust_yes",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "Hm.  That's a really big ask.  You seem to be the sort of person who would ask for this kind of thing, but are you certain you want to be permenantly attached to this suitcase?  You sure you're thinking clearly?  This isn't like the CBMs I sell.  There's no going back.  And you better be able to produce enough power.  These need constant power.  Without it, you're as good as dead.  For a Cyberframe like mine, one power storage unit will last less than an hour of walking.  Less if you're fighting or running.  It's not an easy life.",
+      "str": "Hm.  A mighty ask on a mighty ask.  Ye certainly got the disposition, but you sure you wanna be cut inta' this crowded space?\"  Rubik taps their metal torso.  \"You sure ya' lump is screwed on tight?  This isn't like the bright'n'steelies on offer.  No goin' back.  And ye best be happy with the amount'a power you can generate.  This'ere needs contant power.  Without power, yer good as dead.  The power storage units?  Fer a case this'n kind, one'a the power storage units buys you a little-less'an an hour of walkin'.  Less for scrappin' and scramblin'.  Nothin's easy about it.\""
+    },
+    "responses": [
+      {
+        "text": "[Integrate your body into an Exodii Cyberframe] A robotic body I'll need to keep constantly powered?  Why not?  I'm ready.",
+        "effect": [
+          { "u_add_faction_trust": 5 },
+          {
+            "u_location_variable": { "u_val": "exodii_autodoc_couch_loc" },
+            "target_params": { "om_terrain": "exodii_base_x2y1z1", "om_special": "exodii_base" },
+            "furniture": "f_autodoc_couch",
+            "target_max_radius": 250
+          },
+          { "u_teleport": { "u_val": "exodii_autodoc_couch_loc" } }
+        ],
+        "opinion": { "trust": 7, "value": 5 },
+        "topic": "TALK_EXODII_MERCHANT_Exodize_Cyberframe"
+      },
+      { "text": "I changed my mind.  <done_conversation_section>", "topic": "TALK_NONE" },
+      { "text": "I changed my mind.  <end_talking_leave>  <end_talking_bye>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
     "id": "TALK_EXODII_MERCHANT_Exodize_Cyberframe",
     "type": "talk_topic",
     "dynamic_line": {
@@ -527,7 +588,7 @@
           { "u_add_effect": "sleep", "duration": "12 hours" },
           { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "12 hours" },
           { "u_add_trait": "EXODII_CYBERFRAME_GENERIC" },
-          { "u_add_bionic": "bio_exodii_cyberframe_1a" },
+          { "u_add_bionic": "bio_exodii_cyberframe_1b" },
           { "u_add_bionic": "bio_exodii_leg_bionic_basic_left" },
           { "u_add_bionic": "bio_exodii_leg_bionic_basic_right" },
           { "u_add_bionic": "bio_exodii_arm_bionic_basic_left" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "If the Exodii trust you enough they'll give you a Cyberframe"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Access to full cyborg body outside of mission rewards.  This way you can choose other rewards for all the missions, build trust over time, and then request a Cyberframe.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

If you have an interface and Exodii trust is >=40, you can request a Cyberframe.

If you're too pushy about it, too early, you lose a bit of trust and Rubik worries a bit more about you having some blob-induced psychosis.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Got cyborgified

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Fixed a typo in downstream dialogue giving the wrong cyberframe.  woops.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
