### PR TITLE
Speed up spawning item groups into containers

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -3369,6 +3369,9 @@ class item : public visitable
         std::list<const item *> all_ablative_armor() const;
 
         void clear_items();
+        /** Engage bulk-fill mode on this container's pockets. See item_pocket::begin_bulk_fill. */
+        void begin_bulk_fill();
+        void end_bulk_fill();
         bool empty() const;
         /** Check if contents is empty. Checking only CONTAINER pockets. */
         bool empty_container() const;

--- a/src/item_container.cpp
+++ b/src/item_container.cpp
@@ -342,6 +342,16 @@ std::vector<item_pocket *> item::get_container_and_mod_pockets()
     return contents.get_container_and_mod_pockets();
 }
 
+void item::begin_bulk_fill()
+{
+    contents.begin_bulk_fill();
+}
+
+void item::end_bulk_fill()
+{
+    contents.end_bulk_fill();
+}
+
 item_pocket *item::contained_where( const item &contained )
 {
     return contents.contained_where( contained );

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1586,6 +1586,20 @@ void item_contents::clear_items()
     }
 }
 
+void item_contents::begin_bulk_fill()
+{
+    for( item_pocket &pocket : contents ) {
+        pocket.begin_bulk_fill();
+    }
+}
+
+void item_contents::end_bulk_fill()
+{
+    for( item_pocket &pocket : contents ) {
+        pocket.end_bulk_fill();
+    }
+}
+
 void item_contents::clear_magazines()
 {
     for( item_pocket &pocket : contents ) {

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -362,6 +362,9 @@ class item_contents
         /** Spill items that don't fit in the container. */
         void overflow( map &here, const tripoint_bub_ms &pos, const item_location &loc );
         void clear_items();
+        /** Engage bulk-fill mode on all pockets. See item_pocket::begin_bulk_fill. */
+        void begin_bulk_fill();
+        void end_bulk_fill();
         /** Clear all items from magazine type pockets. */
         void clear_magazines();
         void clear_pockets_if( const std::function<bool( item_pocket const & )> &filter );

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -136,6 +136,11 @@ static void put_into_container(
         ctr.set_itype_variant( *container_variant );
     }
     Item_spawn_data::ItemList excess;
+    // ctr is a fresh, isolated container; nothing else touches its contents
+    // during this loop, so its pockets can track volume/weight incrementally
+    // and avoid re-walking all prior contents on every insertion (O(n^2) when
+    // a group spawns many items into one container, e.g. container depots).
+    ctr.begin_bulk_fill();
     for( auto it = items.end() - num_items; it != items.end(); ++it ) {
         // quiet=true: caller handles failure via the overflow path below.
         const pocket_type pk_type = guess_pocket_for( ctr, *it );
@@ -165,6 +170,7 @@ static void put_into_container(
                 break;
         }
     }
+    ctr.end_bulk_fill();
     ctr.add_automatic_whitelist();
     if( sealed ) {
         ctr.seal();

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2177,12 +2177,20 @@ void item_pocket::add( const item &it, item **ret )
     } else {
         *ret = restack( &contents.back() );
     }
+    if( bulk_fill_volume ) {
+        *bulk_fill_volume += it.volume();
+        *bulk_fill_weight += it.weight();
+    }
 }
 
 void item_pocket::add( const item &it, const int copies, std::vector<item *> &added )
 {
     for( auto iter = contents.insert( contents.end(), copies, it ); iter != contents.end(); iter++ ) {
         added.push_back( &*iter );
+    }
+    if( bulk_fill_volume ) {
+        *bulk_fill_volume += it.volume() * copies;
+        *bulk_fill_weight += it.weight() * copies;
     }
 }
 
@@ -2268,6 +2276,12 @@ ret_val<item *> item_pocket::insert_item( const item &it,
     }
     if( restack_charges ) {
         inserted = restack( inserted );
+    }
+    if( bulk_fill_volume ) {
+        // restack conserves total volume/weight, so the inserted item's own
+        // contribution is the delta regardless of any merge.
+        *bulk_fill_volume += it.volume();
+        *bulk_fill_weight += it.weight();
     }
     return ret_val<item *>::make_success( inserted );
 }
