### PR TITLE
Fireproofing the fungal wall monster

### DIFF
--- a/data/json/monsters/fungus.json
+++ b/data/json/monsters/fungus.json
@@ -111,7 +111,7 @@
     "weight": "200 kg",
     "hp": 20,
     "speed": 100,
-    "material": [ "veggy" ],
+    "material": [ "stone" ],
     "symbol": "T",
     "color": "dark_gray",
     "aggression": 100,


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
For something that meant to protect the fungal spires from harm, it is oddly flammable. So i fireproof it.

#### Describe the solution

Change the fungal wall monster's material into stone like the fungal spire it is protecting.

#### Describe alternatives you've considered

Nah.

#### Testing
<img width="1080" height="2408" alt="Screenshot_20260525_232918" src="https://github.com/user-attachments/assets/ae1943df-64c2-4356-bd12-b4b000760bc9" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
