### PR TITLE
Fix freeze from zero-volume sounds in monster sound clustering

### DIFF
--- a/data/json/speech.json
+++ b/data/json/speech.json
@@ -2465,6 +2465,7 @@
       "mon_dog_auscattle",
       "mon_dog_samoyed",
       "mon_dog_howling",
+      "mon_dog_wad",
       "mon_dog_mutant_mongrel",
       "mon_dog_mutant_loper",
       "mon_mi_go",

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -334,7 +334,10 @@ void sounds::sound( const tripoint_bub_ms &p, int vol, sound_t category,
     }
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
-    recent_sounds.emplace_back( p, monster_sound_event{ vol, is_provocative( category ) } );
+    // Silent sounds are inaudible to monsters and would divide by zero in cluster_sounds.
+    if( vol > 0 ) {
+        recent_sounds.emplace_back( p, monster_sound_event{ vol, is_provocative( category ) } );
+    }
     sounds_since_last_turn.emplace_back( p,
                                          sound_event{ vol, category, description, ambient,
                                                  false, id, variant, seas_str } );
@@ -415,6 +418,11 @@ static std::vector<centroid> cluster_sounds(
         }
         const float volume_sum = static_cast<float>( sound_event_pair.second.volume ) +
                                  found_centroid->weight;
+        if( volume_sum <= 0.0f ) {
+            // Both the sound and its nearest cluster are silent; averaging their
+            // positions would divide by zero and corrupt the centroid.
+            continue;
+        }
         // Set the centroid location to the average of the two locations, weighted by volume.
         found_centroid->x = static_cast<float>( ( sound_event_pair.first.x() *
                                                 sound_event_pair.second.volume ) +


### PR DESCRIPTION
#### Summary
Bugfixes "Fix freeze from zero-volume sounds in monster sound clustering"

#### Purpose of change
Fixes #87206. Diagnosis in https://github.com/CleverRaven/Cataclysm-DDA/issues/87206#issuecomment-4529680705.

#### Describe the solution
Diagnosed from a core dump of the frozen process. Keep volume-0 sounds out of the monster sound clustering, guard the centroid average against zero total volume, and give the Flat-coated Retriever a bark.

#### Describe alternatives you've considered
N/A

#### Testing
Loaded the reported save and drove through the block where it froze, no more freeze.

#### Additional context
N/A