### PR TITLE
Park unattended liquid crafts until you collect them

### DIFF
--- a/data/mods/TEST_DATA/recipes.json
+++ b/data/mods/TEST_DATA/recipes.json
@@ -709,6 +709,18 @@
   },
   {
     "type": "recipe",
+    "result": "water_clean",
+    "id_suffix": "test_unattended_liquid",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_DRINKS",
+    "skill_used": "cooking",
+    "difficulty": 0,
+    "autolearn": true,
+    "components": [ [ [ "water", 1 ] ] ],
+    "steps": [ { "name": "Boil", "time": "10 m", "activity_level": "NO_EXERCISE", "attention": "unattended" } ]
+  },
+  {
+    "type": "recipe",
     "result": "cudgel",
     "id_suffix": "test_unattended_with_qual",
     "category": "CC_WEAPON",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6320,6 +6320,13 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     if( rec.has_steps() ) {
         const recipe_step &cur_step = rec.steps()[craft.get_current_step()];
         if( cur_step.attention == step_attention::unattended ) {
+            // Parked awaiting collection: stop the actor instead of re-stamping a
+            // fresh passive entry.  The player collects via an explicit activate.
+            if( craft.is_awaiting_collection() ) {
+                act.set_to_null();
+                crafter.set_moves( 0 );
+                return;
+            }
             const std::vector<attention_plan> &plans = craft.get_step_plans();
             const int idx = craft.get_current_step();
             const attention_plan plan = idx < static_cast<int>( plans.size() ) ? plans[idx] :

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1377,6 +1377,38 @@ static std::optional<tripoint_bub_ms> craft_loc_for_complete( const item_locatio
     return get_map().get_bub( loc.pos_abs() );
 }
 
+// Checks the main result and byproducts.
+static bool recipe_result_is_liquid( const recipe &rec )
+{
+    if( item::find_type( rec.result() )->phase == phase_id::LIQUID ) {
+        return true;
+    }
+    for( const std::pair<const itype_id, int> &bp : rec.get_byproducts() ) {
+        if( item::find_type( bp.first )->phase == phase_id::LIQUID ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Clear passive timing and wakeups so nothing re-arms the step; the craft holds
+// at full progress until the player collects it via an explicit continue/activate.
+static void park_craft_for_collection( item &craft )
+{
+    craft.set_awaiting_collection( true );
+    craft.item_counter = 10000000;
+    craft.set_passive_started_at( calendar::before_time_starts );
+    craft.set_ready_at( calendar::before_time_starts );
+    craft.set_alarm_at( calendar::before_time_starts );
+    craft.set_fail_at( calendar::before_time_starts );
+    craft.set_pause_started_at( calendar::before_time_starts );
+    craft.set_saved_ready_at( calendar::before_time_starts );
+    craft.set_saved_alarm_at( calendar::before_time_starts );
+    craft.set_saved_fail_at( calendar::before_time_starts );
+    craft.set_env_check_at( calendar::before_time_starts );
+    get_item_wakeups().cancel_all( craft.uid().get_value() );
+}
+
 static void craft_actualize_fail( item &craft, time_point now,
                                   const item_location &loc )
 {
@@ -1610,6 +1642,17 @@ static void craft_actualize_ready( item &craft, time_point now, const item_locat
 
     if( was_last_step ) {
         const bool was_on_craft = activity_targets_loc( get_avatar(), loc );
+        // A liquid result has no non-interactive home: auto-finalizing pops a pour
+        // prompt while the player is away.  Park for explicit collection.  NPCs
+        // finalize silently (handle_npc_liquid).
+        const bool crafter_is_avatar = craft.get_crafter_id() == get_avatar().getID();
+        if( crafter_is_avatar && recipe_result_is_liquid( rec ) ) {
+            park_craft_for_collection( craft );
+            if( !was_on_craft ) {
+                fire_step_complete_distraction( completion_msg, flavor_msg, loc );
+            }
+            return;
+        }
         finalize_passive_craft( craft, loc );
         if( !was_on_craft ) {
             fire_step_complete_distraction( completion_msg, flavor_msg, loc );
@@ -1662,6 +1705,16 @@ void craft_resolve_overdue_passive( item &craft, time_point now, item_location &
             return;
         }
     }
+}
+
+void craft_collect_finalized( item_location &loc )
+{
+    item *craft = loc.get_item();
+    if( craft == nullptr || !craft->is_craft() || !craft->is_awaiting_collection() ) {
+        return;
+    }
+    craft->set_awaiting_collection( false );
+    finalize_passive_craft( *craft, loc );
 }
 
 void craft_stamp_passive_entry( item &craft, const Character &crafter, time_point now,

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -94,6 +94,10 @@ void craft_resolve_overdue_passive( item &craft, time_point now, item_location &
 // this, switching to or away from set_timer mid-step has no effect.
 void craft_apply_resume_replan( item_location &loc );
 
+// Finalizes a craft parked awaiting collection.  Must run with the player
+// present: complete_craft's liquid pour prompt is interactive.
+void craft_collect_finalized( item_location &loc );
+
 // Stamps passive-step runtime state (passive_started_at, ready_at, alarm_at,
 // fail_at, counter bounds) on a craft sitting at the start of an unattended
 // step, then rebuilds wakeups.  Called from the actor's first-entry path and

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -7439,6 +7439,10 @@ void iexamine::workbench_internal( Character &you, const tripoint_bub_ms &examp,
                     break;
                 }
                 selected_craft = crafts[amenu2.ret].get_item();
+                if( selected_craft->is_awaiting_collection() ) {
+                    craft_collect_finalized( crafts[amenu2.ret] );
+                    break;
+                }
                 const recipe &rec = selected_craft->get_making();
                 std::optional<std::vector<attention_plan>> chosen;
                 if( rec.has_remaining_attention_steps( selected_craft->get_current_step() )

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5417,6 +5417,17 @@ void item::set_passive_end_counter( int c )
     craft_data_->passive_end_counter = c;
 }
 
+bool item::is_awaiting_collection() const
+{
+    return craft_data_ && craft_data_->awaiting_collection;
+}
+
+void item::set_awaiting_collection( bool v )
+{
+    cata_assert( craft_data_ );
+    craft_data_->awaiting_collection = v;
+}
+
 const cata::value_ptr<islot_comestible> &item::get_comestible() const
 {
     if( is_craft() && !craft_data_->disassembly ) {

--- a/src/item.h
+++ b/src/item.h
@@ -3285,6 +3285,9 @@ class item : public visitable
         int get_passive_end_counter() const;
         void set_passive_end_counter( int c );
 
+        bool is_awaiting_collection() const;
+        void set_awaiting_collection( bool v );
+
         std::vector<enchant_cache> get_proc_enchantments() const;
         std::vector<enchantment> get_defined_enchantments() const;
         // calculates the enchantment value as if this item were wielded.
@@ -3589,6 +3592,10 @@ class item : public visitable
                 // projects linearly between them without mutation.
                 int passive_start_counter = 0;
                 int passive_end_counter = 0;
+
+                // Terminal unattended liquid step finished; held at full progress
+                // until the player explicitly collects (pours) it.
+                bool awaiting_collection = false;
 
                 // Original crafter (for env-check fallback when craft is on
                 // map/vehicle and the crafter is no longer on top of it).

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8866,6 +8866,10 @@ std::optional<int> iuse::craft( Character *p, item *it, const tripoint_bub_ms & 
         return std::nullopt;
     }
     it = craft_loc.get_item();
+    if( it->is_awaiting_collection() ) {
+        craft_collect_finalized( craft_loc );
+        return 0;
+    }
     const recipe &rec = it->get_making();
     std::optional<std::vector<attention_plan>> chosen;
     if( rec.has_remaining_attention_steps( it->get_current_step() ) && p->is_avatar() ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2889,6 +2889,9 @@ void item::craft_data::serialize( JsonOut &jsout ) const
     if( passive_end_counter != 0 ) {
         jsout.member( "passive_end_counter", passive_end_counter );
     }
+    if( awaiting_collection ) {
+        jsout.member( "awaiting_collection", awaiting_collection );
+    }
     jsout.end_object();
 }
 
@@ -3136,6 +3139,7 @@ void item::craft_data::deserialize( const JsonObject &obj )
     }
     passive_start_counter = obj.get_int( "passive_start_counter", 0 );
     passive_end_counter = obj.get_int( "passive_end_counter", 0 );
+    awaiting_collection = obj.get_bool( "awaiting_collection", false );
     // Recipe-edit migration: drop stale passive runtime on shape mismatch.
     bool stale = false;
     if( making && !disassembly ) {

--- a/tests/craft_attention_test.cpp
+++ b/tests/craft_attention_test.cpp
@@ -36,6 +36,7 @@ static const itype_id itype_2x4( "2x4" );
 static const itype_id itype_hammer( "hammer" );
 static const itype_id itype_microwave( "microwave" );
 static const itype_id itype_soldering_iron_portable( "soldering_iron_portable" );
+static const itype_id itype_water( "water" );
 
 static const recipe_id recipe_cudgel_test_charged_fast_stepless(
     "cudgel_test_charged_fast_stepless" );
@@ -63,6 +64,8 @@ static const recipe_id recipe_cudgel_test_unattended_simple(
     "cudgel_test_unattended_simple" );
 static const recipe_id recipe_cudgel_test_unattended_with_qual(
     "cudgel_test_unattended_with_qual" );
+static const recipe_id recipe_water_clean_test_unattended_liquid(
+    "water_clean_test_unattended_liquid" );
 
 TEST_CASE( "attention_recipe_loads_attention_field", "[craft][attention][schema]" )
 {
@@ -1355,6 +1358,68 @@ TEST_CASE( "craft_actualize_ready_fail_at_precedes_ready",
     craft_resolve_overdue_passive( on_map, calendar::turn + 30_minutes, loc );
 
     CHECK( loc.get_item() == nullptr );
+}
+
+TEST_CASE( "craft_terminal_unattended_liquid_parks_for_collection",
+           "[craft][attention][liquid]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms craft_pos( 60, 60, 0 );
+    // Avatar on the craft tile: a liquid step still parks (collection is always
+    // explicit, so proximity does not gate it).
+    u.setpos( here, craft_pos );
+
+    SECTION( "liquid result parks at full progress instead of finalizing" ) {
+        item ingredient( itype_water, calendar::turn );
+        item placed( &recipe_water_clean_test_unattended_liquid.obj(), 1, ingredient );
+        item &on_map = here.add_item( craft_pos, placed );
+        REQUIRE( on_map.is_craft() );
+
+        on_map.set_current_step( 0 );
+        on_map.set_passive_started_at( calendar::turn );
+        on_map.set_ready_at( calendar::turn + 10_minutes );
+        on_map.set_crafter_id( u.getID() );
+        std::vector<attention_plan> plans( 1 );
+        on_map.set_step_plans( plans );
+
+        item_location loc( map_cursor( here.get_abs( craft_pos ) ), &on_map );
+        get_item_wakeups().rebuild_for_item( loc );
+        const int64_t uid = on_map.uid().get_value();
+
+        // Finalizing a liquid here would hit the pour prompt and abort the test
+        // (cata_assert( !test_mode ) in uilist); parking is what prevents that.
+        craft_resolve_overdue_passive( on_map, calendar::turn + 10_minutes + 1_turns, loc );
+
+        REQUIRE( loc.get_item() != nullptr );
+        item *parked = loc.get_item();
+        CHECK( parked->is_craft() );
+        CHECK( parked->tname().find( "100%" ) != std::string::npos );
+        // Parked, so no ready wakeup remains to re-fire.
+        CHECK_FALSE( get_item_wakeups().is_scheduled( uid, item_wakeup_kind::ready_check ) );
+    }
+
+    SECTION( "solid result still finalizes when overdue" ) {
+        item ingredient( itype_2x4, calendar::turn );
+        item placed( &recipe_cudgel_test_only_unattended.obj(), 1, ingredient );
+        item &on_map = here.add_item( craft_pos, placed );
+        REQUIRE( on_map.is_craft() );
+
+        on_map.set_current_step( 0 );
+        on_map.set_passive_started_at( calendar::turn );
+        on_map.set_ready_at( calendar::turn + 10_minutes );
+        on_map.set_crafter_id( u.getID() );
+        std::vector<attention_plan> plans( 1 );
+        on_map.set_step_plans( plans );
+
+        item_location loc( map_cursor( here.get_abs( craft_pos ) ), &on_map );
+
+        craft_resolve_overdue_passive( on_map, calendar::turn + 10_minutes + 1_turns, loc );
+
+        // Non-liquid result finalizes normally; the parking gate is liquid-only.
+        CHECK( loc.get_item() == nullptr );
+    }
 }
 
 TEST_CASE( "craft_stamp_passive_entry_carries_step_progress_fraction",


### PR DESCRIPTION
#### Summary
Features "Unattended liquid crafts wait for you to pour them"

#### Purpose of change
Unattended recipe steps let a craft finish while you're away. If the result (or a byproduct) is a liquid, finishing fires the "what to do with the clean water?" pour prompt with no one there to answer, so it spills.

#### Describe the solution
When an unattended craft's last step finishes and the result or any byproduct is a liquid, it parks at 100% instead of finalizing. Continue or activate it to pour. NPC crafts and solid/gas results are unchanged.

#### Describe alternatives you've considered
Adding a final active step to every liquid recipe to force you to be present. That's a per-recipe content workaround instead of fixing it once.

Reserving a destination container when the craft starts. More bookkeeping, and it just moves the where-to-pour choice to the front.

#### Testing
New test: a liquid step parks at 100%, a solid one still finalizes. Verified in-game: boil water unattended, walk off, come back, activate, pour.

#### Additional context
N/A