### PR TITLE
[Sky Island] Keep exit room mission markers

### DIFF
--- a/data/mods/Sky_Island/missions/raid_missions.json
+++ b/data/mods/Sky_Island/missions/raid_missions.json
@@ -3,7 +3,7 @@
     "id": "MISSION_REACH_EXTRACT",
     "type": "mission_definition",
     "name": { "str": "Reach one of the exit points!" },
-    "goal": "MGOAL_GO_TO",
+    "goal": "MGOAL_CONDITION",
     "description": "If you want to get home with your stuff, you'll need to reach one of these nearby exit points.  They're only things that can bring you back to your sanctuary island in one piece.",
     "difficulty": 0,
     "value": 0,


### PR DESCRIPTION
#### Summary
Mods "[Sky Island] Keep exit room mission markers"

#### Purpose of change
Make the exist room missions unable to be completed so the mission and marker stay in your log until you leave the raid. Now the exits remain easily found even if you walk near one.

#### Describe the solution
Change the `goal` of the `MISSION_REACH_EXTRACT` to `MGOAL_CONDITION` without a condition so it cannot be completed.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Started raids and ran to multiple exits. The missions remain and markers are still there. They still are cleared upon leaving the raid as usual.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
