### PR TITLE
No perpetual motion cyborgs: nerf joint torsion ratchet CBM

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1452,7 +1452,7 @@
     "id": "bio_torsionratchet",
     "type": "bionic",
     "name": { "str": "Joint Torsion Ratchet" },
-    "description": "Your joints have been surgically equipped with torsion ratchets that slowly generate power when you move.  Whilst this is toggled, moving will require more effort, though more power will be generated.",
+    "description": "Your joints have been surgically equipped with torsion ratchets that slowly generate power when you move, even when turned off.  Whilst this is toggled on, moving will require more effort, but more power will be generated.  This system is actively detrimental to fully mechanical limbs limbs; the additional joint resistance it relies on results in a net loss of bionic power.",
     "occupied_bodyparts": [ [ "arm_l", 8 ], [ "arm_r", 8 ], [ "leg_l", 12 ], [ "leg_r", 12 ] ],
     "fuel_options": [ "muscle" ],
     "fuel_efficiency": 0.125,

--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1452,7 +1452,7 @@
     "id": "bio_torsionratchet",
     "type": "bionic",
     "name": { "str": "Joint Torsion Ratchet" },
-    "description": "Your joints have been surgically equipped with torsion ratchets that slowly generate power when you move, even when turned off.  Whilst this is toggled on, moving will require more effort, but more power will be generated.  This system is actively detrimental to fully mechanical limbs limbs; the additional joint resistance it relies on results in a net loss of bionic power.",
+    "description": "Your joints have been surgically equipped with torsion ratchets that slowly generate power when you move, even when turned off.  Whilst this is toggled on, moving will require more effort, but more power will be generated.  This system is actively detrimental to fully mechanical limbs; the additional joint resistance it relies on causes a net loss of bionic power.",
     "occupied_bodyparts": [ [ "arm_l", 8 ], [ "arm_r", 8 ], [ "leg_l", 12 ], [ "leg_r", 12 ] ],
     "fuel_options": [ "muscle" ],
     "fuel_efficiency": 0.125,

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -1168,7 +1168,7 @@
     "subtypes": [ "BIONIC_ITEM" ],
     "name": { "str": "Joint Torsion Ratchet CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "A set of torsion ratchets that replace the user's joints to slowly generate power when they move.  These can be toggled to generate more power, but movement will require more effort.  This system is actively detrimental to fully mechanical limbs limbs; the additional joint resistance it relies on results in a net loss of bionic power.",
+    "description": "A set of torsion ratchets that replace the user's joints to slowly generate power when they move.  These can be toggled to generate more power, but movement will require more effort.  This system is actively detrimental to fully mechanical limbs; the additional joint resistance it relies on causes a net loss of bionic power.",
     "price": "3 kUSD 800 USD",
     "price_postapoc": "20 USD",
     "weight": "1000 g",

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -1168,7 +1168,7 @@
     "subtypes": [ "BIONIC_ITEM" ],
     "name": { "str": "Joint Torsion Ratchet CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "A set of torsion ratchets that replace the user's joints to slowly generate power when they move.  These can be toggled to generate more power, but movement will require more effort.",
+    "description": "A set of torsion ratchets that replace the user's joints to slowly generate power when they move.  These can be toggled to generate more power, but movement will require more effort.  This system is actively detrimental to fully mechanical limbs limbs; the additional joint resistance it relies on results in a net loss of bionic power.",
     "price": "3 kUSD 800 USD",
     "price_postapoc": "20 USD",
     "weight": "1000 g",

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -956,7 +956,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
         if( has_bionic_limbs ) {
             add_msg_if_player( m_bad, _( "Your torsion ratchets are straining your bionic limbs!" ) );
         }
-            add_msg_if_player( m_info, _( "Your torsion ratchet locks onto your joints." ) );
+        add_msg_if_player( m_info, _( "Your torsion ratchet locks onto your joints." ) );
     } else if( bio.id == bio_jointservo ) {
         add_msg_activate();
         add_msg_if_player( m_info, _( "You can now run faster, assisted by joint servomotors." ) );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -953,10 +953,10 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
                 has_bionic_limbs = true;
             }
         }
+        add_msg_if_player( m_info, _( "Your torsion ratchets lock onto your joints." ) );
         if( has_bionic_limbs ) {
             add_msg_if_player( m_bad, _( "Your torsion ratchets are straining your bionic limbs!" ) );
         }
