### PR TITLE
[XE] Two new blood art refinements

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_refinements.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_refinements.json
@@ -110,7 +110,7 @@
     "valid": false,
     "player_display": true,
     "name": { "str": "Earthen Grave" },
-    "description": "You can part the earth aroung you to create holes to trap your foes into.",
+    "description": "You can part the earth near you to create holes for your foes to fall into.",
     "spells_learned": [ [ "vampire_create_pits", 1 ] ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_refinements.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_refinements.json
@@ -110,7 +110,7 @@
     "valid": false,
     "player_display": true,
     "name": { "str": "Earthen Grave" },
-    "description": "You can part the earth aroung you to create large holes to trap your foes into.",
+    "description": "You can part the earth aroung you to create holes to trap your foes into.",
     "spells_learned": [ [ "vampire_create_pits", 1 ] ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_refinements.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_refinements.json
@@ -87,5 +87,30 @@
     "player_display": true,
     "name": { "str": "Incarnadine Relentlessness" },
     "description": "You gain a temporary stackable cardio boost when using Unholy Endurance."
+  },
+  {
+    "type": "mutation",
+    "id": "VAMPIRE_WALK_ON_WALLS_REFINEMENT_JUMP",
+    "points": 3,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "player_display": true,
+    "name": { "str": "Spider's leap" },
+    "description": "Your gravity has been reduced further, increasing your carry capacity by 10% and granting you the ability to leap over a distance based on your strength.",
+    "spells_learned": [ [ "vampire_spider_jump_spell", 1 ] ],
+    "enchantments": [ { "values": [ { "value": "CARRY_WEIGHT", "multiply": 0.1 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "VAMPIRE_EARTH_SLUMBER_REFINEMENT_TELEPORT",
+    "points": 3,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "player_display": true,
+    "name": { "str": "Earthen Step" },
+    "description": "You can sink into the earth to emerge from it somewhere else nearby.",
+    "spells_learned": [ [ "vampire_earth_to_earth_teleport_spell", 1 ] ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_refinements.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_refinements.json
@@ -90,27 +90,27 @@
   },
   {
     "type": "mutation",
-    "id": "VAMPIRE_WALK_ON_WALLS_REFINEMENT_JUMP",
+    "id": "VAMPIRE_WALK_ON_WALLS_REFINEMENT_LOW_GRAVITY",
     "points": 3,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
     "player_display": true,
-    "name": { "str": "Spider's leap" },
-    "description": "Your gravity has been reduced further, increasing your carry capacity by 10% and granting you the ability to leap over a distance based on your strength.",
-    "spells_learned": [ [ "vampire_spider_jump_spell", 1 ] ],
-    "enchantments": [ { "values": [ { "value": "CARRY_WEIGHT", "multiply": 0.1 } ] } ]
+    "name": { "str": "Light as a Spider's Thread" },
+    "description": "Your gravity has been reduced further, increasing your carry capacity by 25% and granting you the ability to glide down from heights.",
+    "enchantments": [ { "values": [ { "value": "CARRY_WEIGHT", "multiply": 0.25 } ] } ],
+    "flags": [ "GLIDE" ]
   },
   {
     "type": "mutation",
-    "id": "VAMPIRE_EARTH_SLUMBER_REFINEMENT_TELEPORT",
+    "id": "VAMPIRE_EARTH_SLUMBER_REFINEMENT_CREATE_PITS",
     "points": 3,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
     "player_display": true,
-    "name": { "str": "Earthen Step" },
-    "description": "You can sink into the earth to emerge from it somewhere else nearby.",
-    "spells_learned": [ [ "vampire_earth_to_earth_teleport_spell", 1 ] ]
+    "name": { "str": "Earthen Grave" },
+    "description": "You can part the earth aroung you to create large holes to trap your foes into.",
+    "spells_learned": [ [ "vampire_create_pits", 1 ] ]
   }
 ]

--- a/data/mods/Xedra_Evolved/recipes/vampire.json
+++ b/data/mods/Xedra_Evolved/recipes/vampire.json
@@ -455,8 +455,8 @@
             "EOC_REFINE_VAMPIRE_BLOOD_TEMPORARY_BOOST_REFINEMENT_MIND_BOOST",
             "EOC_REFINE_VAMPIRE_BAT_FORM_REFINEMENT_SWARM",
             "EOC_REFINE_VAMPIRE_CARDIO_BONUS_REFINEMENT_STAMINAFORBLOOD",
-            "EOC_REFINE_VAMPIRE_WALK_ON_WALLS_JUMP",
-            "EOC_REFINE_VAMPIRE_EARTH_SLUMBER_TELEPORT",
+            "EOC_REFINE_VAMPIRE_WALK_ON_WALLS_LOW_GRAVITY",
+            "EOC_REFINE_VAMPIRE_EARTH_SLUMBER_CREATE_PITS",
             "EOC_NONE"
           ],
           "allow_cancel": true,
@@ -469,8 +469,8 @@
             "Refine Carmine Vitality: Carmine Clarity",
             "Refine Shape of the Night Flier: Shape of the Night Fliers' Swarm",
             "Refine Incarnadine Energy/Unholy Endurance: Incarnadine Relentlessness",
-            "Refine Spider's Walk: Spider's Leap",
-            "Refine Earthen Slumber: Earthen Step",
+            "Refine Spider's Walk: Light as a Spider's Thread",
+            "Refine Earthen Slumber: Earthen Grave",
             "Nothing"
           ],
           "title": "Your research uncovers…",
@@ -483,8 +483,8 @@
             "Refine your Carmine Vitality so it increases intelligence and perception as well.",
             "Modify your Shape of the Night Flier to turn in a multitude of bats, making you as durable in this form as you are in your default form.",
             "Expand your Incarnadine Energy so that each use of Unholy Endurance temporarily increases its effect.",
-            "Further lessen your gravity, increasing how much you can carry and letting you jump over several meters by spending blood.",
-            "Learn to redirect your earthen movement so you can also sink into the earth and emerge from it somewhere else nearby.",
+            "Further lessen your gravity, increasing how much you can carry and lettiing you glide down from heights.",
+            "Learn to use your Earthen Slumber to instead create large holes for your enemies to fall in them.",
             "End your research."
           ]
         }
@@ -624,28 +624,34 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_REFINE_VAMPIRE_WALK_ON_WALLS_JUMP",
+    "id": "EOC_REFINE_VAMPIRE_WALK_ON_WALLS_LOW_GRAVITY",
     "condition": {
-      "and": [ { "u_has_trait": "VAMPIRE_WALK_ON_WALLS" }, { "not": { "u_has_trait": "VAMPIRE_WALK_ON_WALLS_REFINEMENT_JUMP" } } ]
+      "and": [
+        { "u_has_trait": "VAMPIRE_WALK_ON_WALLS" },
+        { "not": { "u_has_trait": "VAMPIRE_WALK_ON_WALLS_REFINEMENT_LOW_GRAVITY" } }
+      ]
     },
     "effect": [
-      { "u_add_trait": "VAMPIRE_WALK_ON_WALLS_REFINEMENT_JUMP" },
-      { "u_message": "You learned Spider's Leap, a new use for your Spider's Walk Blood Art.", "type": "good" },
+      { "u_add_trait": "VAMPIRE_WALK_ON_WALLS_REFINEMENT_LOW_GRAVITY" },
+      {
+        "u_message": "You learned Light as a Spider's Thread, a new use for your Spider's Walk Blood Art.",
+        "type": "good"
+      },
       { "run_eocs": "EOC_XE_VAMPIRE_BLOOD_REFINEMENT_RESEARCH_SUCCESS" }
     ]
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_REFINE_VAMPIRE_EARTH_SLUMBER_TELEPORT",
+    "id": "EOC_REFINE_VAMPIRE_EARTH_SLUMBER_CREATE_PITS",
     "condition": {
       "and": [
         { "u_has_trait": "VAMPIRE_EARTH_SLUMBER" },
-        { "not": { "u_has_trait": "VAMPIRE_EARTH_SLUMBER_REFINEMENT_TELEPORT" } }
+        { "not": { "u_has_trait": "VAMPIRE_EARTH_SLUMBER_REFINEMENT_CREATE_PITS" } }
       ]
     },
     "effect": [
-      { "u_add_trait": "VAMPIRE_EARTH_SLUMBER_REFINEMENT_TELEPORT" },
-      { "u_message": "You learned Earthen Step, a new use for your Earthen Slumber Blood Art.", "type": "good" },
+      { "u_add_trait": "VAMPIRE_EARTH_SLUMBER_REFINEMENT_CREATE_PITS" },
+      { "u_message": "You learned Earthen Grave, a new use for your Earthen Slumber Blood Art.", "type": "good" },
       { "run_eocs": "EOC_XE_VAMPIRE_BLOOD_REFINEMENT_RESEARCH_SUCCESS" }
     ]
   }

