### PR TITLE
plate armor coverages

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -1261,24 +1261,37 @@
     "armor": [
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 0.7 },
+          { "type": "lc_steel", "covered_by_mat": 90, "thickness": 0.75 },
+          { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
+        ],
+        "covers": [ "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_elbow_l", "arm_elbow_r" ],
+        "coverage": 100,
+        "cover_vitals": 85
+      },
+      {
+        "material": [
+          { "type": "lc_steel", "covered_by_mat": 90, "thickness": 0.7 },
+          { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
+        ],
+        "covers": [ "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_upper_l", "arm_upper_r" ],
+        "coverage": 100,
+        "cover_vitals": 80
+      },
+      {
+        "material": [
+          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 0.8 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_lower_l", "arm_lower_r" ],
         "coverage": 100,
-        "encumbrance": 10
-      },
-      {
-        "material": [
-          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 0.7 },
-          { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
-          { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
-        ],
-        "covers": [ "arm_l", "arm_r" ],
-        "specifically_covers": [ "arm_elbow_l", "arm_elbow_r", "arm_shoulder_l", "arm_shoulder_r", "arm_upper_l", "arm_upper_r" ],
-        "coverage": 100
+        "encumbrance": 8,
+        "cover_vitals": 95
       }
     ],
     "melee_damage": { "bash": 8 }
@@ -1392,24 +1405,26 @@
     "armor": [
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 1.15 },
+          { "type": "lc_steel", "covered_by_mat": 97, "thickness": 1.15 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_lower_l", "arm_lower_r" ],
         "coverage": 100,
-        "encumbrance": 15
+        "cover_vitals": 100,
+        "encumbrance": 12
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 1.15 },
+          { "type": "lc_steel", "covered_by_mat": 94, "thickness": 1.15 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
-        "specifically_covers": [ "arm_elbow_l", "arm_elbow_r", "arm_shoulder_l", "arm_shoulder_r", "arm_upper_l", "arm_upper_r" ],
-        "coverage": 100
+        "specifically_covers": [ "arm_upper_l", "arm_upper_r", "arm_elbow_l", "arm_elbow_r" ],
+        "coverage": 100,
+        "cover_vitals": 90
       }
     ],
     "melee_damage": { "bash": 8 }
@@ -1522,24 +1537,26 @@
     "armor": [
       {
         "material": [
-          { "type": "hc_steel", "covered_by_mat": 100, "thickness": 1.65 },
-          { "type": "hc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 1.65 },
+          { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
-        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ],
+        "specifically_covers": [ "arm_lower_l", "arm_lower_r" ],
+        "cover_vitals": 100,
         "coverage": 100,
-        "encumbrance": 20
+        "encumbrance": 18
       },
       {
         "material": [
-          { "type": "hc_steel", "covered_by_mat": 95, "thickness": 1.65 },
-          { "type": "hc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "lc_steel", "covered_by_mat": 96, "thickness": 1.65 },
+          { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
-        "specifically_covers": [ "arm_elbow_r", "arm_elbow_l", "arm_upper_r", "arm_upper_l" ],
-        "coverage": 100
+        "specifically_covers": [ "arm_upper_l", "arm_upper_r", "arm_elbow_l", "arm_elbow_r" ],
+        "coverage": 100,
+        "cover_vitals": 95
       }
     ],
     "melee_damage": { "bash": 8 }

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -1563,24 +1563,25 @@
     "armor": [
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 0.7 },
+          { "type": "lc_steel", "covered_by_mat": 85, "thickness": 0.75 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_hip_l", "leg_hip_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
         "coverage": 100,
-        "encumbrance": 10
+        "cover_vitals": 85
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 0.7 },
+          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 0.8 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
-        "coverage": 100
+        "coverage": 100,
+        "cover_vitals": 100
       }
     ],
     "melee_damage": { "bash": 8 }
@@ -1696,19 +1697,20 @@
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_hip_l", "leg_hip_r", "leg_knee_l", "leg_knee_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
         "coverage": 100,
-        "encumbrance": 15
+        "cover_vitals": 90
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 1.15 },
+          { "type": "lc_steel", "covered_by_mat": 97, "thickness": 1.15 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
-        "coverage": 100
+        "coverage": 100,
+        "cover_vitals": 100
       }
     ],
     "melee_damage": { "bash": 8 }
@@ -1818,14 +1820,14 @@
     "armor": [
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 1.65 },
+          { "type": "lc_steel", "covered_by_mat": 96, "thickness": 1.65 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_knee_l", "leg_knee_r", "leg_upper_l", "leg_upper_r" ],
-        "coverage": 100,
-        "encumbrance": 15
+        "specifically_covers": [ "leg_knee_l", "leg_knee_r", "leg_upper_l", "leg_upper_r" ],
+        "cover_vitals": 95,
+        "coverage": 96
       },
       {
         "material": [
@@ -1835,7 +1837,8 @@
         ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
-        "coverage": 100
+        "coverage": 100,
+        "cover_vitals": 100
       }
     ],
     "melee_damage": { "bash": 8 }

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -629,66 +629,105 @@
     "armor": [
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 97, "thickness": 1.45 },
+          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 1.55 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_upper" ],
         "coverage": 100,
-        "encumbrance": 15
+        "encumbrance": 11,
+        "cover_vitals": 92
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 1.45 },
+          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 1.45 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_lower" ],
-        "coverage": 100
+        "coverage": 100,
+        "cover_vitals": 100
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 0.7 },
+          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 0.8 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_lower_l", "arm_lower_r" ],
         "coverage": 100,
