### PR TITLE
HIDDEN_SPELL Flag for spells

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1173,7 +1173,7 @@
     "//": "Spellcasting never fails for this spell"
   },
   {
-    "id": "HIDDEN",
+    "id": "HIDDEN_SPELL",
     "type": "json_flag",
     "//": "Spellcasting never shows any messages for this spell"
   },

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1173,6 +1173,11 @@
     "//": "Spellcasting never fails for this spell"
   },
   {
+    "id": "HIDDEN",
+    "type": "json_flag",
+    "//": "Spellcasting never shows any messages for this spell"
+  },
+  {
     "id": "IGNORE_WALLS",
     "type": "json_flag",
     "//": "This makes the spell's Area of Effect ignore walls."

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -185,7 +185,7 @@ std::string enum_to_string<spell_flag>( spell_flag data )
         case spell_flag::SPAWN_GROUP: return "SPAWN_GROUP";
         case spell_flag::IGNITE_FLAMMABLE: return "IGNITE_FLAMMABLE";
         case spell_flag::NO_FAIL: return "NO_FAIL";
-        case spell_flag::HIDDEN: return "HIDDEN";
+        case spell_flag::HIDDEN_SPELL: return "HIDDEN_SPELL";
         case spell_flag::WONDER: return "WONDER";
         case spell_flag::EXTRA_EFFECTS_FIRST: return "EXTRA_EFFECTS_FIRST";
         case spell_flag::MUST_HAVE_CLASS_TO_LEARN: return "MUST_HAVE_CLASS_TO_LEARN";
@@ -1241,7 +1241,7 @@ std::string spell::name() const
 
 std::string spell::message() const
 {
-    if( has_flag( "HIDDEN" ) ) {
+    if( has_flag( "HIDDEN_SPELL" ) ) {
         return {};
     }
     if( !alt_message.empty() ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1242,7 +1242,7 @@ std::string spell::name() const
 std::string spell::message() const
 {
     if( has_flag( "HIDDEN" ) ) {
-    return {};
+        return {};
     }
     if( !alt_message.empty() ) {
         return SNIPPET.expand( alt_message.translated() );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -185,6 +185,7 @@ std::string enum_to_string<spell_flag>( spell_flag data )
         case spell_flag::SPAWN_GROUP: return "SPAWN_GROUP";
         case spell_flag::IGNITE_FLAMMABLE: return "IGNITE_FLAMMABLE";
         case spell_flag::NO_FAIL: return "NO_FAIL";
+        case spell_flag::HIDDEN: return "HIDDEN";
         case spell_flag::WONDER: return "WONDER";
         case spell_flag::EXTRA_EFFECTS_FIRST: return "EXTRA_EFFECTS_FIRST";
         case spell_flag::MUST_HAVE_CLASS_TO_LEARN: return "MUST_HAVE_CLASS_TO_LEARN";
@@ -1240,6 +1241,9 @@ std::string spell::name() const
 
 std::string spell::message() const
 {
+    if( has_flag( "HIDDEN" ) ) {
+    return {};
+    }
     if( !alt_message.empty() ) {
         return SNIPPET.expand( alt_message.translated() );
     }

--- a/src/magic.h
+++ b/src/magic.h
@@ -78,7 +78,7 @@ enum class spell_flag : int {
     EXTRA_EFFECTS_FIRST, // the extra effects are cast before the main spell.
     PAIN_NORESIST, // pain altering spells can't be resisted (like with the deadened trait)
     NO_FAIL, // this spell cannot fail when you cast it
-    HIDDEN, // this spell never shows any message when cast
+    HIDDEN_SPELL, // this spell never shows any message when cast
     SPAWN_GROUP, // spawn or summon from an item or monster group, instead of individual item/monster ID
     IGNITE_FLAMMABLE, // if spell effect area has any thing flammable, a fire will be produced
     MUST_HAVE_CLASS_TO_LEARN, // you can't learn the spell unless you already have the class.

--- a/src/magic.h
+++ b/src/magic.h
@@ -78,6 +78,7 @@ enum class spell_flag : int {
     EXTRA_EFFECTS_FIRST, // the extra effects are cast before the main spell.
     PAIN_NORESIST, // pain altering spells can't be resisted (like with the deadened trait)
     NO_FAIL, // this spell cannot fail when you cast it
+    HIDDEN, // this spell never shows any message when cast
     SPAWN_GROUP, // spawn or summon from an item or monster group, instead of individual item/monster ID
     IGNITE_FLAMMABLE, // if spell effect area has any thing flammable, a fire will be produced
     MUST_HAVE_CLASS_TO_LEARN, // you can't learn the spell unless you already have the class.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Support for #87155.  Makes some spells not show casting messages.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds a flag and a check for it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
