### PR TITLE
Fix crash when opening inventory with bare barrel-swappable gun

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1629,10 +1629,14 @@ std::string item::display_name( unsigned int quantity ) const
                     if( mag != nullptr ) {
                         well_amount = mag->ammo_remaining();
                         const itype *adata = mag->ammo_data();
-                        well_max = adata
-                                   ? mag->ammo_capacity( adata->ammo->type )
-                                   : mag->ammo_capacity( item_controller->find_template(
-                                                             mag->ammo_default() )->ammo->type );
+                        if( adata ) {
+                            well_max = mag->ammo_capacity( adata->ammo->type );
+                        } else if( !mag->ammo_default().is_null() ) {
+                            const itype *tmpl = item_controller->find_template( mag->ammo_default() );
+                            if( tmpl && tmpl->ammo ) {
+                                well_max = mag->ammo_capacity( tmpl->ammo->type );
+                            }
+                        }
                         ammo_for_name = adata;
                         ammo_id_for_name = mag->ammo_current();
                         if( ammo_id_for_name.is_null() ) {
@@ -1731,9 +1735,11 @@ std::string item::display_name( unsigned int quantity ) const
             const itype *adata = mag->ammo_data();
             if( adata ) {
                 max_amount = mag->ammo_capacity( adata->ammo->type );
-            } else {
-                max_amount = mag->ammo_capacity( item_controller->find_template(
-                                                     mag->ammo_default() )->ammo->type );
+            } else if( !mag->ammo_default().is_null() ) {
+                const itype *tmpl = item_controller->find_template( mag->ammo_default() );
+                if( tmpl && tmpl->ammo ) {
+                    max_amount = mag->ammo_capacity( tmpl->ammo->type );
+                }
             }
         }
     } else if( is_tool() && has_flag( flag_USES_NEARBY_AMMO ) ) {
@@ -1746,8 +1752,13 @@ std::string item::display_name( unsigned int quantity ) const
         const itype *adata = ammo_data();
         if( adata ) {
             max_amount = ammo_capacity( adata->ammo->type );
-        } else {
-            max_amount = ammo_capacity( item_controller->find_template( ammo_default() )->ammo->type );
+        } else if( !ammo_default().is_null() ) {
+            // Barrel-swappable guns ("ammo": [ "NULL" ]) resolve to a
+            // template with a null ammo slot.
+            const itype *tmpl = item_controller->find_template( ammo_default() );
+            if( tmpl && tmpl->ammo ) {
+                max_amount = ammo_capacity( tmpl->ammo->type );
+            }
         }
         show_amt = !has_flag( flag_RELOAD_AND_SHOOT );
     } else if( count_by_charges() && !has_infinite_charges() ) {

--- a/tests/multimag_test.cpp
+++ b/tests/multimag_test.cpp
@@ -68,6 +68,7 @@ static const itype_id itype_heavy_battery_cell( "heavy_battery_cell" );
 static const itype_id itype_medium_battery_cell( "medium_battery_cell" );
 static const itype_id itype_oxygen( "oxygen" );
 static const itype_id itype_paper( "paper" );
+static const itype_id itype_robofac_gun( "robofac_gun" );
 static const itype_id itype_stanag30( "stanag30" );
 static const itype_id itype_sw_619( "sw_619" );
 static const itype_id itype_test_multimag_gun( "test_multimag_gun" );
@@ -311,6 +312,19 @@ TEST_CASE( "display_name_multi_well_per_well_counts", "[multimag][display]" )
         CHECK( name.find( variant_556 ) != std::string::npos );
         CHECK( name.find( "15/15" ) != std::string::npos );
         CHECK( name.find( "30/30" ) != std::string::npos );
+    }
+
+    SECTION( "bare HWP with null gun ammotype and no barrel mod does not crash" ) {
+        // robofac_gun is barrel-swappable: ammo_default() resolves to
+        // NULL_ID and find_template(NULL_ID)->ammo is null.
+        item gun( itype_robofac_gun );
+        REQUIRE( gun.is_gun() );
+        REQUIRE( !gun.ammo_types().empty() );
+        REQUIRE( gun.ammo_data() == nullptr );
+        std::string name;
+        name = remove_color_tags( gun.display_name() );
+        CAPTURE( name );
+        CHECK_FALSE( name.empty() );
     }
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix crash when opening inventory with bare barrel-swappable gun"

#### Purpose of change
Fixes #87134. Bare barrel-swappable guns (HWP, modular AR-15, etc) crash the game on inventory open if no barrel mod is installed. These guns declare `"ammo": [ "NULL" ]` and pick up their ammotype from the installed barrel gunmod. `item::display_name` resolves `ammo_capacity(find_template(ammo_default())->ammo->type)` in three places. For these guns `ammo_default()` returns NULL_ID and the synthesised template has no ammo slot, so `->ammo->type` segfaults.

#### Describe the solution
Skip the deref when `ammo_default().is_null()` or the template has no ammo slot.

#### Describe alternatives you've considered
N/A

#### Testing
Verified in game. Added a new section to multimag tests.

#### Additional context
Regression from #87091.