-        "encumbrance": 10
+        "encumbrance": 8,
+        "cover_vitals": 95
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 0.7 },
+          { "type": "lc_steel", "covered_by_mat": 90, "thickness": 0.7 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
-        "specifically_covers": [ "arm_elbow_l", "arm_elbow_r", "arm_shoulder_l", "arm_shoulder_r", "arm_upper_l", "arm_upper_r" ],
-        "coverage": 100
+        "specifically_covers": [ "arm_upper_l", "arm_upper_r" ],
+        "coverage": 100,
+        "cover_vitals": 80
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 0.7 },
+          { "type": "lc_steel", "covered_by_mat": 88, "thickness": 1.45 },
+          { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
+        ],
+        "covers": [ "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r" ],
+        "coverage": 100,
+        "cover_vitals": 85
+      },
+      {
+        "material": [
+          { "type": "lc_steel", "covered_by_mat": 90, "thickness": 0.75 },
+          { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
+        ],
+        "covers": [ "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_elbow_l", "arm_elbow_r" ],
+        "coverage": 100,
+        "cover_vitals": 85
+      },
+      {
+        "material": [
+          { "type": "lc_steel", "covered_by_mat": 90, "thickness": 1.45 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_hip_l", "leg_hip_r", "leg_knee_l", "leg_knee_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
         "coverage": 100,
-        "encumbrance": 10
+        "encumbrance": 8,
+        "cover_vitals": 85
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 0.7 },
+          { "type": "lc_steel", "covered_by_mat": 85, "thickness": 0.75 },
+          { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
+        ],
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
+        "coverage": 100,
+        "cover_vitals": 85
+      },
+      {
+        "material": [
+          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 0.8 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
-        "coverage": 100
+        "coverage": 100,
+        "cover_vitals": 100
       }
     ],
     "melee_damage": { "bash": 8 }
@@ -798,45 +837,72 @@
     "armor": [
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 97, "thickness": 3.4 },
+          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 3.1 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_upper" ],
         "coverage": 100,
-        "encumbrance": 20
+        "cover_vitals": 98,
+        "encumbrance": 18
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 3.4 },
+          { "type": "lc_steel", "covered_by_mat": 98, "thickness": 3 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_lower" ],
+        "cover_vitals": 100,
         "coverage": 100
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 1.15 },
+          { "type": "lc_steel", "covered_by_mat": 97, "thickness": 1.15 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_lower_l", "arm_lower_r" ],
         "coverage": 100,
-        "encumbrance": 15
+        "cover_vitals": 100,
+        "encumbrance": 12
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 1.15 },
+          { "type": "lc_steel", "covered_by_mat": 94, "thickness": 1.15 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
-        "specifically_covers": [ "arm_elbow_l", "arm_elbow_r", "arm_shoulder_l", "arm_shoulder_r", "arm_upper_l", "arm_upper_r" ],
-        "coverage": 100
+        "specifically_covers": [ "arm_upper_l", "arm_upper_r", "arm_elbow_l", "arm_elbow_r" ],
+        "coverage": 100,
+        "cover_vitals": 90
+      },
+      {
+        "material": [
+          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 3 },
+          { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
+        ],
+        "covers": [ "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r" ],
+        "coverage": 100,
+        "cover_vitals": 90
+      },
+      {
+        "material": [
+          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 3 },
+          { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
+        ],
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
+        "coverage": 100,
+        "encumbrance": 12,
+        "cover_vitals": 90
       },
       {
         "material": [
@@ -845,19 +911,20 @@
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_hip_l", "leg_hip_r", "leg_knee_l", "leg_knee_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
         "coverage": 100,
-        "encumbrance": 15
+        "cover_vitals": 90
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 1.15 },
+          { "type": "lc_steel", "covered_by_mat": 97, "thickness": 1.15 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
-        "coverage": 100
+        "coverage": 100,
+        "cover_vitals": 100
       }
     ],
     "melee_damage": { "bash": 8 }
@@ -952,7 +1019,7 @@
     "subtypes": [ "ARMOR" ],
     "category": "armor",
     "name": { "str": "mild steel heavy plate armor" },
-    "description": "A heavy suit of plate armor with a 6 mm thick chestpiece.  This one has been made with mild steel.",
+    "description": "A heavy suit of plate armor with a 5 mm thick chestpiece.  This one has been made with mild steel.",
     "weight": "25 kg",
     "volume": "17500 ml",
     "price": "600 USD",
@@ -970,23 +1037,25 @@
     "armor": [
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 97, "thickness": 4.8 },
+          { "type": "lc_steel", "covered_by_mat": 97, "thickness": 4.1 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "torso" ],
+        "cover_vitals": 100,
         "specifically_covers": [ "torso_upper" ],
         "coverage": 100,
-        "encumbrance": 20
+        "encumbrance": 21
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 4.8 },
+          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 3.4 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_lower" ],
+        "cover_vitals": 100,
         "coverage": 100
       },
       {
@@ -997,29 +1066,55 @@
         ],
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_lower_l", "arm_lower_r" ],
+        "cover_vitals": 100,
         "coverage": 100,
