### PR TITLE
Update vehicle shape menu

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -134,6 +134,7 @@
 #include "units.h"
 #include "value_ptr.h"
 #include "veh_interact.h"
+#include "veh_shape.h"
 #include "veh_type.h"
 #include "veh_utils.h"
 #include "vehicle.h"
@@ -11381,7 +11382,7 @@ void vehicle_activity_actor::complete_vehicle( player_activity &act, Character &
             }
             ::vehicle_part &vp_new = veh.part( partnum );
             if( vp_new.info().variants.size() > 1 ) {
-                veh_interact::do_change_shape_menu( vp_new );
+                veh_shape( here, veh ).change_part_shape( vpart_reference( veh, partnum ) );
             }
 
             // Need map-relative coordinates to compare to output of look_around.

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2022,47 +2022,6 @@ bool veh_interact::do_unload( map &here )
     return true;
 }
 
-void veh_interact::do_change_shape_menu( vehicle_part &vp )
-{
-    const vpart_info &vpi = vp.info();
-    uilist smenu;
-    smenu.text = _( "Choose cosmetic variant:" );
-    int ret_code = 0;
-    int default_selection = 0;
-    std::vector<std::string> variants;
-    for( const auto& [variant_id, vv] : vpi.variants ) {
-        if( variant_id == vp.variant ) {
-            default_selection = ret_code;
-        }
-        uilist_entry entry( vv.get_label() );
-        entry.txt = entry.txt.empty() ? _( "Default" ) : entry.txt;
-        entry.retval = ret_code++;
-        entry.extratxt.left = 1;
-        entry.extratxt.sym = vv.get_symbol_curses( 0_degrees, false );
-        entry.extratxt.color = vpi.color;
-        variants.emplace_back( variant_id );
-        smenu.entries.emplace_back( entry );
-    }
-    std::sort( smenu.entries.begin(), smenu.entries.end(),
-    []( const uilist_entry & a, const uilist_entry & b ) {
-        return localized_compare( a.txt, b.txt );
-    } );
-
-    // get default selection after sorting
-    for( std::size_t i = 0; i < smenu.entries.size(); ++i ) {
-        if( smenu.entries[i].retval == default_selection ) {
-            default_selection = i;
-            break;
-        }
-    }
-
-    smenu.selected = default_selection;
-    smenu.query();
-    if( smenu.ret >= 0 ) {
-        vp.variant = variants[smenu.ret];
-    }
-}
-
 void veh_interact::do_assign_crew( map &here )
 {
     if( cant_do( here, VEHICLE_ASSIGN_CREW ) != task_reason::CAN_DO ) {

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -946,35 +946,6 @@ void veh_interact::move_fuel_cursor( map &here, int delta )
     }
 }
 
-static void sort_uilist_entries_by_line_drawing( std::vector<uilist_entry> &shape_ui_entries )
-{
-    // An ordering of the line drawing symbols that does not result in
-    // connecting when placed adjacent to each other vertically.
-    const static std::map<int, int> symbol_order = {
-        { LINE_XOXO, 0 }, { LINE_OXOX, 1 },
-        { LINE_XOOX, 2 }, { LINE_XXOO, 3 },
-        { LINE_XXXX, 4 }, { LINE_OXXO, 5 },
-        { LINE_OOXX, 6 }
-    };
-
-    std::sort( shape_ui_entries.begin(), shape_ui_entries.end(),
-    []( const uilist_entry & a, const uilist_entry & b ) {
-        auto a_iter = symbol_order.find( a.extratxt.sym );
-        auto b_iter = symbol_order.find( b.extratxt.sym );
-        if( a_iter != symbol_order.end() ) {
-            if( b_iter != symbol_order.end() ) {
-                return a_iter->second < b_iter->second;
-            } else {
-                return true;
-            }
-        } else if( b_iter != symbol_order.end() ) {
-            return false;
-        } else {
-            return a.extratxt.sym < b.extratxt.sym;
-        }
-    } );
-}
-
 void veh_interact::do_install( map &here )
 {
     task_reason reason = cant_do( here, VEHICLE_INSTALL );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2043,7 +2043,10 @@ void veh_interact::do_change_shape_menu( vehicle_part &vp )
         variants.emplace_back( variant_id );
         smenu.entries.emplace_back( entry );
     }
