### PR TITLE
Fix minimap drawing over the Mouse View UI

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -59,6 +59,7 @@
 #include "itype.h"
 #include "iuse.h"
 #include "level_cache.h"
+#include "live_view.h"
 #include "magic.h"
 #include "magic_enchantment.h"
 #include "magic_type.h"
@@ -404,13 +405,19 @@ input_context game::get_player_input( std::string &action )
             }
 
             if( pixel_minimap_option && g->w_pixel_minimap ) {
+                if( liveview.is_enabled() ) {
+                    // Mouse View overlaps the minimap; a direct wnoutrefresh
+                    // ignores ui_adaptor z-order and paints over it.
+                    invalidate_main_ui_adaptor();
+                } else {
 #if defined(TILES)
-                // Mark minimap dirty so beacon colors keep cycling
-                if( tilecontext->has_blinking_minimap() ) {
-                    werase( g->w_pixel_minimap );
-                }
+                    // Mark minimap dirty so beacon colors keep cycling
+                    if( tilecontext->has_blinking_minimap() ) {
+                        werase( g->w_pixel_minimap );
+                    }
 #endif
-                wnoutrefresh( g->w_pixel_minimap );
+                    wnoutrefresh( g->w_pixel_minimap );
+                }
             }
 
             std::unique_ptr<static_popup> deathcam_msg_popup;


### PR DESCRIPTION
#### Summary
Bugfixes "Minimap no longer draws over the Mouse View UI"

#### Purpose of change

Fixes #87010. The sidebar minimap refreshes itself during idle with a direct `wnoutrefresh`, which ignores the UI draw order. When you move the sidebar map to the top it overlaps the Mouse View box, so the minimap ends up painted on top of it. With enemies on the minimap (blinking beacons) it repaints every tick, so the Mouse View flickers even when you're not moving the mouse. This came in with #86508 and #86183.

#### Describe the solution

When the Mouse View is open, redraw the minimap through the normal UI stack via `invalidate_main_ui_adaptor` instead of the direct refresh, so the z-order is respected and the Mouse View stays on top. The fast direct refresh is still used the rest of the time.

#### Describe alternatives you've considered

N/A

#### Testing

Verified in-game: with the sidebar map at the top, the Mouse View no longer gets covered or flickers, with or without enemies on the minimap.

#### Additional context

N/A