--- a/data/mods/Xedra_Evolved/recipes/vampire.json
+++ b/data/mods/Xedra_Evolved/recipes/vampire.json
@@ -483,7 +483,7 @@
             "Refine your Carmine Vitality so it increases intelligence and perception as well.",
             "Modify your Shape of the Night Flier to turn in a multitude of bats, making you as durable in this form as you are in your default form.",
             "Expand your Incarnadine Energy so that each use of Unholy Endurance temporarily increases its effect.",
-            "Further lessen your gravity, increasing how much you can carry and lettiing you glide down from heights.",
+            "Further lessen your gravity, increasing how much you can carry and letting you glide down from heights.",
             "Learn to use your Earthen Slumber to instead create large holes for your enemies to fall in them.",
             "End your research."
           ]

--- a/data/mods/Xedra_Evolved/recipes/vampire.json
+++ b/data/mods/Xedra_Evolved/recipes/vampire.json
@@ -483,7 +483,7 @@
             "Refine your Carmine Vitality so it increases intelligence and perception as well.",
             "Modify your Shape of the Night Flier to turn in a multitude of bats, making you as durable in this form as you are in your default form.",
             "Expand your Incarnadine Energy so that each use of Unholy Endurance temporarily increases its effect.",
-            "Further lessen your gravity, increasing how much you can carry and letting you glide down from heights.",
+            "Further lessen your gravity, increasing how much you can carry and allowing you to glide down from heights.",
             "Learn to use your Earthen Slumber to instead create large holes for your enemies to fall in them.",
             "End your research."
           ]

