### PR TITLE
Fix separators bleeding color into curses menus

### DIFF
--- a/src/third-party/imgui/imgui_widgets.cpp
+++ b/src/third-party/imgui/imgui_widgets.cpp
@@ -1796,12 +1796,24 @@ void ImGui::SeparatorEx(ImGuiSeparatorFlags flags, float thickness)
         // In order to handle scaling we need to scale separator thickness and it would not makes sense to have a disparity depending on height.
         ////float thickness_for_layout = (thickness == 1.0f) ? 0.0f : thickness; // FIXME: See 1.70/1.71 Separator() change: makes legacy 1-px separator not affect layout yet. Should change.
         const ImRect bb(ImVec2(x1, window->DC.CursorPos.y), ImVec2(x2, window->DC.CursorPos.y + thickness));
-        ItemSize(ImVec2(0.0f, thickness));
+// START CDDA PATCH #65709
+#ifdef IMTUI
+        // Legacy thin-separator behavior: a 1px separator takes no layout space.
+        const float thickness_for_layout = (thickness == 1.0f) ? 0.0f : thickness;
+#else
+        const float thickness_for_layout = thickness;
+#endif
+        ItemSize(ImVec2(0.0f, thickness_for_layout));
+// END CDDA PATCH #65709
 
         if (ItemAdd(bb, 0))
         {
+// START CDDA PATCH #65709
+#ifndef IMTUI
             // Draw
             window->DrawList->AddRectFilled(bb.Min, bb.Max, GetColorU32(ImGuiCol_Separator));
+#endif
+// END CDDA PATCH #65709
             if (g.LogEnabled)
                 LogRenderedText(&bb.Min, "--------------------------------\n");
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix separators bleeding color into the next line in curses menus"

#### Purpose of change
Fixes #87222. After the ImGui 1.92.8 update, horizontal separators started painting a pink row in curses menus (butcher, crafting, item info), bleeding into the next line.

#### Describe the solution
When I ported 1.92.8 I reapplied the IMTUI separator patch on the vertical path but missed the horizontal one, and upstream dropped the old hack that made 1px separators take no layout space. So `Separator()` drew a 1px `ImGuiCol_Separator` rect, which the text backend rasterizes across two terminal rows. I restored both behaviors under IMTUI: a default 1px separator isn't drawn and takes no layout space, while thicker custom separators keep their height.

#### Describe alternatives you've considered
N/A

#### Testing
Verified in-game on curses: pink rows gone, menus compact as before.

#### Additional context
N/A