### PR TITLE
`Blank body` can copy your appearance

### DIFF
--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -1384,7 +1384,7 @@
     "name": { "str": "Blank Body Player Copy", "//~": "NO_I18N" },
     "description": { "str": "Blank body copies the player", "//~": "NO_I18N" },
     "message": "The blank body's flesh suddenly begins to flow like wax, warping and changing, and when it's done it's…you.",
-    "flags": [ "NO_PROJECTILE", "SILENT", "NO_EXPLOSION_SFX" ],
+    "flags": [ "NO_PROJECTILE", "SILENT", "NO_EXPLOSION_SFX", "HIDDEN_SPELL ],
     "effect": "targeted_polymorph",
     "effect_str": "mon_blank_avatar_copy",
     "valid_targets": [ "self" ],

--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -1384,7 +1384,7 @@
     "name": { "str": "Blank Body Player Copy", "//~": "NO_I18N" },
     "description": { "str": "Blank body copies the player", "//~": "NO_I18N" },
     "message": "The blank body's flesh suddenly begins to flow like wax, warping and changing, and when it's done it's…you.",
-    "flags": [ "NO_PROJECTILE", "SILENT", "NO_EXPLOSION_SFX", "HIDDEN_SPELL ],
+    "flags": [ "NO_PROJECTILE", "SILENT", "NO_EXPLOSION_SFX", "HIDDEN_SPELL" ],
     "effect": "targeted_polymorph",
     "effect_str": "mon_blank_avatar_copy",
     "valid_targets": [ "self" ],

--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -1352,6 +1352,49 @@
   },
   {
     "type": "SPELL",
+    "id": "blank_body_avatar_copy",
+    "name": { "str": "Blank Body Player Copy Check", "//~": "NO_I18N" },
+    "description": {
+      "str": "Blank body checks and might copy the player.  Needs to be the avatar to apply COPY_AVATAR_LOOK",
+      "//~": "NO_I18N"
+    },
+    "flags": [ "NO_PROJECTILE", "SILENT", "NO_EXPLOSION_SFX" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_BLANK_BODY_AVATAR_COPY",
+    "valid_targets": [ "self", "hostile", "ally" ],
+    "base_casting_time": 200,
+    "min_aoe": 1,
+    "max_aoe": 1,
+    "shape": "blast"
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BLANK_BODY_AVATAR_COPY",
+    "condition": "has_alpha",
+    "effect": [
+      {
+        "if": { "and": [ "u_is_avatar", { "x_in_y_chance": { "x": 1, "y": 100 } } ] },
+        "then": [ { "id": "blank_body_avatar_copy_polymorph", "hit_self": true } ]
+      }
+    ]
+  },
+  {
+    "type": "SPELL",
+    "id": "blank_body_avatar_copy_polymorph",
+    "name": { "str": "Blank Body Player Copy", "//~": "NO_I18N" },
+    "description": { "str": "Blank body copies the player", "//~": "NO_I18N" },
+    "message": "",
+    "flags": [ "NO_PROJECTILE", "SILENT", "NO_EXPLOSION_SFX" ],
+    "effect": "targeted_polymorph",
+    "effect_str": "mon_blank_avatar_copy",
+    "valid_targets": [ "self" ],
+    "min_damage": 10000,
+    "max_damage": 10000,
+    "base_casting_time": 200,
+    "shape": "blast"
+  },
+  {
+    "type": "SPELL",
     "id": "veiled_butterfly_irradiate",
     "name": { "str": "Irradiate Player", "//~": "NO_I18N" },
     "description": { "str": "Adds minor radiation to player.", "//~": "NO_I18N" },

--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -1373,8 +1373,8 @@
     "condition": "has_alpha",
     "effect": [
       {
-        "if": { "and": [ "u_is_avatar", { "x_in_y_chance": { "x": 1, "y": 100 } } ] },
-        "then": [ { "id": "blank_body_avatar_copy_polymorph", "hit_self": true } ]
+        "if": { "and": [ "u_is_avatar", { "x_in_y_chance": { "x": 1, "y": 50 } } ] },
+        "then": [ { "npc_cast_spell": { "id": "blank_body_avatar_copy_polymorph", "hit_self": true } } ]
       }
     ]
   },
@@ -1383,7 +1383,7 @@
     "id": "blank_body_avatar_copy_polymorph",
     "name": { "str": "Blank Body Player Copy", "//~": "NO_I18N" },
     "description": { "str": "Blank body copies the player", "//~": "NO_I18N" },
-    "message": "",
+    "message": "The blank body's flesh suddenly begins to flow like wax, warping and changing, and when it's done it's…you.",
     "flags": [ "NO_PROJECTILE", "SILENT", "NO_EXPLOSION_SFX" ],
     "effect": "targeted_polymorph",
     "effect_str": "mon_blank_avatar_copy",

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -106,8 +106,9 @@
   },
   {
     "id": "mon_blank_avatar_copy",
+    "copy-from": "mon_blank",
     "type": "MONSTER",
-    "name": { "str": "blank body", "str_pl": "blank bodies" },
+    "name": { "str": "blank body?", "str_pl": "blank bodies?" },
     "description": "This was some form of unnatural changeling creature, but now it's you.  It looks like you.  It moves like you.  It even smiles like you.",
     "extend": { "flags": [ "COPY_AVATAR_LOOK" ] }
   },

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -110,7 +110,8 @@
     "type": "MONSTER",
     "name": { "str": "blank body?", "str_pl": "blank bodies?" },
     "description": "This was some form of unnatural changeling creature, but now it's you.  It looks like you.  It moves like you.  It even smiles like you.",
-    "extend": { "flags": [ "COPY_AVATAR_LOOK" ] }
+    "extend": { "flags": [ "COPY_AVATAR_LOOK" ] },
+    "special_attacks": [ [ "SHRIEK", 10 ] ]
   },
   {
     "id": "mon_blood_sacrifice",

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -92,8 +92,24 @@
     "harvest": "demihuman",
     "families": [ "prof_wp_netherium_abomination" ],
     "weakpoint_sets": [ "wps_humanoid_body" ],
-    "special_attacks": [ [ "SHRIEK", 10 ] ],
+    "special_attacks": [
+      [ "SHRIEK", 10 ],
+      {
+        "type": "spell",
+        "cooldown": 50,
+        "spell_data": { "id": "blank_body_avatar_copy", "hit_self": true },
+        "allow_no_target": true,
+        "monster_message": ""
+      }
+    ],
     "flags": [ "SMELLS", "HEARS", "HAS_MIND", "WARM", "ANIMAL", "PATH_AVOID_DANGER", "SUNDEATH", "NO_BREATHE", "HUMAN" ]
+  },
+  {
+    "id": "mon_blank_avatar_copy",
+    "type": "MONSTER",
+    "name": { "str": "blank body", "str_pl": "blank bodies" },
+    "description": "This was some form of unnatural changeling creature, but now it's you.  It looks like you.  It moves like you.  It even smiles like you.",
+    "extend": { "flags": [ "COPY_AVATAR_LOOK" ] }
   },
   {
     "id": "mon_blood_sacrifice",

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -751,8 +751,10 @@ static void magical_polymorph( monster &victim, Creature &caster, const spell &s
         return;
     }
 
-    add_msg_if_player_sees( victim, _( "The %s transforms into a %s." ),
-                            victim.type->nname(), new_id->nname() );
+    if( !sp.message().empty() ) {
+        add_msg_if_player_sees( victim, sp.message(),
+                                victim.type->nname(), new_id->nname() );
+    }
     victim.poly( new_id );
 
     if( sp.has_flag( spell_flag::FRIENDLY_POLY ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "`Blank body` can copy your appearance"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Had this idea for a while for something kind of creepy.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The blank body will occasionally use a spell to check if you are next to it. If you are, there's a 2% chance it copies your appearance exactly, becoming a `blank body?` and looking exactly like you. It still *acts* like a blank body and you can't talk to it or anything.

That's it. Just blank bodies being weird.

C++ edits are so when the polymorph effect triggers you don't see `the blank body transforms into a blank body?`

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Monster empty spell message regression does mean they go around spamming `you cast the blank body` unfortunately.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
