### PR TITLE
[MoM] Using censer from the Highlands raises your Nether Attunement

### DIFF
--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -463,5 +463,19 @@
       { "value": "THROW_DAMAGE", "multiply": 0.05 }
     ],
     "encumbrance_modifier": [ { "part": "torso", "add": -40 } ]
+  },
+  {
+    "//": "This is overwritten in MoM",
+    "id": "ench_mom_incense_nether_attunement",
+    "type": "enchantment",
+    "has": "HELD",
+    "condition": "ALWAYS"
+  },
+  {
+    "//": "This is overwritten in MoM",
+    "id": "ench_mom_incense_nether_attunement_major",
+    "type": "enchantment",
+    "has": "HELD",
+    "condition": "ALWAYS"
   }
 ]

--- a/data/json/items/relics/highland_censer.json
+++ b/data/json/items/relics/highland_censer.json
@@ -204,7 +204,10 @@
     "show_in_info": true,
     "max_intensity": 1,
     "remove_message": "Things seem to stitch back together.",
-    "enchantments": [ { "values": [ { "value": "ARTIFACT_RESONANCE", "add": 4500 }, { "value": "SPEED", "add": -10 } ] } ]
+    "enchantments": [
+      "ench_mom_incense_nether_attunement",
+      { "values": [ { "value": "ARTIFACT_RESONANCE", "add": 4500 }, { "value": "SPEED", "add": -10 } ] }
+    ]
   },
   {
     "type": "effect_type",
@@ -226,7 +229,7 @@
     "show_in_info": true,
     "max_intensity": 1,
     "remove_message": "The feeling of calm fades away.",
-    "enchantments": [ { "values": [ { "value": "SPEED", "add": -10 } ] } ]
+    "enchantments": [ "ench_mom_incense_nether_attunement", { "values": [ { "value": "SPEED", "add": -10 } ] } ]
   },
   {
     "type": "effect_type",
@@ -261,6 +264,7 @@
     "max_intensity": 1,
     "remove_message": "Things seem to stitch back together.",
     "enchantments": [
+      "ench_mom_incense_nether_attunement_major",
       {
         "values": [
           { "value": "PHASE_DISTANCE", "add": 2 },

--- a/data/mods/MindOverMatter/effects/effects_nether_attunement.json
+++ b/data/mods/MindOverMatter/effects/effects_nether_attunement.json
@@ -184,5 +184,21 @@
     "//": "Hidden effect, used as a tracker",
     "name": [ "" ],
     "desc": [ "" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_mom_incense_nether_attunement",
+    "//": "Hidden effect, part of an enchantment",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "vitamins": [ { "vitamin": "vitamin_psionic_drain", "rate": [ [ 2, 6 ] ], "tick": [ "20 s" ] } ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_mom_incense_nether_attunement_major",
+    "//": "Hidden effect, part of an enchantment",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "vitamins": [ { "vitamin": "vitamin_psionic_drain", "rate": [ [ 3, 6 ] ], "tick": [ "5 s" ] } ]
   }
 ]

--- a/data/mods/MindOverMatter/effects/effects_nether_attunement.json
+++ b/data/mods/MindOverMatter/effects/effects_nether_attunement.json
@@ -187,11 +187,11 @@
   },
   {
     "type": "effect_type",
-    "id": "effect_mom_incense_nether_attunement",
+    "id": "effect_mom_incense_nether_attunement_minor",
     "//": "Hidden effect, part of an enchantment",
     "name": [ "" ],
     "desc": [ "" ],
-    "vitamins": [ { "vitamin": "vitamin_psionic_drain", "rate": [ [ 1, 5 ] ], "tick": [ "20 s" ] } ]
+    "vitamins": [ { "vitamin": "vitamin_psionic_drain", "rate": [ [ 1, 5 ] ], "tick": [ "30 s" ] } ]
   },
   {
     "type": "effect_type",

--- a/data/mods/MindOverMatter/effects/effects_nether_attunement.json
+++ b/data/mods/MindOverMatter/effects/effects_nether_attunement.json
@@ -191,7 +191,7 @@
     "//": "Hidden effect, part of an enchantment",
     "name": [ "" ],
     "desc": [ "" ],
-    "vitamins": [ { "vitamin": "vitamin_psionic_drain", "rate": [ [ 2, 6 ] ], "tick": [ "20 s" ] } ]
+    "vitamins": [ { "vitamin": "vitamin_psionic_drain", "rate": [ [ 1, 5 ] ], "tick": [ "20 s" ] } ]
   },
   {
     "type": "effect_type",

--- a/data/mods/MindOverMatter/enchantments/enchantments_nether_attunement.json
+++ b/data/mods/MindOverMatter/enchantments/enchantments_nether_attunement.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ench_mom_incense_nether_attunement",
+    "type": "enchantment",
+    "has": "HELD",
+    "condition": {
+      "u_has_any_trait": [
+        "BIOKINETIC",
+        "CLAIRSENTIENT",
+        "ELECTROKINETIC",
+        "PHOTOKINETIC",
+        "PYROKINETIC",
+        "TELEKINETIC",
+        "TELEPATH",
+        "TELEPORTER",
+        "VITAKINETIC",
+        "PSYCHIC_KNACK"
+      ]
+    },
+    "ench_effects": [ { "effect": "effect_mom_incense_nether_attunement", "intensity": 1 } ]
+  },
+  {
+    "id": "ench_mom_incense_nether_attunement_major",
+    "type": "enchantment",
+    "has": "HELD",
+    "condition": {
+      "u_has_any_trait": [
+        "BIOKINETIC",
+        "CLAIRSENTIENT",
+        "ELECTROKINETIC",
+        "PHOTOKINETIC",
+        "PYROKINETIC",
+        "TELEKINETIC",
+        "TELEPATH",
+        "TELEPORTER",
+        "VITAKINETIC",
+        "PSYCHIC_KNACK"
+      ]
+    },
+    "ench_effects": [ { "effect": "effect_mom_incense_nether_attunement_major", "intensity": 1 } ]
+  }
+]

--- a/data/mods/MindOverMatter/enchantments/enchantments_nether_attunement.json
+++ b/data/mods/MindOverMatter/enchantments/enchantments_nether_attunement.json
@@ -17,7 +17,7 @@
         "PSYCHIC_KNACK"
       ]
     },
-    "ench_effects": [ { "effect": "effect_mom_incense_nether_attunement", "intensity": 1 } ]
+    "ench_effects": [ { "effect": "effect_mom_incense_nether_attunement_minor", "intensity": 1 } ]
   },
   {
     "id": "ench_mom_incense_nether_attunement_major",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Using censer from the Highlands raises your Nether Attunement"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

New content/MoM interactions! 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Using the censor raises your Nether Attunement! Yellow and purple incense raises it a bit, green incense raises it a lot. 

Your Nether Attunement only goes up if you're psychic.

This is done by attaching empty enchantments in vanilla and overriding them in MoM. I did load the game vanilla-only and make sure no errors were thrown (they were not). 

If you use the incense indoors and marinate in it you're going to get a _lot_ of Nether Attunement. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Used the censor, Nether Attunement went up. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