@@ -2357,6 +2371,9 @@ units::length item_pocket::min_containable_length() const
 
 units::volume item_pocket::contents_volume() const
 {
+    if( bulk_fill_volume ) {
+        return *bulk_fill_volume;
+    }
     units::volume vol = 0_ml;
     for( const item &it : contents ) {
         vol += it.volume();
@@ -2366,11 +2383,26 @@ units::volume item_pocket::contents_volume() const
 
 units::mass item_pocket::contains_weight() const
 {
+    if( bulk_fill_weight ) {
+        return *bulk_fill_weight;
+    }
     units::mass weight = 0_gram;
     for( const item &it : contents ) {
         weight += it.weight();
     }
     return weight;
+}
+
+void item_pocket::begin_bulk_fill()
+{
+    bulk_fill_volume = contents_volume();
+    bulk_fill_weight = contains_weight();
+}
+
+void item_pocket::end_bulk_fill()
+{
+    bulk_fill_volume.reset();
+    bulk_fill_weight.reset();
 }
 
 units::mass item_pocket::remaining_weight() const
@@ -2383,25 +2415,13 @@ int item_pocket::charges_per_remaining_volume( const item &it ) const
     if( !it.count_by_charges() ) {
         return it.charges_per_volume( remaining_volume(), true );
     }
-    // Skip contents walk when no typeId match is possible.
-    bool any_same_type = false;
-    for( const item &contained : contents ) {
-        if( contained.typeId() == it.typeId() ) {
-            any_same_type = true;
-            break;
-        }
-    }
-    if( !any_same_type ) {
-        return it.charges_per_volume( remaining_volume(), true );
-    }
+    // Single pass: subtract the volume of every item that doesn't stack with
+    // `it`, and tally charges of those that do. When nothing stacks this
+    // reduces to volume_capacity() - contents_volume() == remaining_volume().
     units::volume non_it_volume = volume_capacity();
     int contained_charges = 0;
     for( const item &contained : contents ) {
-        if( contained.typeId() != it.typeId() ) {
-            non_it_volume -= contained.volume();
-            continue;
-        }
-        if( contained.stacks_with( it ) ) {
+        if( contained.typeId() == it.typeId() && contained.stacks_with( it ) ) {
             contained_charges += contained.charges;
         } else {
             non_it_volume -= contained.volume();
@@ -2415,24 +2435,13 @@ int item_pocket::charges_per_remaining_weight( const item &it ) const
     if( !it.count_by_charges() ) {
         return it.charges_per_weight( remaining_weight(), true );
     }
-    bool any_same_type = false;
-    for( const item &contained : contents ) {
-        if( contained.typeId() == it.typeId() ) {
-            any_same_type = true;
-            break;
-        }
-    }
-    if( !any_same_type ) {
-        return it.charges_per_weight( remaining_weight(), true );
-    }
+    // Single pass: subtract the weight of every item that doesn't stack with
+    // `it`, and tally charges of those that do. When nothing stacks this
+    // reduces to weight_capacity() - contains_weight() == remaining_weight().
     units::mass non_it_weight = weight_capacity();
     int contained_charges = 0;
     for( const item &contained : contents ) {
-        if( contained.typeId() != it.typeId() ) {
-            non_it_weight -= contained.weight();
-            continue;
-        }
-        if( contained.stacks_with( it ) ) {
+        if( contained.typeId() == it.typeId() && contained.stacks_with( it ) ) {
             contained_charges += contained.charges;
         } else {
             non_it_weight -= contained.weight();

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -216,6 +216,14 @@ class item_pocket
         // combined volume of contained items
         units::volume contents_volume() const;
         units::volume remaining_volume() const;
+
+        // While bulk-fill is active, contents_volume()/contains_weight() return
+        // a running total updated on each insertion rather than re-summing all
+        // contents, turning an O(n^2) fill into O(n). Only correct while nothing
+        // else mutates the contents between the paired calls (e.g. filling one
+        // fresh container); end_bulk_fill() drops the totals.
+        void begin_bulk_fill();
+        void end_bulk_fill();
         // how many more of @it can this pocket hold?
         int remaining_capacity_for_item( const item &it ) const;
         // the amount of space this pocket can hold before it starts expanding
@@ -430,6 +438,9 @@ class item_pocket
         // the items inside the pocket
         std::list<item> contents;
         bool _sealed = false;
+        // Running totals tracked only between begin_bulk_fill()/end_bulk_fill().
+        std::optional<units::volume> bulk_fill_volume; // NOLINT(cata-serialize)
+        std::optional<units::mass> bulk_fill_weight; // NOLINT(cata-serialize)
         // list of sub body parts that can't currently support rigid ablative armor
         std::set<sub_bodypart_id> no_rigid;
 


### PR DESCRIPTION
#### Summary
Performance "Speed up spawning item groups into containers"

#### Purpose of change
Spawning an item group into a container re-summed the container's entire contents on every insertion, making a fill O(n^2). Dense spawns like container depots got bad enough to hang mapgen for minutes. Closes #87048.

#### Describe the solution
Add a scoped bulk-fill mode to `item_pocket`: while filling a fresh, isolated container, it tracks contents volume/weight incrementally instead of re-walking everything in `can_contain`. `put_into_container` brackets its loop with `begin_bulk_fill`/`end_bulk_fill`. Containment rules are untouched. Also merged a redundant double contents-walk in `charges_per_remaining_volume`/`weight`.

#### Describe alternatives you've considered
A persistent volume/weight cache on the pocket would also speed up inventory reads, but keeping it valid when nested contents mutate is a headache, so this stays scoped to the fill where nothing else touches the container.

#### Testing
A container depot that used to take over two minutes to generate now finishes in seconds. Existing item and pocket tests pass.

#### Additional context
N/A