### PR TITLE
Stop neutral NPCs from taking stuff from your vehicles

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4408,6 +4408,11 @@ void npc::find_item()
             cache_tile();
             continue;
         }
+        // Only allow allies to take items from your vehicle
+        if( !is_player_ally() && vp->vehicle().is_owned_by( get_player_character() ) ) {
+            cache_tile();
+            continue;
+        }
         const std::optional<vpart_reference> cargo = vp.cargo();
         static const std::string locked_string( "LOCKED" );
         // TODO: Let player know what parts are safe from NPC thieves


### PR DESCRIPTION
#### Summary
Bugfixes "Stop neutral NPCs from taking stuff from your vehicles"

#### Purpose of change
Random NPCs can come and steal stuff from your vehicle when they are in search of items.  Not cool!

#### Describe the solution
Add a check if the NPC is an ally and also if the vehicle is owned by you to the NPCs valid options selection.  Neutral NPCs can still take stuff from vehicles that are not owned by you.

#### Describe alternatives you've considered
None.

#### Testing
None.

#### Additional context
Same approach that was applied in #86792