--- a/data/mods/Xedra_Evolved/recipes/vampire.json
+++ b/data/mods/Xedra_Evolved/recipes/vampire.json
@@ -334,10 +334,8 @@
       { "u_lose_trait": "VAMPIRE_WEAKNESS_NEED_HUMAN_BLOOD" },
       { "u_lose_trait": "VAMPIRE_WEAKNESS_BLOOD_CRAVING" },
       { "u_lose_trait": "VAMPIRE_WEAKNESS_NO_FUN" },
-      { "u_lose_trait": "VAMPIRE_WEAKNESS_GUILT" },
       { "u_lose_effect": "vampire_need_living_blood" },
       { "u_lose_morale": "morale_vw_no_fun" },
-      { "u_lose_morale": "morale_vampire_guilt" },
       { "run_eocs": "EOC_VAMPIRE_ADD_WEAKNESSES" },
       { "u_lose_effect": "effect_vampire_reshuffling_weaknesses" },
       { "u_add_effect": "effect_vampire_recently_reshuffled_weaknesses", "duration": "5 days" }

--- a/data/mods/Xedra_Evolved/recipes/vampire.json
+++ b/data/mods/Xedra_Evolved/recipes/vampire.json
@@ -455,6 +455,8 @@
             "EOC_REFINE_VAMPIRE_BLOOD_TEMPORARY_BOOST_REFINEMENT_MIND_BOOST",
             "EOC_REFINE_VAMPIRE_BAT_FORM_REFINEMENT_SWARM",
             "EOC_REFINE_VAMPIRE_CARDIO_BONUS_REFINEMENT_STAMINAFORBLOOD",