-    sort_uilist_entries_by_line_drawing( smenu.entries );
+    std::sort( smenu.entries.begin(), smenu.entries.end(),
+    []( const uilist_entry & a, const uilist_entry & b ) {
+        return localized_compare( a.txt, b.txt );
+    } );
 
     // get default selection after sorting
     for( std::size_t i = 0; i < smenu.entries.size(); ++i ) {

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -95,8 +95,6 @@ class veh_interact
                 const part_selector &sel,
                 const std::string &title = std::string() );
 
-        static void do_change_shape_menu( vehicle_part &vp );
-
     private:
         explicit veh_interact( map &here, vehicle &veh, const point_rel_ms &p = point_rel_ms::zero );
         ~veh_interact();

--- a/src/veh_shape.cpp
+++ b/src/veh_shape.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <map>
 #include <memory>
-#include <utility>
 
 #include "avatar.h"
 #include "cata_scope_helpers.h"

--- a/src/veh_shape.cpp
+++ b/src/veh_shape.cpp
@@ -156,7 +156,6 @@ void veh_shape::change_part_shape( vpart_reference vpr ) const
         .skip_locked_check()
         .skip_theft_check()
         .location( veh.bub_part_pos( here, part ).raw() )
-        .select( part.variant == vvid )
         .desc( _( "Confirm to save or exit to revert" ) )
         .symbol( vv.get_symbol_curses( 0_degrees, false ) )
         .symbol_color( vpi.color )

--- a/src/veh_shape.cpp
+++ b/src/veh_shape.cpp
@@ -16,8 +16,6 @@
 #include "map_scale_constants.h"
 #include "memory_fast.h"
 #include "options.h"
-#include "output.h"
-#include "localized_comparator.h"
 #include "player_activity.h"
 #include "point.h"
 #include "ret_val.h"

--- a/src/veh_shape.cpp
+++ b/src/veh_shape.cpp
@@ -152,32 +152,28 @@ void veh_shape::change_part_shape( vpart_reference vpr ) const
     veh_menu menu( this->veh, _( "Choose cosmetic variant:" ) );
     std::string chosen_variant = part.variant; // support for cancel
 
-    do {
-        menu.reset( false );
-
-        for( const auto &[vvid, vv] : vpi.variants ) {
-            menu.add( vv.get_label() )
-            .text_color( ( part.variant == vvid ) ? c_light_green : c_light_gray )
-            .keep_menu_open()
-            .skip_locked_check()
-            .skip_theft_check()
-            .location( veh.bub_part_pos( here, part ).raw() )
-            .select( part.variant == vvid )
-            .desc( _( "Confirm to save or exit to revert" ) )
-            .symbol( vv.get_symbol_curses( 0_degrees, false ) )
-            .symbol_color( vpi.color )
-            .on_select( [&part, variant_id = vvid]() {
-                part.variant = variant_id;
-            } )
-            .on_submit( [&chosen_variant, variant_id = vvid]() {
-                chosen_variant = variant_id;
-            } );
-        }
-
-        menu.sort( []( const veh_menu_item & a, const veh_menu_item & b ) {
-            return localized_compare( a._text, b._text );
+    for( const auto &[vvid, vv] : vpi.variants ) {
+        menu.add( vv.get_label() )
+        .text_color( ( part.variant == vvid ) ? c_light_green : c_light_gray )
+        .skip_locked_check()
+        .skip_theft_check()
+        .location( veh.bub_part_pos( here, part ).raw() )
+        .select( part.variant == vvid )
+        .desc( _( "Confirm to save or exit to revert" ) )
+        .symbol( vv.get_symbol_curses( 0_degrees, false ) )
+        .symbol_color( vpi.color )
+        .on_select( [&part, variant_id = vvid]() {
+            part.variant = variant_id;
+        } )
+        .on_submit( [&chosen_variant, variant_id = vvid]() {
+            chosen_variant = variant_id;
         } );
-    } while( menu.query() );
+    }
+
+    menu.sort( []( const veh_menu_item & a, const veh_menu_item & b ) {
+        return localized_compare( a._text, b._text );
+    } );
+    menu.query();
 
     part.variant = chosen_variant;
 }

--- a/src/veh_shape.cpp
+++ b/src/veh_shape.cpp
@@ -12,6 +12,7 @@
 #include "game.h"
 #include "game_constants.h"
 #include "input_enums.h"
+#include "localized_comparator.h"
 #include "map.h"
 #include "map_scale_constants.h"
 #include "memory_fast.h"
@@ -168,7 +169,7 @@ void veh_shape::change_part_shape( vpart_reference vpr ) const
         } );
     }
 
