### PR TITLE
Fix SDL3 sound freeze from mixer lock-order deadlock

### DIFF
--- a/src/sound_backend_sdl3.cpp
+++ b/src/sound_backend_sdl3.cpp
@@ -12,6 +12,7 @@
 #include <mutex>
 #include <ostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "debug.h"
@@ -205,12 +206,18 @@ void shutdown()
     }
     g_reserved_tracks.fill( nullptr );
 
+    // Snapshot under the lock, destroy outside it: calling MIX_* while
+    // holding g_oneshots_mutex deadlocks against the mixer thread.
+    std::vector<MIX_Track *> to_destroy;
     {
         std::lock_guard<std::mutex> lock( g_oneshots_mutex );
         for( const oneshot_entry &o : g_oneshots ) {
-            MIX_DestroyTrack( o.track );
+            to_destroy.push_back( o.track );
         }
         g_oneshots.clear();
+    }
+    for( MIX_Track *t : to_destroy ) {
+        MIX_DestroyTrack( t );
     }
 
     if( g_music_track != nullptr ) {
@@ -456,11 +463,17 @@ float reserved_track_frequency_ratio( sfx::channel slot )
 }
 float last_oneshot_frequency_ratio()
 {
-    std::lock_guard<std::mutex> lock( g_oneshots_mutex );
-    if( g_oneshots.empty() ) {
-        return 0.0f;
+    // Read the track under the lock, query the mixer outside it: calling
+    // MIX_* while holding g_oneshots_mutex deadlocks against the mixer thread.
+    MIX_Track *track = nullptr;
+    {
+        std::lock_guard<std::mutex> lock( g_oneshots_mutex );
+        if( g_oneshots.empty() ) {
+            return 0.0f;
+        }
+        track = g_oneshots.back().track;
     }
-    return MIX_GetTrackFrequencyRatio( g_oneshots.back().track );
+    return MIX_GetTrackFrequencyRatio( track );
 }
 sfx_audio *make_synthetic_sfx_audio()
 {
@@ -531,18 +544,28 @@ void poll()
             MIX_SetTrackFrequencyRatio( t, ( 1.0f / g_reserved_base_pitch[i] ) * slow );
         }
     }
-    std::lock_guard<std::mutex> lock( g_oneshots_mutex );
-    // Reap stopped one-shots: destroy tracks the stopped callback
-    // flagged, then drop them from the vector. Running one-shots
-    // get their frequency ratio refreshed below.
-    for( auto it = g_oneshots.begin(); it != g_oneshots.end(); ) {
-        if( it->stopped ) {
-            MIX_DestroyTrack( it->track );
-            it = g_oneshots.erase( it );
-        } else {
-            MIX_SetTrackFrequencyRatio( it->track, ( 1.0f / it->base_pitch ) * slow );
-            ++it;
+    // oneshot_stopped_cb locks g_oneshots_mutex from the mixer thread while
+    // the mixer holds its own lock, so calling MIX_* under our lock is a
+    // lock-order inversion that deadlocks. Snapshot here, touch mixer below.
+    std::vector<MIX_Track *> to_destroy;
+    std::vector<std::pair<MIX_Track *, float>> to_retune;
+    {
+        std::lock_guard<std::mutex> lock( g_oneshots_mutex );
+        for( auto it = g_oneshots.begin(); it != g_oneshots.end(); ) {
+            if( it->stopped ) {
+                to_destroy.push_back( it->track );
+                it = g_oneshots.erase( it );
+            } else {
+                to_retune.emplace_back( it->track, ( 1.0f / it->base_pitch ) * slow );
+                ++it;
+            }
         }
+    }
+    for( MIX_Track *t : to_destroy ) {
+        MIX_DestroyTrack( t );
+    }
+    for( const std::pair<MIX_Track *, float> &r : to_retune ) {
+        MIX_SetTrackFrequencyRatio( r.first, r.second );
     }
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix SDL3 sound freeze when many sound effects play at once"

#### Purpose of change
Fixes #87187. SDL3 linux builds freeze when lots of audio plays at once (tabbing a horde, gunfire). SDL2 is fine.

A coredump of the frozen process showed the main thread stuck inside the mixer while holding `g_oneshots_mutex`.

#### Describe the solution
`oneshot_stopped_cb` runs on the mixer thread and locks `g_oneshots_mutex` while the mixer holds its own lock. `poll()`, `shutdown()`, and `last_oneshot_frequency_ratio` did the reverse: held `g_oneshots_mutex` and then called into the mixer. Opposite lock order on two threads, so they deadlock under load.

Fix: snapshot the tracks under the lock, release it, then make the `MIX_*` calls.

Same change also fixes the second deadlock in the dump, where Ctrl-C during the freeze re-enters `poll()` through the quit prompt and blocks on the lock `poll()` already holds.

#### Describe alternatives you've considered
A recursive mutex would only hide the same-thread reentrancy, not the cross-thread inversion that's the actual bug.

#### Testing
Froze before, fine after. Verified in-game, sound on, holding tab through the horde, and waited several minutes to accumulate sounds even faster -- all good.

#### Additional context
N/A