+            "EOC_REFINE_VAMPIRE_WALK_ON_WALLS_JUMP",
+            "EOC_REFINE_VAMPIRE_EARTH_SLUMBER_TELEPORT",
             "EOC_NONE"
           ],
           "allow_cancel": true,
@@ -467,6 +469,8 @@
             "Refine Carmine Vitality: Carmine Clarity",
             "Refine Shape of the Night Flier: Shape of the Night Fliers' Swarm",
             "Refine Incarnadine Energy/Unholy Endurance: Incarnadine Relentlessness",
+            "Refine Spider's Walk: Spider's Leap",
+            "Refine Earthen Slumber: Earthen Step",
             "Nothing"
           ],
           "title": "Your research uncovers…",
@@ -479,6 +483,8 @@
             "Refine your Carmine Vitality so it increases intelligence and perception as well.",
             "Modify your Shape of the Night Flier to turn in a multitude of bats, making you as durable in this form as you are in your default form.",
             "Expand your Incarnadine Energy so that each use of Unholy Endurance temporarily increases its effect.",
+            "Further lessen your gravity, increasing how much you can carry and letting you jump over several meters by spending blood.",
+            "Learn to redirect your earthen movement so you can also sink into the earth and emerge from it somewhere else nearby.",
             "End your research."
           ]
         }
@@ -613,6 +619,33 @@
         "u_message": "You learned Incarnadine Relentlessness, a new use for your Incarnadine Energy and Unholy Endurance Blood Arts.",
         "type": "good"
       },
