### PR TITLE
Fix crash spawning items with a null default ammo or magazine slot

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cstdlib>
 #include <iterator>
-#include <memory>
 #include <optional>
 #include <set>
 #include <stdexcept>
@@ -27,7 +26,6 @@
 #include "iexamine.h"
 #include "inventory.h"
 #include "item.h"
-#include "item_factory.h"
 #include "item_location.h"
 #include "itype.h"
 #include "iuse.h"
@@ -48,7 +46,6 @@
 #include "type_id.h"
 #include "uilist.h"
 #include "units.h"
-#include "value_ptr.h"
 #include "vehicle.h"
 #include "vpart_position.h"
 #include "weather.h"
@@ -602,10 +599,10 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
             ammo_name = _( "bionic power" );
 
         } else {
-            if( used_tool->ammo_current().is_null() ) {
-                current_ammo = item_controller->find_template( used_tool->ammo_default() )->ammo->type;
-            } else {
-                current_ammo = item_controller->find_template( used_tool->ammo_current() )->ammo->type;
+            const itype_id ammo_id = used_tool->ammo_current().is_null()
+                                     ? used_tool->ammo_default() : used_tool->ammo_current();
+            if( const std::optional<ammotype> at = item::ammotype_of( ammo_id ) ) {
+                current_ammo = *at;
             }
             ammo_name = item::nname( used_tool->ammo_current() );
         }

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -42,7 +42,6 @@
 #include "inventory.h"
 #include "item.h"
 #include "item_contents.h"
-#include "item_factory.h"
 #include "item_location.h"
 #include "item_pocket.h"
 #include "item_stack.h"
@@ -1619,12 +1618,11 @@ std::string Character::weapname_ammo() const
                 if( const item *mag = p->magazine_current() ) {
                     cur = mag->ammo_remaining( );
                     const itype *adata = mag->ammo_data();
-                    max = adata
-                          ? mag->ammo_capacity( adata->ammo->type )
-                          : ( !mag->ammo_default().is_null()
-                              ? mag->ammo_capacity( item_controller->find_template(
-                                                        mag->ammo_default() )->ammo->type )
-                              : 0 );
+                    if( adata ) {
+                        max = mag->ammo_capacity( adata->ammo->type );
+                    } else if( const std::optional<ammotype> at = item::ammotype_of( mag->ammo_default() ) ) {
+                        max = mag->ammo_capacity( *at );
+                    }
                 } else {
                     const pocket_data *pd = p->get_pocket_data();
                     if( pd && !pd->default_magazine.is_null() && pd->default_magazine->magazine ) {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -3743,8 +3743,9 @@ void Character::complete_disassemble( item_location &target, const recipe &dis )
 
             // If the recipe has a `FULL_MAGAZINE` flag, spawn any magazines full of ammo
             if( newit.is_magazine() && dis.has_flag( flag_FULL_MAGAZINE ) ) {
-                newit.ammo_set( newit.ammo_default(),
-                                newit.ammo_capacity( item::find_type( newit.ammo_default() )->ammo->type ) );
+                if( const std::optional<ammotype> at = item::ammotype_of( newit.ammo_default() ) ) {
+                    newit.ammo_set( newit.ammo_default(), newit.ammo_capacity( *at ) );
+                }
             }
 
             for( ; compcount > 0; compcount-- ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1767,8 +1767,8 @@ std::string item::display_name( unsigned int quantity ) const
         const itype *adata = ammo_data();
         if( adata ) {
             max_amount = ammo_capacity( adata->ammo->type );
-        } else if( !ammo_default().is_null() ) {
-            max_amount = ammo_capacity( item_controller->find_template( ammo_default() )->ammo->type );
+        } else if( const std::optional<ammotype> at = ammotype_of( ammo_default() ) ) {
+            max_amount = ammo_capacity( *at );
         }
     } else if( is_vehicle_battery() ) {
         show_amt = true;
@@ -5069,6 +5069,18 @@ bool item::type_is_defined( const itype_id &id )
 const itype *item::find_type( const itype_id &type )
 {
     return item_controller->find_template( type );
+}
+
+std::optional<ammotype> item::ammotype_of( const itype_id &id )
+{
+    if( id.is_null() ) {
+        return std::nullopt;
+    }
+    const itype *t = find_type( id );
+    if( t == nullptr || !t->ammo ) {
+        return std::nullopt;
+    }
+    return t->ammo->type;
 }
 
 bool item::has_label() const

--- a/src/item.h
+++ b/src/item.h
@@ -3094,6 +3094,9 @@ class item : public visitable
          * Returns the item type of the given identifier. Never returns null.
          */
         static const itype *find_type( const itype_id &type );
+        // Ammotype of id's ammo slot, or nullopt when it has none. Null-safe for
+        // NULL-ammo guns and pocket-defined magazines.
+        static std::optional<ammotype> ammotype_of( const itype_id &id );
         /**
          * Whether the item is counted by charges, this is a static wrapper
          * around @ref count_by_charges, that does not need an items instance.

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -562,11 +562,15 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
 
             if( new_item.is_magazine() ) {
                 // Get the ammo capacity of the new item itself
-                max_ammo = new_item.ammo_capacity( item_controller->find_template(
-                                                       new_item.ammo_default() )->ammo->type );
+                if( const std::optional<ammotype> at = item::ammotype_of( new_item.ammo_default() ) ) {
+                    max_ammo = new_item.ammo_capacity( *at );
+                }
             } else if( !new_item.magazine_default().is_null() ) {
-                // Get the capacity of the item's default magazine
-                max_ammo = item_controller->find_template( new_item.magazine_default() )->magazine->capacity;
+                // Default magazine may be a non-magazine itype, so guard the slot.
+                const itype *mag = item_controller->find_template( new_item.magazine_default() );
+                if( mag != nullptr && mag->magazine ) {
+                    max_ammo = mag->magazine->capacity;
+                }
             }
             // Don't change the ammo capacity from 0 if the item isn't a magazine
             // and doesn't have a default magazine with a capacity
@@ -666,8 +670,9 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
             }
             // Make sure the item is in valid state
             if( new_item.magazine_integral() ) {
-                new_item.charges = std::min( new_item.charges,
-                                             new_item.ammo_capacity( item_controller->find_template( new_item.ammo_default() )->ammo->type ) );
+                if( const std::optional<ammotype> at = item::ammotype_of( new_item.ammo_default() ) ) {
+                    new_item.charges = std::min( new_item.charges, new_item.ammo_capacity( *at ) );
+                }
             } else {
                 new_item.charges = 0;
             }

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -977,11 +977,10 @@ void item_pocket::set_item_defaults()
     for( item &contained_item : contents ) {
         /* for guns and other items defined to have a magazine but don't use "ammo" */
         if( contained_item.is_magazine() ) {
-            contained_item.ammo_set(
-                contained_item.ammo_default(),
-                contained_item.ammo_capacity( item_controller->find_template(
-                                                  contained_item.ammo_default() )->ammo->type ) / 2
-            );
+            if( const std::optional<ammotype> at = item::ammotype_of( contained_item.ammo_default() ) ) {
+                contained_item.ammo_set( contained_item.ammo_default(),
+                                         contained_item.ammo_capacity( *at ) / 2 );
+            }
         } else { //Contents are batteries or food
             contained_item.charges =
                 item::find_type( contained_item.typeId() )->charges_default();

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2788,17 +2788,15 @@ double Character::evaluate_weapon( const item &maybe_weapon, const bool pretend_
     // ABSOLUTELY disgusting fake gun assembly for character creation
     int pretend_ammo = 0;
     if( pretend_have_ammo && maybe_weapon.is_gun() ) {
-        itype_id ammo_id = itype_id::NULL_ID();
-        if( maybe_weapon.ammo_default().is_null() ) {
-            ammo_id = item( maybe_weapon.magazine_default() ).ammo_default();
-        } else {
-            ammo_id = maybe_weapon.ammo_default();
-        }
-        const ammotype &type_of_ammo = item::find_type( ammo_id )->ammo->type;
-        if( maybe_weapon.magazine_integral() ) {
-            pretend_ammo = maybe_weapon.ammo_capacity( type_of_ammo );
-        } else {
-            pretend_ammo = item( maybe_weapon.magazine_default() ).ammo_capacity( type_of_ammo );
+        const itype_id ammo_id = maybe_weapon.ammo_default().is_null()
+                                 ? item( maybe_weapon.magazine_default() ).ammo_default()
+                                 : maybe_weapon.ammo_default();
+        if( const std::optional<ammotype> type_of_ammo = item::ammotype_of( ammo_id ) ) {
+            if( maybe_weapon.magazine_integral() ) {
+                pretend_ammo = maybe_weapon.ammo_capacity( *type_of_ammo );
+            } else {
+                pretend_ammo = item( maybe_weapon.magazine_default() ).ammo_capacity( *type_of_ammo );
+            }
         }
     }
     return evaluate_weapon_internal( maybe_weapon, can_use_gun, use_silent, pretend_ammo );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -61,7 +61,6 @@
 #include "iexamine.h"
 #include "inventory.h"
 #include "item.h"
-#include "item_factory.h"
 #include "item_location.h"
 #include "item_transformation.h"
 #include "itype.h"
@@ -3511,9 +3510,9 @@ bool npc::enough_time_to_reload( const item &gun ) const
 {
     const map &here = get_map();
 
+    const std::optional<ammotype> at = item::ammotype_of( gun.ammo_default() );
     int rltime = item_reload_cost( gun, item( gun.ammo_default() ),
-                                   gun.ammo_capacity(
-                                       item_controller->find_template( gun.ammo_default() )->ammo->type ) );
+                                   at ? gun.ammo_capacity( *at ) : 0 );
     const float turns_til_reloaded = static_cast<float>( rltime ) / get_speed();
 
     const Creature *target = current_target();

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1145,8 +1145,9 @@ std::vector<item> recipe::create_result( bool set_components, bool is_food,
 
     // If the recipe has a `FULL_MAGAZINE` flag, fill it with ammo
     if( newit.is_magazine() && has_flag( flag_FULL_MAGAZINE ) ) {
-        newit.ammo_set( newit.ammo_default(),
-                        newit.ammo_capacity( item::find_type( newit.ammo_default() )->ammo->type ) );
+        if( const std::optional<ammotype> at = item::ammotype_of( newit.ammo_default() ) ) {
+            newit.ammo_set( newit.ammo_default(), newit.ammo_capacity( *at ) );
+        }
     }
 
     // if the first component has compatible pockets, try to preserve the contents


### PR DESCRIPTION
#### Summary
Bugfixes "Fix crash spawning items with a null default ammo or magazine slot"

#### Purpose of change
Follow-up to #87136. The same null ammo/magazine slot deref it fixed in `item::display_name` still exists in other functions.

#### Describe the solution
Cover those places with guards, via a shared helper `item::ammotype_of`.

#### Describe alternatives you've considered
N/A

#### Testing
Reproduced the crash, confirmed gone.

#### Additional context
N/A