### PR TITLE
[MoM] Dimensional Anchors will eventually cancel your concentration powers

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_items.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_items.json
@@ -284,5 +284,41 @@
     "required_event": "character_loses_effect",
     "condition": { "compare_string": [ "effect_mom_cascade_stone", { "context_val": "effect" } ] },
     "effect": [ { "u_lose_trait": "PSI_TORRENTIAL_CHANNELING_active" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MOM_DIMENSIONAL_ANCHOR_WILL_CANCEL_POWERS",
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
+    "condition": { "compare_string": [ "effect_psi_dimensionally_anchored", { "context_val": "trait" } ] },
+    "effect": [
+      { "u_add_effect": "effect_mom_dimensionally_anchored_eventually_cancel_concentration", "duration": 100 },
+      { "run_eocs": "EOC_MOM_DIMENSIONAL_ANCHOR_WILL_CANCEL_POWERS_ESCALATING_CHECKER" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MOM_DIMENSIONAL_ANCHOR_WILL_CANCEL_POWERS_ESCALATING_CHECKER",
+    "condition": {
+      "and": [
+        { "u_has_worn_with_flag": "DIMENSIONAL_ANCHOR" },
+        { "u_has_effect": "effect_mom_dimensionally_anchored_eventually_cancel_concentration" }
+      ]
+    },
+    "effect": [
+      {
+        "if": {
+          "x_in_y_chance": {
+            "x": { "math": [ "u_effect_intensity('effect_mom_dimensionally_anchored_eventually_cancel_concentration')" ] },
+            "y": 100
+          }
+        },
+        "then": [
+          { "u_lose_effect": "effect_mom_dimensionally_anchored_eventually_cancel_concentration" },
+          { "run_eocs": "EOC_END_PSI_POWERS" }
+        ],
+        "else": [ { "run_eocs": "EOC_MOM_DIMENSIONAL_ANCHOR_WILL_CANCEL_POWERS_ESCALATING_CHECKER", "time_in_future": 1 } ]
+      }
+    ]
   }
 ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_items.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_items.json
@@ -290,7 +290,7 @@
     "id": "EOC_MOM_DIMENSIONAL_ANCHOR_WILL_CANCEL_POWERS",
     "eoc_type": "EVENT",
     "required_event": "character_gains_effect",
-    "condition": { "compare_string": [ "effect_psi_dimensionally_anchored", { "context_val": "trait" } ] },
+    "condition": { "compare_string": [ "effect_psi_dimensionally_anchored", { "context_val": "effect" } ] },
     "effect": [
       { "u_add_effect": "effect_mom_dimensionally_anchored_eventually_cancel_concentration", "duration": 100 },
       { "run_eocs": "EOC_MOM_DIMENSIONAL_ANCHOR_WILL_CANCEL_POWERS_ESCALATING_CHECKER" }

--- a/data/mods/MindOverMatter/effects/effects_penalty.json
+++ b/data/mods/MindOverMatter/effects/effects_penalty.json
@@ -136,6 +136,14 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_psi_dimensionally_anchored",
+    "//": "This exists to trigger EoCs or as a rider on other psi effects",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "flags": [ "NO_PSIONICS" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_psi_neutralized",
     "name": [ "Neutralized" ],
     "//": "Same as above but it also cancels all active psionic buffs on the target.  Should be used very rarely.",
@@ -491,5 +499,16 @@
     "show_in_info": true,
     "removes_effects": [ "hay_fever" ],
     "base_mods": { "per_mod": [ -4 ], "int_mod": [ -3 ], "stamina_min": [ -75 ], "stamina_max": [ -225 ], "stamina_chance": [ 200 ] }
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_mom_dimensionally_anchored_eventually_cancel_concentration",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "rating": "bad",
+    "max_intensity": 100,
+    "int_add_val": 1,
+    "int_decay_step": 1,
+    "int_decay_tick": 1
   }
 ]

--- a/data/mods/MindOverMatter/items/armor/head.json
+++ b/data/mods/MindOverMatter/items/armor/head.json
@@ -16,7 +16,13 @@
     "material_thickness": 1,
     "flags": [ "DIMENSIONAL_ANCHOR", "PADDED" ],
     "armor": [ { "encumbrance": 1, "coverage": 20, "covers": [ "head" ], "specifically_covers": [ "head_crown" ] } ],
-    "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "ANCHORCROWN_NOSPELL" ] } ]
+    "passive_effects": [
+      {
+        "has": "WORN",
+        "condition": "ALWAYS",
+        "ench_effects": [ { "effect": "effect_psi_dimensionally_anchored", "intensity": 1 } ]
+      }
+    ]
   },
   {
     "id": "psionic_telepathic_dampener",
@@ -37,7 +43,14 @@
       { "encumbrance": 4, "coverage": 100, "covers": [ "head" ], "specifically_covers": [ "head_crown", "head_forehead" ] }
     ],
     "flags": [ "PADDED", "PORTAL_PROOF" ],
-    "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "mutations": [ "TELEPATHICDAMPENER_SHIELD" ] } ]
+    "passive_effects": [
+      {
+        "has": "WORN",
+        "condition": "ALWAYS",
+        "ench_effects": [ { "effect": "effect_psi_dimensionally_anchored", "intensity": 1 } ],
+        "incoming_damage_mod": [ { "type": "psi_telepathic_damage", "multiply": -1 } ]
+      }
+    ]
   },
   {
     "id": "psionic_mindsight_glasses",

--- a/data/mods/MindOverMatter/items/armor/overrides.json
+++ b/data/mods/MindOverMatter/items/armor/overrides.json
@@ -6,7 +6,14 @@
     "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "category": "clothing",
     "name": { "str": "5-point anchor" },
-    "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "mutations": [ "ANCHORCROWN_NOSPELL" ] } ]
+    "passive_effects": [
+      {
+        "has": "WORN",
+        "condition": "ACTIVE",
+        "ench_effects": [ { "effect": "effect_psi_dimensionally_anchored", "intensity": 1 } ]
+      }
+    ],
+    "extend": { "flags": [ "MUNDANE" ] }
   },
   {
     "id": "dimensional_anchor_on",
@@ -15,6 +22,41 @@
     "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "category": "clothing",
     "name": { "str": "5-point anchor (on)", "str_pl": "5-point anchors (on)" },
-    "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "mutations": [ "ANCHORCROWN_NOSPELL" ] } ]
+    "passive_effects": [
+      {
+        "has": "WORN",
+        "condition": "ACTIVE",
+        "ench_effects": [ { "effect": "effect_psi_dimensionally_anchored", "intensity": 1 } ]
+      }
+    ],
+    "extend": { "flags": [ "MUNDANE" ] }
+  },
+  {
+    "id": "robofac_armor_anchor",
+    "copy-from": "robofac_armor_anchor",
+    "type": "ITEM",
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
+    "passive_effects": [
+      {
+        "has": "WORN",
+        "condition": "ACTIVE",
+        "ench_effects": [ { "effect": "effect_psi_dimensionally_anchored", "intensity": 1 } ]
+      }
+    ],
+    "extend": { "flags": [ "MUNDANE" ] }
+  },
+  {
+    "id": "robofac_armor_anchor_on",
+    "copy-from": "robofac_armor_anchor_on",
+    "type": "ITEM",
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
+    "passive_effects": [
+      {
+        "has": "WORN",
+        "condition": "ACTIVE",
+        "ench_effects": [ { "effect": "effect_psi_dimensionally_anchored", "intensity": 1 } ]
+      }
+    ],
+    "extend": { "flags": [ "MUNDANE" ] }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Dimensional Anchors will eventually cancel your concentration powers"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #85113 

Also fixes an oversight where the Hub Modular Defensive Anchor was missed.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Hub Modular Defensive Anchor is now treated as a 5-point Anchor.

When you activate your anchor, you can no longer channel any new powers. This also starts a countdown--every turn it rolls a check, which gets more likely over time, and if the check succeeds any current concentration powers you have are cancelled. So you can turn on your anchor in times of stress but your powers may fail at the exact wrong time. 

I also set this up for the Anchoring Crown and the Telepathic Dampener, and set the Telepathic Dampener to reduce all telepathic damage received to 0. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Turned on modular defense anchor. Ran to the other side of the room and back. On the way back, concentration powers turned off. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