-    menu.sort( []( const veh_menu_item & a, const veh_menu_item & b ) {
+    menu.sort( []( const veh_menu_item & a, const veh_menu_item & b ) -> int {
         return localized_compare( a._text, b._text );
     } );
     menu.query();

--- a/src/veh_shape.cpp
+++ b/src/veh_shape.cpp
@@ -17,6 +17,7 @@
 #include "memory_fast.h"
 #include "options.h"
 #include "output.h"
+#include "localized_comparator.h"
 #include "player_activity.h"
 #include "point.h"
 #include "ret_val.h"
@@ -173,20 +174,8 @@ void veh_shape::change_part_shape( vpart_reference vpr ) const
             } );
         }
 
-        // An ordering of the line drawing symbols that does not result in
-        // connecting when placed adjacent to each other vertically.
         menu.sort( []( const veh_menu_item & a, const veh_menu_item & b ) {
-            const static std::map<int, int> symbol_order = {
-                { LINE_XOXO, 0 }, { LINE_OXOX, 1 }, { LINE_XOOX, 2 }, { LINE_XXOO, 3 },
-                { LINE_XXXX, 4 }, { LINE_OXXO, 5 }, { LINE_OOXX, 6 },
-            };
-            const auto a_iter = symbol_order.find( a._symbol );
-            const auto b_iter = symbol_order.find( b._symbol );
-            if( a_iter != symbol_order.end() ) {
-                return ( b_iter == symbol_order.end() ) || ( a_iter->second < b_iter->second );
-            } else {
-                return ( b_iter == symbol_order.end() ) && ( a._symbol < b._symbol );
-            }
+            return localized_compare( a._text, b._text );
         } );
     } while( menu.query() );
 

--- a/src/veh_shape.h
+++ b/src/veh_shape.h
@@ -55,6 +55,7 @@ class veh_shape
             const std::function<ret_val<void>( const vpart_reference & )> &predicate,
             const std::optional<vpart_reference> &preselect ) const;
 
+    public:
         void change_part_shape( vpart_reference vpr ) const;
 };
 


### PR DESCRIPTION
#### Summary
Interface "Update vehicle shape menu"

#### Purpose of change
When installing a new vehicle part (eg a window), the shape selection uses a completely different menu from the existing "change shape" option in the vehicle UI, despite doing the same thing. The vehicle UI shape menu is preferable as it shows real-time part graphic updates as you navigate. There is no reason for these to be separate implementations.

#### Describe the solution
Use the shape menu for when a new part is installed and also for changing existing parts.  I have also made the menu alphabetical so you can find the name of the part you need easier.  Confirming the selection will also confirm you selection and exit the menu now; because you can see the change in real time, it doesn't make sense to keep the menu open.

#### Describe alternatives you've considered
None.

#### Testing
Compiled in Windows.
Started a game and verified the `shape` option in the vehicle screen still worked as expected.
Installed a new part to the vehicle and verified the `shape` menu was also used here.

#### Additional context
None.