-        "encumbrance": 15
+        "encumbrance": 18
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 1.65 },
+          { "type": "lc_steel", "covered_by_mat": 96, "thickness": 1.65 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
-        "specifically_covers": [ "arm_elbow_l", "arm_elbow_r", "arm_shoulder_l", "arm_shoulder_r", "arm_upper_l", "arm_upper_r" ],
-        "coverage": 100
+        "specifically_covers": [ "arm_upper_l", "arm_upper_r", "arm_elbow_l", "arm_elbow_r" ],
+        "coverage": 100,
+        "cover_vitals": 95
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 1.65 },
+          { "type": "lc_steel", "covered_by_mat": 96, "thickness": 3.4 },
+          { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
+        ],
+        "covers": [ "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r" ],
+        "coverage": 100,
+        "cover_vitals": 100
+      },
+      {
+        "material": [
+          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 3.4 },
+          { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
+        ],
+        "//": "This version would have a comprehensive fauld over the groin and butt, which is why coverage is at 100",
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
+        "coverage": 100,
+        "cover_vitals": 100,
+        "encumbrance": 18
+      },
+      {
+        "material": [
+          { "type": "lc_steel", "covered_by_mat": 96, "thickness": 1.65 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_knee_l", "leg_knee_r", "leg_upper_l", "leg_upper_r" ],
-        "coverage": 100,
-        "encumbrance": 15
+        "specifically_covers": [ "leg_knee_l", "leg_knee_r", "leg_upper_l", "leg_upper_r" ],
+        "cover_vitals": 95,
+        "coverage": 96
       },
       {
         "material": [
@@ -1029,7 +1124,8 @@
         ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
-        "coverage": 100
+        "coverage": 100,
+        "cover_vitals": 100
       }
     ],
     "melee_damage": { "bash": 8 }

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -1783,35 +1783,49 @@
     "armor": [
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 97, "thickness": 1.45 },
+          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 1.55 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_upper" ],
         "coverage": 100,
-        "encumbrance": 15
+        "encumbrance": 11,
+        "cover_vitals": 92
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 1.45 },
+          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 1.45 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_lower" ],
-        "coverage": 100
+        "coverage": 100,
+        "cover_vitals": 100
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 1.45 },
+          { "type": "lc_steel", "covered_by_mat": 90, "thickness": 1.45 },
+          { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
+        ],
+        "covers": [ "leg_l", "leg_r", "gastropod_foot" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
+        "coverage": 100,
+        "encumbrance": 8,
+        "cover_vitals": 85
+      },
+      {
+        "material": [
+          { "type": "lc_steel", "covered_by_mat": 88, "thickness": 0.75 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "gastropod_foot" ],
-        "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l", "leg_hip_l", "leg_hip_r", "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
+        "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l" ],
         "coverage": 100,
-        "encumbrance": 10
+        "cover_vitals": 85
       }
     ],
     "melee_damage": { "bash": 8 }