-        add_msg_if_player( m_info, _( "Your torsion ratchet locks onto your joints." ) );
     } else if( bio.id == bio_jointservo ) {
         add_msg_activate();
         add_msg_if_player( m_info, _( "You can now run faster, assisted by joint servomotors." ) );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -139,6 +139,7 @@ static const itype_id itype_water_clean( "water_clean" );
 static const json_character_flag json_flag_BIONIC_ARMOR_INTERFACE( "BIONIC_ARMOR_INTERFACE" );
 static const json_character_flag json_flag_BIONIC_FAULTY( "BIONIC_FAULTY" );
 static const json_character_flag json_flag_BIONIC_GUN( "BIONIC_GUN" );
+static const json_character_flag json_flag_BIONIC_LIMB( "BIONIC_LIMB" );
 static const json_character_flag json_flag_BIONIC_POWER_SOURCE( "BIONIC_POWER_SOURCE" );
 static const json_character_flag json_flag_BIONIC_REMOVABLE( "BIONIC_REMOVABLE" );
 static const json_character_flag json_flag_BIONIC_TOGGLED( "BIONIC_TOGGLED" );
@@ -946,7 +947,16 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
         conduct_blood_analysis();
     } else if( bio.id == bio_torsionratchet ) {
         add_msg_activate();
-        add_msg_if_player( m_info, _( "Your torsion ratchet locks onto your joints." ) );
+        bool has_bionic_limbs = false;
+        for( const bodypart_id &bp : get_all_body_parts() ) {
+            if( bp->has_flag( json_flag_BIONIC_LIMB ) ) {
+                has_bionic_limbs = true;
+            }
+        }
+        if( has_bionic_limbs ) {
+            add_msg_if_player( m_bad, _( "Your torsion ratchets are straining your bionic limbs!" ) );
+        }
+            add_msg_if_player( m_info, _( "Your torsion ratchet locks onto your joints." ) );
     } else if( bio.id == bio_jointservo ) {
         add_msg_activate();
         add_msg_if_player( m_info, _( "You can now run faster, assisted by joint servomotors." ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4335,6 +4335,13 @@ void Character::recalc_limb_energy_usage()
             bionic_limb_count++;
         }
     }
+    for( const bionic_id &bid : get_bionic_fueled_with_muscle() ) {
+        if( has_active_bionic( bid ) ) {
+            bionic_powercost = bionic_powercost * 50;
+        } else {
+            bionic_powercost = bionic_powercost * 5;
+        }
+    }
     arms_power_use = bionic_powercost;
     if( bionic_limb_count > 0 ) {
         arms_stam_mult = 1 - ( bionic_limb_count / total_limb_count );
@@ -4358,6 +4365,13 @@ void Character::recalc_limb_energy_usage()
         if( bp->has_flag( json_flag_BIONIC_LIMB ) ) {
             bionic_powercost += bp->power_efficiency;
             bionic_limb_count++;
+        }
+    }
+    for( const bionic_id &bid : get_bionic_fueled_with_muscle() ) {
+        if( has_active_bionic( bid ) ) {
+            bionic_powercost = bionic_powercost * 50;
+        } else {
+            bionic_powercost = bionic_powercost * 5;
         }
     }
     legs_power_use = bionic_powercost;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Joint Torsion Ratchet CBM doesn't allow for perpetual motion cyborgs"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

If you had bionic limbs the Joint Torsion Ratchet CBM could keep your power reserves at max when walking around.  Walking generated more bionic power than it used.

This violates conservation of energy.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. Bionic limbs have greatly increased energy requirements if the Joint Torsion Ratchets are installed, and even more if they are turned on.  A full cyborg will now quickly deplete their power reserves if they use one.
2. The CBM/item now warn of this in the description.
3. If the user has a bionic limb, they are given a warning when activating the bionic.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Making it completely incompatible and impossible to install.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Built locally.  Debugged myself into a cyborg.  Ran around without the ratchet.  Installed ratchet and ran around and saw worse power performance.  Turned on ratchet, got the message, ran around and quickly drained my batteries.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Some kind of regenerative braking/kinetic energy recapture CBM for cyborgs could be cool.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
