### PR TITLE
Fungal terrain doesn't spread fire

### DIFF
--- a/data/json/furniture_and_terrain/terrain-fungal.json
+++ b/data/json/furniture_and_terrain/terrain-fungal.json
@@ -8,7 +8,7 @@
     "color": "pink",
     "move_cost": 8,
     "coverage": 40,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "FUNGUS", "SHRUB", "SHORT", "GRAZER_INEDIBLE" ],
+    "flags": [ "TRANSPARENT", "FUNGUS", "SHRUB", "SHORT", "GRAZER_INEDIBLE" ],
     "examine_action": "shrub_marloss",
     "bash": {
       "str_min": 4,
@@ -28,7 +28,7 @@
     "symbol": ".",
     "color": "light_gray",
     "move_cost": 3,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "DIGGABLE", "FUNGUS", "NOCOLLIDE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FUNGUS", "NOCOLLIDE" ],
     "bash": {
       "sound": "smash",
       "//": "muffled because fungus",
@@ -50,7 +50,7 @@
     "color": "light_gray",
     "move_cost": 2,
     "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "FUNGUS" ],
+    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "FUNGUS" ],
     "bash": {
       "sound": "smash",
       "ter_set": "t_null",
@@ -70,7 +70,7 @@
     "symbol": ".",
     "color": "light_gray",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "SUPPORTS_ROOF", "FLAT", "FUNGUS" ],
+    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "FLAT", "FUNGUS" ],
     "bash": {
       "sound": "smash",
       "ter_set": "t_null",
@@ -90,7 +90,7 @@
     "symbol": ".",
     "color": "light_gray",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "FLAT", "FUNGUS" ],
+    "flags": [ "TRANSPARENT", "FLAT", "FUNGUS" ],
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
@@ -112,7 +112,7 @@
     "coverage": 100,
     "connect_groups": "WALL",
     "connects_to": "WALL",
-    "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "FUNGUS", "WALL", "REDUCE_SCENT", "MINEABLE" ],
+    "flags": [ "NOITEM", "SUPPORTS_ROOF", "FUNGUS", "WALL", "REDUCE_SCENT", "MINEABLE" ],
     "bash": {
       "str_min": 30,
       "str_max": 180,
@@ -134,7 +134,7 @@
     "coverage": 100,
     "connect_groups": "WALL",
     "connects_to": "WALL",
-    "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "FUNGUS", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE" ],
+    "flags": [ "NOITEM", "SUPPORTS_ROOF", "FUNGUS", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE" ],
     "bash": {
       "str_min": 30,
       "str_max": 180,
@@ -153,7 +153,7 @@
     "symbol": "#",
     "color": "light_gray",
     "move_cost": 4,
-    "flags": [ "TRANSPARENT", "THIN_OBSTACLE", "FLAMMABLE_ASH", "FUNGUS", "MOUNTABLE" ],
+    "flags": [ "TRANSPARENT", "THIN_OBSTACLE", "FUNGUS", "MOUNTABLE" ],
     "bash": {
       "str_min": 10,
       "str_max": 70,
@@ -173,17 +173,7 @@
     "color": "dark_gray",
     "move_cost": 8,
     "coverage": 40,
-    "flags": [
-      "TRANSPARENT",
-      "CONTAINER",
-      "FLAMMABLE_ASH",
-      "THIN_OBSTACLE",
-      "PLACE_ITEM",
-      "SHRUB",
-      "FUNGUS",
-      "SHORT",
-      "GRAZER_INEDIBLE"
-    ],
+    "flags": [ "TRANSPARENT", "CONTAINER", "THIN_OBSTACLE", "PLACE_ITEM", "SHRUB", "FUNGUS", "SHORT", "GRAZER_INEDIBLE" ],
     "bash": {
       "str_min": 4,
       "str_max": 60,
@@ -214,7 +204,7 @@
     "symbol": "1",
     "color": "dark_gray",
     "move_cost": 4,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "NOITEM", "FUNGUS", "YOUNG", "REDUCE_SCENT" ],
+    "flags": [ "TRANSPARENT", "NOITEM", "FUNGUS", "YOUNG", "REDUCE_SCENT" ],
     "bash": { "str_min": 4, "str_max": 50, "sound": "crunch!", "sound_fail": "poof!", "ter_set": "t_fungus" }
   },
   {
@@ -226,7 +216,7 @@
     "color": "pink",
     "move_cost": 0,
     "coverage": 80,
-    "flags": [ "FLAMMABLE_ASH", "NOITEM", "FUNGUS", "TREE", "REDUCE_SCENT" ],
+    "flags": [ "NOITEM", "FUNGUS", "TREE", "REDUCE_SCENT" ],
     "examine_action": "tree_marloss",
     "bash": { "str_min": 40, "str_max": 180, "sound": "crunch!", "sound_fail": "poof!", "ter_set": "t_fungus" }
   }

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -2300,6 +2300,10 @@ std::vector<FieldProcessorPtr> map_field_processing::processors_for_type( const 
     }
     if( ft.id == fd_fire ) {
         processors.push_back( &field_processor_fd_fire );
+        // Removes fungal terrain and "kills it".
+        // The non-flammability of fungal terrain makes fire not spread.
+        // But fire acting as a fungicide still "clears it", as far as you can spread the fire.
+        processors.push_back( &field_processor_fd_fungicidal_gas );
     }
     if( ft.id == fd_fungal_haze ) {
         processors.push_back( &field_processor_fd_fungal_haze );


### PR DESCRIPTION
#### Summary
Balance "Fungal terrain doesn't spread fire"

#### Purpose of change
The overall intention of our multi-apocalypse scenario is that the "Big three" (the blob, fungus, and triffids) will be carving up the world in the short and medium term until the blob invariably wins. (For the unawares, the zombies are all members of team blob.)

Right now that's not really the case - The zombies are mostly doing their thing, but the fungus is... trivially defeatable. A stray spark will burn the entire fungal world down. 

#### Describe the solution
Make fungus actually a world-ending catastrophe. Fire does not spread on fungal terrain.

In order to preserve fire working against them at all, fire fields have been gifted fungicidal effects. It will burn away floors and walls of fungus, but fire still won't spread. To burn down the world you need to actually burn down the world, not just drop a match.

This means that fungus requires a steady, concerted effort to "push back" in any capacity, and ends up leaving nothing but ashes and dead ground in its wake. You can try to fight the apocalypse, but there are no real victories here.

#### Describe alternatives you've considered
* #52242

#### Testing
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/c820b5b4-8e6f-41d2-bfc1-d4ad761cb571" />

<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/5a419682-24b2-441c-8f08-c32335878cd2" />

Gas grenades:
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/7746bfb1-aa88-4f97-a279-b939ff1a6a5c" />



#### Additional context
Triffids also need some love at some point.