@@ -1921,35 +1935,48 @@
     "armor": [
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 97, "thickness": 3.4 },
+          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 3.15 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_upper" ],
         "coverage": 100,
-        "encumbrance": 20
+        "cover_vitals": 98,
+        "encumbrance": 18
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 3.4 },
+          { "type": "lc_steel", "covered_by_mat": 98, "thickness": 3 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_lower" ],
+        "cover_vitals": 100,
         "coverage": 100
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 3.4 },
+          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 3 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
-        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "gastropod_foot" ],
-        "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l", "leg_hip_l", "leg_hip_r", "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
+        "covers": [ "leg_l", "leg_r", "gastropod_foot" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
         "coverage": 100,
-        "encumbrance": 10
+        "encumbrance": 12,
+        "cover_vitals": 90
+      },
+      {
+        "material": [
+          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 3 },
+          { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
+        ],
+        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l" ],
+        "coverage": 100
       }
     ],
     "melee_damage": { "bash": 8 }
@@ -2059,35 +2086,50 @@
     "armor": [
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 97, "thickness": 4.8 },
+          { "type": "lc_steel", "covered_by_mat": 97, "thickness": 4.1 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "torso" ],
+        "cover_vitals": 100,
         "specifically_covers": [ "torso_upper" ],
         "coverage": 100,
-        "encumbrance": 25
+        "encumbrance": 21
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 4.8 },
+          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 3.4 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_lower" ],
+        "cover_vitals": 100,
         "coverage": 100
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 4.8 },
+          { "type": "lc_steel", "covered_by_mat": 100, "thickness": 3.4 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
-        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "gastropod_foot" ],
-        "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l", "leg_hip_l", "leg_hip_r", "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
+        "//": "This version would have a comprehensive fauld over the groin and butt, which is why coverage is at 100",
+        "covers": [ "leg_l", "leg_r", "gastropod_foot" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
         "coverage": 100,
-        "encumbrance": 10
+        "cover_vitals": 100,
+        "encumbrance": 18
+      },
+      {
+        "material": [
+          { "type": "lc_steel", "covered_by_mat": 96, "thickness": 3.4 },
+          { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
+        ],
+        "covers": [ "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r" ],
+        "coverage": 100,
+        "cover_vitals": 100
       }
     ],
     "melee_damage": { "bash": 8 }


