### PR TITLE
Charged tools on unattended crafting steps

### DIFF
--- a/data/json/recipes/food/dry.json
+++ b/data/json/recipes/food/dry.json
@@ -221,19 +221,32 @@
   },
   {
     "type": "recipe",
-    "activity_level": "NO_EXERCISE",
     "result": "dry_meat",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_DRY",
     "delete_flags": [ "BAD_TASTE" ],
     "skill_used": "cooking",
     "difficulty": 2,
-    "time": "18 m",
     "autolearn": true,
-    "batch_time_factors": [ 67, 5 ],
-    "tools": [ [ [ "dehydrating_heat", 30, "LIST" ] ] ],
-    "//": "300g of stuff",
-    "components": [ [ [ "meat_red_raw", 1, "LIST" ] ] ]
+    "//": "300g of stuff. Slicing is hands-on; dehydration runs unattended and drains the heat source over the wait.",
+    "components": [ [ [ "meat_red_raw", 1, "LIST" ] ] ],
+    "steps": [
+      {
+        "name": "Slice the meat into thin strips",
+        "time": "3 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "batch_time_factors": [ 67, 5 ],
+        "qualities": [ { "id": "CUT", "level": 1 } ]
+      },
+      {
+        "name": "Dehydrate the strips",
+        "time": "15 m",
+        "activity_level": "NO_EXERCISE",
+        "attention": "unattended",
+        "batch_time_factors": [ 67, 5 ],
+        "tools": [ [ [ "dehydrating_heat", 30, "LIST" ] ] ]
+      }
+    ]
   },
   {
     "type": "recipe",

--- a/data/mods/TEST_DATA/recipes.json
+++ b/data/mods/TEST_DATA/recipes.json
@@ -488,6 +488,48 @@
   {
     "type": "recipe",
     "result": "cudgel",
+    "id_suffix": "test_unattended_charged",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "steps": [
+      { "name": "Shape", "time": "5 m", "activity_level": "MODERATE_EXERCISE" },
+      {
+        "name": "Cure",
+        "time": "10 m",
+        "activity_level": "NO_EXERCISE",
+        "attention": "unattended",
+        "tools": [ [ [ "soldering_iron_portable", 20 ] ] ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_unattended_charged_big",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "steps": [
+      { "name": "Shape", "time": "5 m", "activity_level": "MODERATE_EXERCISE" },
+      {
+        "name": "Cure",
+        "time": "10 m",
+        "activity_level": "NO_EXERCISE",
+        "attention": "unattended",
+        "tools": [ [ [ "soldering_iron_portable", 40 ] ] ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
     "id_suffix": "test_root_charged",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_BASHING",

--- a/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
+++ b/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
@@ -237,6 +237,7 @@ Each entry in the `"steps"` array is an object with these fields:
 - Batch savings are applied per-step and summed.
 - The current step name appears in the crafting progress message.
 - Tool speed modifiers (see `"speed"` in item quality definitions) apply per-step: a tool with `"speed": 0.5` on a quality halves the time of steps requiring that quality, without affecting other steps.
+- Tool charges are consumed per-step, in proportion to that step's progress, so a charged tool listed on one step drains only while that step runs.  Recipe-root tools (root `"using"`/`"tools"`) are spread across the steps by each step's share of the total time.
 
 ### Unattended steps
 
@@ -254,7 +255,7 @@ When the wall-clock deadline elapses:
 - Terminal: craft auto-finalizes at the deadline, so morale, EOCs, heat, and birthday use in-game completion time.
 - `max_time + grace_period` past start: craft is destroyed.
 
-If the step's tools or qualities become unavailable, the step pauses and the deadline slides forward once the env is restored.  `crafter_id` is remembered so env-check picks up the crafter's pseudo-tools, bionics, and trait qualities when they are next to the craft.
+If the step's tools or qualities become unavailable, or a charged tool runs short on charges, the step pauses and the deadline slides forward once the requirement is restored.  `crafter_id` is remembered so env-check picks up the crafter's pseudo-tools, bionics, and trait qualities when they are next to the craft.
 
 NPCs do not see the planning modal and behave as if implicitly waiting; the unattended block in the craft activity actor still drives their craft forward.
 
@@ -263,7 +264,7 @@ Schema:
 - `"max_time"`, when set, must be strictly greater than `"time"`.
 - `"grace_period"` requires `"max_time"`.
 - `"attention": "supervised"` is rejected at load (reserved).
-- An unattended step cannot list charged tools yet (charge debit during wallclock pause/resume not implemented).
+- An unattended step may list charged tools.  Their charges are drained over the step's wall-clock progress (fully spent by completion), drawn from the crafter when next to the craft or from the craft's own tile otherwise; running short pauses the step until charges return.
 
 Example:
 

--- a/src/character.h
+++ b/src/character.h
@@ -3847,6 +3847,19 @@ class Character : public Creature, public visitable
         /** Advance per-step tool consumption so each step's allocations match its
          *  current progress.  Returns false (consuming nothing) if charges are short. */
         bool craft_consume_step_tools( item &craft );
+        /** Advance the active unattended step's tool consumption to match its
+         *  wall-clock progress.  Returns false (consuming nothing) if charges are short. */
+        bool craft_consume_passive_step_tools( item &craft, time_point now, const item_location &loc );
+        /** Consume each step's tool allocations up to its 5% bucket target.
+         *  active_step is the in-progress step, whose non-charged selected tools are
+         *  re-checked for presence every call (even once their buckets are full) so a
+         *  tool removed before completion cannot finish the step.  When pin_to_map is
+         *  set, usage_from::player and usage_from::both allocations draw from the map
+         *  at origin instead of the crafter.  Returns false (consuming nothing) on a
+         *  shortfall. */
+        bool consume_step_tool_targets( item &craft, const std::vector<int> &targets,
+                                        int active_step, const tripoint_bub_ms &origin, int radius,
+                                        bool pin_to_map );
         void consume_tools( const comp_selection<tool_comp> &tool, int batch );
         void consume_tools( map &m, const comp_selection<tool_comp> &tool, int batch,
                             const tripoint_bub_ms &origin = tripoint_bub_ms::zero, int radius = PICKUP_RANGE,

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -536,29 +536,26 @@ std::vector<std::vector<step_tool_alloc>> select_step_tool_allocs(
     }
 
     // Recipe-root tools belong to the whole craft.  Distribute their charges
-    // across the active steps pro-rata by each step's move budget (so per-step
+    // across all timed steps pro-rata by each step's move budget (so per-step
     // time, proficiency, and tool-speed modifiers are reflected); the last
-    // active step takes the rounding remainder so the shares sum exactly.
-    // Unattended steps are excluded from the active-step distribution.
+    // weighted step takes the rounding remainder so the shares sum exactly.
     const std::vector<std::vector<tool_comp>> &root_groups = rec.root_requirements().get_tools();
     if( root_groups.empty() ) {
         return allocs;
     }
     const crafting_cost_context ctx = crafting_cost_context::for_recipe( crafter, rec );
-    std::vector<int64_t> active_budget( steps.size(), 0 );
-    int64_t total_active = 0;
-    int last_active = -1;
+    std::vector<int64_t> step_budget( steps.size(), 0 );
+    int64_t total_budget = 0;
+    int last_weighted = -1;
     for( size_t i = 0; i < steps.size(); ++i ) {
-        if( steps[i].attention != step_attention::unattended ) {
-            active_budget[i] = std::max<int64_t>(
-                                   static_cast<int64_t>( rec.step_budget_moves( crafter, i, batch, ctx ) ), 0 );
-            total_active += active_budget[i];
-            if( active_budget[i] > 0 ) {
-                last_active = static_cast<int>( i );
-            }
+        step_budget[i] = std::max<int64_t>(
+                             static_cast<int64_t>( rec.step_budget_moves( crafter, i, batch, ctx ) ), 0 );
+        total_budget += step_budget[i];
+        if( step_budget[i] > 0 ) {
+            last_weighted = static_cast<int>( i );
         }
     }
-    if( total_active <= 0 ) {
+    if( total_budget <= 0 ) {
         return allocs;
     }
     for( const std::vector<tool_comp> &group : root_groups ) {
@@ -570,12 +567,12 @@ std::vector<std::vector<step_tool_alloc>> select_step_tool_allocs(
         const int total_units = std::max( 0, ts.comp.count ) * std::max( batch, 1 );
         int assigned = 0;
         for( size_t i = 0; i < steps.size(); ++i ) {
-            if( active_budget[i] <= 0 ) {
+            if( step_budget[i] <= 0 ) {
                 continue;
             }
-            const int share = static_cast<int>( i ) == last_active
+            const int share = static_cast<int>( i ) == last_weighted
                               ? total_units - assigned
-                              : static_cast<int>( total_units * active_budget[i] / total_active );
+                              : static_cast<int>( total_units * step_budget[i] / total_budget );
             assigned += share;
             step_tool_alloc alloc;
             alloc.sel = ts;

--- a/src/craft_command.h
+++ b/src/craft_command.h
@@ -72,7 +72,7 @@ struct step_tool_alloc {
 
 /**
 *   Builds per-step tool allocations for a step recipe: each step's own tools
-*   plus recipe-root tools distributed across the active steps pro-rata by each
+*   plus recipe-root tools distributed across the timed steps pro-rata by each
 *   step's move budget.  Sets cancelled when the crafter cancels a tool prompt so
 *   the caller can abort instead of silently dropping that tool group.
 *   When reselect_step >= 0 (resume), only that step's own tools are reselected

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1181,6 +1181,22 @@ static bool step_has_env_requirements( const recipe_step &step )
            || !step.requirements.get_qualities().empty();
 }
 
+// True when the step owns a charged allocation (step tool or root-derived share)
+// that needs draining even if the step has no step-level env requirement.
+static bool step_has_charged_alloc( const item &craft, int idx )
+{
+    const std::vector<std::vector<step_tool_alloc>> &allocs = craft.get_step_tool_allocs();
+    if( idx < 0 || idx >= static_cast<int>( allocs.size() ) ) {
+        return false;
+    }
+    for( const step_tool_alloc &a : allocs[idx] ) {
+        if( a.step_count_units > 0 ) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static Character *resolve_crafter( const character_id &cid )
 {
     if( !cid.is_valid() ) {
@@ -1193,32 +1209,77 @@ static Character *resolve_crafter( const character_id &cid )
     return g->find_npc( cid );
 }
 
-static bool env_satisfied_for_step( const recipe_step &step, const item &craft,
-                                    const item_location &loc )
+namespace
 {
-    if( !step_has_env_requirements( step ) ) {
+// Where a step's tools and charges are sourced.  origin is the craft tile;
+// present_char is the holder (held craft) or the crafter when standing within
+// radius (map craft), else null when only the map at the craft is reachable.
+struct step_source_context {
+    tripoint_bub_ms origin;
+    int radius = PICKUP_RANGE;
+    Character *present_char = nullptr;
+};
+} // namespace
+
+static step_source_context resolve_step_source( const item &craft, const item_location &loc )
+{
+    map &m = get_map();
+    step_source_context src;
+    src.origin = m.get_bub( loc.pos_abs() );
+    src.radius = PICKUP_RANGE;
+    if( loc.where() == item_location::type::character ) {
+        src.present_char = loc.carrier();
+    } else {
+        Character *crafter = resolve_crafter( craft.get_crafter_id() );
+        if( crafter != nullptr && rl_dist( crafter->pos_bub( m ), src.origin ) <= src.radius ) {
+            src.present_char = crafter;
+        }
+    }
+    return src;
+}
+
+// The character whose charges back a passive debit: the holder of a held craft,
+// otherwise the recorded crafter.
+static Character *resolve_consume_crafter( const item &craft, const item_location &loc )
+{
+    if( loc.where() == item_location::type::character ) {
+        return loc.carrier();
+    }
+    return resolve_crafter( craft.get_crafter_id() );
+}
+
+// The unattended gate verifies only qualities; the passive debit enforces the
+// chosen tool option and its remaining charges, so checking tools here too would
+// pause on a generic-OR match or a start-only reduced charge the debit still covers.
+static bool env_qualities_satisfied_for_step( const recipe_step &step, const item &craft,
+        const item_location &loc )
+{
+    const requirement_data::alter_quali_req_vector &quals = step.requirements.get_qualities();
+    if( quals.empty() ) {
         return true;
     }
     map &m = get_map();
-    const tripoint_bub_ms craft_pos = m.get_bub( loc.pos_abs() );
+    const step_source_context src = resolve_step_source( craft, loc );
 
     inventory inv;
-    if( loc.where() == item_location::type::character ) {
-        Character *holder = loc.carrier();
-        if( holder != nullptr ) {
-            inv = holder->crafting_inventory( craft_pos, PICKUP_RANGE );
-        }
+    if( src.present_char != nullptr ) {
+        inv = src.present_char->crafting_inventory( src.origin, src.radius );
     } else {
-        Character *crafter = resolve_crafter( craft.get_crafter_id() );
-        if( crafter != nullptr
-            && rl_dist( crafter->pos_bub( m ), craft_pos ) <= PICKUP_RANGE ) {
-            inv = crafter->crafting_inventory( craft_pos, PICKUP_RANGE );
-        } else {
-            inv.form_from_map( &m, craft_pos, PICKUP_RANGE, /*pl=*/nullptr );
+        inv.form_from_map( &m, src.origin, src.radius, /*pl=*/nullptr );
+    }
+    for( const std::vector<quality_requirement> &group : quals ) {
+        bool group_ok = false;
+        for( const quality_requirement &q : group ) {
+            if( q.has( inv, return_true<item> ) ) {
+                group_ok = true;
+                break;
+            }
+        }
+        if( !group_ok ) {
+            return false;
         }
     }
-    return step.requirements.can_make_with_inventory(
-               inv, return_true<item>, /*batch=*/1, craft_flags::start_only );
+    return true;
 }
 
 static std::string compose_unattend_message( const item &craft, const recipe_step &step )
@@ -1361,6 +1422,23 @@ enum class env_check_result {
 };
 } // namespace
 
+// Park the in-flight deadlines and turn ready_at into a 1-minute polling cursor
+// so a paused step keeps re-checking until its requirements return.
+static void craft_enter_env_pause( item &craft, time_point now, const item_location &loc )
+{
+    if( craft.get_pause_started_at() == calendar::before_time_starts ) {
+        craft.set_pause_started_at( now );
+        craft.set_saved_ready_at( craft.get_ready_at() );
+        craft.set_saved_alarm_at( craft.get_alarm_at() );
+        craft.set_saved_fail_at( craft.get_fail_at() );
+        craft.set_alarm_at( calendar::before_time_starts );
+        craft.set_fail_at( calendar::before_time_starts );
+    }
+    craft.set_ready_at( now + 1_minutes );
+    craft.set_env_check_at( calendar::before_time_starts );
+    get_item_wakeups().rebuild_for_item( loc );
+}
+
 // Shared env-pause / env-restore helper.  Owns env_check_at re-arm
 // cadence and rebuilds wakeups in all paths.
 static env_check_result craft_check_env_step( item &craft, time_point now,
@@ -1373,20 +1451,8 @@ static env_check_result craft_check_env_step( item &craft, time_point now,
     }
     const recipe_step &step = rec.steps()[step_idx];
 
-    if( !env_satisfied_for_step( step, craft, loc ) ) {
-        if( craft.get_pause_started_at() == calendar::before_time_starts ) {
-            craft.set_pause_started_at( now );
-            craft.set_saved_ready_at( craft.get_ready_at() );
-            craft.set_saved_alarm_at( craft.get_alarm_at() );
-            craft.set_saved_fail_at( craft.get_fail_at() );
-            craft.set_alarm_at( calendar::before_time_starts );
-            craft.set_fail_at( calendar::before_time_starts );
-        }
-        craft.set_ready_at( now + 1_minutes );
-        // While paused, ready_at is the 1-minute polling cursor; clear
-        // env_check_at to avoid double-arming the queue.
-        craft.set_env_check_at( calendar::before_time_starts );
-        get_item_wakeups().rebuild_for_item( loc );
+    if( !env_qualities_satisfied_for_step( step, craft, loc ) ) {
+        craft_enter_env_pause( craft, now, loc );
         return env_check_result::paused;
     }
 
@@ -1400,6 +1466,12 @@ static env_check_result craft_check_env_step( item &craft, time_point now,
         }
         if( craft.get_saved_fail_at() != calendar::before_time_starts ) {
             craft.set_fail_at( craft.get_saved_fail_at() + paused_for );
+        }
+        // Slide the step entry with the deadline so paused wall-clock is not
+        // counted as progress when the passive debit derives its fraction from
+        // now - passive_started_at over the (slid) step duration.
+        if( craft.get_passive_started_at() != calendar::before_time_starts ) {
+            craft.set_passive_started_at( craft.get_passive_started_at() + paused_for );
         }
         craft.set_pause_started_at( calendar::before_time_starts );
         craft.set_saved_ready_at( calendar::before_time_starts );
@@ -1425,7 +1497,7 @@ static env_check_result craft_check_env_step( item &craft, time_point now,
     // Normal mid-step env check (no pause entered or exited).  Re-arm the
     // cursor for the next minute; clamp to ready_at so a poll never fires
     // after step completion.
-    if( step_has_env_requirements( step ) ) {
+    if( step_has_env_requirements( step ) || step_has_charged_alloc( craft, step_idx ) ) {
         const time_point next = now + 1_minutes;
         craft.set_env_check_at( std::min( next, craft.get_ready_at() ) );
     } else {
@@ -1452,7 +1524,16 @@ static void craft_actualize_env( item &craft, time_point now, const item_locatio
         now >= craft.get_fail_at() ) {
         return;
     }
-    ( void ) craft_check_env_step( craft, now, loc );
+    if( craft_check_env_step( craft, now, loc ) == env_check_result::paused ) {
+        return;
+    }
+    // Drain the step's charged tools to match wall-clock progress; a shortfall
+    // pauses the step until the tools are recharged.
+    if( Character *consumer = resolve_consume_crafter( craft, loc ) ) {
+        if( !consumer->craft_consume_passive_step_tools( craft, now, loc ) ) {
+            craft_enter_env_pause( craft, now, loc );
+        }
+    }
 }
 
 static void craft_actualize_ready( item &craft, time_point now, const item_location &loc )
@@ -1499,6 +1580,18 @@ static void craft_actualize_ready( item &craft, time_point now, const item_locat
     if( env_result == env_check_result::paused ) {
         return;
     }
+
+    // Drain the step's charged tools to current progress (the full allocation at
+    // completion); a shortfall re-pauses.  Runs before the restored-but-not-ready
+    // return below, since craft_check_env_step only restores on qualities: a pause
+    // for missing charges must not clear while the charges are still short.
+    if( Character *consumer = resolve_consume_crafter( craft, loc ) ) {
+        if( !consumer->craft_consume_passive_step_tools( craft, now, loc ) ) {
+            craft_enter_env_pause( craft, now, loc );
+            return;
+        }
+    }
+
     if( env_result == env_check_result::restored && now < craft.get_ready_at() ) {
         return;
     }
@@ -1619,10 +1712,10 @@ void craft_stamp_passive_entry( item &craft, const Character &crafter, time_poin
     if( plan.choice == step_choice::set_timer && plan.alarm_offset.has_value() ) {
         craft.set_alarm_at( entry_time + *plan.alarm_offset );
     }
-    // Periodic env-check cursor: arm only when the step actually has env
-    // requirements.  Clamp to ready_at so a short step never schedules a
-    // poll past completion.
-    if( step_has_env_requirements( cur_step ) ) {
+    // Periodic env-check cursor: arm when the step has env requirements or any
+    // charged allocation to drain.  Clamp to ready_at so a short step never
+    // schedules a poll past completion.
+    if( step_has_env_requirements( cur_step ) || step_has_charged_alloc( craft, idx ) ) {
         const time_point next = now + 1_minutes;
         craft.set_env_check_at( std::min( next, craft.get_ready_at() ) );
     } else {
@@ -1655,6 +1748,13 @@ void craft_stamp_passive_entry( item &craft, const Character &crafter, time_poin
                                               ( prior_moves + step_default ) / base_total * 10000000.0 ) ) );
     craft.set_passive_start_counter( start_counter );
     craft.set_passive_end_counter( end_counter );
+    // Drain the entry (bucket 0) charges now so a passive step pays its entry
+    // debit like an active one.  A shortfall pauses the step.
+    if( Character *consumer = resolve_consume_crafter( craft, loc ) ) {
+        if( !consumer->craft_consume_passive_step_tools( craft, now, loc ) ) {
+            craft_enter_env_pause( craft, now, loc );
+        }
+    }
     get_item_wakeups().rebuild_for_item( loc );
 }
 
@@ -3391,61 +3491,34 @@ bool Character::craft_consume_tools( item &craft, int multiplier, bool start_cra
     return true;
 }
 
-bool Character::craft_consume_step_tools( item &craft )
+// Charges (count units) consumed through `count` 5% buckets.  Front-loads the
+// remainder at bucket 0 and caps at the step total.
+static int step_bucket_cumulative( int total, int count )
 {
-    if( has_trait( trait_DEBUG_HS ) ) {
-        return true;
+    if( count <= 0 ) {
+        return 0;
     }
-    const recipe &rec = craft.get_making();
+    return std::min( total, total % 20 + count * ( total / 20 ) );
+}
+
+// 5% bucket count (0..20) a step should reach at progress fraction `f`.  Bucket
+// 0 (entry) fires at fraction 0; the final 5% is never charged.
+static int step_buckets_for_fraction( double f )
+{
+    if( f <= 0.0 ) {
+        return 1;
+    }
+    return std::min( 20, 1 + std::min( static_cast<int>( std::floor( f * 20.0 ) ), 19 ) );
+}
+
+bool Character::consume_step_tool_targets( item &craft, const std::vector<int> &targets,
+        int active_step, const tripoint_bub_ms &origin, int radius, bool pin_to_map )
+{
     std::vector<std::vector<step_tool_alloc>> allocs = craft.get_step_tool_allocs();
-    // A stepless recipe meters as a single implicit step whose progress is the
-    // whole-recipe item_counter.
-    const int n_steps = rec.has_steps() ? static_cast<int>( rec.steps().size() ) : 1;
-    const int batch = craft.get_making_batch_size();
-    const int cur_step = craft.get_current_step();
-    const double cur_progress = craft.get_step_progress();
-    const bool craft_done = craft.item_counter >= 10000000;
-    const crafting_cost_context ctx = crafting_cost_context::for_recipe( *this, rec );
-
-    // 5% bucket count (0..20) a step's allocations should reach given progress.
-    // Bucket 0 (entry) fires at fraction 0; the final 5% is never charged.
-    const auto buckets_for_fraction = []( double f ) -> int {
-        if( f <= 0.0 )
-        {
-            return 1;
-        }
-        return std::min( 20, 1 + std::min( static_cast<int>( std::floor( f * 20.0 ) ), 19 ) );
-    };
-    const auto target_buckets = [&]( int step_idx ) -> int {
-        if( !rec.has_steps() )
-        {
-            return craft_done ? 20 : buckets_for_fraction(
-                static_cast<double>( craft.item_counter ) / 10000000.0 );
-        }
-        if( step_idx > cur_step )
-        {
-            return 0;
-        }
-        if( step_idx < cur_step || craft_done )
-        {
-            return 20;
-        }
-        const double budget = rec.step_budget_moves( *this, step_idx, batch, ctx );
-        return buckets_for_fraction( budget > 0.0 ? cur_progress / budget : 1.0 );
-    };
-
-    // Charges (count units) consumed through `count` buckets.  Front-loads the
-    // remainder at bucket 0 and caps at the step total.
-    const auto cumulative = []( int total, int count ) -> int {
-        if( count <= 0 )
-        {
-            return 0;
-        }
-        return std::min( total, total % 20 + count * ( total / 20 ) );
-    };
 
     struct pending_debit {
         comp_selection<tool_comp> sel;
+        usage_from eff_use = usage_from::none;
         int units = 0;
         int step_idx = 0;
         int alloc_idx = 0;
@@ -3459,17 +3532,17 @@ bool Character::craft_consume_step_tools( item &craft )
         int alloc_idx = 0;
         int new_count = 0;
     };
-    const int active_step = rec.has_steps() ? cur_step : 0;
     std::vector<pending_debit> debits;
     std::vector<pending_presence> presence;
-    for( int s = 0; s < n_steps && s < static_cast<int>( allocs.size() ); ++s ) {
-        const int tgt = target_buckets( s );
+    for( int s = 0; s < static_cast<int>( allocs.size() ) &&
+         s < static_cast<int>( targets.size() ); ++s ) {
+        const int tgt = targets[s];
         for( int a = 0; a < static_cast<int>( allocs[s].size() ); ++a ) {
             step_tool_alloc &alloc = allocs[s][a];
             if( alloc.sel.comp.count <= 0 ) {
-                // A non-charged tool's buckets fill before the step is ready, so
-                // re-check the in-progress step's tool even once full, or the step
-                // could finish using a tool that was removed.
+                // step_buckets_for_fraction reaches 20 before the step is ready,
+                // so a tool removed after its last bucket must still be re-checked
+                // here or the final true-up would finish using a tool that is gone.
                 if( s == active_step ? tgt > 0 : tgt > alloc.consumed_buckets ) {
                     presence.push_back( { alloc.sel.comp.type, s, a, tgt } );
                 }
@@ -3482,13 +3555,20 @@ bool Character::craft_consume_step_tools( item &craft )
                 alloc.consumed_buckets = tgt;
                 continue;
             }
-            const int units = cumulative( alloc.step_count_units, tgt ) -
-                              cumulative( alloc.step_count_units, alloc.consumed_buckets );
+            const int units = step_bucket_cumulative( alloc.step_count_units, tgt ) -
+                              step_bucket_cumulative( alloc.step_count_units, alloc.consumed_buckets );
             if( units <= 0 ) {
                 alloc.consumed_buckets = tgt;
                 continue;
             }
-            debits.push_back( { alloc.sel, units, s, a, tgt } );
+            // Pin player- and both-sourced charges to the map when the crafter
+            // cannot reach the craft, so the preflight and the debit both hit the
+            // charges sitting at the craft rather than an absent crafter's pack.
+            usage_from eff = alloc.sel.use_from;
+            if( pin_to_map && ( eff == usage_from::both || eff == usage_from::player ) ) {
+                eff = usage_from::map;
+            }
+            debits.push_back( { alloc.sel, eff, units, s, a, tgt } );
         }
     }
 
@@ -3500,13 +3580,13 @@ bool Character::craft_consume_step_tools( item &craft )
     // Aggregate the required charges per tool type, then preflight, so shared
     // pools cannot pass per-alloc yet fail in total.
     inventory map_inv;
-    map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
+    map_inv.form_from_map( origin, radius, this );
     std::map<itype_id, int> need_player;
     std::map<itype_id, int> need_map;
     std::map<itype_id, int> need_both;
     for( const pending_debit &d : debits ) {
         const int qty = d.units * item::find_type( d.sel.comp.type )->charge_factor();
-        switch( d.sel.use_from ) {
+        switch( d.eff_use ) {
             case usage_from::player:
                 need_player[d.sel.comp.type] += qty;
                 break;
@@ -3538,7 +3618,11 @@ bool Character::craft_consume_step_tools( item &craft )
     };
     bool presence_short = false;
     for( const pending_presence &p : presence ) {
-        if( !crafting_inventory().has_tools( p.type, 1 ) ) {
+        // Source the presence check the same way charges are: from the craft tile
+        // when the crafter is out of reach, otherwise from the crafter.
+        const bool present = pin_to_map ? map_inv.has_tools( p.type, 1 )
+                             : crafting_inventory().has_tools( p.type, 1 );
+        if( !present ) {
             add_msg_player_or_npc(
                 _( "You no longer have the %s and can't continue crafting." ),
                 _( "<npcname> no longer has the %s and can't continue crafting." ),
@@ -3553,10 +3637,12 @@ bool Character::craft_consume_step_tools( item &craft )
         return false;
     }
 
+    map &m = get_map();
     for( const pending_debit &d : debits ) {
         comp_selection<tool_comp> to_consume = d.sel;
+        to_consume.use_from = d.eff_use;
         to_consume.comp.count = d.units;
-        consume_tools( to_consume, 1 );
+        consume_tools( m, to_consume, 1, origin, radius );
         allocs[d.step_idx][d.alloc_idx].consumed_buckets = d.new_count;
     }
     for( const pending_presence &p : presence ) {
@@ -3564,6 +3650,83 @@ bool Character::craft_consume_step_tools( item &craft )
     }
     craft.set_step_tool_allocs( allocs );
     return true;
+}
+
+bool Character::craft_consume_step_tools( item &craft )
+{
+    if( has_trait( trait_DEBUG_HS ) ) {
+        return true;
+    }
+    const recipe &rec = craft.get_making();
+    // A stepless recipe meters as a single implicit step whose progress is the
+    // whole-recipe item_counter.
+    const int n_steps = rec.has_steps() ? static_cast<int>( rec.steps().size() ) : 1;
+    const int batch = craft.get_making_batch_size();
+    const int cur_step = craft.get_current_step();
+    const double cur_progress = craft.get_step_progress();
+    const bool craft_done = craft.item_counter >= 10000000;
+    const crafting_cost_context ctx = crafting_cost_context::for_recipe( *this, rec );
+
+    std::vector<int> targets( n_steps, 0 );
+    for( int s = 0; s < n_steps; ++s ) {
+        if( !rec.has_steps() ) {
+            targets[s] = craft_done ? 20 : step_buckets_for_fraction(
+                             static_cast<double>( craft.item_counter ) / 10000000.0 );
+        } else if( s > cur_step ) {
+            targets[s] = 0;
+        } else if( s < cur_step || craft_done ) {
+            targets[s] = 20;
+        } else {
+            const double budget = rec.step_budget_moves( *this, s, batch, ctx );
+            targets[s] = step_buckets_for_fraction( budget > 0.0 ? cur_progress / budget : 1.0 );
+        }
+    }
+    return consume_step_tool_targets( craft, targets, rec.has_steps() ? cur_step : 0,
+                                      pos_bub(), PICKUP_RANGE, /*pin_to_map=*/false );
+}
+
+bool Character::craft_consume_passive_step_tools( item &craft, time_point now,
+        const item_location &loc )
+{
+    if( has_trait( trait_DEBUG_HS ) ) {
+        return true;
+    }
+    const recipe &rec = craft.get_making();
+    if( !rec.has_steps() ) {
+        return true;
+    }
+    const time_point start = craft.get_passive_started_at();
+    if( start == calendar::before_time_starts ) {
+        return true;
+    }
+    // During an env pause ready_at is a polling cursor; the real deadline parks
+    // in saved_ready_at.
+    time_point ready = craft.get_ready_at();
+    if( craft.get_pause_started_at() != calendar::before_time_starts &&
+        craft.get_saved_ready_at() != calendar::before_time_starts ) {
+        ready = craft.get_saved_ready_at();
+    }
+    const bool step_done = now >= ready;
+    double f = 1.0;
+    if( ready > start ) {
+        f = std::clamp( to_turns<double>( now - start ) / to_turns<double>( ready - start ), 0.0, 1.0 );
+    }
+
+    const int n_steps = static_cast<int>( rec.steps().size() );
+    const int cur_step = craft.get_current_step();
+    std::vector<int> targets( n_steps, 0 );
+    for( int s = 0; s < n_steps; ++s ) {
+        if( s > cur_step ) {
+            targets[s] = 0;
+        } else if( s < cur_step ) {
+            targets[s] = 20;
+        } else {
+            targets[s] = step_done ? 20 : step_buckets_for_fraction( f );
+        }
+    }
+    const step_source_context src = resolve_step_source( craft, loc );
+    return consume_step_tool_targets( craft, targets, cur_step, src.origin, src.radius,
+                                      /*pin_to_map=*/src.present_char == nullptr );
 }
 
 void Character::consume_tools( const comp_selection<tool_comp> &tool, int batch )

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -19,6 +19,7 @@
 #include "activity_actor_definitions.h"
 #include "activity_handlers.h"
 #include "avatar.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_assert.h"
 #include "cata_utility.h"
@@ -1049,6 +1050,11 @@ std::optional<std::vector<attention_plan>> show_craft_planning_modal(
         const recipe &rec, const Character &crafter, int batch, int from_step,
         const std::vector<attention_plan> &existing, const item *current_craft )
 {
+    // Headless contexts (tests) cannot open the planning uilist; behave like an
+    // NPC with implicit-wait plans instead of blocking on UI.
+    if( test_mode ) {
+        return std::vector<attention_plan> {};
+    }
     const std::vector<recipe_step> &steps = rec.steps();
     std::vector<attention_plan> plans( steps.size() );
     for( size_t i = 0; i < std::min( existing.size(), plans.size() ); ++i ) {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1484,7 +1484,7 @@ static env_check_result craft_check_env_step( item &craft, time_point now,
         }
         // Re-arm env_check cursor, clamped to ready_at so a near-end-of-step
         // restore does not arm a poll past completion.
-        if( step_has_env_requirements( step ) ) {
+        if( step_has_env_requirements( step ) || step_has_charged_alloc( craft, step_idx ) ) {
             const time_point next = now + 1_minutes;
             craft.set_env_check_at( std::min( next, craft.get_ready_at() ) );
         } else {

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -855,45 +855,10 @@ void recipe::finalize()
             step.requirements = std::accumulate(
                                     step.reqs_internal.begin(), step.reqs_internal.end(),
                                     step.requirements );
-            // TODO: charged-tool consumption is not modeled on unattended steps
-            // (the active 5%-loop debit path is bypassed).  Reject after
-            // requirements are fully resolved so step-level "using" injections
-            // are also caught.  Lift once metered charge debit is implemented.
-            if( step.attention == step_attention::unattended ) {
-                for( const std::vector<tool_comp> &tool_group : step.requirements.get_tools() ) {
-                    for( const tool_comp &t : tool_group ) {
-                        if( t.by_charges() ) {
-                            debugmsg( "recipe %s step '%s' is unattended and cannot require charged tools yet",
-                                      ident().str(), step.name.translated() );
-                        }
-                    }
-                }
-            }
             // Merge step requirements into recipe-level for whole-recipe gating
             requirements_ = requirements_ + step.requirements;
             step.reqs_external.clear();
             step.reqs_internal.clear();
-        }
-
-        // Root charged tools are distributed only across active (attended,
-        // timed) steps, so a recipe with charged root tools but no active step
-        // has nowhere to meter them and is rejected.
-        bool has_active_step = false;
-        for( const recipe_step &step : steps_ ) {
-            if( step.attention != step_attention::unattended && step.time > 0 ) {
-                has_active_step = true;
-                break;
-            }
-        }
-        if( !has_active_step ) {
-            for( const std::vector<tool_comp> &tool_group : root_requirements_.get_tools() ) {
-                for( const tool_comp &t : tool_group ) {
-                    if( t.by_charges() ) {
-                        debugmsg( "recipe %s has charged root tools but no active step to meter them yet",
-                                  ident().str() );
-                    }
-                }
-            }
         }
 
         deduped_requirements_ = deduped_requirement_data( requirements_, ident() );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2917,10 +2917,10 @@ static bool alloc_source_valid( const step_tool_alloc &a )
 
 // True when saved allocations still line up with the recipe: one step-owned
 // allocation per step tool group, then one root-derived allocation per root
-// group on each active (attended, timed) step, each matching a tool type and
-// count its group still offers.  A tool-group edit that breaks this shape fails.
-// Also rejects corrupt counters and units that disagree with the selected count,
-// so consumption never runs off an inconsistent allocation.
+// group on each timed step, each matching a tool type and count its group still
+// offers.  Also rejects corrupt counters and units that disagree with the
+// selected count, so a recipe edit or stale save forces a rebuild instead of
+// metering off an inconsistent allocation.
 static bool step_tool_allocs_fit_recipe(
     const recipe &making, int batch, const std::vector<std::vector<step_tool_alloc>> &allocs )
 {
@@ -2930,6 +2930,10 @@ static bool step_tool_allocs_fit_recipe(
     const int batch_mult = std::max( batch, 1 );
     const std::vector<std::vector<tool_comp>> &root_groups =
             making.root_requirements().get_tools();
+    int64_t total_time = 0;
+    for( const recipe_step &step : making.steps() ) {
+        total_time += std::max<int64_t>( step.time, 0 );
+    }
     // Root shares are crafter-dependent per step but always sum to the tool's
     // whole-craft total; check that invariant rather than the per-step split.
     std::vector<int> root_unit_sum( root_groups.size(), 0 );
@@ -2938,8 +2942,7 @@ static bool step_tool_allocs_fit_recipe(
         const recipe_step &step = making.steps()[s];
         const std::vector<std::vector<tool_comp>> &step_groups =
                 step.requirements.get_tools();
-        const bool step_active =
-            step.attention != step_attention::unattended && step.time > 0;
+        const bool step_timed = total_time > 0 && step.time > 0;
         std::vector<const step_tool_alloc *> owned;
         std::vector<const step_tool_alloc *> root;
         for( const step_tool_alloc &a : allocs[s] ) {
@@ -2950,7 +2953,7 @@ static bool step_tool_allocs_fit_recipe(
             ( a.root_derived ? root : owned ).push_back( &a );
         }
         if( owned.size() != step_groups.size() ||
-            root.size() != ( step_active ? root_groups.size() : 0u ) ) {
+            root.size() != ( step_timed ? root_groups.size() : 0u ) ) {
             return false;
         }
         for( size_t i = 0; i < owned.size(); ++i ) {
@@ -3018,6 +3021,7 @@ void item::craft_data::deserialize( const JsonObject &obj )
     }
     current_step = obj.get_int( "current_step", 0 );
     step_progress = obj.get_float( "step_progress", 0.0 );
+    bool allocs_cleared = false;
     // Validate step index against the recipe's actual step count.
     if( making && making->has_steps() ) {
         int max_step = static_cast<int>( making->steps().size() ) - 1;
@@ -3027,6 +3031,7 @@ void item::craft_data::deserialize( const JsonObject &obj )
         if( !step_tool_allocs_fit_recipe( *making, batch_size, step_tool_allocs ) ) {
             step_tool_allocs.clear();
             tools_to_continue = false;
+            allocs_cleared = true;
         }
     } else if( making ) {
         current_step = 0;
@@ -3079,6 +3084,7 @@ void item::craft_data::deserialize( const JsonObject &obj )
         if( !stepless_ok ) {
             step_tool_allocs.clear();
             tools_to_continue = false;
+            allocs_cleared = true;
         }
     } else {
         current_step = 0;
@@ -3133,6 +3139,12 @@ void item::craft_data::deserialize( const JsonObject &obj )
     // Recipe-edit migration: drop stale passive runtime on shape mismatch.
     bool stale = false;
     if( making && !disassembly ) {
+        // Scrubbed allocs leave nothing to meter; drop the passive runtime too so
+        // an in-flight unattended step freezes for rebuild instead of finishing
+        // unmetered on load.
+        if( allocs_cleared ) {
+            stale = true;
+        }
         if( !step_plans.empty() && making->has_steps() &&
             step_plans.size() != making->steps().size() ) {
             stale = true;

--- a/tests/craft_attention_test.cpp
+++ b/tests/craft_attention_test.cpp
@@ -1662,6 +1662,50 @@ TEST_CASE( "craft_env_check_rearms_for_charged_only_step",
                                             item_wakeup_kind::env_check ) );
 }
 
+TEST_CASE( "craft_env_check_restore_rearms_for_charged_only_step",
+           "[craft][attention][charge][env_check]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    u.i_add( tool_with_ammo( itype_soldering_iron_portable, 50 ) );
+    u.invalidate_crafting_inventory();
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    on_map.set_current_step( 1 );
+    on_map.set_crafter_id( u.getID() );
+
+    step_tool_alloc alloc;
+    alloc.sel.use_from = usage_from::both;
+    alloc.sel.comp.type = itype_soldering_iron_portable;
+    alloc.sel.comp.count = 20;
+    alloc.step_count_units = 20;
+    alloc.root_derived = true;
+    on_map.set_step_tool_allocs( { {}, { alloc } } );
+
+    // Installed pause state, as if a prior shortfall paused the step.
+    const time_point t0 = calendar::turn;
+    on_map.set_passive_started_at( t0 - 2_minutes );
+    on_map.set_ready_at( t0 + 1_minutes );
+    on_map.set_saved_ready_at( t0 + 8_minutes );
+    on_map.set_pause_started_at( t0 - 1_minutes );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+
+    // Restoring from pause on a charged-only step must keep polling.
+    craft_actualize_scheduled( on_map, item_wakeup_kind::env_check, t0, loc );
+
+    CHECK( on_map.get_pause_started_at() == calendar::before_time_starts );
+    CHECK( on_map.get_env_check_at() != calendar::before_time_starts );
+    CHECK( get_item_wakeups().is_scheduled( on_map.uid().get_value(),
+                                            item_wakeup_kind::env_check ) );
+}
+
 TEST_CASE( "craft_env_check_dispatch_pauses_when_quality_missing",
            "[craft][attention][env_check]" )
 {

--- a/tests/craft_attention_test.cpp
+++ b/tests/craft_attention_test.cpp
@@ -55,6 +55,10 @@ static const recipe_id recipe_cudgel_test_steps_two_tools(
     "cudgel_test_steps_two_tools" );
 static const recipe_id recipe_cudgel_test_timeout_recipe(
     "cudgel_test_timeout_recipe" );
+static const recipe_id recipe_cudgel_test_unattended_charged(
+    "cudgel_test_unattended_charged" );
+static const recipe_id recipe_cudgel_test_unattended_charged_big(
+    "cudgel_test_unattended_charged_big" );
 static const recipe_id recipe_cudgel_test_unattended_simple(
     "cudgel_test_unattended_simple" );
 static const recipe_id recipe_cudgel_test_unattended_with_qual(
@@ -411,6 +415,10 @@ TEST_CASE( "craft_data_resets_step_tool_allocs_on_tool_shape_change",
     alloc.step_count_units = 8;
     built.set_step_tool_allocs( { {}, { alloc } } );
     built.set_tools_to_continue( true );
+    // Mid-flight on the unattended step, with live passive timers.
+    built.set_current_step( 1 );
+    built.set_passive_started_at( calendar::turn );
+    built.set_ready_at( calendar::turn + 10_minutes );
 
     std::ostringstream ss;
     JsonOut jsout( ss );
@@ -423,6 +431,10 @@ TEST_CASE( "craft_data_resets_step_tool_allocs_on_tool_shape_change",
     REQUIRE( restored.get_making().steps().size() == 2 );
     CHECK( restored.get_step_tool_allocs().empty() );
     CHECK_FALSE( restored.has_tools_to_continue() );
+    // Scrubbing the allocs also drops the passive timers, so the step cannot
+    // finish unmetered on load.
+    CHECK( restored.get_passive_started_at() == calendar::before_time_starts );
+    CHECK( restored.get_ready_at() == calendar::before_time_starts );
 }
 
 TEST_CASE( "craft_data_validates_step_tool_alloc_shape_on_load",
@@ -648,7 +660,7 @@ TEST_CASE( "craft_data_resets_step_tool_allocs_on_group_reorder",
     }
 }
 
-TEST_CASE( "craft_data_root_alloc_shape_follows_active_steps",
+TEST_CASE( "craft_data_root_alloc_shape_follows_timed_steps",
            "[craft][attention][persist][migration]" )
 {
     const recipe &rec = recipe_cudgel_test_root_unattended.obj();
@@ -676,30 +688,32 @@ TEST_CASE( "craft_data_root_alloc_shape_follows_active_steps",
         return restored;
     };
 
-    const auto root_alloc = [&root_tool]() -> step_tool_alloc {
+    const auto root_alloc = [&root_tool]( int units ) -> step_tool_alloc {
         step_tool_alloc a;
         a.sel.use_from = usage_from::both;
         a.sel.comp.type = root_tool.type;
         a.sel.comp.count = root_tool.count;
-        a.step_count_units = std::max( root_tool.count, 1 );
+        a.step_count_units = units;
         a.root_derived = true;
         return a;
     };
 
-    GIVEN( "a root allocation on the active step and none on the unattended step" ) {
-        item restored = round_trip( { { root_alloc() }, {} } );
+    GIVEN( "a root allocation on every timed step" ) {
+        // Per-step shares must sum to the tool's whole-craft total.
+        const int half = root_tool.count / 2;
+        item restored = round_trip( { { root_alloc( root_tool.count - half ) }, { root_alloc( half ) } } );
         REQUIRE( restored.is_craft() );
 
         THEN( "it is preserved" ) {
             REQUIRE( restored.get_step_tool_allocs().size() == 2 );
             CHECK( restored.get_step_tool_allocs()[0].size() == 1 );
-            CHECK( restored.get_step_tool_allocs()[1].empty() );
+            CHECK( restored.get_step_tool_allocs()[1].size() == 1 );
             CHECK( restored.has_tools_to_continue() );
         }
     }
 
-    GIVEN( "a root allocation on the unattended step" ) {
-        item restored = round_trip( { { root_alloc() }, { root_alloc() } } );
+    GIVEN( "a root allocation missing from a timed step" ) {
+        item restored = round_trip( { { root_alloc( root_tool.count ) }, {} } );
         REQUIRE( restored.is_craft() );
 
         THEN( "the stale shape is dropped" ) {
@@ -840,6 +854,431 @@ TEST_CASE( "craft_apply_resume_replan_targets_correct_alarm_slot",
 
         CHECK( on_map.get_alarm_at() == calendar::before_time_starts );
         CHECK( on_map.get_saved_alarm_at() == calendar::before_time_starts );
+    }
+}
+
+TEST_CASE( "craft_unattended_charged_tool_debits_at_step_completion",
+           "[craft][attention][charge]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    item iron = tool_with_ammo( itype_soldering_iron_portable, 50 );
+    REQUIRE( iron.ammo_remaining() == 50 );
+    u.i_add( iron );
+    u.invalidate_crafting_inventory();
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_charged.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+
+    // Position at the unattended Cure step (idx 1) carrying its charged tool.
+    on_map.set_current_step( 1 );
+    on_map.set_passive_started_at( calendar::turn );
+    on_map.set_ready_at( calendar::turn + 10_minutes );
+    on_map.set_crafter_id( u.getID() );
+
+    step_tool_alloc alloc;
+    alloc.sel.use_from = usage_from::both;
+    alloc.sel.comp.type = itype_soldering_iron_portable;
+    alloc.sel.comp.count = 20;
+    alloc.step_count_units = 20;
+    on_map.set_step_tool_allocs( { {}, { alloc } } );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+    REQUIRE( u.craft_consume_passive_step_tools( on_map, calendar::turn + 10_minutes, loc ) );
+
+    u.invalidate_crafting_inventory();
+    CHECK( get_remaining_charges( itype_soldering_iron_portable ) == 30 );
+    REQUIRE( on_map.get_step_tool_allocs().size() == 2 );
+    REQUIRE_FALSE( on_map.get_step_tool_allocs()[1].empty() );
+    CHECK( on_map.get_step_tool_allocs()[1][0].consumed_buckets == 20 );
+}
+
+TEST_CASE( "craft_unattended_charged_tool_drains_per_tick_and_pauses",
+           "[craft][attention][charge]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_charged.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    on_map.set_current_step( 1 );
+    on_map.set_passive_started_at( calendar::turn );
+    on_map.set_ready_at( calendar::turn + 10_minutes );
+    on_map.set_crafter_id( u.getID() );
+
+    step_tool_alloc alloc;
+    alloc.sel.use_from = usage_from::both;
+    alloc.sel.comp.type = itype_soldering_iron_portable;
+    alloc.sel.comp.count = 20;
+    alloc.step_count_units = 20;
+    on_map.set_step_tool_allocs( { {}, { alloc } } );
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+    get_item_wakeups().rebuild_for_item( loc );
+
+    GIVEN( "the crafter carries enough charges for the whole step" ) {
+        u.i_add( tool_with_ammo( itype_soldering_iron_portable, 50 ) );
+        u.invalidate_crafting_inventory();
+
+        WHEN( "an env tick fires halfway through the step" ) {
+            craft_actualize_scheduled( on_map, item_wakeup_kind::env_check,
+                                       calendar::turn + 5_minutes, loc );
+            u.invalidate_crafting_inventory();
+
+            THEN( "the buckets so far are drained and the step keeps running" ) {
+                CHECK( get_remaining_charges( itype_soldering_iron_portable ) == 39 );
+                CHECK( on_map.get_pause_started_at() == calendar::before_time_starts );
+            }
+        }
+    }
+
+    GIVEN( "the step's charged tool is not present" ) {
+        u.invalidate_crafting_inventory();
+
+        WHEN( "an env tick fires mid-step" ) {
+            craft_actualize_scheduled( on_map, item_wakeup_kind::env_check,
+                                       calendar::turn + 5_minutes, loc );
+
+            THEN( "the step pauses with its real deadline parked" ) {
+                CHECK( on_map.get_pause_started_at() != calendar::before_time_starts );
+                CHECK( on_map.get_ready_at() == calendar::turn + 6_minutes );
+                CHECK( on_map.get_saved_ready_at() == calendar::turn + 10_minutes );
+            }
+
+            AND_WHEN( "the tool returns and the polling tick fires" ) {
+                u.i_add( tool_with_ammo( itype_soldering_iron_portable, 50 ) );
+                u.invalidate_crafting_inventory();
+                craft_actualize_scheduled( on_map, item_wakeup_kind::env_check,
+                                           calendar::turn + 6_minutes, loc );
+
+                THEN( "the step unpauses and slides its deadline forward" ) {
+                    CHECK( on_map.get_pause_started_at() == calendar::before_time_starts );
+                    CHECK( on_map.get_ready_at() == calendar::turn + 11_minutes );
+                    // Entry slides with the deadline so the paused minute is not
+                    // counted as progress by the passive debit fraction.
+                    CHECK( on_map.get_passive_started_at() == calendar::turn + 1_minutes );
+                }
+            }
+
+            AND_WHEN( "a ready-check poll fires while the tool is still absent" ) {
+                craft_actualize_scheduled( on_map, item_wakeup_kind::ready_check,
+                                           calendar::turn + 6_minutes, loc );
+
+                THEN( "the step stays paused instead of resuming on the quality gate" ) {
+                    CHECK( on_map.get_pause_started_at() != calendar::before_time_starts );
+                    CHECK( on_map.get_current_step() == 1 );
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE( "craft_unattended_charged_tool_offset_crafter_uses_map_source",
+           "[craft][attention][charge]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms craft_pos( 75, 75, 0 );
+    // Crafter stands well outside PICKUP_RANGE of the workbench craft.
+    u.setpos( here, tripoint_bub_ms( 60, 60, 0 ) );
+
+    // The charged tool sits on the map at the craft, not in the crafter's pack.
+    item &map_iron = here.add_item( craft_pos, tool_with_ammo( itype_soldering_iron_portable, 50 ) );
+    REQUIRE( map_iron.ammo_remaining() == 50 );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_charged.obj(), 1, ingredient );
+    item &on_map = here.add_item( craft_pos, placed );
+    REQUIRE( on_map.is_craft() );
+    on_map.set_current_step( 1 );
+    on_map.set_passive_started_at( calendar::turn );
+    on_map.set_ready_at( calendar::turn + 10_minutes );
+    on_map.set_crafter_id( u.getID() );
+
+    step_tool_alloc alloc;
+    alloc.sel.use_from = usage_from::map;
+    alloc.sel.comp.type = itype_soldering_iron_portable;
+    alloc.sel.comp.count = 20;
+    alloc.step_count_units = 20;
+    on_map.set_step_tool_allocs( { {}, { alloc } } );
+
+    item_location loc( map_cursor( here.get_abs( craft_pos ) ), &on_map );
+
+    REQUIRE( u.craft_consume_passive_step_tools( on_map, calendar::turn + 10_minutes, loc ) );
+
+    CHECK( map_iron.ammo_remaining() == 30 );
+    REQUIRE( on_map.get_step_tool_allocs().size() == 2 );
+    REQUIRE_FALSE( on_map.get_step_tool_allocs()[1].empty() );
+    CHECK( on_map.get_step_tool_allocs()[1][0].consumed_buckets == 20 );
+}
+
+TEST_CASE( "recipe_unattended_charged_tool_finalizes_without_reject",
+           "[craft][attention][charge][schema]" )
+{
+    const recipe &r = recipe_cudgel_test_unattended_charged.obj();
+    REQUIRE( r.has_steps() );
+    const recipe_step &cure = r.steps().back();
+    REQUIRE( cure.attention == step_attention::unattended );
+
+    bool has_charged_tool = false;
+    for( const std::vector<tool_comp> &group : cure.requirements.get_tools() ) {
+        for( const tool_comp &tc : group ) {
+            if( tc.type == itype_soldering_iron_portable && tc.count > 0 ) {
+                has_charged_tool = true;
+            }
+        }
+    }
+    CHECK( has_charged_tool );
+}
+
+TEST_CASE( "craft_unattended_or_group_uses_noncharged_alternative_free",
+           "[craft][attention][charge]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    u.i_add( tool_with_ammo( itype_soldering_iron_portable, 50 ) );
+    u.invalidate_crafting_inventory();
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_charged.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    on_map.set_current_step( 1 );
+    on_map.set_passive_started_at( calendar::turn );
+    on_map.set_ready_at( calendar::turn + 10_minutes );
+    on_map.set_crafter_id( u.getID() );
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+
+    GIVEN( "the pinned selection is a non-charged OR alternative" ) {
+        step_tool_alloc alloc;
+        alloc.sel.use_from = usage_from::none;
+        alloc.sel.comp.type = itype_soldering_iron_portable;
+        alloc.sel.comp.count = -1;
+        alloc.step_count_units = 0;
+        on_map.set_step_tool_allocs( { {}, { alloc } } );
+
+        WHEN( "the step completes" ) {
+            REQUIRE( u.craft_consume_passive_step_tools(
+                         on_map, calendar::turn + 10_minutes, loc ) );
+            u.invalidate_crafting_inventory();
+
+            THEN( "no charges are drained but the step still trues up" ) {
+                CHECK( get_remaining_charges( itype_soldering_iron_portable ) == 50 );
+                CHECK( on_map.get_step_tool_allocs()[1][0].consumed_buckets == 20 );
+            }
+        }
+    }
+
+    GIVEN( "the pinned selection is the charged OR alternative" ) {
+        step_tool_alloc alloc;
+        alloc.sel.use_from = usage_from::both;
+        alloc.sel.comp.type = itype_soldering_iron_portable;
+        alloc.sel.comp.count = 20;
+        alloc.step_count_units = 20;
+        on_map.set_step_tool_allocs( { {}, { alloc } } );
+
+        WHEN( "the step completes" ) {
+            REQUIRE( u.craft_consume_passive_step_tools(
+                         on_map, calendar::turn + 10_minutes, loc ) );
+            u.invalidate_crafting_inventory();
+
+            THEN( "the full charged amount is drained" ) {
+                CHECK( get_remaining_charges( itype_soldering_iron_portable ) == 30 );
+            }
+        }
+    }
+}
+
+TEST_CASE( "craft_unattended_charged_tools_shared_pool_no_partial_debit",
+           "[craft][attention][charge]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    // Enough charges to satisfy one allocation but not both together.
+    u.i_add( tool_with_ammo( itype_soldering_iron_portable, 30 ) );
+    u.invalidate_crafting_inventory();
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_charged.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    on_map.set_current_step( 1 );
+    on_map.set_passive_started_at( calendar::turn );
+    on_map.set_ready_at( calendar::turn + 10_minutes );
+    on_map.set_crafter_id( u.getID() );
+
+    step_tool_alloc alloc;
+    alloc.sel.use_from = usage_from::both;
+    alloc.sel.comp.type = itype_soldering_iron_portable;
+    alloc.sel.comp.count = 20;
+    alloc.step_count_units = 20;
+    on_map.set_step_tool_allocs( { {}, { alloc, alloc } } );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+
+    REQUIRE_FALSE( u.craft_consume_passive_step_tools(
+                       on_map, calendar::turn + 10_minutes, loc ) );
+
+    u.invalidate_crafting_inventory();
+    CHECK( get_remaining_charges( itype_soldering_iron_portable ) == 30 );
+    REQUIRE( on_map.get_step_tool_allocs()[1].size() == 2 );
+    CHECK( on_map.get_step_tool_allocs()[1][0].consumed_buckets == 0 );
+    CHECK( on_map.get_step_tool_allocs()[1][1].consumed_buckets == 0 );
+}
+
+TEST_CASE( "craft_unattended_charged_tool_completion_pauses_on_partial_charges",
+           "[craft][attention][charge]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    // 25 charges clears the start-only gate for a 40-charge step but cannot
+    // cover the full completion debit.
+    u.i_add( tool_with_ammo( itype_soldering_iron_portable, 25 ) );
+    u.invalidate_crafting_inventory();
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_charged_big.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    on_map.set_current_step( 1 );
+    on_map.set_passive_started_at( calendar::turn );
+    on_map.set_ready_at( calendar::turn + 10_minutes );
+    on_map.set_crafter_id( u.getID() );
+    on_map.set_step_plans( std::vector<attention_plan>( 2 ) );
+
+    step_tool_alloc alloc;
+    alloc.sel.use_from = usage_from::both;
+    alloc.sel.comp.type = itype_soldering_iron_portable;
+    alloc.sel.comp.count = 40;
+    alloc.step_count_units = 40;
+    on_map.set_step_tool_allocs( { {}, { alloc } } );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+
+    craft_actualize_scheduled( on_map, item_wakeup_kind::ready_check,
+                               calendar::turn + 10_minutes, loc );
+
+    REQUIRE( loc.get_item() != nullptr );
+    CHECK( on_map.get_current_step() == 1 );
+    CHECK( on_map.get_pause_started_at() == calendar::turn + 10_minutes );
+    CHECK( on_map.get_saved_ready_at() == calendar::turn + 10_minutes );
+}
+
+TEST_CASE( "craft_unattended_charged_tool_overdue_load_pauses_when_drained",
+           "[craft][attention][charge][overdue]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    // No charged tool present anywhere.
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_charged.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    on_map.set_current_step( 1 );
+    on_map.set_passive_started_at( calendar::turn );
+    on_map.set_ready_at( calendar::turn + 10_minutes );
+    on_map.set_crafter_id( u.getID() );
+    on_map.set_step_plans( std::vector<attention_plan>( 2 ) );
+
+    step_tool_alloc alloc;
+    alloc.sel.use_from = usage_from::both;
+    alloc.sel.comp.type = itype_soldering_iron_portable;
+    alloc.sel.comp.count = 20;
+    alloc.step_count_units = 20;
+    on_map.set_step_tool_allocs( { {}, { alloc } } );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+
+    craft_resolve_overdue_passive( on_map, calendar::turn + 20_minutes, loc );
+
+    REQUIRE( loc.get_item() != nullptr );
+    CHECK( on_map.get_current_step() == 1 );
+    CHECK( on_map.get_pause_started_at() != calendar::before_time_starts );
+}
+
+TEST_CASE( "craft_unattended_noncharged_tool_offset_crafter_uses_map_source",
+           "[craft][attention][charge]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms craft_pos( 75, 75, 0 );
+    u.setpos( here, tripoint_bub_ms( 60, 60, 0 ) );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_charged.obj(), 1, ingredient );
+    item &on_map = here.add_item( craft_pos, placed );
+    on_map.set_current_step( 1 );
+    on_map.set_passive_started_at( calendar::turn );
+    on_map.set_ready_at( calendar::turn + 10_minutes );
+    on_map.set_crafter_id( u.getID() );
+
+    step_tool_alloc alloc;
+    alloc.sel.use_from = usage_from::map;
+    alloc.sel.comp.type = itype_soldering_iron_portable;
+    alloc.sel.comp.count = -1;
+    alloc.step_count_units = 0;
+    on_map.set_step_tool_allocs( { {}, { alloc } } );
+    item_location loc( map_cursor( here.get_abs( craft_pos ) ), &on_map );
+
+    GIVEN( "the non-charged tool sits on the map at the craft" ) {
+        here.add_item( craft_pos, item( itype_soldering_iron_portable, calendar::turn ) );
+
+        THEN( "the step trues up without pausing" ) {
+            CHECK( u.craft_consume_passive_step_tools( on_map, calendar::turn + 10_minutes, loc ) );
+            CHECK( on_map.get_step_tool_allocs()[1][0].consumed_buckets == 20 );
+        }
+    }
+
+    GIVEN( "the non-charged tool is absent from the craft and the crafter" ) {
+        THEN( "the step consume fails instead of running free" ) {
+            CHECK_FALSE( u.craft_consume_passive_step_tools(
+                             on_map, calendar::turn + 10_minutes, loc ) );
+        }
+    }
+
+    GIVEN( "the tool is removed after its last bucket but before completion" ) {
+        item &tool = here.add_item( craft_pos, item( itype_soldering_iron_portable, calendar::turn ) );
+        // A near-end tick reaches bucket 20 while the tool is still present.
+        REQUIRE( u.craft_consume_passive_step_tools(
+                     on_map, calendar::turn + 9_minutes + 30_seconds, loc ) );
+        REQUIRE( on_map.get_step_tool_allocs()[1][0].consumed_buckets == 20 );
+
+        WHEN( "the tool is gone at the completion true-up" ) {
+            here.i_rem( craft_pos, &tool );
+
+            THEN( "completion re-checks presence and the step does not finish free" ) {
+                CHECK_FALSE( u.craft_consume_passive_step_tools(
+                                 on_map, calendar::turn + 10_minutes, loc ) );
+            }
+        }
     }
 }
 
@@ -1140,6 +1579,89 @@ TEST_CASE( "craft_stamp_skips_env_check_when_step_has_no_env_requirements",
                  item_wakeup_kind::env_check ) );
 }
 
+TEST_CASE( "craft_stamp_arms_env_check_and_debits_entry_for_charged_alloc",
+           "[craft][attention][charge][env_check]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    u.i_add( tool_with_ammo( itype_soldering_iron_portable, 50 ) );
+    u.invalidate_crafting_inventory();
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+    on_map.set_current_step( 1 );
+    on_map.set_crafter_id( u.getID() );
+    on_map.set_step_plans( std::vector<attention_plan>( 2 ) );
+
+    // A charged (root-derived) allocation on a step with no step-level env
+    // requirements still needs metering.
+    step_tool_alloc alloc;
+    alloc.sel.use_from = usage_from::both;
+    alloc.sel.comp.type = itype_soldering_iron_portable;
+    alloc.sel.comp.count = 20;
+    alloc.step_count_units = 20;
+    alloc.root_derived = true;
+    on_map.set_step_tool_allocs( { {}, { alloc } } );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+    craft_stamp_passive_entry( on_map, u, calendar::turn, loc );
+
+    REQUIRE( on_map.get_passive_started_at() == calendar::turn );
+    CHECK( on_map.get_env_check_at() != calendar::before_time_starts );
+    CHECK( get_item_wakeups().is_scheduled( on_map.uid().get_value(),
+                                            item_wakeup_kind::env_check ) );
+    u.invalidate_crafting_inventory();
+    CHECK( on_map.get_step_tool_allocs()[1][0].consumed_buckets >= 1 );
+    CHECK( get_remaining_charges( itype_soldering_iron_portable ) < 50 );
+}
+
+TEST_CASE( "craft_env_check_rearms_for_charged_only_step",
+           "[craft][attention][charge][env_check]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    u.i_add( tool_with_ammo( itype_soldering_iron_portable, 50 ) );
+    u.invalidate_crafting_inventory();
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_unattended_simple.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    on_map.set_current_step( 1 );
+    on_map.set_passive_started_at( calendar::turn );
+    on_map.set_ready_at( calendar::turn + 10_minutes );
+    on_map.set_crafter_id( u.getID() );
+
+    step_tool_alloc alloc;
+    alloc.sel.use_from = usage_from::both;
+    alloc.sel.comp.type = itype_soldering_iron_portable;
+    alloc.sel.comp.count = 20;
+    alloc.step_count_units = 20;
+    alloc.root_derived = true;
+    on_map.set_step_tool_allocs( { {}, { alloc } } );
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+
+    // A mid-step env tick on a step with only a charged allocation (no
+    // step-level env requirement) must keep polling so the drain continues.
+    craft_actualize_scheduled( on_map, item_wakeup_kind::env_check,
+                               calendar::turn + 5_minutes, loc );
+    u.invalidate_crafting_inventory();
+
+    CHECK( on_map.get_pause_started_at() == calendar::before_time_starts );
+    CHECK( on_map.get_env_check_at() != calendar::before_time_starts );
+    CHECK( get_item_wakeups().is_scheduled( on_map.uid().get_value(),
+                                            item_wakeup_kind::env_check ) );
+}
+
 TEST_CASE( "craft_env_check_dispatch_pauses_when_quality_missing",
            "[craft][attention][env_check]" )
 {
@@ -1149,7 +1671,7 @@ TEST_CASE( "craft_env_check_dispatch_pauses_when_quality_missing",
     map &here = get_map();
     const tripoint_bub_ms origin( 60, 60, 0 );
     u.setpos( here, origin );
-    // No OVEN tool: env_satisfied_for_step returns false.
+    // No OVEN quality present: the quality gate fails and the step pauses.
 
     item ingredient( itype_2x4, calendar::turn );
     item placed( &recipe_cudgel_test_unattended_with_qual.obj(), 1, ingredient );

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -21,6 +21,7 @@
 #include "character_attire.h"
 #include "coordinates.h"
 #include "craft_command.h"
+#include "crafting.h"
 #include "enums.h"
 #include "game.h"
 #include "game_constants.h"
@@ -2751,6 +2752,15 @@ TEST_CASE( "recipes_inherit_rot_of_components_properly", "[crafting][rot]" )
 
             THEN( "it should have 1 percent of its shelf life left" ) {
                 item_location dehydrated_meat = player_character.get_wielded_item();
+
+                // Dehydrating runs unattended, so the active loop parks the craft
+                // on wall-clock; resolve it past its deadline to finish it.
+                if( dehydrated_meat && dehydrated_meat->is_craft() ) {
+                    const time_point ready = dehydrated_meat->get_ready_at();
+                    REQUIRE( ready != calendar::before_time_starts );
+                    craft_resolve_overdue_passive( *dehydrated_meat, ready, dehydrated_meat );
+                    dehydrated_meat = player_character.get_wielded_item();
+                }
 
                 REQUIRE( dehydrated_meat->type->get_id() == recipe_dry_meat->result() );
 

--- a/tests/recipe_steps_test.cpp
+++ b/tests/recipe_steps_test.cpp
@@ -173,10 +173,9 @@ TEST_CASE( "step_recipe_root_requirements_separate_from_step_tools", "[recipe][s
         }
     }
 
-    // Root charged tools are metered only across active (attended, timed) steps,
-    // so a recipe carrying them must have an active step to debit them against.
-    // These cases need inline finalize: a charged all-unattended recipe cannot
-    // live in TEST_DATA without erroring at load.
+    // Root charged tools are metered across all timed steps, attended or
+    // unattended, so finalize accepts them regardless of which tiers the recipe
+    // uses.  Inline finalize keeps these probe recipes out of loaded TEST_DATA.
     const auto finalize_msg = []( const std::string & steps_json ) -> std::string {
         recipe r;
         JsonObject jo = json_loader::from_string( string_format(
@@ -193,12 +192,12 @@ TEST_CASE( "step_recipe_root_requirements_separate_from_step_tools", "[recipe][s
         } );
     };
 
-    GIVEN( "a charged root tool but no active step" ) {
+    GIVEN( "a charged root tool and only unattended steps" ) {
         const std::string msg = finalize_msg(
                                     R"({ "name": "Cure", "time": "10 m", "attention": "unattended", "activity_level": "NO_EXERCISE" },)"
                                     R"({ "name": "Dry", "time": "10 m", "attention": "unattended", "activity_level": "NO_EXERCISE" })" );
-        THEN( "finalize rejects it" ) {
-            CHECK( msg.find( "active step" ) != std::string::npos );
+        THEN( "finalize accepts it" ) {
+            CHECK( msg.empty() );
         }
     }
 


### PR DESCRIPTION
#### Summary
Features "Charged tools can be used on unattended crafting steps"

#### Purpose of change
Builds on #87178. Unattended crafting steps, the kind that run on a wall clock while you do something else (drying or curing food, say), couldn't use charged tools. They run outside the normal craft loop that drains charges, so nothing metered the power, and the recipe loader rejected any charged tool on an unattended step.

#### Describe the solution
Now that each step meters its own tools (#87178), an unattended step already knows which tools it picked, it just needed something to drain them during the wait. The unattended system already wakes up periodically to check the step's surroundings are still fine; this hooks charge draining onto that same tick.

A charged tool drains gradually over the step and is fully spent by the time it finishes. Run short on power partway through and the step pauses, exactly like it already pauses when a required quality tool goes missing, then picks back up once the charges are back. Whole-craft root tools now spread their charges over unattended steps too, not just active ones.

It works whether you're holding the craft or it's sitting on the ground or a workbench with you nearby. If you've wandered off, the charges come from the tile the craft is on.

Also converts dry_meat into a stepped recipe as the first real user: slice the meat (hands-on), then dehydrate it unattended, with the heat source draining over the drying time.

#### Describe alternatives you've considered
Drying meat by staring at it

#### Testing
New tests cover draining over the wait, pause and resume on a power shortfall, the held-versus-on-the-ground source, and load-time handling. Existing crafting tests pass. To try it in-game: start the dry_meat recipe with a powered dehydrator and walk away; the charge drains over the drying time and it pauses if the dehydrator runs out.

#### Additional context
N/A