### PR TITLE
Consume crafting tools per recipe step

### DIFF
--- a/data/mods/TEST_DATA/recipes.json
+++ b/data/mods/TEST_DATA/recipes.json
@@ -401,6 +401,125 @@
   {
     "type": "recipe",
     "result": "cudgel",
+    "id_suffix": "test_steps_charged",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "steps": [
+      { "name": "Shape", "time": "10 m", "activity_level": "MODERATE_EXERCISE" },
+      {
+        "name": "Solder",
+        "time": "10 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "tools": [ [ [ "soldering_iron_portable", 40 ] ] ]
+      },
+      { "name": "Finish", "time": "10 m", "activity_level": "NO_EXERCISE" }
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_steps_dual_charged",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "steps": [
+      {
+        "name": "Solder",
+        "time": "10 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "tools": [ [ [ "soldering_iron_portable", 10 ] ], [ [ "soldering_iron_portable", 10 ] ] ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_steps_two_tools",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "steps": [
+      {
+        "name": "Work",
+        "time": "10 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "tools": [ [ [ "soldering_iron_portable", -1 ] ], [ [ "hammer", -1 ] ] ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_charged_fast",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "steps": [
+      { "name": "Zap", "time": "1 s", "activity_level": "NO_EXERCISE", "tools": [ [ [ "soldering_iron_portable", 30 ] ] ] }
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_charged_fast_stepless",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "time": "1 s",
+    "activity_level": "NO_EXERCISE",
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "tools": [ [ [ "soldering_iron_portable", 30 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_root_charged",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "using": [ [ "soldering_standard", 10 ] ],
+    "steps": [
+      { "name": "Shape", "time": "10 m", "activity_level": "MODERATE_EXERCISE" },
+      { "name": "Finish", "time": "10 m", "activity_level": "NO_EXERCISE" }
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_root_unattended",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "using": [ [ "soldering_standard", 10 ] ],
+    "steps": [
+      { "name": "Shape", "time": "10 m", "activity_level": "MODERATE_EXERCISE" },
+      { "name": "Cure", "time": "10 m", "activity_level": "NO_EXERCISE", "attention": "unattended" }
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
     "id_suffix": "test_steps_shared_prof",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_BASHING",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6403,6 +6403,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     // item_counter represents the percent progress relative to the base batch time
     // stored precise to 5 decimal places ( e.g. 67.32 percent would be stored as 6732000 )
     const int old_counter = craft.item_counter;
+    const int old_moves = crafter.get_moves();
 
     // Delta progress in moves adjusted for current crafting speed /
     //crafter.exertion_adjusted_move_multiplier( exertion_level() )
@@ -6420,7 +6421,11 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     craft.item_counter = std::min( craft.item_counter, 10000000 );
 
     // Step transitions: accumulate work and advance through step boundaries.
+    int old_step = 0;
+    double old_step_progress = 0.0;
     if( rec.has_steps() ) {
+        old_step = craft.get_current_step();
+        old_step_progress = craft.get_step_progress();
         craft.mod_step_progress( delta_progress );
         const int last_step_idx = static_cast<int>( rec.steps().size() ) - 1;
         while( craft.get_current_step() < last_step_idx ) {
@@ -6433,6 +6438,20 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
             craft.set_step_progress( craft.get_step_progress() - budget );
             craft.set_current_step( craft.get_current_step() + 1 );
         }
+    }
+    // Consume tools to match progress: per recipe step, or the whole recipe as a
+    // single implicit step for stepless recipes.  A charge shortfall rewinds this
+    // turn's step and counter state before any skill gain.
+    if( !crafter.craft_consume_step_tools( craft ) ) {
+        if( rec.has_steps() ) {
+            craft.set_current_step( old_step );
+            craft.set_step_progress( old_step_progress );
+        }
+        craft.item_counter = old_counter;
+        crafter.set_moves( old_moves );
+        craft.erase_var( "crafter" );
+        crafter.cancel_activity();
+        return;
     }
 
     // This nominal craft time is also how many practice ticks to perform
@@ -6459,20 +6478,6 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
         use_cached_workbench_multiplier = false;
     }
 
-    // Unlike skill, tools are consumed once at the start and should not be consumed at the end
-    if( craft.item_counter >= 10000000 ) {
-        --five_percent_steps;
-    }
-
-    if( five_percent_steps > 0 ) {
-        if( !crafter.craft_consume_tools( craft, five_percent_steps, false ) ) {
-            // So we don't skip over any tool comsuption
-            craft.item_counter -= craft.item_counter % 500000 + 1;
-            craft.erase_var( "crafter" );
-            crafter.cancel_activity();
-            return;
-        }
-    }
 
     // if item_counter has reached 100% or more
     if( craft.item_counter >= 10000000 ) {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2425,9 +2425,28 @@ activity_reason_info multi_craft_activity_actor::multi_activity_can_do( Characte
             const recipe &r = to_craft->get_making();
             std::vector<std::vector<item_comp>> item_comp_vector =
                                                  to_craft->get_continue_reqs().get_components();
-            std::vector<std::vector<quality_requirement>> quality_comp_vector =
-                        r.simple_requirements().get_qualities();
-            std::vector<std::vector<tool_comp>> tool_comp_vector = r.simple_requirements().get_tools();
+            std::vector<std::vector<quality_requirement>> quality_comp_vector;
+            std::vector<std::vector<tool_comp>> tool_comp_vector;
+            if( r.has_steps() ) {
+                // Step recipes consume tools per step; gate continuation on the
+                // current step's tools and qualities plus the recipe-root tools,
+                // not the whole recipe, so a later step's tool cannot block the
+                // current one.
+                const int n_steps = static_cast<int>( r.steps().size() );
+                const int cur = std::clamp( to_craft->get_current_step(), 0, n_steps - 1 );
+                const recipe_step &step = r.steps()[cur];
+                const requirement_data &root = r.root_requirements();
+                quality_comp_vector = step.requirements.get_qualities();
+                const std::vector<std::vector<quality_requirement>> &root_quals = root.get_qualities();
+                quality_comp_vector.insert( quality_comp_vector.end(), root_quals.begin(),
+                                            root_quals.end() );
+                tool_comp_vector = step.requirements.get_tools();
+                const std::vector<std::vector<tool_comp>> &root_tools = root.get_tools();
+                tool_comp_vector.insert( tool_comp_vector.end(), root_tools.begin(), root_tools.end() );
+            } else {
+                quality_comp_vector = r.simple_requirements().get_qualities();
+                tool_comp_vector = r.simple_requirements().get_tools();
+            }
             requirement_data req = requirement_data( tool_comp_vector, quality_comp_vector, item_comp_vector );
             if( req.can_make_with_inventory( inv, is_crafting_component ) ) {
                 return activity_reason_info::ok( do_activity_reason::NEEDS_CRAFT );

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -1008,6 +1008,13 @@ basecamp_action_components::basecamp_action_components(
 
 bool basecamp_action_components::choose_components()
 {
+    // Basecamp crafting selects and consumes tools whole-recipe; the per-step
+    // tool model is not wired through this path, so step recipes are excluded
+    // here rather than risk mis-metering their tools.
+    if( making_.has_steps() ) {
+        debugmsg( "step recipe %s cannot be crafted at a basecamp yet", making_.ident().str() );
+        return false;
+    }
     const auto filter = is_crafting_component;
     avatar &player_character = get_avatar();
     const requirement_data *req;

--- a/src/character.h
+++ b/src/character.h
@@ -3844,6 +3844,9 @@ class Character : public Creature, public visitable
         } );
         /** Consume tools for the next multiplier * 5% progress of the craft */
         bool craft_consume_tools( item &craft, int multiplier, bool start_craft );
+        /** Advance per-step tool consumption so each step's allocations match its
+         *  current progress.  Returns false (consuming nothing) if charges are short. */
+        bool craft_consume_step_tools( item &craft );
         void consume_tools( const comp_selection<tool_comp> &tool, int batch );
         void consume_tools( map &m, const comp_selection<tool_comp> &tool, int batch,
                             const tripoint_bub_ms &origin = tripoint_bub_ms::zero, int radius = PICKUP_RANGE,

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <climits>
+#include <cstdint>
 #include <cstdlib>
 #include <functional>
 #include <limits>
@@ -113,6 +114,24 @@ template void comp_selection<item_comp>::serialize( JsonOut &jsout ) const;
 template void comp_selection<tool_comp>::deserialize( const JsonObject &data );
 template void comp_selection<item_comp>::deserialize( const JsonObject &data );
 
+void step_tool_alloc::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.member( "sel", sel );
+    jsout.member( "step_count_units", step_count_units );
+    jsout.member( "consumed_buckets", consumed_buckets );
+    jsout.member( "root_derived", root_derived );
+    jsout.end_object();
+}
+
+void step_tool_alloc::deserialize( const JsonObject &data )
+{
+    data.read( "sel", sel );
+    data.read( "step_count_units", step_count_units );
+    data.read( "consumed_buckets", consumed_buckets );
+    data.read( "root_derived", root_derived );
+}
+
 void craft_command::execute( const std::optional<tripoint_bub_ms> &new_loc )
 {
     loc = new_loc;
@@ -194,21 +213,37 @@ void craft_command::execute( bool only_cache_comps )
             item_selections.push_back( is );
         }
 
+        // Step recipes select their tools per step, so only stepless recipes
+        // select from the flattened whole-recipe tool list here; doing both would
+        // prompt for the same tools twice.
         tool_selections.clear();
-        for( const auto &it : needs->get_tools() ) {
-            comp_selection<tool_comp> ts = crafter->select_tool_component(
-            it, batch_size, map_inv, true, true, true, []( int charges ) {
-                return charges / 20 + charges % 20;
-            } );
-            if( ts.use_from == usage_from::cancel ) {
-                return;
+        if( !rec->has_steps() ) {
+            for( const auto &it : needs->get_tools() ) {
+                comp_selection<tool_comp> ts = crafter->select_tool_component(
+                it, batch_size, map_inv, true, true, true, []( int charges ) {
+                    return charges / 20 + charges % 20;
+                } );
+                if( ts.use_from == usage_from::cancel ) {
+                    return;
+                }
+                tool_selections.push_back( ts );
             }
-            tool_selections.push_back( ts );
         }
     }
 
     if( only_cache_comps ) {
         return;
+    }
+
+    // Only (re)select per-step tools when fresh selection is needed; a cached
+    // repeat craft whose tools are all still present reuses the stored
+    // allocations rather than reselecting and reprompting.
+    if( need_selections && rec->has_steps() ) {
+        bool cancelled = false;
+        step_tool_allocs = select_step_tool_allocs( *crafter, *rec, batch_size, map_inv, cancelled );
+        if( cancelled ) {
+            return;
+        }
     }
 
     std::vector<attention_plan> plans;
@@ -433,6 +468,125 @@ bool craft_command::safe_to_unload_comp( const item &it )
     return true;
 }
 
+std::vector<std::vector<step_tool_alloc>> select_step_tool_allocs(
+        Character &crafter, const recipe &rec, int batch, read_only_visitable &map_inv,
+        bool &cancelled, int reselect_step )
+{
+    cancelled = false;
+    const std::vector<recipe_step> &steps = rec.steps();
+    std::vector<std::vector<step_tool_alloc>> allocs( steps.size() );
+
+    const auto start_charges = []( int charges ) {
+        return charges / 20 + charges % 20;
+    };
+
+    // Replay a tool group's selection across groups with the same options and
+    // counts, so a group shared between steps prompts the crafter only once.
+    std::vector<std::pair<std::string, comp_selection<tool_comp>>> replay;
+    const auto group_key = []( const std::vector<tool_comp> &group ) -> std::string {
+        std::vector<std::string> parts;
+        parts.reserve( group.size() );
+        for( const tool_comp &tc : group )
+        {
+            parts.push_back( tc.type.str() + ":" + std::to_string( tc.count ) );
+        }
+        std::sort( parts.begin(), parts.end() );
+        std::string key;
+        for( const std::string &p : parts )
+        {
+            key += p;
+            key += ',';
+        }
+        return key;
+    };
+    const auto select_group = [&]( const std::vector<tool_comp> &group ) -> comp_selection<tool_comp> {
+        const std::string key = group_key( group );
+        for( const std::pair<std::string, comp_selection<tool_comp>> &r : replay )
+        {
+            if( r.first == key ) {
+                return r.second;
+            }
+        }
+        comp_selection<tool_comp> ts = crafter.select_tool_component(
+                                           group, batch, map_inv, true, true, true, start_charges );
+        if( ts.use_from != usage_from::cancel )
+        {
+            replay.emplace_back( key, ts );
+        }
+        return ts;
+    };
+
+    for( size_t i = 0; i < steps.size(); ++i ) {
+        // On resume only the current step's own tools are reselected; other
+        // steps keep their prior selections (filled in by the caller).
+        if( reselect_step >= 0 && static_cast<int>( i ) != reselect_step ) {
+            continue;
+        }
+        for( const std::vector<tool_comp> &group : steps[i].requirements.get_tools() ) {
+            comp_selection<tool_comp> ts = select_group( group );
+            if( ts.use_from == usage_from::cancel ) {
+                cancelled = true;
+                return allocs;
+            }
+            step_tool_alloc alloc;
+            alloc.sel = ts;
+            alloc.step_count_units = std::max( 0, ts.comp.count ) * std::max( batch, 1 );
+            allocs[i].push_back( alloc );
+        }
+    }
+
+    // Recipe-root tools belong to the whole craft.  Distribute their charges
+    // across the active steps pro-rata by each step's move budget (so per-step
+    // time, proficiency, and tool-speed modifiers are reflected); the last
+    // active step takes the rounding remainder so the shares sum exactly.
+    // Unattended steps are excluded from the active-step distribution.
+    const std::vector<std::vector<tool_comp>> &root_groups = rec.root_requirements().get_tools();
+    if( root_groups.empty() ) {
+        return allocs;
+    }
+    const crafting_cost_context ctx = crafting_cost_context::for_recipe( crafter, rec );
+    std::vector<int64_t> active_budget( steps.size(), 0 );
+    int64_t total_active = 0;
+    int last_active = -1;
+    for( size_t i = 0; i < steps.size(); ++i ) {
+        if( steps[i].attention != step_attention::unattended ) {
+            active_budget[i] = std::max<int64_t>(
+                                   static_cast<int64_t>( rec.step_budget_moves( crafter, i, batch, ctx ) ), 0 );
+            total_active += active_budget[i];
+            if( active_budget[i] > 0 ) {
+                last_active = static_cast<int>( i );
+            }
+        }
+    }
+    if( total_active <= 0 ) {
+        return allocs;
+    }
+    for( const std::vector<tool_comp> &group : root_groups ) {
+        comp_selection<tool_comp> ts = select_group( group );
+        if( ts.use_from == usage_from::cancel ) {
+            cancelled = true;
+            return allocs;
+        }
+        const int total_units = std::max( 0, ts.comp.count ) * std::max( batch, 1 );
+        int assigned = 0;
+        for( size_t i = 0; i < steps.size(); ++i ) {
+            if( active_budget[i] <= 0 ) {
+                continue;
+            }
+            const int share = static_cast<int>( i ) == last_active
+                              ? total_units - assigned
+                              : static_cast<int>( total_units * active_budget[i] / total_active );
+            assigned += share;
+            step_tool_alloc alloc;
+            alloc.sel = ts;
+            alloc.step_count_units = share;
+            alloc.root_derived = true;
+            allocs[i].push_back( alloc );
+        }
+    }
+    return allocs;
+}
+
 item craft_command::create_in_progress_craft()
 {
     // Use up the components and tools
@@ -461,6 +615,36 @@ item craft_command::create_in_progress_craft()
         !continue_prompt_liquids( filter ) ) {
         // player cancelled when prompted to unload liquid
         return item();
+    }
+
+    // Build the per-step allocations the craft will carry.  A stepless recipe
+    // collapses its whole-recipe tool selections into one implicit step.
+    std::vector<std::vector<step_tool_alloc>> start_allocs;
+    if( rec->has_steps() ) {
+        start_allocs = step_tool_allocs;
+    } else {
+        std::vector<step_tool_alloc> step0;
+        step0.reserve( tool_selections.size() );
+        for( const comp_selection<tool_comp> &sel : tool_selections ) {
+            step_tool_alloc alloc;
+            alloc.sel = sel;
+            alloc.step_count_units = std::max( 0, sel.comp.count ) * std::max( batch_size, 1 );
+            step0.push_back( alloc );
+        }
+        start_allocs = { step0 };
+    }
+
+    // Run the start (bucket-0) tool debit on a probe before consuming components
+    // so a charge shortfall aborts without losing them; the debited allocations
+    // carry over to the real craft.
+    {
+        item probe( rec, batch_size, item_components{}, std::vector<item_comp> {} );
+        probe.set_step_tool_allocs( start_allocs );
+        if( !crafter->craft_consume_step_tools( probe ) ) {
+            debugmsg( "start tool debit failed for craft %s", rec->ident().str() );
+            return item();
+        }
+        start_allocs = probe.get_step_tool_allocs();
     }
 
     for( const auto &it : item_selections ) {
@@ -495,10 +679,9 @@ item craft_command::create_in_progress_craft()
 
     item new_craft( rec, batch_size, used, comps_used );
 
-    new_craft.set_cached_tool_selections( tool_selections );
+    // Carry the probe's debited start buckets onto the real craft.
+    new_craft.set_step_tool_allocs( start_allocs );
     new_craft.set_tools_to_continue( true );
-    // Pass true to indicate that we are starting the craft and the remainder should be consumed as well
-    crafter->craft_consume_tools( new_craft, 1, true );
     new_craft.set_next_failure_point( *crafter );
     new_craft.set_owner( *crafter );
 
@@ -580,7 +763,28 @@ std::vector<comp_selection<tool_comp>> craft_command::check_tool_components_miss
 {
     std::vector<comp_selection<tool_comp>> missing;
 
-    for( const auto &tool_sel : tool_selections ) {
+    // Step recipes store their tools per step; a root tool repeats across steps
+    // with the same selection, so check each distinct selection once.  Stepless
+    // recipes carry the flat whole-recipe selection list.
+    std::vector<comp_selection<tool_comp>> to_check;
+    if( rec->has_steps() ) {
+        for( const std::vector<step_tool_alloc> &step_allocs : step_tool_allocs ) {
+            for( const step_tool_alloc &a : step_allocs ) {
+                const bool seen = std::any_of( to_check.begin(), to_check.end(),
+                [&a]( const comp_selection<tool_comp> &s ) {
+                    return s.comp.type == a.sel.comp.type && s.comp.count == a.sel.comp.count &&
+                           s.use_from == a.sel.use_from;
+                } );
+                if( !seen ) {
+                    to_check.push_back( a.sel );
+                }
+            }
+        }
+    } else {
+        to_check = tool_selections;
+    }
+
+    for( const auto &tool_sel : to_check ) {
         itype_id type = tool_sel.comp.type;
         if( tool_sel.comp.count > 0 ) {
             const int count = tool_sel.comp.count * batch_size;
@@ -596,6 +800,10 @@ std::vector<comp_selection<tool_comp>> craft_command::check_tool_components_miss
                     }
                     break;
                 case usage_from::both:
+                    if( !crafter->crafting_inventory().has_charges( type, count ) ) {
+                        missing.push_back( tool_sel );
+                    }
+                    break;
                 case usage_from::none:
                 case usage_from::cancel:
                 case usage_from::num_usages_from:

--- a/src/craft_command.h
+++ b/src/craft_command.h
@@ -55,6 +55,35 @@ struct comp_selection {
     void deserialize( const JsonObject &data );
 };
 
+/** One recipe step's allocation of a single chosen tool. */
+struct step_tool_alloc {
+    comp_selection<tool_comp> sel;
+    // count * batch units allocated to this step, in tool_comp.count units
+    // (NOT scaled by charge_factor).  Zero for non-charged tools.
+    int step_count_units = 0;
+    // 5% buckets (0..20) already debited for this step.
+    int consumed_buckets = 0;
+    // Pro-rated from a recipe-root tool rather than the step's own tools.
+    bool root_derived = false;
+
+    void serialize( JsonOut &jsout ) const;
+    void deserialize( const JsonObject &data );
+};
+
+/**
+*   Builds per-step tool allocations for a step recipe: each step's own tools
+*   plus recipe-root tools distributed across the active steps pro-rata by each
+*   step's move budget.  Sets cancelled when the crafter cancels a tool prompt so
+*   the caller can abort instead of silently dropping that tool group.
+*   When reselect_step >= 0 (resume), only that step's own tools are reselected
+*   (root is still distributed across all steps); other steps get no own
+*   allocations, so the caller can keep their prior selections and an absent
+*   future step's tool neither cancels nor degrades the resume.
+*/
+std::vector<std::vector<step_tool_alloc>> select_step_tool_allocs(
+        Character &crafter, const recipe &rec, int batch, read_only_visitable &map_inv,
+        bool &cancelled, int reselect_step = -1 );
+
 /**
 *   Class that describes a crafting job.
 *
@@ -93,7 +122,7 @@ class craft_command
         }
 
         bool has_cached_selections() const {
-            return !item_selections.empty() || !tool_selections.empty();
+            return !item_selections.empty() || !tool_selections.empty() || !step_tool_allocs.empty();
         }
 
         bool empty() const {
@@ -124,6 +153,8 @@ class craft_command
 
         std::vector<comp_selection<item_comp>> item_selections;
         std::vector<comp_selection<tool_comp>> tool_selections;
+        // Per-step tool allocations for step recipes (empty for stepless).
+        std::vector<std::vector<step_tool_alloc>> step_tool_allocs;
 
         /** Checks if tools we selected in a previous call to execute() are still available. */
         std::vector<comp_selection<item_comp>> check_item_components_missing(

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2553,8 +2553,20 @@ bool Character::can_continue_craft( item &craft, const requirement_data &continu
 
     if( !craft.has_tools_to_continue() ) {
 
-        const std::vector<std::vector<tool_comp>> &tool_reqs = rec.simple_requirements().get_tools();
         const int batch_size = craft.get_making_batch_size();
+        // Step recipes meter tools per step; preflight only the current step's
+        // tools plus the recipe-root tools, not the whole recipe, so a later
+        // step's tool cannot block resuming the current one.
+        std::vector<std::vector<tool_comp>> tool_reqs;
+        if( rec.has_steps() ) {
+            const int cur = std::clamp( craft.get_current_step(), 0,
+                                        static_cast<int>( rec.steps().size() ) - 1 );
+            tool_reqs = rec.steps()[cur].requirements.get_tools();
+            const std::vector<std::vector<tool_comp>> &root_tools = rec.root_requirements().get_tools();
+            tool_reqs.insert( tool_reqs.end(), root_tools.begin(), root_tools.end() );
+        } else {
+            tool_reqs = rec.simple_requirements().get_tools();
+        }
 
         std::vector<std::vector<tool_comp>> adjusted_tool_reqs;
         for( const std::vector<tool_comp> &alternatives : tool_reqs ) {
@@ -2590,20 +2602,89 @@ bool Character::can_continue_craft( item &craft, const requirement_data &continu
         inventory map_inv;
         map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
 
-        std::vector<comp_selection<tool_comp>> new_tool_selections;
-        for( const std::vector<tool_comp> &alternatives : tool_reqs ) {
-            // NPC always picks the first candidate
-            comp_selection<tool_comp> selection = select_tool_component( alternatives, batch_size,
-            map_inv, true, true, false, []( int charges ) {
-                return charges / 20;
-            } );
-            if( selection.use_from == usage_from::cancel ) {
+        if( rec.has_steps() ) {
+            const std::vector<std::vector<step_tool_alloc>> &prior = craft.get_step_tool_allocs();
+            const int cur = std::clamp( craft.get_current_step(), 0,
+                                        static_cast<int>( rec.steps().size() ) - 1 );
+            // With a full prior shape, reselect only the current step's own tools
+            // (root is still redistributed across all steps) and keep future steps'
+            // prior selections, so an absent later-step tool does not block the
+            // resume.  When prior was cleared (stale save), rebuild every step.
+            const bool prior_full = prior.size() == rec.steps().size();
+            bool cancelled = false;
+            std::vector<std::vector<step_tool_alloc>> fresh =
+                    select_step_tool_allocs( *this, rec, batch_size, map_inv, cancelled,
+                                             prior_full ? cur : -1 );
+            if( cancelled ) {
                 return false;
             }
-            new_tool_selections.push_back( selection );
-        }
+            // For steps other than the current one, keep the prior step-owned
+            // allocations ahead of the freshly redistributed root allocations,
+            // matching select's own-then-root order so the bucket carry below
+            // still pairs positionally.
+            if( prior_full ) {
+                for( size_t s = 0; s < fresh.size(); ++s ) {
+                    if( static_cast<int>( s ) == cur ) {
+                        continue;
+                    }
+                    std::vector<step_tool_alloc> merged;
+                    for( const step_tool_alloc &pa : prior[s] ) {
+                        if( !pa.root_derived ) {
+                            merged.push_back( pa );
+                        }
+                    }
+                    for( const step_tool_alloc &fa : fresh[s] ) {
+                        merged.push_back( fa );
+                    }
+                    fresh[s] = merged;
+                }
+            }
+            // Carry already-debited buckets forward so resuming does not re-debit
+            // charges this craft has already paid.  select rebuilds allocations in
+            // recipe order, so prior[s][a] aligns with fresh[s][a]; carry the prior
+            // depth even when the selected option drifted at a position, so an
+            // unmatched alloc fails safe (never re-debits) rather than recharging.
+            for( size_t s = 0; s < fresh.size() && s < prior.size(); ++s ) {
+                for( size_t a = 0; a < fresh[s].size() && a < prior[s].size(); ++a ) {
+                    step_tool_alloc &fa = fresh[s][a];
+                    const step_tool_alloc &pa = prior[s][a];
+                    fa.consumed_buckets = std::max( fa.consumed_buckets, pa.consumed_buckets );
+                }
+            }
+            craft.set_step_tool_allocs( fresh );
+        } else {
+            std::vector<comp_selection<tool_comp>> new_tool_selections;
+            for( const std::vector<tool_comp> &alternatives : tool_reqs ) {
+                // NPC always picks the first candidate
+                comp_selection<tool_comp> selection = select_tool_component( alternatives, batch_size,
+                map_inv, true, true, false, []( int charges ) {
+                    return charges / 20;
+                } );
+                if( selection.use_from == usage_from::cancel ) {
+                    return false;
+                }
+                new_tool_selections.push_back( selection );
+            }
 
-        craft.set_cached_tool_selections( new_tool_selections );
+            std::vector<step_tool_alloc> step0;
+            step0.reserve( new_tool_selections.size() );
+            for( const comp_selection<tool_comp> &sel : new_tool_selections ) {
+                step_tool_alloc alloc;
+                alloc.sel = sel;
+                alloc.step_count_units = std::max( 0, sel.comp.count ) * std::max( batch_size, 1 );
+                step0.push_back( alloc );
+            }
+            // Carry already-debited buckets forward positionally so resuming a
+            // stepless craft does not re-debit charges it has already paid.
+            const std::vector<std::vector<step_tool_alloc>> &prior = craft.get_step_tool_allocs();
+            if( !prior.empty() ) {
+                for( size_t a = 0; a < step0.size() && a < prior[0].size(); ++a ) {
+                    step0[a].consumed_buckets = std::max( step0[a].consumed_buckets,
+                                                          prior[0][a].consumed_buckets );
+                }
+            }
+            craft.set_step_tool_allocs( { step0 } );
+        }
         craft.set_tools_to_continue( true );
     }
 
@@ -3240,8 +3321,12 @@ bool Character::craft_consume_tools( item &craft, int multiplier, bool start_cra
     };
 
     // First check if we still have our cached selections
-    const std::vector<comp_selection<tool_comp>> &cached_tool_selections =
-                craft.get_cached_tool_selections();
+    std::vector<comp_selection<tool_comp>> cached_tool_selections;
+    for( const std::vector<step_tool_alloc> &step_allocs : craft.get_step_tool_allocs() ) {
+        for( const step_tool_alloc &alloc : step_allocs ) {
+            cached_tool_selections.push_back( alloc.sel );
+        }
+    }
 
     inventory map_inv;
     map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
@@ -3303,6 +3388,181 @@ bool Character::craft_consume_tools( item &craft, int multiplier, bool start_cra
         to_consume.comp.count = calc_charges( to_consume.comp.count );
         consume_tools( to_consume, 1 );
     }
+    return true;
+}
+
+bool Character::craft_consume_step_tools( item &craft )
+{
+    if( has_trait( trait_DEBUG_HS ) ) {
+        return true;
+    }
+    const recipe &rec = craft.get_making();
+    std::vector<std::vector<step_tool_alloc>> allocs = craft.get_step_tool_allocs();
+    // A stepless recipe meters as a single implicit step whose progress is the
+    // whole-recipe item_counter.
+    const int n_steps = rec.has_steps() ? static_cast<int>( rec.steps().size() ) : 1;
+    const int batch = craft.get_making_batch_size();
+    const int cur_step = craft.get_current_step();
+    const double cur_progress = craft.get_step_progress();
+    const bool craft_done = craft.item_counter >= 10000000;
+    const crafting_cost_context ctx = crafting_cost_context::for_recipe( *this, rec );
+
+    // 5% bucket count (0..20) a step's allocations should reach given progress.
+    // Bucket 0 (entry) fires at fraction 0; the final 5% is never charged.
+    const auto buckets_for_fraction = []( double f ) -> int {
+        if( f <= 0.0 )
+        {
+            return 1;
+        }
+        return std::min( 20, 1 + std::min( static_cast<int>( std::floor( f * 20.0 ) ), 19 ) );
+    };
+    const auto target_buckets = [&]( int step_idx ) -> int {
+        if( !rec.has_steps() )
+        {
+            return craft_done ? 20 : buckets_for_fraction(
+                static_cast<double>( craft.item_counter ) / 10000000.0 );
+        }
+        if( step_idx > cur_step )
+        {
+            return 0;
+        }
+        if( step_idx < cur_step || craft_done )
+        {
+            return 20;
+        }
+        const double budget = rec.step_budget_moves( *this, step_idx, batch, ctx );
+        return buckets_for_fraction( budget > 0.0 ? cur_progress / budget : 1.0 );
+    };
+
+    // Charges (count units) consumed through `count` buckets.  Front-loads the
+    // remainder at bucket 0 and caps at the step total.
+    const auto cumulative = []( int total, int count ) -> int {
+        if( count <= 0 )
+        {
+            return 0;
+        }
+        return std::min( total, total % 20 + count * ( total / 20 ) );
+    };
+
+    struct pending_debit {
+        comp_selection<tool_comp> sel;
+        int units = 0;
+        int step_idx = 0;
+        int alloc_idx = 0;
+        int new_count = 0;
+    };
+    // A selected non-charged tool drains nothing but must still be present, or
+    // the step would advance free using a tool the crafter no longer has.
+    struct pending_presence {
+        itype_id type;
+        int step_idx = 0;
+        int alloc_idx = 0;
+        int new_count = 0;
+    };
+    const int active_step = rec.has_steps() ? cur_step : 0;
+    std::vector<pending_debit> debits;
+    std::vector<pending_presence> presence;
+    for( int s = 0; s < n_steps && s < static_cast<int>( allocs.size() ); ++s ) {
+        const int tgt = target_buckets( s );
+        for( int a = 0; a < static_cast<int>( allocs[s].size() ); ++a ) {
+            step_tool_alloc &alloc = allocs[s][a];
+            if( alloc.sel.comp.count <= 0 ) {
+                // A non-charged tool's buckets fill before the step is ready, so
+                // re-check the in-progress step's tool even once full, or the step
+                // could finish using a tool that was removed.
+                if( s == active_step ? tgt > 0 : tgt > alloc.consumed_buckets ) {
+                    presence.push_back( { alloc.sel.comp.type, s, a, tgt } );
+                }
+                continue;
+            }
+            if( tgt <= alloc.consumed_buckets ) {
+                continue;
+            }
+            if( alloc.step_count_units <= 0 ) {
+                alloc.consumed_buckets = tgt;
+                continue;
+            }
+            const int units = cumulative( alloc.step_count_units, tgt ) -
+                              cumulative( alloc.step_count_units, alloc.consumed_buckets );
+            if( units <= 0 ) {
+                alloc.consumed_buckets = tgt;
+                continue;
+            }
+            debits.push_back( { alloc.sel, units, s, a, tgt } );
+        }
+    }
+
+    if( debits.empty() && presence.empty() ) {
+        craft.set_step_tool_allocs( allocs );
+        return true;
+    }
+
+    // Aggregate the required charges per tool type, then preflight, so shared
+    // pools cannot pass per-alloc yet fail in total.
+    inventory map_inv;
+    map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
+    std::map<itype_id, int> need_player;
+    std::map<itype_id, int> need_map;
+    std::map<itype_id, int> need_both;
+    for( const pending_debit &d : debits ) {
+        const int qty = d.units * item::find_type( d.sel.comp.type )->charge_factor();
+        switch( d.sel.use_from ) {
+            case usage_from::player:
+                need_player[d.sel.comp.type] += qty;
+                break;
+            case usage_from::map:
+                need_map[d.sel.comp.type] += qty;
+                break;
+            case usage_from::both:
+                need_both[d.sel.comp.type] += qty;
+                break;
+            default:
+                break;
+        }
+    }
+    const auto shortfall = [&]( const std::map<itype_id, int> &need, int which ) -> bool {
+        for( const std::pair<const itype_id, int> &n : need )
+        {
+            bool ok = which == 0 ? has_charges( n.first, n.second )
+            : which == 1 ? map_inv.has_charges( n.first, n.second )
+            : crafting_inventory().has_charges( n.first, n.second );
+            if( !ok ) {
+                add_msg_player_or_npc(
+                    _( "You have insufficient %s charges and can't continue crafting." ),
+                    _( "<npcname> has insufficient %s charges and can't continue crafting." ),
+                    item::nname( n.first ) );
+                return true;
+            }
+        }
+        return false;
+    };
+    bool presence_short = false;
+    for( const pending_presence &p : presence ) {
+        if( !crafting_inventory().has_tools( p.type, 1 ) ) {
+            add_msg_player_or_npc(
+                _( "You no longer have the %s and can't continue crafting." ),
+                _( "<npcname> no longer has the %s and can't continue crafting." ),
+                item::nname( p.type ) );
+            presence_short = true;
+            break;
+        }
+    }
+    if( shortfall( need_player, 0 ) || shortfall( need_map, 1 ) || shortfall( need_both, 2 )
+        || presence_short ) {
+        craft.set_tools_to_continue( false );
+        return false;
+    }
+
+    for( const pending_debit &d : debits ) {
+        comp_selection<tool_comp> to_consume = d.sel;
+        to_consume.comp.count = d.units;
+        consume_tools( to_consume, 1 );
+        allocs[d.step_idx][d.alloc_idx].consumed_buckets = d.new_count;
+    }
+    for( const pending_presence &p : presence ) {
+        allocs[p.step_idx][p.alloc_idx].consumed_buckets = p.new_count;
+    }
+    craft.set_step_tool_allocs( allocs );
     return true;
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5203,16 +5203,16 @@ bool item::has_tools_to_continue() const
     return craft_data_->tools_to_continue;
 }
 
-void item::set_cached_tool_selections( const std::vector<comp_selection<tool_comp>> &selections )
+void item::set_step_tool_allocs( const std::vector<std::vector<step_tool_alloc>> &allocs )
 {
     cata_assert( craft_data_ );
-    craft_data_->cached_tool_selections = selections;
+    craft_data_->step_tool_allocs = allocs;
 }
 
-const std::vector<comp_selection<tool_comp>> &item::get_cached_tool_selections() const
+const std::vector<std::vector<step_tool_alloc>> &item::get_step_tool_allocs() const
 {
     cata_assert( craft_data_ );
-    return craft_data_->cached_tool_selections;
+    return craft_data_->step_tool_allocs;
 }
 
 int item::get_current_step() const

--- a/src/item.h
+++ b/src/item.h
@@ -3237,8 +3237,10 @@ class item : public visitable
 
         void set_tools_to_continue( bool value );
         bool has_tools_to_continue() const;
-        void set_cached_tool_selections( const std::vector<comp_selection<tool_comp>> &selections );
-        const std::vector<comp_selection<tool_comp>> &get_cached_tool_selections() const;
+        // Per-step tool allocations, indexed by recipe step (single entry for
+        // stepless recipes).
+        void set_step_tool_allocs( const std::vector<std::vector<step_tool_alloc>> &allocs );
+        const std::vector<std::vector<step_tool_alloc>> &get_step_tool_allocs() const;
 
         // Step iteration state for step recipes.
         // get_current_step clamps to valid range as a defensive measure.
@@ -3546,7 +3548,7 @@ class item : public visitable
                 // If the crafter has insufficient tools to continue to the next 5% progress step
                 bool tools_to_continue = false;
                 int batch_size = -1;
-                std::vector<comp_selection<tool_comp>> cached_tool_selections;
+                std::vector<std::vector<step_tool_alloc>> step_tool_allocs;
                 std::optional<units::mass> cached_weight; // NOLINT(cata-serialize)
                 std::optional<units::volume> cached_volume; // NOLINT(cata-serialize)
 

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -843,6 +843,10 @@ void recipe::finalize()
         reqs_external.clear();
         reqs_internal.clear();
 
+        // Snapshot the root-only requirements so root tools stay attributable
+        // after per-step requirements merge into requirements_ below.
+        root_requirements_ = requirements_;
+
         for( recipe_step &step : steps_ ) {
             // Resolve each step's external (using) + inline requirements
             step.requirements = std::accumulate(
@@ -869,6 +873,27 @@ void recipe::finalize()
             requirements_ = requirements_ + step.requirements;
             step.reqs_external.clear();
             step.reqs_internal.clear();
+        }
+
+        // Root charged tools are distributed only across active (attended,
+        // timed) steps, so a recipe with charged root tools but no active step
+        // has nowhere to meter them and is rejected.
+        bool has_active_step = false;
+        for( const recipe_step &step : steps_ ) {
+            if( step.attention != step_attention::unattended && step.time > 0 ) {
+                has_active_step = true;
+                break;
+            }
+        }
+        if( !has_active_step ) {
+            for( const std::vector<tool_comp> &tool_group : root_requirements_.get_tools() ) {
+                for( const tool_comp &t : tool_group ) {
+                    if( t.by_charges() ) {
+                        debugmsg( "recipe %s has charged root tools but no active step to meter them yet",
+                                  ident().str() );
+                    }
+                }
+            }
         }
 
         deduped_requirements_ = deduped_requirement_data( requirements_, ident() );

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -226,6 +226,12 @@ class recipe
             return deduped_requirements_;
         }
 
+        // Root-level requirements (inline + "using"), captured before per-step
+        // requirements merge in.  Empty for stepless recipes.
+        const requirement_data &root_requirements() const {
+            return root_requirements_;
+        }
+
         const recipe_id &ident() const {
             return id;
         }
@@ -458,6 +464,9 @@ class recipe
 
         /** Combined requirements cached when recipe finalized */
         requirement_data requirements_;
+
+        /** Snapshot backing root_requirements() */
+        requirement_data root_requirements_;
 
         /** Deduped version constructed from the above requirements_ */
         deduped_requirement_data deduped_requirements_;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2837,7 +2837,7 @@ void item::craft_data::serialize( JsonOut &jsout ) const
     jsout.member( "next_failure_point", next_failure_point );
     jsout.member( "tools_to_continue", tools_to_continue );
     jsout.member( "batch_size", batch_size );
-    jsout.member( "cached_tool_selections", cached_tool_selections );
+    jsout.member( "step_tool_allocs", step_tool_allocs );
     jsout.member( "current_step", current_step );
     jsout.member( "step_progress", step_progress );
     if( !step_plans.empty() ) {
@@ -2912,7 +2912,27 @@ void item::craft_data::deserialize( const JsonObject &obj )
     next_failure_point = obj.get_int( "next_failure_point", -1 );
     tools_to_continue = obj.get_bool( "tools_to_continue", false );
     batch_size = obj.get_int( "batch_size", -1 );
-    obj.read( "cached_tool_selections", cached_tool_selections );
+    if( obj.has_member( "step_tool_allocs" ) ) {
+        obj.read( "step_tool_allocs", step_tool_allocs );
+    } else if( making && !making->has_steps() ) {
+        // A stepless save carries a single flat whole-recipe selection list;
+        // migrate it into the one implicit step.  Step recipes instead rebuild
+        // per-step on resume (handled by the shape check below).
+        std::vector<comp_selection<tool_comp>> legacy;
+        obj.read( "cached_tool_selections", legacy );
+        step_tool_allocs.clear();
+        if( !legacy.empty() ) {
+            std::vector<step_tool_alloc> step0;
+            step0.reserve( legacy.size() );
+            for( const comp_selection<tool_comp> &sel : legacy ) {
+                step_tool_alloc alloc;
+                alloc.sel = sel;
+                alloc.step_count_units = sel.comp.count * std::max( batch_size, 1 );
+                step0.push_back( alloc );
+            }
+            step_tool_allocs.push_back( std::move( step0 ) );
+        }
+    }
     current_step = obj.get_int( "current_step", 0 );
     step_progress = obj.get_float( "step_progress", 0.0 );
     // Validate step index against the recipe's actual step count.

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2892,6 +2892,89 @@ void item::craft_data::serialize( JsonOut &jsout ) const
     jsout.end_object();
 }
 
+static bool tool_in_group( const std::vector<tool_comp> &group,
+                           const step_tool_alloc &a )
+{
+    for( const tool_comp &tc : group ) {
+        if( tc.type == a.sel.comp.type && tc.count == a.sel.comp.count ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// A charged allocation must draw from a real source; a none/cancel source would
+// let consumption mark its buckets without debiting any charge.  Non-charged
+// presence tools (count <= 0) may legitimately be usage_from::none.
+static bool alloc_source_valid( const step_tool_alloc &a )
+{
+    if( a.sel.comp.count <= 0 ) {
+        return true;
+    }
+    return a.sel.use_from == usage_from::player || a.sel.use_from == usage_from::map ||
+           a.sel.use_from == usage_from::both;
+}
+
+// True when saved allocations still line up with the recipe: one step-owned
+// allocation per step tool group, then one root-derived allocation per root
+// group on each active (attended, timed) step, each matching a tool type and
+// count its group still offers.  A tool-group edit that breaks this shape fails.
+// Also rejects corrupt counters and units that disagree with the selected count,
+// so consumption never runs off an inconsistent allocation.
+static bool step_tool_allocs_fit_recipe(
+    const recipe &making, int batch, const std::vector<std::vector<step_tool_alloc>> &allocs )
+{
+    if( allocs.size() != making.steps().size() ) {
+        return false;
+    }
+    const int batch_mult = std::max( batch, 1 );
+    const std::vector<std::vector<tool_comp>> &root_groups =
+            making.root_requirements().get_tools();
+    // Root shares are crafter-dependent per step but always sum to the tool's
+    // whole-craft total; check that invariant rather than the per-step split.
+    std::vector<int> root_unit_sum( root_groups.size(), 0 );
+    std::vector<int> root_unit_expected( root_groups.size(), -1 );
+    for( size_t s = 0; s < allocs.size(); ++s ) {
+        const recipe_step &step = making.steps()[s];
+        const std::vector<std::vector<tool_comp>> &step_groups =
+                step.requirements.get_tools();
+        const bool step_active =
+            step.attention != step_attention::unattended && step.time > 0;
+        std::vector<const step_tool_alloc *> owned;
+        std::vector<const step_tool_alloc *> root;
+        for( const step_tool_alloc &a : allocs[s] ) {
+            if( a.consumed_buckets < 0 || a.consumed_buckets > 20 || a.step_count_units < 0 ||
+                !alloc_source_valid( a ) ) {
+                return false;
+            }
+            ( a.root_derived ? root : owned ).push_back( &a );
+        }
+        if( owned.size() != step_groups.size() ||
+            root.size() != ( step_active ? root_groups.size() : 0u ) ) {
+            return false;
+        }
+        for( size_t i = 0; i < owned.size(); ++i ) {
+            if( !tool_in_group( step_groups[i], *owned[i] ) ||
+                owned[i]->step_count_units != std::max( 0, owned[i]->sel.comp.count ) * batch_mult ) {
+                return false;
+            }
+        }
+        for( size_t j = 0; j < root.size(); ++j ) {
+            if( !tool_in_group( root_groups[j], *root[j] ) ) {
+                return false;
+            }
+            root_unit_sum[j] += root[j]->step_count_units;
+            root_unit_expected[j] = std::max( 0, root[j]->sel.comp.count ) * batch_mult;
+        }
+    }
+    for( size_t j = 0; j < root_groups.size(); ++j ) {
+        if( root_unit_expected[j] >= 0 && root_unit_sum[j] != root_unit_expected[j] ) {
+            return false;
+        }
+    }
+    return true;
+}
+
 void item::craft_data::deserialize( const JsonObject &obj )
 {
     obj.allow_omitted_members();
@@ -2927,7 +3010,7 @@ void item::craft_data::deserialize( const JsonObject &obj )
             for( const comp_selection<tool_comp> &sel : legacy ) {
                 step_tool_alloc alloc;
                 alloc.sel = sel;
-                alloc.step_count_units = sel.comp.count * std::max( batch_size, 1 );
+                alloc.step_count_units = std::max( 0, sel.comp.count ) * std::max( batch_size, 1 );
                 step0.push_back( alloc );
             }
             step_tool_allocs.push_back( std::move( step0 ) );
@@ -2939,6 +3022,64 @@ void item::craft_data::deserialize( const JsonObject &obj )
     if( making && making->has_steps() ) {
         int max_step = static_cast<int>( making->steps().size() ) - 1;
         current_step = std::clamp( current_step, 0, max_step );
+        // A legacy or recipe-edited save whose allocations no longer fit the
+        // recipe is dropped and rebuilt per-step on resume.
+        if( !step_tool_allocs_fit_recipe( *making, batch_size, step_tool_allocs ) ) {
+            step_tool_allocs.clear();
+            tools_to_continue = false;
+        }
+    } else if( making ) {
+        current_step = 0;
+        step_progress = 0.0;
+        // A stepless craft carries a single implicit-step allocation; drop it on
+        // a corrupt counter, units that disagree with the selected count, or a
+        // tool shape that no longer covers the recipe's tool groups, so a resume
+        // rebuilds it rather than metering off stale data and skipping a group.
+        bool stepless_ok = step_tool_allocs.size() <= 1;
+        if( stepless_ok ) {
+            const int batch_mult = std::max( batch_size, 1 );
+            const std::vector<std::vector<tool_comp>> &tool_groups =
+                    making->simple_requirements().get_tools();
+            // An empty list means no implicit-step row; treat it as a zero-length
+            // row so the bijection below rejects it when the recipe has tools.
+            const std::vector<step_tool_alloc> empty_row;
+            const std::vector<step_tool_alloc> &step0 =
+                step_tool_allocs.empty() ? empty_row : step_tool_allocs[0];
+            for( const step_tool_alloc &a : step0 ) {
+                if( a.consumed_buckets < 0 || a.consumed_buckets > 20 ||
+                    a.step_count_units != std::max( 0, a.sel.comp.count ) * batch_mult ||
+                    !alloc_source_valid( a ) ) {
+                    stepless_ok = false;
+                    break;
+                }
+            }
+            // Require one allocation per tool group, each matching a distinct
+            // group, so a stale shape cannot leave a group unmetered.
+            if( stepless_ok && step0.size() != tool_groups.size() ) {
+                stepless_ok = false;
+            }
+            if( stepless_ok ) {
+                std::vector<bool> alloc_used( step0.size(), false );
+                for( const std::vector<tool_comp> &grp : tool_groups ) {
+                    bool matched = false;
+                    for( size_t k = 0; k < step0.size(); ++k ) {
+                        if( !alloc_used[k] && tool_in_group( grp, step0[k] ) ) {
+                            alloc_used[k] = true;
+                            matched = true;
+                            break;
+                        }
+                    }
+                    if( !matched ) {
+                        stepless_ok = false;
+                        break;
+                    }
+                }
+            }
+        }
+        if( !stepless_ok ) {
+            step_tool_allocs.clear();
+            tools_to_continue = false;
+        }
     } else {
         current_step = 0;
         step_progress = 0.0;

--- a/tests/craft_attention_test.cpp
+++ b/tests/craft_attention_test.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstdint>
 #include <optional>
 #include <sstream>
@@ -10,6 +11,7 @@
 #include "cata_catch.h"
 #include "character_id.h"
 #include "coordinates.h"
+#include "craft_command.h"
 #include "crafting.h"
 #include "crafting_enums.h"
 #include "flexbuffer_json.h"
@@ -31,16 +33,26 @@
 #include "type_id.h"
 
 static const itype_id itype_2x4( "2x4" );
+static const itype_id itype_hammer( "hammer" );
 static const itype_id itype_microwave( "microwave" );
+static const itype_id itype_soldering_iron_portable( "soldering_iron_portable" );
 
+static const recipe_id recipe_cudgel_test_charged_fast_stepless(
+    "cudgel_test_charged_fast_stepless" );
 static const recipe_id recipe_cudgel_test_consecutive_unattended(
     "cudgel_test_consecutive_unattended" );
 static const recipe_id recipe_cudgel_test_first_step_unattended(
     "cudgel_test_first_step_unattended" );
 static const recipe_id recipe_cudgel_test_only_unattended(
     "cudgel_test_only_unattended" );
+static const recipe_id recipe_cudgel_test_root_unattended(
+    "cudgel_test_root_unattended" );
 static const recipe_id recipe_cudgel_test_steps_basic(
     "cudgel_test_steps_basic" );
+static const recipe_id recipe_cudgel_test_steps_charged(
+    "cudgel_test_steps_charged" );
+static const recipe_id recipe_cudgel_test_steps_two_tools(
+    "cudgel_test_steps_two_tools" );
 static const recipe_id recipe_cudgel_test_timeout_recipe(
     "cudgel_test_timeout_recipe" );
 static const recipe_id recipe_cudgel_test_unattended_simple(
@@ -314,6 +326,387 @@ TEST_CASE( "craft_data_persists_attention_runtime_fields",
     CHECK( restored.get_saved_alarm_at() == calendar::turn + 8_minutes );
     CHECK( restored.get_saved_fail_at() == calendar::turn + 26_minutes );
     CHECK( restored.get_crafter_id() == character_id( 42 ) );
+}
+
+TEST_CASE( "craft_data_persists_step_tool_allocs", "[craft][attention][persist]" )
+{
+    // Round-trip a single allocation directly, so this covers serialization
+    // independent of the load-time recipe-shape validation (exercised by the
+    // craft_data_validates_* cases).
+    step_tool_alloc alloc;
+    alloc.sel.use_from = usage_from::player;
+    alloc.sel.comp.type = itype_soldering_iron_portable;
+    alloc.sel.comp.count = 8;
+    alloc.step_count_units = 8;
+    alloc.consumed_buckets = 5;
+    alloc.root_derived = true;
+
+    std::ostringstream ss;
+    JsonOut jsout( ss );
+    alloc.serialize( jsout );
+
+    step_tool_alloc restored;
+    restored.deserialize( json_loader::from_string( ss.str() ).get_object() );
+
+    CHECK( restored.sel.use_from == usage_from::player );
+    CHECK( restored.sel.comp.type == itype_soldering_iron_portable );
+    CHECK( restored.sel.comp.count == 8 );
+    CHECK( restored.step_count_units == 8 );
+    CHECK( restored.consumed_buckets == 5 );
+    CHECK( restored.root_derived );
+}
+
+TEST_CASE( "craft_data_resets_stale_step_tool_allocs_on_size_mismatch",
+           "[craft][attention][persist][migration]" )
+{
+    item ingredient( itype_2x4, calendar::turn );
+    item_components comps;
+    comps.add( ingredient );
+    item built( &recipe_cudgel_test_unattended_simple.obj(), 1, comps,
+                std::vector<item_comp> {} );
+    REQUIRE( built.is_craft() );
+    REQUIRE( built.get_making().steps().size() == 2 );
+
+    // A save whose allocation rows do not match the recipe's step count (a
+    // legacy flat save deserializes to zero rows the same way).
+    step_tool_alloc alloc;
+    alloc.sel.use_from = usage_from::player;
+    alloc.sel.comp.type = itype_soldering_iron_portable;
+    alloc.sel.comp.count = 8;
+    alloc.step_count_units = 8;
+    alloc.consumed_buckets = 3;
+    built.set_step_tool_allocs( { { alloc } } );
+    built.set_tools_to_continue( true );
+
+    std::ostringstream ss;
+    JsonOut jsout( ss );
+    built.serialize( jsout );
+
+    item restored;
+    restored.deserialize( json_loader::from_string( ss.str() ).get_object() );
+
+    REQUIRE( restored.is_craft() );
+    REQUIRE( restored.get_making().steps().size() == 2 );
+    CHECK( restored.get_step_tool_allocs().empty() );
+    CHECK_FALSE( restored.has_tools_to_continue() );
+}
+
+TEST_CASE( "craft_data_resets_step_tool_allocs_on_tool_shape_change",
+           "[craft][attention][persist][migration]" )
+{
+    item ingredient( itype_2x4, calendar::turn );
+    item_components comps;
+    comps.add( ingredient );
+    item built( &recipe_cudgel_test_unattended_simple.obj(), 1, comps,
+                std::vector<item_comp> {} );
+    REQUIRE( built.is_craft() );
+    REQUIRE( built.get_making().steps().size() == 2 );
+
+    // Right row count, but the allocation references a tool the recipe's steps
+    // no longer list (a tool-group edit that preserved the step count).
+    step_tool_alloc alloc;
+    alloc.sel.use_from = usage_from::player;
+    alloc.sel.comp.type = itype_soldering_iron_portable;
+    alloc.sel.comp.count = 8;
+    alloc.step_count_units = 8;
+    built.set_step_tool_allocs( { {}, { alloc } } );
+    built.set_tools_to_continue( true );
+
+    std::ostringstream ss;
+    JsonOut jsout( ss );
+    built.serialize( jsout );
+
+    item restored;
+    restored.deserialize( json_loader::from_string( ss.str() ).get_object() );
+
+    REQUIRE( restored.is_craft() );
+    REQUIRE( restored.get_making().steps().size() == 2 );
+    CHECK( restored.get_step_tool_allocs().empty() );
+    CHECK_FALSE( restored.has_tools_to_continue() );
+}
+
+TEST_CASE( "craft_data_validates_step_tool_alloc_shape_on_load",
+           "[craft][attention][persist][migration]" )
+{
+    REQUIRE( recipe_cudgel_test_steps_charged.obj().steps().size() == 3 );
+
+    const auto round_trip = []( const std::vector<std::vector<step_tool_alloc>> &allocs ) -> item {
+        item ingredient( itype_2x4, calendar::turn );
+        item_components comps;
+        comps.add( ingredient );
+        item built( &recipe_cudgel_test_steps_charged.obj(), 1, comps,
+        std::vector<item_comp> {} );
+        built.set_step_tool_allocs( allocs );
+        built.set_tools_to_continue( true );
+        std::ostringstream ss;
+        JsonOut jsout( ss );
+        built.serialize( jsout );
+        item restored;
+        restored.deserialize( json_loader::from_string( ss.str() ).get_object() );
+        return restored;
+    };
+
+    step_tool_alloc good;
+    good.sel.use_from = usage_from::both;
+    good.sel.comp.type = itype_soldering_iron_portable;
+    good.sel.comp.count = 40;
+    good.step_count_units = 40;
+    good.consumed_buckets = 4;
+
+    GIVEN( "allocations matching the recipe's tool groups" ) {
+        item restored = round_trip( { {}, { good }, {} } );
+        REQUIRE( restored.is_craft() );
+
+        THEN( "they are preserved on load" ) {
+            REQUIRE( restored.get_step_tool_allocs().size() == 3 );
+            REQUIRE_FALSE( restored.get_step_tool_allocs()[1].empty() );
+            CHECK( restored.get_step_tool_allocs()[1][0].consumed_buckets == 4 );
+            CHECK( restored.has_tools_to_continue() );
+        }
+    }
+
+    GIVEN( "an allocation whose count no longer matches the tool group" ) {
+        step_tool_alloc stale = good;
+        stale.sel.comp.count = 99;
+        item restored = round_trip( { {}, { stale }, {} } );
+        REQUIRE( restored.is_craft() );
+
+        THEN( "the allocations are dropped for a rebuild" ) {
+            CHECK( restored.get_step_tool_allocs().empty() );
+            CHECK_FALSE( restored.has_tools_to_continue() );
+        }
+    }
+
+    GIVEN( "an allocation with an out-of-range consumed bucket count" ) {
+        step_tool_alloc corrupt = good;
+        corrupt.consumed_buckets = 99;
+        item restored = round_trip( { {}, { corrupt }, {} } );
+        REQUIRE( restored.is_craft() );
+
+        THEN( "the allocations are dropped for a rebuild" ) {
+            CHECK( restored.get_step_tool_allocs().empty() );
+            CHECK_FALSE( restored.has_tools_to_continue() );
+        }
+    }
+
+    GIVEN( "an allocation whose units disagree with its selected count" ) {
+        step_tool_alloc inconsistent = good;
+        inconsistent.step_count_units = 7;
+        item restored = round_trip( { {}, { inconsistent }, {} } );
+        REQUIRE( restored.is_craft() );
+
+        THEN( "the allocations are dropped for a rebuild" ) {
+            CHECK( restored.get_step_tool_allocs().empty() );
+            CHECK_FALSE( restored.has_tools_to_continue() );
+        }
+    }
+
+    GIVEN( "a charged allocation with no usable source" ) {
+        step_tool_alloc sourceless = good;
+        sourceless.sel.use_from = usage_from::none;
+        item restored = round_trip( { {}, { sourceless }, {} } );
+        REQUIRE( restored.is_craft() );
+
+        THEN( "the allocations are dropped for a rebuild" ) {
+            CHECK( restored.get_step_tool_allocs().empty() );
+            CHECK_FALSE( restored.has_tools_to_continue() );
+        }
+    }
+}
+
+TEST_CASE( "craft_data_validates_stepless_step_tool_allocs_on_load",
+           "[craft][attention][persist][migration]" )
+{
+    const recipe &rec = recipe_cudgel_test_charged_fast_stepless.obj();
+    REQUIRE_FALSE( rec.has_steps() );
+    REQUIRE( rec.simple_requirements().get_tools().size() == 1 );
+    const tool_comp tool = rec.simple_requirements().get_tools()[0].front();
+
+    const auto round_trip = [&rec]( const std::vector<std::vector<step_tool_alloc>> &allocs ) -> item {
+        item ingredient( itype_2x4, calendar::turn );
+        item_components comps;
+        comps.add( ingredient );
+        item built( &rec, 1, comps, std::vector<item_comp> {} );
+        built.set_step_tool_allocs( allocs );
+        built.set_tools_to_continue( true );
+        std::ostringstream ss;
+        JsonOut jsout( ss );
+        built.serialize( jsout );
+        item restored;
+        restored.deserialize( json_loader::from_string( ss.str() ).get_object() );
+        return restored;
+    };
+
+    const auto alloc_for = [&tool]( int count, int consumed ) -> step_tool_alloc {
+        step_tool_alloc a;
+        a.sel.use_from = usage_from::both;
+        a.sel.comp.type = tool.type;
+        a.sel.comp.count = count;
+        a.step_count_units = std::max( 0, count );
+        a.consumed_buckets = consumed;
+        return a;
+    };
+
+    GIVEN( "a stepless allocation matching the recipe tool" ) {
+        item restored = round_trip( { { alloc_for( tool.count, 4 ) } } );
+        REQUIRE( restored.is_craft() );
+        THEN( "it is preserved" ) {
+            REQUIRE( restored.get_step_tool_allocs().size() == 1 );
+            REQUIRE( restored.get_step_tool_allocs()[0].size() == 1 );
+            CHECK( restored.get_step_tool_allocs()[0][0].consumed_buckets == 4 );
+            CHECK( restored.has_tools_to_continue() );
+        }
+    }
+
+    GIVEN( "a stepless charged allocation with no usable source" ) {
+        step_tool_alloc sourceless = alloc_for( tool.count, 4 );
+        sourceless.sel.use_from = usage_from::none;
+        item restored = round_trip( { { sourceless } } );
+        REQUIRE( restored.is_craft() );
+        THEN( "the unsourced allocation is dropped for a rebuild" ) {
+            CHECK( restored.get_step_tool_allocs().empty() );
+            CHECK_FALSE( restored.has_tools_to_continue() );
+        }
+    }
+
+    GIVEN( "a stepless allocation whose count the recipe no longer offers" ) {
+        item restored = round_trip( { { alloc_for( tool.count + 1, 4 ) } } );
+        REQUIRE( restored.is_craft() );
+        THEN( "the stale allocation is dropped for a rebuild" ) {
+            CHECK( restored.get_step_tool_allocs().empty() );
+            CHECK_FALSE( restored.has_tools_to_continue() );
+        }
+    }
+
+    GIVEN( "more allocations than the recipe has tool groups" ) {
+        item restored = round_trip( { { alloc_for( tool.count, 4 ), alloc_for( tool.count, 4 ) } } );
+        REQUIRE( restored.is_craft() );
+        THEN( "the mismatched shape is dropped for a rebuild" ) {
+            CHECK( restored.get_step_tool_allocs().empty() );
+            CHECK_FALSE( restored.has_tools_to_continue() );
+        }
+    }
+
+    GIVEN( "no allocations when the recipe needs a tool" ) {
+        item restored = round_trip( {} );
+        REQUIRE( restored.is_craft() );
+        THEN( "the unmetered shape is dropped for a rebuild" ) {
+            CHECK( restored.get_step_tool_allocs().empty() );
+            CHECK_FALSE( restored.has_tools_to_continue() );
+        }
+    }
+}
+
+TEST_CASE( "craft_data_resets_step_tool_allocs_on_group_reorder",
+           "[craft][attention][persist][migration]" )
+{
+    REQUIRE( recipe_cudgel_test_steps_two_tools.obj().steps().size() == 1 );
+
+    const auto round_trip = []( const std::vector<std::vector<step_tool_alloc>> &allocs ) -> item {
+        item ingredient( itype_2x4, calendar::turn );
+        item_components comps;
+        comps.add( ingredient );
+        item built( &recipe_cudgel_test_steps_two_tools.obj(), 1, comps,
+        std::vector<item_comp> {} );
+        built.set_step_tool_allocs( allocs );
+        built.set_tools_to_continue( true );
+        std::ostringstream ss;
+        JsonOut jsout( ss );
+        built.serialize( jsout );
+        item restored;
+        restored.deserialize( json_loader::from_string( ss.str() ).get_object() );
+        return restored;
+    };
+
+    const auto presence = []( const itype_id & type ) -> step_tool_alloc {
+        step_tool_alloc a;
+        a.sel.use_from = usage_from::map;
+        a.sel.comp.type = type;
+        a.sel.comp.count = -1;
+        return a;
+    };
+
+    GIVEN( "allocations lined up with the step's tool groups in order" ) {
+        item restored = round_trip( { { presence( itype_soldering_iron_portable ), presence( itype_hammer ) } } );
+        REQUIRE( restored.is_craft() );
+
+        THEN( "they are preserved" ) {
+            REQUIRE( restored.get_step_tool_allocs().size() == 1 );
+            CHECK( restored.get_step_tool_allocs()[0].size() == 2 );
+            CHECK( restored.has_tools_to_continue() );
+        }
+    }
+
+    GIVEN( "a duplicate that no longer fits the second group positionally" ) {
+        item restored = round_trip( { { presence( itype_soldering_iron_portable ), presence( itype_soldering_iron_portable ) } } );
+        REQUIRE( restored.is_craft() );
+
+        THEN( "the stale shape is dropped" ) {
+            CHECK( restored.get_step_tool_allocs().empty() );
+            CHECK_FALSE( restored.has_tools_to_continue() );
+        }
+    }
+}
+
+TEST_CASE( "craft_data_root_alloc_shape_follows_active_steps",
+           "[craft][attention][persist][migration]" )
+{
+    const recipe &rec = recipe_cudgel_test_root_unattended.obj();
+    REQUIRE( rec.steps().size() == 2 );
+    REQUIRE( rec.steps()[0].attention != step_attention::unattended );
+    REQUIRE( rec.steps()[1].attention == step_attention::unattended );
+    const std::vector<std::vector<tool_comp>> &root_groups =
+            rec.root_requirements().get_tools();
+    REQUIRE( root_groups.size() == 1 );
+    REQUIRE_FALSE( root_groups[0].empty() );
+    const tool_comp root_tool = root_groups[0].front();
+
+    const auto round_trip = [&rec]( const std::vector<std::vector<step_tool_alloc>> &allocs ) -> item {
+        item ingredient( itype_2x4, calendar::turn );
+        item_components comps;
+        comps.add( ingredient );
+        item built( &rec, 1, comps, std::vector<item_comp> {} );
+        built.set_step_tool_allocs( allocs );
+        built.set_tools_to_continue( true );
+        std::ostringstream ss;
+        JsonOut jsout( ss );
+        built.serialize( jsout );
+        item restored;
+        restored.deserialize( json_loader::from_string( ss.str() ).get_object() );
+        return restored;
+    };
+
+    const auto root_alloc = [&root_tool]() -> step_tool_alloc {
+        step_tool_alloc a;
+        a.sel.use_from = usage_from::both;
+        a.sel.comp.type = root_tool.type;
+        a.sel.comp.count = root_tool.count;
+        a.step_count_units = std::max( root_tool.count, 1 );
+        a.root_derived = true;
+        return a;
+    };
+
+    GIVEN( "a root allocation on the active step and none on the unattended step" ) {
+        item restored = round_trip( { { root_alloc() }, {} } );
+        REQUIRE( restored.is_craft() );
+
+        THEN( "it is preserved" ) {
+            REQUIRE( restored.get_step_tool_allocs().size() == 2 );
+            CHECK( restored.get_step_tool_allocs()[0].size() == 1 );
+            CHECK( restored.get_step_tool_allocs()[1].empty() );
+            CHECK( restored.has_tools_to_continue() );
+        }
+    }
+
+    GIVEN( "a root allocation on the unattended step" ) {
+        item restored = round_trip( { { root_alloc() }, { root_alloc() } } );
+        REQUIRE( restored.is_craft() );
+
+        THEN( "the stale shape is dropped" ) {
+            CHECK( restored.get_step_tool_allocs().empty() );
+            CHECK_FALSE( restored.has_tools_to_continue() );
+        }
+    }
 }
 
 TEST_CASE( "craft_data_default_step_plan_serializes_minimally",

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -168,6 +168,12 @@ static const recipe_id recipe_brew_rum( "brew_rum" );
 static const recipe_id recipe_carver_off_test( "carver_off_test" );
 static const recipe_id recipe_cudgel_simple( "cudgel_simple" );
 static const recipe_id recipe_cudgel_slow( "cudgel_slow" );
+static const recipe_id recipe_cudgel_test_charged_fast( "cudgel_test_charged_fast" );
+static const recipe_id
+recipe_cudgel_test_charged_fast_stepless( "cudgel_test_charged_fast_stepless" );
+static const recipe_id recipe_cudgel_test_steps_basic( "cudgel_test_steps_basic" );
+static const recipe_id recipe_cudgel_test_steps_charged( "cudgel_test_steps_charged" );
+static const recipe_id recipe_cudgel_test_steps_dual_charged( "cudgel_test_steps_dual_charged" );
 static const recipe_id recipe_dry_meat( "dry_meat" );
 static const recipe_id recipe_fishing_hook_basic( "fishing_hook_basic" );
 static const recipe_id recipe_helmet_kabuto( "helmet_kabuto" );
@@ -593,6 +599,27 @@ static int actually_test_craft( const recipe_id &rid, int interrupt_after_turns,
         }
     }
     return turns;
+}
+
+// Drive an active craft turn-by-turn until its current step reaches target_step
+// (or the activity ends).  Returns the current step when it stops (-1 if gone).
+static int craft_until_step( const recipe_id &rid, int target_step )
+{
+    setup_test_craft( rid );
+    avatar &player_character = get_avatar();
+
+    int guard = 0;
+    while( player_character.activity.id() == ACT_CRAFT ) {
+        item_location craft = player_character.get_wielded_item();
+        if( craft && craft->is_craft() && craft->get_current_step() >= target_step ) {
+            break;
+        }
+        REQUIRE( ++guard < 100000 );
+        player_character.set_moves( 100 );
+        player_character.activity.do_turn( player_character );
+    }
+    item_location craft = player_character.get_wielded_item();
+    return ( craft && craft->is_craft() ) ? craft->get_current_step() : -1;
 }
 
 static int test_craft_for_prof( const recipe_id &rid, const proficiency_id &prof,
@@ -1057,6 +1084,373 @@ TEST_CASE( "tools_use_charge_to_craft", "[crafting][charge]" )
                 prep_craft( recipe_carver_off_test, tools, false, 0, false, false );
                 CHECK( get_remaining_charges( itype_UPS_off ) == 10 );
             }
+        }
+    }
+}
+
+TEST_CASE( "craft_per_step_tool_consumption", "[crafting][charge][steps]" )
+{
+    GIVEN( "a 3-step recipe with a charged tool (40 charges) only on the middle step" ) {
+        std::vector<item> tools;
+        tools.emplace_back( itype_2x4 );
+        tools.push_back( tool_with_ammo( itype_soldering_iron_portable, 50 ) );
+        prep_craft( recipe_cudgel_test_steps_charged, tools, true );
+
+        WHEN( "the craft is created but no work has been done yet" ) {
+            setup_test_craft( recipe_cudgel_test_steps_charged );
+
+            THEN( "the middle step's charged tool is untouched" ) {
+                CHECK( get_remaining_charges( itype_soldering_iron_portable ) == 50 );
+            }
+        }
+
+        WHEN( "the craft has only just entered the Solder step" ) {
+            const int step = craft_until_step( recipe_cudgel_test_steps_charged, 1 );
+
+            // Entering a step debits its first 5% bucket (40 / 20 = 2 charges);
+            // the rest drains across the step.
+            THEN( "only the step's entry bucket has been debited" ) {
+                CHECK( step == 1 );
+                CHECK( get_remaining_charges( itype_soldering_iron_portable ) == 48 );
+            }
+        }
+
+        WHEN( "the craft has finished the Solder step" ) {
+            craft_until_step( recipe_cudgel_test_steps_charged, 2 );
+
+            THEN( "the step's full 40 charges have been consumed" ) {
+                CHECK( get_remaining_charges( itype_soldering_iron_portable ) == 10 );
+            }
+        }
+
+        WHEN( "the craft runs to completion" ) {
+            THEN( "total charge consumption matches the single step's 40" ) {
+                actually_test_craft( recipe_cudgel_test_steps_charged, INT_MAX );
+                CHECK( get_remaining_charges( itype_soldering_iron_portable ) == 10 );
+            }
+        }
+    }
+}
+
+TEST_CASE( "craft_charged_step_caps_fast_turn_consumption", "[crafting][charge][steps]" )
+{
+    // A remainder-heavy charge count (30) crafted in one fast turn consumes
+    // exactly its total, with no per-bucket rounding overdraw.  This holds for
+    // both a per-step recipe and a stepless recipe metered as one implicit step.
+    std::vector<item> tools;
+    tools.emplace_back( itype_2x4 );
+    tools.push_back( tool_with_ammo( itype_soldering_iron_portable, 50 ) );
+
+    SECTION( "step recipe" ) {
+        prep_craft( recipe_cudgel_test_charged_fast, tools, true );
+        actually_test_craft( recipe_cudgel_test_charged_fast, INT_MAX );
+        CHECK( get_remaining_charges( itype_soldering_iron_portable ) == 20 );
+    }
+
+    SECTION( "stepless recipe" ) {
+        prep_craft( recipe_cudgel_test_charged_fast_stepless, tools, true );
+        actually_test_craft( recipe_cudgel_test_charged_fast_stepless, INT_MAX );
+        CHECK( get_remaining_charges( itype_soldering_iron_portable ) == 20 );
+    }
+}
+
+TEST_CASE( "craft_continue_preserves_per_step_tool_buckets", "[crafting][charge][steps]" )
+{
+    std::vector<item> tools;
+    tools.emplace_back( itype_2x4 );
+    tools.push_back( tool_with_ammo( itype_soldering_iron_portable, 50 ) );
+    avatar &u = get_avatar();
+
+    SECTION( "step recipe" ) {
+        prep_craft( recipe_cudgel_test_steps_charged, tools, true );
+        setup_test_craft( recipe_cudgel_test_steps_charged );
+
+        item_location craft_loc = u.get_wielded_item();
+        REQUIRE( craft_loc );
+        item &craft = *craft_loc;
+        REQUIRE( craft.is_craft() );
+
+        // Mark the Solder step partly debited, then force a continuation rebuild.
+        craft.set_current_step( 1 );
+        std::vector<std::vector<step_tool_alloc>> allocs = craft.get_step_tool_allocs();
+        REQUIRE( allocs.size() == 3 );
+        REQUIRE_FALSE( allocs[1].empty() );
+        allocs[1][0].consumed_buckets = 7;
+        craft.set_step_tool_allocs( allocs );
+        craft.set_tools_to_continue( false );
+
+        REQUIRE( u.can_continue_craft( craft ) );
+
+        const std::vector<std::vector<step_tool_alloc>> &rebuilt = craft.get_step_tool_allocs();
+        CHECK( rebuilt.size() == 3 );
+        REQUIRE_FALSE( rebuilt[1].empty() );
+        CHECK( rebuilt[1][0].consumed_buckets == 7 );
+        CHECK( craft.has_tools_to_continue() );
+    }
+
+    SECTION( "cleared prior allocations rebuild every step" ) {
+        prep_craft( recipe_cudgel_test_steps_charged, tools, true );
+        setup_test_craft( recipe_cudgel_test_steps_charged );
+
+        item_location craft_loc = u.get_wielded_item();
+        REQUIRE( craft_loc );
+        item &craft = *craft_loc;
+        REQUIRE( craft.is_craft() );
+
+        // Simulate a save whose allocations were scrubbed by load validation:
+        // resume must rebuild all steps, not just the current one.
+        craft.set_current_step( 0 );
+        craft.set_step_tool_allocs( {} );
+        craft.set_tools_to_continue( false );
+
+        REQUIRE( u.can_continue_craft( craft ) );
+
+        const std::vector<std::vector<step_tool_alloc>> &rebuilt = craft.get_step_tool_allocs();
+        REQUIRE( rebuilt.size() == 3 );
+        // The charged Solder step (1) is reallocated even though step 0 is current.
+        CHECK_FALSE( rebuilt[1].empty() );
+        CHECK( craft.has_tools_to_continue() );
+    }
+
+    SECTION( "stepless recipe keeps its implicit-step buckets" ) {
+        prep_craft( recipe_cudgel_test_charged_fast_stepless, tools, true );
+        setup_test_craft( recipe_cudgel_test_charged_fast_stepless );
+
+        item_location craft_loc = u.get_wielded_item();
+        REQUIRE( craft_loc );
+        item &craft = *craft_loc;
+        REQUIRE( craft.is_craft() );
+
+        std::vector<std::vector<step_tool_alloc>> allocs = craft.get_step_tool_allocs();
+        REQUIRE( allocs.size() == 1 );
+        REQUIRE_FALSE( allocs[0].empty() );
+        allocs[0][0].consumed_buckets = 7;
+        craft.set_step_tool_allocs( allocs );
+        craft.set_tools_to_continue( false );
+
+        REQUIRE( u.can_continue_craft( craft ) );
+
+        const std::vector<std::vector<step_tool_alloc>> &rebuilt = craft.get_step_tool_allocs();
+        REQUIRE( rebuilt.size() == 1 );
+        REQUIRE_FALSE( rebuilt[0].empty() );
+        // Without carrying buckets, a stepless resume would re-debit from zero.
+        CHECK( rebuilt[0][0].consumed_buckets == 7 );
+        CHECK( craft.has_tools_to_continue() );
+    }
+}
+
+TEST_CASE( "craft_continue_matches_duplicate_step_tool_allocs_positionally",
+           "[crafting][charge][steps]" )
+{
+    std::vector<item> tools;
+    tools.emplace_back( itype_2x4 );
+    tools.push_back( tool_with_ammo( itype_soldering_iron_portable, 50 ) );
+    prep_craft( recipe_cudgel_test_steps_dual_charged, tools, true );
+    setup_test_craft( recipe_cudgel_test_steps_dual_charged );
+
+    avatar &u = get_avatar();
+    item_location craft_loc = u.get_wielded_item();
+    REQUIRE( craft_loc );
+    item &craft = *craft_loc;
+    REQUIRE( craft.is_craft() );
+
+    std::vector<std::vector<step_tool_alloc>> allocs = craft.get_step_tool_allocs();
+    REQUIRE( allocs.size() == 1 );
+    REQUIRE( allocs[0].size() == 2 );
+
+    SECTION( "same-type allocations keep their own depth" ) {
+        // Two same-type allocations debited to different depths.
+        allocs[0][0].consumed_buckets = 5;
+        allocs[0][1].consumed_buckets = 12;
+        craft.set_step_tool_allocs( allocs );
+        craft.set_tools_to_continue( false );
+
+        REQUIRE( u.can_continue_craft( craft ) );
+
+        const std::vector<std::vector<step_tool_alloc>> &rebuilt = craft.get_step_tool_allocs();
+        REQUIRE( rebuilt.size() == 1 );
+        REQUIRE( rebuilt[0].size() == 2 );
+        // Each allocation keeps its own depth instead of both inheriting the first's.
+        CHECK( rebuilt[0][0].consumed_buckets == 5 );
+        CHECK( rebuilt[0][1].consumed_buckets == 12 );
+    }
+
+    SECTION( "a drifted option carries its prior depth as a fail-safe" ) {
+        // Prior allocation at this position references a tool the recipe no
+        // longer selects, so positional pairing finds a type mismatch.
+        allocs[0][0].sel.comp.type = itype_2x4;
+        allocs[0][0].consumed_buckets = 5;
+        allocs[0][1].consumed_buckets = 12;
+        craft.set_step_tool_allocs( allocs );
+        craft.set_tools_to_continue( false );
+
+        REQUIRE( u.can_continue_craft( craft ) );
+
+        const std::vector<std::vector<step_tool_alloc>> &rebuilt = craft.get_step_tool_allocs();
+        REQUIRE( rebuilt.size() == 1 );
+        REQUIRE( rebuilt[0].size() == 2 );
+        // The depth carries forward instead of resetting to zero, so the resume
+        // does not re-debit charges already paid at that position.
+        CHECK( rebuilt[0][0].consumed_buckets == 5 );
+        CHECK( rebuilt[0][1].consumed_buckets == 12 );
+    }
+}
+
+TEST_CASE( "select_step_tool_allocs_resume_reselects_only_current_step",
+           "[crafting][charge][steps]" )
+{
+    // recipe_cudgel_test_steps_charged has its charged tool on step 1 (Solder);
+    // steps 0 and 2 have no tools.
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    u.set_skill_level( skill_fabrication, 10 );
+    const recipe &r = recipe_cudgel_test_steps_charged.obj();
+    REQUIRE( r.steps().size() == 3 );
+    inventory map_inv;
+    bool cancelled = false;
+
+    SECTION( "a full build selects the charged step's tool" ) {
+        u.i_add( tool_with_ammo( itype_soldering_iron_portable, 50 ) );
+        u.invalidate_crafting_inventory();
+        const std::vector<std::vector<step_tool_alloc>> allocs =
+                    select_step_tool_allocs( u, r, 1, map_inv, cancelled, -1 );
+        CHECK_FALSE( cancelled );
+        REQUIRE( allocs.size() == 3 );
+        CHECK_FALSE( allocs[1].empty() );
+    }
+
+    SECTION( "resuming step 0 reselects only step 0, skipping the charged step" ) {
+        u.i_add( tool_with_ammo( itype_soldering_iron_portable, 50 ) );
+        u.invalidate_crafting_inventory();
+        const std::vector<std::vector<step_tool_alloc>> allocs =
+                    select_step_tool_allocs( u, r, 1, map_inv, cancelled, 0 );
+        CHECK_FALSE( cancelled );
+        REQUIRE( allocs.size() == 3 );
+        CHECK( allocs[1].empty() );
+    }
+
+    SECTION( "resuming step 0 ignores an absent future-step tool" ) {
+        // No soldering tool present; resuming step 0 must not cancel on step 1's
+        // missing tool.
+        u.invalidate_crafting_inventory();
+        const std::vector<std::vector<step_tool_alloc>> allocs =
+                    select_step_tool_allocs( u, r, 1, map_inv, cancelled, 0 );
+        CHECK_FALSE( cancelled );
+        REQUIRE( allocs.size() == 3 );
+        CHECK( allocs[1].empty() );
+    }
+}
+
+TEST_CASE( "craft_step_charge_shortfall_rewinds_turn_progress",
+           "[crafting][charge][steps]" )
+{
+    std::vector<item> tools;
+    tools.emplace_back( itype_2x4 );
+    tools.push_back( tool_with_ammo( itype_soldering_iron_portable, 50 ) );
+    prep_craft( recipe_cudgel_test_steps_charged, tools, true );
+    setup_test_craft( recipe_cudgel_test_steps_charged );
+
+    avatar &u = get_avatar();
+
+    // Drive into the charged Solder step.
+    int guard = 0;
+    while( u.activity.id() == ACT_CRAFT ) {
+        item_location craft = u.get_wielded_item();
+        if( craft && craft->is_craft() && craft->get_current_step() >= 1 ) {
+            break;
+        }
+        REQUIRE( ++guard < 100000 );
+        u.set_moves( 100 );
+        u.activity.do_turn( u );
+    }
+    REQUIRE( u.activity.id() == ACT_CRAFT );
+
+    // Empty the tool mid-step so the next turn cannot cover its charge debit.
+    for( item *it : u.items_with( []( const item & i ) {
+    return i.typeId() == itype_soldering_iron_portable;
+    } ) ) {
+        it->ammo_consume( it->ammo_remaining(), u.pos_bub(), &u );
+    }
+    u.invalidate_crafting_inventory();
+
+    // Drive on until a step bucket crossing tries to debit the now-empty tool.
+    int counter_before_fail = -1;
+    while( u.activity.id() == ACT_CRAFT ) {
+        item_location craft = u.get_wielded_item();
+        REQUIRE( craft );
+        REQUIRE( craft->is_craft() );
+        counter_before_fail = craft->item_counter;
+        REQUIRE( ++guard < 100000 );
+        u.set_moves( 100 );
+        u.activity.do_turn( u );
+    }
+
+    // The shortfall cancels the craft but leaves it resumable: progress is
+    // rewound to exactly where the failed turn began, not backed to a 5% mark.
+    item_location craft = u.get_wielded_item();
+    REQUIRE( craft );
+    REQUIRE( craft->is_craft() );
+    CHECK( craft->item_counter == counter_before_fail );
+    // The failed turn's moves are returned rather than spent, so the cancelled
+    // craft leaves the crafter free to act.
+    CHECK( u.get_moves() == 100 );
+}
+
+TEST_CASE( "craft_step_consume_requires_selected_noncharged_tool",
+           "[crafting][charge][steps]" )
+{
+    avatar &u = get_avatar();
+    clear_avatar();
+    clear_map();
+    u.setpos( get_map(), tripoint_bub_ms( 60, 60, 0 ) );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item craft( &recipe_cudgel_test_steps_basic.obj(), 1, ingredient );
+    REQUIRE( craft.is_craft() );
+    // Treat the craft as complete so every step trues up to its full target.
+    craft.item_counter = 10000000;
+
+    // A pinned non-charged tool selection (count -1) on the first step.
+    step_tool_alloc alloc;
+    alloc.sel.use_from = usage_from::player;
+    alloc.sel.comp.type = itype_soldering_iron_portable;
+    alloc.sel.comp.count = -1;
+    alloc.step_count_units = 0;
+    std::vector<std::vector<step_tool_alloc>> allocs( craft.get_making().steps().size() );
+    REQUIRE_FALSE( allocs.empty() );
+    allocs[0].push_back( alloc );
+    craft.set_step_tool_allocs( allocs );
+
+    GIVEN( "the pinned non-charged tool is absent" ) {
+        u.invalidate_crafting_inventory();
+
+        THEN( "consuming the step's tools fails instead of running free" ) {
+            CHECK_FALSE( u.craft_consume_step_tools( craft ) );
+            CHECK( craft.get_step_tool_allocs()[0][0].consumed_buckets == 0 );
+        }
+    }
+
+    GIVEN( "the pinned non-charged tool is present" ) {
+        u.i_add( item( itype_soldering_iron_portable, calendar::turn ) );
+        u.invalidate_crafting_inventory();
+
+        THEN( "the step trues up with no charge drain" ) {
+            CHECK( u.craft_consume_step_tools( craft ) );
+            CHECK( craft.get_step_tool_allocs()[0][0].consumed_buckets == 20 );
+        }
+    }
+
+    GIVEN( "the tool's buckets are full but the craft is not done" ) {
+        // Buckets filled earlier with the tool present, then it was removed
+        // before completion; the active step must re-check, not free-finish.
+        allocs[0][0].consumed_buckets = 20;
+        craft.set_step_tool_allocs( allocs );
+        craft.item_counter = 0;
+        u.invalidate_crafting_inventory();
+
+        THEN( "the active step re-checks presence and fails" ) {
+            CHECK_FALSE( u.craft_consume_step_tools( craft ) );
         }
     }
 }

--- a/tests/recipe_steps_test.cpp
+++ b/tests/recipe_steps_test.cpp
@@ -45,6 +45,7 @@ static const itype_id itype_battery( "battery" );
 static const itype_id itype_cudgel( "cudgel" );
 static const itype_id itype_heavy_battery_cell( "heavy_battery_cell" );
 static const itype_id itype_knife_hunting( "knife_hunting" );
+static const itype_id itype_soldering_iron_portable( "soldering_iron_portable" );
 static const itype_id itype_test_charged_fast_cutter( "test_charged_fast_cutter" );
 static const itype_id itype_test_fast_cutter( "test_fast_cutter" );
 static const itype_id itype_test_slow_cutter( "test_slow_cutter" );
@@ -57,7 +58,9 @@ static const quality_id qual_BUTCHER( "BUTCHER" );
 static const quality_id qual_CUT( "CUT" );
 
 static const recipe_id recipe_cudgel_simple( "cudgel_simple" );
+static const recipe_id recipe_cudgel_test_root_charged( "cudgel_test_root_charged" );
 static const recipe_id recipe_cudgel_test_steps_basic( "cudgel_test_steps_basic" );
+static const recipe_id recipe_cudgel_test_steps_charged( "cudgel_test_steps_charged" );
 static const recipe_id recipe_cudgel_test_steps_required_prof(
     "cudgel_test_steps_required_prof" );
 static const recipe_id recipe_cudgel_test_steps_shared_prof(
@@ -129,6 +132,82 @@ TEST_CASE( "step_recipe_tools_merged", "[recipe][steps]" )
         }
     }
     CHECK( has_cut );
+}
+
+static bool reqs_have_tool( const requirement_data &reqs, const itype_id &tool )
+{
+    for( const std::vector<tool_comp> &group : reqs.get_tools() ) {
+        for( const tool_comp &t : group ) {
+            if( t.type == tool ) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+TEST_CASE( "step_recipe_root_requirements_separate_from_step_tools", "[recipe][steps]" )
+{
+    GIVEN( "a step recipe with a charged tool only on a step" ) {
+        const recipe &r = recipe_cudgel_test_steps_charged.obj();
+        THEN( "the root requirements hold no tools" ) {
+            CHECK_FALSE( reqs_have_tool( r.root_requirements(), itype_soldering_iron_portable ) );
+        }
+        THEN( "the owning step still lists the charged tool" ) {
+            REQUIRE( r.steps().size() == 3 );
+            CHECK( reqs_have_tool( r.steps()[1].requirements, itype_soldering_iron_portable ) );
+        }
+    }
+
+    GIVEN( "a step recipe with a charged tool at the recipe root" ) {
+        const recipe &r = recipe_cudgel_test_root_charged.obj();
+        THEN( "the root requirements hold the charged tool" ) {
+            CHECK( reqs_have_tool( r.root_requirements(), itype_soldering_iron_portable ) );
+        }
+        THEN( "no step lists the charged tool" ) {
+            for( const recipe_step &s : r.steps() ) {
+                CHECK_FALSE( reqs_have_tool( s.requirements, itype_soldering_iron_portable ) );
+            }
+        }
+    }
+
+    // Root charged tools are metered only across active (attended, timed) steps,
+    // so a recipe carrying them must have an active step to debit them against.
+    // These cases need inline finalize: a charged all-unattended recipe cannot
+    // live in TEST_DATA without erroring at load.
+    const auto finalize_msg = []( const std::string & steps_json ) -> std::string {
+        recipe r;
+        JsonObject jo = json_loader::from_string( string_format(
+                    R"({ "type": "recipe", "result": "cudgel", "id_suffix": "test_charged_root",
+                                "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+                                "skill_used": "fabrication", "difficulty": 1,
+                                "using": [ [ "soldering_standard", 1 ] ], "components": [[ [ "2x4", 1 ] ]],
+                                "steps": [ %s ] })", steps_json ) );
+        jo.allow_omitted_members();
+        r.load( jo, "dda" );
+        return capture_debugmsg_during( [&]()
+        {
+            r.finalize();
+        } );
+    };
+
+    GIVEN( "a charged root tool but no active step" ) {
+        const std::string msg = finalize_msg(
+                                    R"({ "name": "Cure", "time": "10 m", "attention": "unattended", "activity_level": "NO_EXERCISE" },)"
+                                    R"({ "name": "Dry", "time": "10 m", "attention": "unattended", "activity_level": "NO_EXERCISE" })" );
+        THEN( "finalize rejects it" ) {
+            CHECK( msg.find( "active step" ) != std::string::npos );
+        }
+    }
+
+    GIVEN( "a charged root tool and an active step" ) {
+        const std::string msg = finalize_msg(
+                                    R"({ "name": "Shape", "time": "10 m", "activity_level": "MODERATE_EXERCISE" },)"
+                                    R"({ "name": "Dry", "time": "10 m", "attention": "unattended", "activity_level": "NO_EXERCISE" })" );
+        THEN( "finalize accepts it" ) {
+            CHECK( msg.empty() );
+        }
+    }
 }
 
 TEST_CASE( "step_recipe_deduped_requirements_craftable", "[recipe][steps]" )

--- a/tests/recipe_steps_test.cpp
+++ b/tests/recipe_steps_test.cpp
@@ -14,6 +14,7 @@
 #include "cata_utility.h"
 #include "character.h"
 #include "coordinates.h"
+#include "craft_command.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
 #include "inventory.h"
@@ -33,6 +34,7 @@
 #include "recipe.h"
 #include "requirements.h"
 #include "ret_val.h"
+#include "string_formatter.h"
 #include "translation.h"
 #include "type_id.h"
 
@@ -2300,4 +2302,60 @@ TEST_CASE( "tool_speed_negative_rejected", "[recipe][steps][tool_speed]" )
         "symbol": "x", "color": "white",
         "qualities": [ { "id": "CUT", "level": 1, "speed": -1 } ]
     })" );
+}
+
+TEST_CASE( "step_recipe_root_tool_distributed_by_step_budget", "[recipe][steps][crafting]" )
+{
+    // Root tool charges split across active steps by move budget, not raw time,
+    // so a per-step proficiency malus shifts more of the root tool onto the
+    // slower step even when the steps share the same nominal duration.
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    u.set_skill_level( skill_fabrication, 10 );
+    // Has the Finish proficiency but not the Shape one, so only Shape is slowed.
+    u.add_proficiency( proficiency_prof_test_step_b, true );
+    u.i_add( tool_with_ammo( itype_soldering_iron_portable, 500 ) );
+    u.i_add( item( itype_2x4 ) );
+    u.invalidate_crafting_inventory();
+
+    recipe r;
+    JsonObject jo = json_loader::from_string( R"({
+        "type": "recipe", "result": "cudgel", "id_suffix": "test_root_charged_profs",
+        "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+        "skill_used": "fabrication", "difficulty": 1,
+        "using": [ [ "soldering_standard", 10 ] ], "components": [[ [ "2x4", 1 ] ]],
+        "steps": [
+            { "name": "Shape", "time": "10 m", "activity_level": "MODERATE_EXERCISE",
+              "proficiencies": [ { "proficiency": "prof_test_step_a" } ] },
+            { "name": "Finish", "time": "10 m", "activity_level": "NO_EXERCISE",
+              "proficiencies": [ { "proficiency": "prof_test_step_b" } ] }
+        ]
+    })" );
+    jo.allow_omitted_members();
+    r.load( jo, "dda" );
+    r.finalize();
+
+    inventory map_inv;
+    bool cancelled = false;
+    const std::vector<std::vector<step_tool_alloc>> allocs =
+                select_step_tool_allocs( u, r, 1, map_inv, cancelled );
+    REQUIRE_FALSE( cancelled );
+    REQUIRE( allocs.size() == 2 );
+
+    const auto root_units = [&]( size_t step ) -> int {
+        for( const step_tool_alloc &a : allocs[step] )
+        {
+            if( a.root_derived ) {
+                return a.step_count_units;
+            }
+        }
+        return -1;
+    };
+    const int shape = root_units( 0 );
+    const int finish = root_units( 1 );
+    REQUIRE( shape > 0 );
+    REQUIRE( finish > 0 );
+    // Raw time alone would split the root tool evenly; the Shape malus tips it.
+    CHECK( shape > finish );
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Consume crafting tools per recipe step"

#### Purpose of change
Recipes can be split into steps, each with its own time. But tool and charge consumption never learned about steps: tools are picked once when the craft starts, and charges drain against the whole recipe's progress. So a charged tool that only one step needs gets smeared across the entire craft, and unattended steps (which run on a wall clock instead of the normal craft loop) can't meter their tools at all, which is why charged tools are currently banned on them outright.

This sorts out the foundation by making tool consumption per-step.

#### Describe the solution
Each step now owns the tools it selected and drains them in proportion to that step's own progress, not the whole recipe's. A charged tool listed on step 2 is drained during step 2, and nowhere else.

Tools that belong to the whole craft rather than any single step (a recipe's root "using" toolset, like a forge) are split across the steps by how much time each one takes, so a longer step pays the bigger share.

Consumption reuses the same 5% bucket model crafting already uses, so a normal single-step or stepless craft drains exactly what it did before. Two deliberate differences, both covered by tests: multi-step recipes now charge the right step (with small rounding on the split), and a pre-existing overdraw, where one fast turn could consume more charges than the recipe actually needs, is now capped at the real total.

This is groundwork only. It does not yet meter unattended steps, so charged root tools stay confined to active steps and a charged tool with nowhere to be metered is still rejected at load. Enabling charged tools on unattended steps is a follow-up.

Per-step allocations are saved with the craft and validated on load; a save whose recipe changed underneath it drops the stale data and rebuilds on resume.

#### Describe alternatives you've considered
A second, parallel "passive tools" store alongside the existing selection. Quicker, but it leaves two mechanisms doing the same job that drift apart, so making consumption per-step everywhere was the cleaner fix.

#### Testing
New tests cover per-step attribution, the fast-turn cap, the root-tool split, save/load migration, and resuming an interrupted craft. Existing crafting tests pass.

#### Additional context
Foundation for charged tools on unattended steps, which builds on this in a follow-up PR.