+      { "run_eocs": "EOC_XE_VAMPIRE_BLOOD_REFINEMENT_RESEARCH_SUCCESS" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_REFINE_VAMPIRE_WALK_ON_WALLS_JUMP",
+    "condition": {
+      "and": [ { "u_has_trait": "VAMPIRE_WALK_ON_WALLS" }, { "not": { "u_has_trait": "VAMPIRE_WALK_ON_WALLS_REFINEMENT_JUMP" } } ]
+    },
+    "effect": [
+      { "u_add_trait": "VAMPIRE_WALK_ON_WALLS_REFINEMENT_JUMP" },
+      { "u_message": "You learned Spider's Leap, a new use for your Spider's Walk Blood Art.", "type": "good" },
+      { "run_eocs": "EOC_XE_VAMPIRE_BLOOD_REFINEMENT_RESEARCH_SUCCESS" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_REFINE_VAMPIRE_EARTH_SLUMBER_TELEPORT",
+    "condition": {
+      "and": [
+        { "u_has_trait": "VAMPIRE_EARTH_SLUMBER" },
+        { "not": { "u_has_trait": "VAMPIRE_EARTH_SLUMBER_REFINEMENT_TELEPORT" } }
+      ]
+    },
+    "effect": [
+      { "u_add_trait": "VAMPIRE_EARTH_SLUMBER_REFINEMENT_TELEPORT" },
+      { "u_message": "You learned Earthen Step, a new use for your Earthen Slumber Blood Art.", "type": "good" },
       { "run_eocs": "EOC_XE_VAMPIRE_BLOOD_REFINEMENT_RESEARCH_SUCCESS" }
     ]
   }

--- a/data/mods/Xedra_Evolved/spells/vampire_spells.json
+++ b/data/mods/Xedra_Evolved/spells/vampire_spells.json
@@ -127,7 +127,7 @@
     "id": "vampire_create_pits",
     "type": "SPELL",
     "name": "Earthen Grave",
-    "description": "Part the earth to create pits for your foes to fall into.  \n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
+    "description": "Part the earth to create pits for your foes to fall into.\n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
     "//": "This spell is mechanically similar to the Ierde's Pit-making spell, with the difference that the vampire does a far more controlled and contained effect by repurposing the Earthen Slumber blood art.",
     "teachable": false,
     "magic_type": "xe_vampire_blood_powers",

--- a/data/mods/Xedra_Evolved/spells/vampire_spells.json
+++ b/data/mods/Xedra_Evolved/spells/vampire_spells.json
@@ -124,6 +124,86 @@
     "difficulty": 0
   },
   {
+    "id": "vampire_spider_jump_spell",
+    "type": "SPELL",
+    "name": "Spider's Leap",
+    "description": "Jump forward several meters, with your strength boosting how far this jump can reach.  \n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
+    "message": "Blood dissolves within your legs as you leap forward.",
+    "teachable": false,
+    "magic_type": "xe_vampire_blood_powers",
+    "caster_condition": { "math": [ "u_vitamin('human_blood_vitamin') > -500" ] },
+    "caster_condition_fail_message": "You do not have enough stolen blood.",
+    "effect": "dash",
+    "shape": "cone",
+    "damage_type": "bash",
+    "valid_targets": [ "ground" ],
+    "min_range": { "math": [ "(u_val('strength') * 0.3) + 1" ] },
+    "max_range": { "math": [ "(u_val('strength') * 0.3) + 1" ] },
+    "flags": [ "SILENT", "NO_HANDS", "NO_FAIL", "NO_EXPLOSION_SFX" ],
+    "skill": "deduction",
+    "spell_class": "VAMPIRE_BLOOD_ARTS",
+    "base_energy_cost": 50,
+    "base_casting_time": 100,
+    "difficulty": 2
+  },
+  {
+    "id": "vampire_earth_to_earth_teleport_spell",
+    "type": "SPELL",
+    "name": "Earthen Step",
+    "description": "Sink into the earth and emerge from it somewhere nearby.  \n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
+    "message": "",
+    "teachable": false,
+    "magic_type": "xe_vampire_blood_powers",
+    "caster_condition": { "math": [ "u_vitamin('human_blood_vitamin') > -500" ] },
+    "caster_condition_fail_message": "You do not have enough stolen blood.",
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_VAMPIRE_EARTH_TELEPORT_CHECK",
+    "shape": "blast",
+    "valid_targets": [ "self" ],
+    "flags": [ "SILENT", "NO_LEGS", "NO_HANDS", "NO_FAIL", "NO_EXPLOSION_SFX" ],
+    "skill": "deduction",
+    "spell_class": "VAMPIRE_BLOOD_ARTS",
+    "//": "Earthen slumber costs no blood as it only provide shelter from the day.  This is a teleport-like ability, so it needs a cost.",
+    "base_energy_cost": 250,
+    "base_casting_time": 150,
+    "difficulty": 2
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VAMPIRE_EARTH_TELEPORT_CHECK",
+    "effect": [
+      {
+        "if": { "u_is_on_terrain_with_flag": "DIGGABLE" },
+        "then": [
+          {
+            "u_query_tile": "line_of_sight",
+            "target_var": { "context_val": "vampire_earth_teleport_location" },
+            "range": {
+              "math": [
+                "min((1 + (vampire_total_tier_one_traits_plus_potency() * 0.1) + (vampire_total_tier_two_traits() * 0.2) + (vampire_total_tier_three_traits() * 0.3) + (vampire_total_tier_four_traits_plus_potence() * 0.4) + (vampire_total_tier_five_traits_plus_cauldron() * 0.5)), 25)"
+              ]
+            },
+            "z_level": false,
+            "message": "Select nearby earth to emerge from."
+          },
+          {
+            "if": { "math": [ "has_var(vampire_earth_teleport_location)" ] },
+            "then": {
+              "if": { "map_terrain_with_flag": "DIGGABLE", "loc": { "context_val": "vampire_earth_teleport_location" } },
+              "then": [
+                { "u_teleport": { "context_val": "vampire_earth_teleport_location" }, "force": true },
+                { "u_message": "You sink into the earth and re-emerge nearby.", "type": "neutral" }
+              ],
+              "else": { "u_message": "You must select a patch of earth to transport to." }
+            },
+            "else": { "u_message": "Canceled" }
+          }
+        ],
+        "else": { "u_message": "You must stand on the earth to use this blood art.", "type": "bad" }
+      }
+    ]
+  },
+  {
     "id": "vampire_commune_with_night_spell",
     "type": "SPELL",
     "name": "Learn from the Children of the Night",

--- a/data/mods/Xedra_Evolved/spells/vampire_spells.json
+++ b/data/mods/Xedra_Evolved/spells/vampire_spells.json
@@ -124,84 +124,38 @@
     "difficulty": 0
   },
   {
-    "id": "vampire_spider_jump_spell",
+    "id": "vampire_create_pits",
     "type": "SPELL",
-    "name": "Spider's Leap",
-    "description": "Jump forward several meters, with your strength boosting how far this jump can reach.  \n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
-    "message": "Blood dissolves within your legs as you leap forward.",
+    "description": "Part the earth to create pits for your foes to fall into.  \n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
+    "//": "This spell is mechanically similar to the Ierde's Pit-making spell, with the difference that the vampire does a far more controlled and contained effect by repurposing the Earthen Slumber blood art.",
     "teachable": false,
     "magic_type": "xe_vampire_blood_powers",
     "caster_condition": { "math": [ "u_vitamin('human_blood_vitamin') > -500" ] },
     "caster_condition_fail_message": "You do not have enough stolen blood.",
-    "effect": "dash",
-    "shape": "cone",
-    "damage_type": "bash",
-    "valid_targets": [ "ground" ],
-    "min_range": { "math": [ "(u_val('strength') * 0.3) + 1" ] },
-    "max_range": { "math": [ "(u_val('strength') * 0.3) + 1" ] },
-    "flags": [ "SILENT", "NO_HANDS", "NO_FAIL", "NO_EXPLOSION_SFX" ],
-    "skill": "deduction",
+    "valid_targets": [ "hostile", "ground", "ally" ],
     "spell_class": "VAMPIRE_BLOOD_ARTS",
-    "base_energy_cost": 50,
-    "base_casting_time": 100,
-    "difficulty": 2
-  },
-  {
-    "id": "vampire_earth_to_earth_teleport_spell",
-    "type": "SPELL",
-    "name": "Earthen Step",
-    "description": "Sink into the earth and emerge from it somewhere nearby.  \n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
-    "message": "",
-    "teachable": false,
-    "magic_type": "xe_vampire_blood_powers",
-    "caster_condition": { "math": [ "u_vitamin('human_blood_vitamin') > -500" ] },
-    "caster_condition_fail_message": "You do not have enough stolen blood.",
-    "effect": "effect_on_condition",
-    "effect_str": "EOC_VAMPIRE_EARTH_TELEPORT_CHECK",
+    "skill": "deduction",
+    "flags": [ "NO_HANDS", "NO_FAIL" ],
+    "difficulty": 3,
+    "effect": "ter_transform",
+    "effect_str": "ierde_create_pits_transform",
     "shape": "blast",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT", "NO_LEGS", "NO_HANDS", "NO_FAIL", "NO_EXPLOSION_SFX" ],
-    "skill": "deduction",
-    "spell_class": "VAMPIRE_BLOOD_ARTS",
-    "//": "Earthen slumber costs no blood as it only provide shelter from the day.  This is a teleport-like ability, so it needs a cost.",
-    "base_energy_cost": 250,
-    "base_casting_time": 150,
-    "difficulty": 2
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_VAMPIRE_EARTH_TELEPORT_CHECK",
-    "effect": [
-      {
-        "if": { "u_is_on_terrain_with_flag": "DIGGABLE" },
-        "then": [
-          {
-            "u_query_tile": "line_of_sight",
-            "target_var": { "context_val": "vampire_earth_teleport_location" },
-            "range": {
-              "math": [
-                "min((1 + (vampire_total_tier_one_traits_plus_potency() * 0.1) + (vampire_total_tier_two_traits() * 0.2) + (vampire_total_tier_three_traits() * 0.3) + (vampire_total_tier_four_traits_plus_potence() * 0.4) + (vampire_total_tier_five_traits_plus_cauldron() * 0.5)), 25)"
-              ]
-            },
-            "z_level": false,
-            "message": "Select nearby earth to emerge from."
-          },
-          {
-            "if": { "math": [ "has_var(vampire_earth_teleport_location)" ] },
-            "then": {
-              "if": { "map_terrain_with_flag": "DIGGABLE", "loc": { "context_val": "vampire_earth_teleport_location" } },
-              "then": [
-                { "u_teleport": { "context_val": "vampire_earth_teleport_location" }, "force": true },
-                { "u_message": "You sink into the earth and re-emerge nearby.", "type": "neutral" }
-              ],
-              "else": { "u_message": "You must select a patch of earth to transport to." }
-            },
-            "else": { "u_message": "Canceled" }
-          }
-        ],
-        "else": { "u_message": "You must stand on the earth to use this blood art.", "type": "bad" }
-      }
-    ]
+    "min_range": {
+      "math": [
+        "min((vampire_total_tier_one_traits_plus_potency() + (vampire_total_tier_two_traits() * 2) + (vampire_total_tier_three_traits() * 3) + (vampire_total_tier_four_traits_plus_potence() * 4) + (vampire_total_tier_five_traits_plus_cauldron() * 5)), 35)"
+      ]
+    },
+    "max_range": {
+      "math": [
+        "min((vampire_total_tier_one_traits_plus_potency() + (vampire_total_tier_two_traits() * 2) + (vampire_total_tier_three_traits() * 3) + (vampire_total_tier_four_traits_plus_potence() * 4) + (vampire_total_tier_five_traits_plus_cauldron() * 5)), 35)"
+      ]
+    },
+    "max_aoe": 0,
+    "base_energy_cost": 100,
+    "base_casting_time": 50,
+    "sound_description": "the ground shakes!",
+    "sound_id": "earth_spell",
+    "sound_variant": "strong"
   },
   {
     "id": "vampire_commune_with_night_spell",

--- a/data/mods/Xedra_Evolved/spells/vampire_spells.json
+++ b/data/mods/Xedra_Evolved/spells/vampire_spells.json
@@ -126,6 +126,7 @@
   {
     "id": "vampire_create_pits",
     "type": "SPELL",
+    "name": "Earthen Grave",
     "description": "Part the earth to create pits for your foes to fall into.  \n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
     "//": "This spell is mechanically similar to the Ierde's Pit-making spell, with the difference that the vampire does a far more controlled and contained effect by repurposing the Earthen Slumber blood art.",
     "teachable": false,


### PR DESCRIPTION
#### Summary
Mods "[XE] Two new blood art refinements"


#### Purpose of change

I wanted to add refinements to Spider's Walk and Earthen Slumber back then but wasn't satisfied with how they would've worked.

After finding better effects for both, I'll finally add them.


#### Describe the solution

Add the following refinements:
-Light as a Spider's Thread (Spider's Walk): Gain 25% more carry weight and can glide from buildings (Intensify the gravity-lowering effects of Spider's Walk)
-Earthen Grave (Earthen Slumber): Spend blood to create a pit on the earth (Instead of digging under yourself and closing after you, you dig under someone else and don't close the earth)


#### Describe alternatives you've considered

Spider's Leap (jump ability) and Earthen Step (earth-to-earth teleport)
Vampires already get multiple mobility options: super speed, bat form, mist form, breaking walls, wall climb, etc. so I decided against adding late-game powers that would compete for blood use with the other mobility options.


#### Testing

Opened the game and debuged in both traits and some inner blood
Light as a Spider's Thread: gain more carry capacity and can glide down buildings.
Earthen Grave: can open pits on dirt, can't open pits on asphalt and open a single 1x1 pit per use of Earthen Grave.


#### Additional context

Research for more weaknesses is ongoing. I've considered vulnerability to a material like the fae gets, but I'm still examinating the options. Weakness to iron and steel risk being far more severe than the rest, while a vulnerability to silver or gold or another common material wouldn't impact much.