### PR TITLE
[XE] Implement asking others for dreamdross.

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -4365,6 +4365,12 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_follower_summoned_dross",
+    "name": "Recently created dreamdross",
+    "desc": "This person has recently produced dreamdross.  It will take some time before they produce an usable amount of dross again."
+  },
+  {
+    "type": "effect_type",
     "id": "march_baron",
     "name": [ "March Baron" ],
     "//": "Used to target a slightly different winning screen upon exiting the mortal realms as a Lord in Boann's court."

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -4366,8 +4366,10 @@
   {
     "type": "effect_type",
     "id": "effect_follower_summoned_dross",
-    "name": "Recently created dreamdross",
-    "desc": "This person has recently produced dreamdross.  It will take some time before they produce an usable amount of dross again."
+    "name": [ "Recently created dreamdross" ],
+    "desc": [
+      "This person has recently gave you dreamdross.  It will take some time before they gather an usable amount of dross again."
+    ]
   },
   {
     "type": "effect_type",

--- a/data/mods/Xedra_Evolved/npc/follower_ask_for_dreams.json
+++ b/data/mods/Xedra_Evolved/npc/follower_ask_for_dreams.json
@@ -1,0 +1,146 @@
+[
+  {
+    "id": [ "TALK_FRIEND", "TALK_FRIEND_Liam", "TALK_FRIEND_Luo" ],
+    "//": "Based on their respective abilities, dreamers produce more dross than dreamwalkers.",
+    "//2": "This is why they gain experience for the spell and for deduction, like player dreamers.",
+    "type": "talk_topic",
+    "insert_before_standard_exits": true,
+    "responses": [
+      {
+        "text": "[Ask them to produce dreamdross]",
+        "topic": "TALK_PRODUCE_DREAMDROSS",
+        "//": "Based on the dreamer spell.  That's why it costs mana and has no cooldown.",
+        "condition": { "and": [ { "npc_has_trait": "DREAMER" }, { "math": [ "n_val('mana') >= 1000" ] } ] },
+        "effect": [
+          {
+            "if": { "npc_is_wearing": "dream_attuning_necklace" },
+            "then": [
+              { "u_spawn_item": "scrap_dreamdross", "count": { "math": [ "3.5 + (0.5 * n_spell_level('create_dream_dross'))" ] } },
+              { "math": [ "n_val('mana') -= 1000" ] },
+              { "math": [ "n_skill_exp('deduction', 'format': 'raw') += 250 * game_option('SKILL_TRAINING_SPEED')" ] },
+              {
+                "math": [
+                  "n_spell_exp('create_dream_dross')",
+                  "+=",
+                  "(spell_exp_for_level('create_dream_dross', n_spell_level('create_dream_dross')+1) - spell_exp_for_level('create_dream_dross', n_spell_level('create_dream_dross')))/spell_train_factor(200)"
+                ]
+              }
+            ],
+            "else": [
+              { "u_spawn_item": "scrap_dreamdross", "count": { "math": [ "1 + (0.5 * n_spell_level('create_dream_dross'))" ] } },
+              { "math": [ "n_val('mana') -= 1000" ] },
+              { "math": [ "n_skill_exp('deduction', 'format': 'raw') += 250 * game_option('SKILL_TRAINING_SPEED')" ] },
+              {
+                "math": [
+                  "n_spell_exp('create_dream_dross')",
+                  "+=",
+                  "(spell_exp_for_level('create_dream_dross', n_spell_level('create_dream_dross')+1) - spell_exp_for_level('create_dream_dross', n_spell_level('create_dream_dross')))/spell_train_factor(200)"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "text": "[Ask them to produce dreamdross]",
+        "topic": "TALK_PRODUCE_DREAMDROSS",
+        "//": "Based on 1/5 odds of post-thresh to passively make 1 to 4 dross.  Pre-thresh have 1/10 odds.",
+        "condition": {
+          "and": [
+            { "or": [ { "npc_has_trait": "HOMULLUS_DREAMWALKER" }, { "npc_has_trait": "CHANGELING_NOBLE_DREAMWALKER" } ] },
+            { "not": { "npc_has_effect": "effect_follower_summoned_dross" } }
+          ]
+        },
+        "effect": [
+          { "u_spawn_item": "scrap_dreamdross", "count": [ 1, 4 ] },
+          {
+            "if": { "or": [ { "npc_has_trait": "THRESH_HOMULLUS" }, { "npc_has_trait": "THRESH_FAIR_FOLK_NOBLE" } ] },
+            "then": [ { "npc_add_effect": "effect_follower_summoned_dross", "duration": "5 days" } ],
+            "else": [ { "npc_add_effect": "effect_follower_summoned_dross", "duration": "10 days" } ]
+          }
+        ]
+      },
+      {
+        "text": "[Ask them to produce dreamdross]",
+        "topic": "TALK_CANNOT_PRODUCE_DREAMDROSS_MANA",
+        "condition": { "and": [ { "or": [ { "npc_has_trait": "DREAMER" } ] }, { "math": [ "n_val('mana') < 1000" ] } ] }
+      },
+      {
+        "text": "[Ask them to produce dreamdross]",
+        "topic": "TALK_CANNOT_PRODUCE_DREAMDROSS_TIME",
+        "condition": {
+          "and": [
+            { "or": [ { "npc_has_trait": "HOMULLUS_DREAMWALKER" }, { "npc_has_trait": "CHANGELING_NOBLE_DREAMWALKER" } ] },
+            { "npc_has_effect": "effect_follower_summoned_dross" }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": "TALK_PRODUCE_DREAMDROSS",
+    "type": "talk_topic",
+    "dynamic_line": "Here's some dreamdross as you asked.",
+    "responses": [
+      {
+        "text": "[Ask them to produce more dreamdross]",
+        "topic": "TALK_PRODUCE_DREAMDROSS",
+        "condition": { "and": [ { "npc_has_trait": "DREAMER" }, { "math": [ "n_val('mana') >= 1000" ] } ] },
+        "effect": [
+          {
+            "if": { "npc_is_wearing": "dream_attuning_necklace" },
+            "then": [
+              { "u_spawn_item": "scrap_dreamdross", "count": { "math": [ "3.5 + (0.5 * n_spell_level('create_dream_dross'))" ] } },
+              { "math": [ "n_val('mana') -= 1000" ] },
+              { "math": [ "n_skill_exp('deduction', 'format': 'raw') += 250 * game_option('SKILL_TRAINING_SPEED')" ] },
+              {
+                "math": [
+                  "n_spell_exp('create_dream_dross')",
+                  "+=",
+                  "(spell_exp_for_level('create_dream_dross', n_spell_level('create_dream_dross')+1) - spell_exp_for_level('create_dream_dross', n_spell_level('create_dream_dross')))/spell_train_factor(200)"
+                ]
+              }
+            ],
+            "else": [
+              { "u_spawn_item": "scrap_dreamdross", "count": { "math": [ "1 + (0.5 * n_spell_level('create_dream_dross'))" ] } },
+              { "math": [ "n_val('mana') -= 1000" ] },
+              { "math": [ "n_skill_exp('deduction', 'format': 'raw') += 250 * game_option('SKILL_TRAINING_SPEED')" ] },
+              {
+                "math": [
+                  "n_spell_exp('create_dream_dross')",
+                  "+=",
+                  "(spell_exp_for_level('create_dream_dross', n_spell_level('create_dream_dross')+1) - spell_exp_for_level('create_dream_dross', n_spell_level('create_dream_dross')))/spell_train_factor(200)"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "text": "[Ask them to produce more dreamdross]",
+        "topic": "TALK_CANNOT_PRODUCE_DREAMDROSS_MANA",
+        "condition": { "and": [ { "npc_has_trait": "DREAMER" }, { "math": [ "n_val('mana') < 1000" ] } ] }
+      },
+      { "text": "Thanks.  Can we talk about something else?", "topic": "TALK_NONE" },
+      { "text": "Thanks.  See you later.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_CANNOT_PRODUCE_DREAMDROSS_MANA",
+    "type": "talk_topic",
+    "dynamic_line": "I can't do that right now.  I need time to recover my mana.",
+    "responses": [
+      { "text": "Got it.  Can we talk about something else?", "topic": "TALK_NONE" },
+      { "text": "Got it.  See you later.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_CANNOT_PRODUCE_DREAMDROSS_TIME",
+    "type": "talk_topic",
+    "dynamic_line": "I can't do that right now.  I need time to gather more dreamdross.",
+    "responses": [
+      { "text": "Got it.  Can we talk about something else?", "topic": "TALK_NONE" },
+      { "text": "Got it.  See you later.", "topic": "TALK_DONE" }
+    ]
+  }
+]

--- a/data/mods/Xedra_Evolved/npc/vampire_askblood.json
+++ b/data/mods/Xedra_Evolved/npc/vampire_askblood.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": [ "TALK_FRIEND" ],
+    "id": [ "TALK_FRIEND", "TALK_FRIEND_Liam", "TALK_FRIEND_Luo" ],
     "type": "talk_topic",
     "insert_before_standard_exits": true,
     "//": "Drinking from willing targets doesn't check for worn holy symbols, as the follower is cooperating.",
@@ -28,7 +28,7 @@
     ]
   },
   {
-    "id": [ "TALK_FRIEND" ],
+    "id": [ "TALK_FRIEND", "TALK_FRIEND_Liam", "TALK_FRIEND_Luo" ],
     "type": "talk_topic",
     "insert_before_standard_exits": true,
     "responses": [
@@ -55,7 +55,7 @@
     ]
   },
   {
-    "id": [ "TALK_FRIEND" ],
+    "id": [ "TALK_FRIEND", "TALK_FRIEND_Liam", "TALK_FRIEND_Luo" ],
     "type": "talk_topic",
     "insert_before_standard_exits": true,
     "responses": [
@@ -83,7 +83,7 @@
     ]
   },
   {
-    "id": [ "TALK_FRIEND" ],
+    "id": [ "TALK_FRIEND", "TALK_FRIEND_Liam", "TALK_FRIEND_Luo" ],
     "type": "talk_topic",
     "insert_before_standard_exits": true,
     "responses": [
@@ -118,7 +118,7 @@
     "responses": [
       {
         "text": "[Drink from them] Thank you.  Can we talk about something else?",
-        "topic": "TALK_FRIEND",
+        "topic": "TALK_NONE",
         "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
         "effect": [ { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN" }, { "run_eocs": "EOC_NPC_GOT_DRANK_FROM_FRIEND" } ]
       },
@@ -135,7 +135,7 @@
       },
       {
         "text": "Got it.  Can we talk about something else?",
-        "topic": "TALK_FRIEND",
+        "topic": "TALK_NONE",
         "condition": { "npc_has_effect": "feed_from_recently" }
       },
       {
@@ -156,7 +156,7 @@
     "responses": [
       {
         "text": "[Drink from them] Thank you.  Can we talk about something else?",
-        "topic": "TALK_FRIEND",
+        "topic": "TALK_NONE",
         "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
         "effect": [ { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN" }, { "run_eocs": "EOC_NPC_GOT_DRANK_FROM_ALLY" } ],
         "opinion": { "trust": -1, "value": -1 }


### PR DESCRIPTION
#### Summary
Mods "[XE] Implement asking others for dreamdross."



#### Purpose of change

@Maleclypse mentionned long ago that he'd like for the Dreamer and Homullus followers to have a dialogue allowing the player to ask for dreamdross.

After adding dialogues to ask other things from followers, I'm adding the same for dreamdross.

I've noticed that another dialogue needed fixing, so Liam and Luo being able to be asked for blood is also part of this PR.



#### Describe the solution

The player can now ask Dreamers, Homullus and Changeling Noble NPCs for dreamdross.

-Dreamers: If they have enough mana, they can produce dreamdross based on their spell level. This creates some dreamdross (a little more if the follower wears the dream-attuning necklace to represent its caster level increase), reduces their mana and grants them xp for deduction and the spell itself, just like casting the spell does.

-Homullus and Changeling Nobles: If they have the dreamwalker trait, they can be asked for dross every 10 days (or 5 days if they have their threshold). This results in the player gaining 1 to 4 dreamdross, as per the dreamwalker trait's effect.

Asking manaless dreamers or Homullus and Changeling Nobles that still have the cooldown effect will instead have them say that they can't do that right now. 

Dreamer followers have the dreamers' restrictions on mana regeneration, so having them produce mana will either take multiple days for sleep-based regen or investment to have mood-based regen.

As far as I'm aware, there's no way to force massive negative mood on followers (and if there was, enduring that every day would be a valid reason for mutiny), so investment will consist of keeping them very happy all day long.



I've also edited another dialogue so you can now ask Liam and Luo for blood, as I noticed this dialogue was missed during the last dialogue adjustment.



#### Describe alternatives you've considered

Implement the infrastructure for NPCs to properly cast spells and trigger all related EOCs. As this would be a massive undertaking beyond my current time and knowledge, I kept it simple and used dialogues to replicate that.

Do the ask-blood dialogue fixes in another PR, but they're too small to warrant an entire PR for them alone.



#### Testing

Game loads

Can't ask for dreamdross to those not Dreamers or Dreamwalkers.

Dreamwalkers without threshold produce dross when asked and have a 10-day cooldown. Those with the threshold have a 5-day cooldown instead.

Dreamers produce dross based on the spell's level and them wearing the necklace. They cannot produce dross if they lack mana and they gain xp when creating dreamdross. Both the spell's level and the necklace increase how much dross is made with this option.



#### Additional context
A debug command to increase a follower's mana would've been useful to test this, as even the debug mana mutation can't make a dreamer regain mana over time without sufficient emotions.