### PR TITLE
Multi-activity fetch segfault fix

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5378,7 +5378,7 @@ bool multi_zone_activity_actor::simulate_turn( player_activity &act, Character &
         req_fail_reason = requirement_failure_reasons();
         const requirement_check_result req_res = check_requirements( you, act_info, src, src_bub, src_set,
                 check_only );
-        if( req_res == requirement_check_result::RETURN_EARLY ) {
+        if( req_res == requirement_check_result::RETURN_EARLY || !you.activity ) {
             // Fetch dispatched -- prune so we don't re-trigger it.
             if( use_cache ) {
                 cache.sources.erase( src );
@@ -5612,6 +5612,8 @@ requirement_check_result multi_zone_activity_actor::fetch_requirements( Characte
         candidates.push_back( point_elem );
     }
     if( candidates.empty() ) {
+        add_msg_if_player_sees( you,
+                                _( "Failed to find a non-zoned suitably empty tile to drop fetched items within range of work activity." ) );
         you.activity = player_activity();
         you.backlog.clear();
         multi_activity_actor::check_npc_revert( you );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2565,59 +2565,6 @@ bool activity_must_be_in_zone( activity_id act_id, const tripoint_bub_ms &src_lo
           !here.partial_con_at( src_loc ) );
 }
 
-requirement_check_result fetch_requirements( Character &you, requirement_id what_we_need,
-        const activity_id &act_id,
-        activity_reason_info &act_info, const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc,
-        const std::unordered_set<tripoint_abs_ms> &src_set )
-{
-
-    map &here = get_map();
-
-    if( you.as_npc() && you.as_npc()->job.fetch_history.count( what_we_need.str() ) != 0 &&
-        you.as_npc()->job.fetch_history[what_we_need.str()] == calendar::turn ) {
-        // this may be faild fetch already. give up task for a while to avoid infinite loop.
-        you.activity = player_activity();
-        you.backlog.clear();
-        check_npc_revert( you );
-        return requirement_check_result::SKIP_LOCATION;
-    }
-    you.backlog.emplace_front( act_id );
-    you.assign_activity( ACT_FETCH_REQUIRED );
-    player_activity &act_prev = you.backlog.front();
-    act_prev.str_values.push_back( what_we_need.str() );
-    act_prev.values.push_back( static_cast<int>( act_info.reason ) );
-    // come back here after successfully fetching your stuff
-    if( act_prev.coords.empty() ) {
-        std::vector<tripoint_bub_ms> local_src_set;
-        local_src_set.reserve( src_set.size() );
-        for( const tripoint_abs_ms &elem : src_set ) {
-            local_src_set.push_back( here.get_bub( elem ) );
-        }
-        std::vector<tripoint_bub_ms> candidates;
-        for( const tripoint_bub_ms &point_elem :
-             here.points_in_radius( src_loc, PICKUP_RANGE - 1, 0 ) ) {
-            // we don't want to place the components where they could interfere with our ( or someone else's ) construction spots
-            if( ( std::find( local_src_set.begin(), local_src_set.end(),
-                             point_elem ) != local_src_set.end() ) || !here.can_put_items_ter_furn( point_elem ) ) {
-                continue;
-            }
-            candidates.push_back( point_elem );
-        }
-        if( candidates.empty() ) {
-            you.activity = player_activity();
-            you.backlog.clear();
-            check_npc_revert( you );
-            return requirement_check_result::SKIP_LOCATION_NO_LOCATION;
-        }
-        act_prev.coords.push_back(
-            here.get_abs(
-                candidates[std::max( 0, static_cast<int>( candidates.size() / 2 ) )] )
-        );
-    }
-    act_prev.placement = src;
-    return requirement_check_result::RETURN_EARLY;
-}
-
 requirement_check_result requirement_fail( Character &you, const do_activity_reason &reason,
         const activity_id &act_id, const zone_data *zone )
 {

--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -179,11 +179,6 @@ bool activity_reason_quit( do_activity_reason reason );
 // the activity (reason) requires picking up tools
 bool activity_reason_picks_up_tools( do_activity_reason reason );
 void check_npc_revert( Character &you );
-// assigns fetch activity to find requirements
-requirement_check_result fetch_requirements( Character &you, requirement_id what_we_need,
-        const activity_id &act_id,
-        activity_reason_info &act_info, const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc,
-        const std::unordered_set<tripoint_abs_ms> &src_set );
 // converts invalid do_activity_reason into failed requirement_check_result
 requirement_check_result requirement_fail( Character &you, const do_activity_reason &reason,
         const activity_id &act_id, const zone_data *zone );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "multi-activity fetch segfault fix"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Fixes #86995
- Fixes #87020

If fetching for multi-activities failed to find a destination (`PICKUP_RANGE - 1` tiles around the zone tile position) , `Character::activity` would be reset but continue processing zone tiles in `multi_zone_activity_actor::simulate_turn()`, leading to an inevitable segfault.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

If `you.activity` is no longer valid, quit the zone tile loop immediately, add a feedback message for when fetching for multi-activities fails to find a destination.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested saves from linked issues, no segfault when following provided steps (including those from @PatrikLundell).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Removes an unused function that I forgot to clean up in #85237

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
