### PR TITLE
Add dialogue effect for adding and removing wounds

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -3190,7 +3190,7 @@ Allow to select the bodypart and store it in variable
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- |
-| "u_pick_bodypart`, `npc_pick_bodypart" | **mandatory** | [variable object](#variable-object) | variable where the bodypart will be stored |
+| "u_pick_bodypart", "npc_pick_bodypart" | **mandatory** | [variable object](#variable-object) | variable where the bodypart will be stored |
 | "whitelist_flag" | optional | string or [variable object](#variable-object) | If used, only bodyparts that has this flag will be allowed |
 | "blacklist_flag" | optional | string or [variable object](#variable-object) | If used, bodyparts that has this flag are excluded |
 | "whitelist_type" | optional | array of strings or [variable objects](#variable-object) | If used, only bodyparts of this type will be allowed |
@@ -3215,6 +3215,66 @@ Allows to pick any bodypart and store it in context val `bp`
     "id": "Test",
     "effect": [ { "u_pick_bodypart": { "context_val": "bp" } } ]
   },
+```
+
+#### `u_add_wound`, `npc_add_wound`
+
+Adds a specific wound on specific bodypart
+
+| Syntax | Optionality | Value  | Info |
+| --- | --- | --- | --- |
+| "u_add_wound", "npc_add_wound" | **mandatory** | string or [variable object](#variable-object) | id of a bodypart where the wound should be added |
+| "wound_id" | optional | string or [variable object](#variable-object) | id of a wound that will be applied |
+
+##### Valid talkers:
+
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------ | --- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+
+##### Examples
+
+Adds deep_scratch to bodypart alpha talker picks from
+```jsonc
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ADD_WOUND",
+    "effect": [
+      { "u_pick_bodypart": { "context_val": "bp" } },
+      { "u_add_wound": { "context_val": "bp" }, "wound_id": "deep_scratch" },
+      { "u_message": "Added deep_scratch wound to <context_val:bp>" }
+    ]
+  }
+```
+
+#### `u_remove_wound`, `npc_remove_wound`
+
+Removes specifc wounds from a specific bodypart
+
+| Syntax | Optionality | Value  | Info |
+| --- | --- | --- | --- |
+| "u_remove_wound", "npc_remove_wound" | **mandatory** | string or [variable object](#variable-object) | id of a bodypart where the wound should be added |
+| "wound_id" | optional | array of strings or [variable objects](#variable-object) | id of a wounds that will be removed |
+
+##### Valid talkers:
+
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------ | --- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+
+##### Examples
+
+Removes all scratch and deep_scratch wounds from bodypart alpha talker picks from
+```jsonc
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_REMOVE_WOUND",
+    "effect": [
+      { "u_pick_bodypart": { "context_val": "bp" } },
+      { "u_remove_wound": { "context_val": "bp" }, "wound_id": [ "scratch", "deep_scratch" ] },
+      { "u_message": "Removed scratch and deep_scratch wounds from <context_val:bp>" }
+    ]
+  }
 ```
 
 #### `u_deal_damage`, `npc_deal_damage`

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -1086,7 +1086,12 @@ float bodypart::get_limb_score_max( const limb_score_id &score ) const
     return id->get_limb_score_max( score );
 }
 
-std::vector<wound> bodypart::get_wounds() const
+const std::vector<wound> &bodypart::get_wounds() const
+{
+    return wounds;
+}
+
+std::vector<wound> &bodypart::get_wounds()
 {
     return wounds;
 }
@@ -1196,6 +1201,13 @@ void bodypart::remove_wound( const wound_type_id wd )
     if( it != wounds.end() ) {
         wounds.erase( it );
     }
+}
+
+void bodypart::remove_all_wounds_of_type( const wound_type_id wd )
+{
+    wounds.erase( std::remove_if( wounds.begin(), wounds.end(), [wd]( const wound & existing_wound ) {
+        return existing_wound.type == wd;
+    } ), wounds.end() );
 }
 
 void bodypart::update_wounds( time_duration time_passed )

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -501,7 +501,8 @@ class bodypart
                               int override_wounds = -1 ) const;
         float get_limb_score_max( const limb_score_id &score ) const;
 
-        std::vector<wound> get_wounds() const;
+        const std::vector<wound> &get_wounds() const;
+        std::vector<wound> &get_wounds();
 
         void add_or_worsen_wound( wound_type_id wd );
         void add_or_worsen_wound( const wound &wd );
@@ -513,6 +514,7 @@ class bodypart
         wound *get_wound( wound_type_id wd_id );
         void remove_wound( wound wd );
         void remove_wound( wound_type_id wd );
+        void remove_all_wounds_of_type( wound_type_id wd );
         void update_wounds( time_duration time_passed );
 
         int get_hp_cur() const;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3741,13 +3741,13 @@ talk_effect_fun_t::func f_pick_bodypart( const JsonObject &jo, std::string_view 
 
     if( jo.has_array( "whitelist_type" ) ) {
         for( JsonValue jv : jo.get_array( "whitelist_type" ) ) {
-            whitelist_type.emplace_back( get_str_or_var( jv, member ) );
+            whitelist_type.emplace_back( get_str_or_var( jv, "whitelist_type" ) );
         }
     }
 
     if( jo.has_array( "blacklist_type" ) ) {
         for( JsonValue jv : jo.get_array( "blacklist_type" ) ) {
-            blacklist_type.emplace_back( get_str_or_var( jv, member ) );
+            blacklist_type.emplace_back( get_str_or_var( jv, "blacklist_type" ) );
         }
     }
     std::optional<bool> wounded;
@@ -3845,6 +3845,56 @@ talk_effect_fun_t::func f_pick_bodypart( const JsonObject &jo, std::string_view 
     };
 }
 
+talk_effect_fun_t::func f_add_wound( const JsonObject &jo, std::string_view member,
+                                     std::string_view, bool is_npc )
+{
+    str_or_var bodypart_var;
+    mandatory( jo, false, member, bodypart_var );
+
+    str_or_var wound_to_be_added_var;
+    optional( jo, false, "wound_id", wound_to_be_added_var );
+
+    return [is_npc, bodypart_var, wound_to_be_added_var]( dialogue & d ) {
+
+        bodypart *bp =
+            d.actor( is_npc )->get_character()->get_part( bodypart_id( bodypart_var.evaluate( d ) ) );
+
+        wound_type_id wound_to_be_added = wound_type_id( wound_to_be_added_var.evaluate( d ) );
+
+        bp->add_or_worsen_wound( wound_to_be_added );
+    };
+}
+
+talk_effect_fun_t::func f_remove_wound( const JsonObject &jo, std::string_view member,
+                                        std::string_view, bool is_npc )
+{
+    str_or_var bodypart_var;
+    mandatory( jo, false, member, bodypart_var );
+
+    std::vector<str_or_var> wound_to_be_removed_var;
+    if( jo.has_array( "wound_id" ) ) {
+        for( JsonValue jv : jo.get_array( "wound_id" ) ) {
+            wound_to_be_removed_var.emplace_back( get_str_or_var( jv, member ) );
+        }
+    }
+
+    return [is_npc, bodypart_var, wound_to_be_removed_var]( dialogue & d ) {
+
+        bodypart *bp =
+            d.actor( is_npc )->get_character()->get_part( bodypart_id( bodypart_var.evaluate( d ) ) );
+
+        std::vector<wound_type_id> wound_to_be_removed;
+        wound_to_be_removed.reserve( wound_to_be_removed_var.size() );
+        for( const str_or_var &v : wound_to_be_removed_var ) {
+            wound_to_be_removed.emplace_back( v.evaluate( d ) );
+        }
+
+        for( const wound_type_id &wd_id : wound_to_be_removed ) {
+            bp->remove_all_wounds_of_type( wd_id );
+        }
+
+    };
+}
 
 talk_effect_fun_t::func f_add_var( const JsonObject &jo, std::string_view member,
                                    std::string_view, bool is_npc )
@@ -8390,6 +8440,8 @@ parsers = {
     { "u_buy_item", jarg::member, &talk_effect_fun::f_u_buy_item },
     { "u_spawn_item", jarg::member, &talk_effect_fun::f_spawn_item },
     { "u_pick_bodypart", "npc_pick_bodypart", jarg::member, &talk_effect_fun::f_pick_bodypart },
+    { "u_add_wound", "npc_add_wound", jarg::member, &talk_effect_fun::f_add_wound },
+    { "u_remove_wound", "npc_remove_wound", jarg::member, &talk_effect_fun::f_remove_wound },
     { "toggle_npc_rule", jarg::member, &talk_effect_fun::f_toggle_npc_rule },
     { "set_npc_rule", jarg::member, &talk_effect_fun::f_set_npc_rule },
     { "clear_npc_rule", jarg::member, &talk_effect_fun::f_clear_npc_rule },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Dialogue power 💪 
#### Describe the solution
Add eoc/dialogue effect that applies/removes wound from a specific bodypart
#### Testing
Before using eoc
<img width="1321" height="728" alt="image" src="https://github.com/user-attachments/assets/e1f1acba-2399-43a3-980b-d91a49bc4ae8" />

After using eoc that removes deep_scratch
<img width="1300" height="705" alt="image" src="https://github.com/user-attachments/assets/e39663d5-de9e-49b1-be6d-3862afb70d88" />

After using eoc that adds deep_scratch wound
<img width="1311" height="717" alt="image" src="https://github.com/user-attachments/assets/b6da841f-1e77-4344-95b6-72cc7211480f" />
