### PR TITLE
Prettify weight/volume display

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -764,6 +764,7 @@
     "price": "5 USD",
     "price_postapoc": "20 USD",
     "name": { "str_sp": "mixed smokeless gunpowder" },
+    "display_type": "BY_WEIGHT",
     "symbol": "=",
     "color": "dark_gray",
     "description": "Firearm-quality gunpowder, mixed without concern for composition, burn rate, or shape, making it thoroughly useless for reloading ammunition.  It has been slightly ground to make its properties more uniform.",

--- a/src/units_utility.cpp
+++ b/src/units_utility.cpp
@@ -141,6 +141,30 @@ double convert_velocity( int velocity, const units_type vel_units )
 
     return ret;
 }
+
+static std::pair<double, std::string> convert_weight_pretty( const units::mass &weight )
+{
+    double ret = to_milligram( weight );
+    const double mg_to_kg = 1'000'000.0;
+    const double mg_to_g = 1'000.0;
+
+    const double mg_to_lbs = 453600.0;
+
+    std::string ret_string;
+    if( get_option<std::string>( "USE_METRIC_WEIGHTS" ) == "kg" ) {
+        if( ret / mg_to_kg >= 1.0 ) {
+            return {ret / mg_to_kg, _( "kg" )};
+        } else if( ret / mg_to_g >= 1.0 ) {
+            return {ret / mg_to_g, _( "g" )};
+        } else {
+            return {ret, _( "mg" )};
+        }
+    }
+
+    // TODO: Ounces???
+    return {ret / mg_to_lbs, _( "lbs" )};
+}
+
 double convert_weight( const units::mass &weight )
 {
     double ret = to_gram( weight );
@@ -317,11 +341,12 @@ std::string weight_to_string( const units::mass &weight, const bool compact,
                               const bool remove_trailing_zeroes )
 {
     const int default_decimal_places = 2;
-    const double converted_weight = round_with_places( convert_weight( weight ),
-                                    default_decimal_places );
+    std::pair<double, std::string> converted_weight = convert_weight_pretty( weight );
+    converted_weight.first = round_with_places( converted_weight.first, default_decimal_places );
     std::string string_to_format = remove_trailing_zeroes ? "%g%s%s" : "%." +
                                    std::to_string( default_decimal_places ) + "f%s%s";
-    return string_format( string_to_format, converted_weight, compact ? "" : " ", weight_units() );
+    return string_format( string_to_format, converted_weight.first, compact ? "" : " ",
+                          converted_weight.second );
 }
 
 std::pair<std::string, std::string> weight_to_string( const
@@ -337,6 +362,33 @@ std::pair<std::string, std::string> weight_to_string( const
         return {string_format( "%.0f", weight.value() / 1000.f ), "mg"};
     }
     return {string_format( "%d", weight.value() ), "μg"};
+}
+
+static std::pair<double, std::string> convert_volume_pretty( units::volume volume )
+{
+    double ret = to_milliliter( volume );
+    const double mL_to_Liter = 1000.0;
+    const double mL_to_gallons = 3784.0;
+    const double mL_to_quarts = 946.0;
+    const double mL_to_cups = 250.0;
+
+    std::string ret_string;
+
+    if( get_option<std::string>( "VOLUME_UNITS" ) == "l" ) {
+        if( ret / mL_to_Liter >= 1.0 ) {
+            return {ret / mL_to_Liter, pgettext( "Volume unit", "L" )};
+        } else {
+            return {ret, pgettext( "Volume unit", "mL" )};
+        }
+    }
+
+    if( ret / mL_to_gallons >= 1.0 ) {
+        return {ret / mL_to_gallons, pgettext( "Volume unit", "gal" )};
+    } else if( ret / mL_to_quarts >= 1.0 ) {
+        return {ret / mL_to_quarts, pgettext( "Volume unit", "qt" )};
+    } else {
+        return {ret / mL_to_cups, pgettext( "Volume unit", "c" )};
+    }
 }
 
 double convert_volume( int volume )
@@ -356,6 +408,7 @@ double convert_volume( int volume, int *out_scale )
         ret *= 0.001;
         scale = 2;
     } else {
+        // quarts.
         ret *= 0.00105669;
         scale = 2;
     }
@@ -368,14 +421,13 @@ double convert_volume( int volume, int *out_scale )
 std::string vol_to_string( const units::volume &vol, const bool compact,
                            const bool remove_trailing_zeroes )
 {
-    int converted_volume_scale = 0;
     const int default_decimal_places = 3;
-    const double converted_volume =
-        round_with_places( convert_volume( vol.value(),
-                                           &converted_volume_scale ), default_decimal_places );
+    std::pair<double, std::string> converted_volume = convert_volume_pretty( vol );
+    converted_volume.first = round_with_places( converted_volume.first, default_decimal_places );
     std::string string_to_format = remove_trailing_zeroes ? "%g%s%s" : "%." +
                                    std::to_string( default_decimal_places ) + "f%s%s";
-    return string_format( string_to_format, converted_volume, compact ? "" : " ", volume_units_abbr() );
+    return string_format( string_to_format, converted_volume.first, compact ? "" : " ",
+                          converted_volume.second );
 }
 
 std::string unit_to_string( const units::volume &unit, const bool compact,


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
`0.425kg of salt` is a bit unwieldy, isn't it?

#### Describe the solution
`425g of salt`. We use the smallest unit we have at least one of.

Yes this works for imperial too. Except for imperial weights, which are always in pounds. (That was already the case I hate doing imperial conversions aaaaaaaa)

#### Describe alternatives you've considered
Lots of places call convert_weight() and convert_volume() directly and then assemble their own strings, that's horrifying. Future to-do list.

#### Testing
<img width="399" height="384" alt="image" src="https://github.com/user-attachments/assets/fcfdfda4-5c75-4836-a780-3224c1feabd2" />


#### Additional context

Also moved gunpowder to BY_WEIGHT so we can de-charge it (again) soon

Special note: Because volume/weight is metric under the hood it is possible for us to have less than 1 full unit of pounds/cups, as there is no smaller unit to use.