### PR DESCRIPTION
#### Summary
Balance "Plate armor coverages tweaked"

#### Purpose of change

Changes in material thickness demand changes in design. Differing encumbrance demands changes in coverage of armor

#### Describe the solution

Plate armor has been changed, both coverage, encumbrance and thickness tweaks to further portray a clear divide between the types and a more true-to-reality approach.

Shoulders (pauldrons) and hips (tassets) are part of the chestpiece, so they have had their thicknesses adjusted accordingly universally.

**_Light plate armor_** has more gaps, decreased encumbrance (by 2 for limbs, 4 for torso), much worse vital protection than the other two, but sports a bit more thickness in vital areas than before.

**_Medium plate._** follows the wisdom of a girl with golden locks who liked soup, and sits right in the middle. Its chestplate thickness has also been decreased (my earlier increase to compensate for chain was too much, and the plate itself should NOT be that thick. Lower torso is also thinner than upper torso). Thus, the encumbrance has also been decreased very slightly. The coverage by the plate is at a medium, more than light plate, but less than heavy plate armor (by a lot where it counts). 

**_The heavy armor._** It's heavy. Its chestpiece thickness is decreased a lot. **Only the upper torso sports full thickness, which has been decreased from 4.8 to 4.1,  with the abdomen being much thinner (3.4 mm). It still sports incredibly high!! protection values despite this, just not the ludicrous uniform values of before.**  Gaps are minimal, but still there. Vital protection is near perfect. Encumbrance is... high, although torso encumbrance lowered very slightly from 25 to 21 for the chestpiece being overall thinner. Same with limb encumbrance going to 18.
(I made a small mistake in the last PR and set the encumbrance for this at 20, it should be 25 ignore the change history. Also, I had included hips and shoulders in arm guards out of carelessness, which I fixed in this).

This should create actual reason to choose one armor over the other, as they are now reasonably different and IMO, all viable.

#### Describe alternatives you've considered

Leave plate armor as it is

#### Testing

Booted it up, checked protection 

#### Additional context

My sources:
https://archive.org/details/arms-armor-of-the-medieval-knight-an-illustrated-history-of-weaponry-in-the-middle-ages
The Sword and the Crucible, Alan Williams.

The plate armor I based my coverages and design on:

1. Light Plate.  Based on the armour of Archduke Sigismund of Tyrol, by Lorenz Helnschmied of Augsburg, 1480. Late German gothic plate armor:
<img width="523" height="666" alt="image" src="https://github.com/user-attachments/assets/f6199cef-a731-4845-bb2b-50b818aa1729" />

2. Medium Plate. Based on the armor belonging to a member of the Vou Match Family. Hand crafted Milanese plate, circa 1450
<img width="588" height="961" alt="image" src="https://github.com/user-attachments/assets/71cc31d9-3cd5-490f-b2cd-ededb79b2ed5" />

3. Heavy plate. Based on the legendary Greenwich armors and various late 16th century German armors:
<img width="766" height="967" alt="image" src="https://github.com/user-attachments/assets/3407b363-5f3d-4c63-aa9e-6a2494e49bab" />
<img width="269" height="626" alt="image" src="https://github.com/user-attachments/assets/ccc3dc78-6d1f-4f95-a70d-9118618bd7cf" />
<img width="683" height="1024" alt="image" src="https://github.com/user-attachments/assets/7a1165c1-3011-4b64-8a71-ac0b50be2062" />