### PR TITLE
Split the MSVC static library in two to fix the 4GB archive limit

### DIFF
--- a/msvc-full-features/Cataclysm-libAL-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-libAL-vcpkg-static.vcxproj
@@ -60,7 +60,7 @@
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnabled>true</VcpkgEnabled>
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
-    <VcpkgManifestInstall>false</VcpkgManifestInstall>
+    <VcpkgManifestInstall>true</VcpkgManifestInstall>
     <VcpkgUseStatic>true</VcpkgUseStatic>
     <VcpkgAutoLink>true</VcpkgAutoLink>
     <VcpkgTriplet Condition="'$(Platform)'=='Win32'">x86-windows-static</VcpkgTriplet>

--- a/msvc-full-features/Cataclysm-libAL-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-libAL-vcpkg-static.vcxproj
@@ -52,13 +52,10 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
-    <ProjectGuid>{2C1ECEE1-9686-4C3C-8DE1-88996EE43378}</ProjectGuid>
+    <ProjectGuid>{AD10F767-9A9B-43F9-9482-88981CDC95F5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>CataclysmTest</RootNamespace>
+    <RootNamespace>CataclysmLibAL</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <VcpkgTriplet Condition="'$(Platform)'=='Win32'">x86-windows-static</VcpkgTriplet>
-    <VcpkgTriplet Condition="'$(Platform)'=='x64'">x64-windows-static</VcpkgTriplet>
-    <VcpkgTriplet Condition="'$(Platform)'=='ARM64EC'">x64-windows-static</VcpkgTriplet>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnabled>true</VcpkgEnabled>
@@ -66,14 +63,15 @@
     <VcpkgManifestInstall>false</VcpkgManifestInstall>
     <VcpkgUseStatic>true</VcpkgUseStatic>
     <VcpkgAutoLink>true</VcpkgAutoLink>
-    <VcpkgUserTriplet Condition="'$(Platform)'=='Win32'">x86-windows-static</VcpkgUserTriplet>
-    <VcpkgUserTriplet Condition="'$(Platform)'=='x64'">x64-windows-static</VcpkgUserTriplet>
-    <VcpkgUserTriplet Condition="'$(Platform)'=='ARM64EC'">x64-windows-static</VcpkgUserTriplet>
+    <VcpkgTriplet Condition="'$(Platform)'=='Win32'">x86-windows-static</VcpkgTriplet>
+    <VcpkgTriplet Condition="'$(Platform)'=='x64'">x64-windows-static</VcpkgTriplet>
+    <VcpkgTriplet Condition="'$(Platform)'=='ARM64EC'">x64-windows-static</VcpkgTriplet>
+    <VcpkgHostTriplet>$(VcpkgTriplet)</VcpkgHostTriplet>
     <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -105,9 +103,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <LocalDebuggerWorkingDirectory>$(ProjectDir)..</LocalDebuggerWorkingDirectory>
-    <OutDir>$(ProjectDir)..\</OutDir>
-    <TargetExt>.exe</TargetExt>
+    <TargetExt>.lib</TargetExt>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <LinkIncremental>true</LinkIncremental>
@@ -123,18 +119,13 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>_CONSOLE;SDL_SOUND;SDL_MAIN_HANDLED;CATCH_CONFIG_ENABLE_BENCHMARKING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CONSOLE;SDL_SOUND;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>legacy_stdio_float_rounding.obj;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>false</IntrinsicFunctions>
-      <PreprocessorDefinitions>_DEBUG;TILES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
@@ -142,7 +133,6 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>false</IntrinsicFunctions>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
@@ -152,7 +142,6 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
-      <PreprocessorDefinitions>TILES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -179,21 +168,24 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="..\tests\*.h" />
-    <ClInclude Include="..\src\messages.h" />
+    <ClCompile Include="..\src\cata_allocator_c.c">
+      <ForcedIncludeFiles />
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\src\a*.cpp;..\src\b*.cpp;..\src\c*.cpp;..\src\d*.cpp;..\src\e*.cpp;..\src\f*.cpp;..\src\g*.cpp;..\src\h*.cpp;..\src\i*.cpp;..\src\j*.cpp;..\src\k*.cpp;..\src\l*.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\tests\*.cpp" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\msvc-full-features\Cataclysm-libMZ-vcpkg-static.vcxproj">
-      <Project>{0009bb11-11ad-4c14-a5fc-d882a942c00b}</Project>
+    <ProjectReference Include="flatbuffers.vcxproj">
+      <Project>{8a533a64-435d-4d4f-9ff0-1e97aace9374}</Project>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
     </ProjectReference>
-    <ProjectReference Include="..\msvc-full-features\Cataclysm-libAL-vcpkg-static.vcxproj">
-      <Project>{ad10f767-9a9b-43f9-9482-88981cdc95f5}</Project>
+    <ProjectReference Include="fmt.vcxproj">
+      <Project>{f2098959-aad9-4210-a64c-fc4a09a45556}</Project>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
     </ProjectReference>
-    <ProjectReference Include="ImGui-lib-vcpkg-static.vcxproj">
-      <Project>{0c0b2bea-311f-473c-9652-87923ef639e3}</Project>
+    <ProjectReference Include="zstd.vcxproj">
+      <Project>{f49f14c6-b046-41c7-b707-03366f4b1578}</Project>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/msvc-full-features/Cataclysm-libMZ-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-libMZ-vcpkg-static.vcxproj
@@ -54,7 +54,7 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{0009BB11-11AD-4C14-A5FC-D882A942C00B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>CataclysmLib</RootNamespace>
+    <RootNamespace>CataclysmLibMZ</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
@@ -174,11 +174,7 @@
     <ClInclude Include="..\src\*.h" Exclude="..\src\messages.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\cata_allocator_c.c">
-      <ForcedIncludeFiles />
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-    </ClCompile>
-    <ClCompile Include="..\src\*.cpp" Exclude="..\src\main.cpp;..\src\messages.cpp" />
+    <ClCompile Include="..\src\*.cpp" Exclude="..\src\main.cpp;..\src\messages.cpp;..\src\a*.cpp;..\src\b*.cpp;..\src\c*.cpp;..\src\d*.cpp;..\src\e*.cpp;..\src\f*.cpp;..\src\g*.cpp;..\src\h*.cpp;..\src\i*.cpp;..\src\j*.cpp;..\src\k*.cpp;..\src\l*.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="flatbuffers.vcxproj">

--- a/msvc-full-features/Cataclysm-vcpkg-static.sln
+++ b/msvc-full-features/Cataclysm-vcpkg-static.sln
@@ -18,7 +18,9 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Cataclysm-vcpkg-static", "C
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Cataclysm-test-vcpkg-static", "Cataclysm-test-vcpkg-static.vcxproj", "{2C1ECEE1-9686-4C3C-8DE1-88996EE43378}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Cataclysm-lib-vcpkg-static", "Cataclysm-lib-vcpkg-static.vcxproj", "{0009BB11-11AD-4C14-A5FC-D882A942C00B}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Cataclysm-libMZ-vcpkg-static", "Cataclysm-libMZ-vcpkg-static.vcxproj", "{0009BB11-11AD-4C14-A5FC-D882A942C00B}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Cataclysm-libAL-vcpkg-static", "Cataclysm-libAL-vcpkg-static.vcxproj", "{AD10F767-9A9B-43F9-9482-88981CDC95F5}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "JsonFormatter-vcpkg-static", "JsonFormatter-vcpkg-static.vcxproj", "{35D74C75-FC4A-442F-AF44-43BC9D845BAF}"
 EndProject
@@ -158,6 +160,42 @@ Global
 		{0009BB11-11AD-4C14-A5FC-D882A942C00B}.Release-NoTiles|x64.Build.0 = Release-NoTiles|x64
 		{0009BB11-11AD-4C14-A5FC-D882A942C00B}.Release-NoTiles|x86.ActiveCfg = Release-NoTiles|Win32
 		{0009BB11-11AD-4C14-A5FC-D882A942C00B}.Release-NoTiles|x86.Build.0 = Release-NoTiles|Win32
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Debug|ARM64EC.ActiveCfg = Debug|ARM64EC
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Debug|ARM64EC.Build.0 = Debug|ARM64EC
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Debug|x64.ActiveCfg = Debug|x64
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Debug|x64.Build.0 = Debug|x64
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Debug|x86.ActiveCfg = Debug|Win32
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Debug|x86.Build.0 = Debug|Win32
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Debug-NoTiles|ARM64EC.ActiveCfg = Debug-NoTiles|ARM64EC
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Debug-NoTiles|ARM64EC.Build.0 = Debug-NoTiles|ARM64EC
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Debug-NoTiles|x64.ActiveCfg = Debug-NoTiles|x64
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Debug-NoTiles|x64.Build.0 = Debug-NoTiles|x64
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Debug-NoTiles|x86.ActiveCfg = Debug-NoTiles|Win32
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Debug-NoTiles|x86.Build.0 = Debug-NoTiles|Win32
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Quick|ARM64EC.ActiveCfg = Release|ARM64EC
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Quick|ARM64EC.Build.0 = Release|ARM64EC
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Quick|x64.ActiveCfg = Release|x64
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Quick|x64.Build.0 = Release|x64
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Quick|x86.ActiveCfg = Release|Win32
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Quick|x86.Build.0 = Release|Win32
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Quick-NoTiles|ARM64EC.ActiveCfg = Release-NoTiles|ARM64EC
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Quick-NoTiles|ARM64EC.Build.0 = Release-NoTiles|ARM64EC
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Quick-NoTiles|x64.ActiveCfg = Release-NoTiles|x64
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Quick-NoTiles|x64.Build.0 = Release-NoTiles|x64
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Quick-NoTiles|x86.ActiveCfg = Release-NoTiles|Win32
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Quick-NoTiles|x86.Build.0 = Release-NoTiles|Win32
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release|ARM64EC.ActiveCfg = Release|ARM64EC
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release|ARM64EC.Build.0 = Release|ARM64EC
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release|x64.ActiveCfg = Release|x64
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release|x64.Build.0 = Release|x64
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release|x86.ActiveCfg = Release|Win32
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release|x86.Build.0 = Release|Win32
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release-NoTiles|ARM64EC.ActiveCfg = Release-NoTiles|ARM64EC
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release-NoTiles|ARM64EC.Build.0 = Release-NoTiles|ARM64EC
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release-NoTiles|x64.ActiveCfg = Release-NoTiles|x64
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release-NoTiles|x64.Build.0 = Release-NoTiles|x64
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release-NoTiles|x86.ActiveCfg = Release-NoTiles|Win32
+		{AD10F767-9A9B-43F9-9482-88981CDC95F5}.Release-NoTiles|x86.Build.0 = Release-NoTiles|Win32
 		{35D74C75-FC4A-442F-AF44-43BC9D845BAF}.Debug|ARM64EC.ActiveCfg = Debug|x64
 		{35D74C75-FC4A-442F-AF44-43BC9D845BAF}.Debug|x64.ActiveCfg = Debug|x64
 		{35D74C75-FC4A-442F-AF44-43BC9D845BAF}.Debug|x64.Build.0 = Debug|x64

--- a/msvc-full-features/Cataclysm-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-vcpkg-static.vcxproj
@@ -231,8 +231,11 @@
     <ClCompile Include="..\src\messages.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\msvc-full-features\Cataclysm-lib-vcpkg-static.vcxproj">
+    <ProjectReference Include="..\msvc-full-features\Cataclysm-libMZ-vcpkg-static.vcxproj">
       <Project>{0009bb11-11ad-4c14-a5fc-d882a942c00b}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\msvc-full-features\Cataclysm-libAL-vcpkg-static.vcxproj">
+      <Project>{ad10f767-9a9b-43f9-9482-88981cdc95f5}</Project>
     </ProjectReference>
     <ProjectReference Include="ImGui-lib-vcpkg-static.vcxproj">
       <Project>{0c0b2bea-311f-473c-9652-87923ef639e3}</Project>

--- a/msvc-full-features/JsonFormatter-lib-vcpkg-static.vcxproj
+++ b/msvc-full-features/JsonFormatter-lib-vcpkg-static.vcxproj
@@ -126,7 +126,7 @@
     <ClCompile Include="..\tools\format\*.cpp" Exclude="..\tools\format\format_main.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\msvc-full-features\Cataclysm-lib-vcpkg-static.vcxproj">
+    <ProjectReference Include="..\msvc-full-features\Cataclysm-libMZ-vcpkg-static.vcxproj">
       <Project>{0009bb11-11ad-4c14-a5fc-d882a942c00b}</Project>
       <LinkLibraryDependencies>false</LinkLibraryDependencies>
     </ProjectReference>

--- a/msvc-full-features/JsonFormatter-vcpkg-static.vcxproj
+++ b/msvc-full-features/JsonFormatter-vcpkg-static.vcxproj
@@ -141,8 +141,11 @@
     <ClCompile Include="..\tools\format\format_main.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\msvc-full-features\Cataclysm-lib-vcpkg-static.vcxproj">
+    <ProjectReference Include="..\msvc-full-features\Cataclysm-libMZ-vcpkg-static.vcxproj">
       <Project>{0009bb11-11ad-4c14-a5fc-d882a942c00b}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\msvc-full-features\Cataclysm-libAL-vcpkg-static.vcxproj">
+      <Project>{ad10f767-9a9b-43f9-9482-88981cdc95f5}</Project>
     </ProjectReference>
     <ProjectReference Include="..\msvc-full-features\JsonFormatter-lib-vcpkg-static.vcxproj">
       <Project>{534a4e38-96a1-40e4-bda7-8d17607f0270}</Project>


### PR DESCRIPTION
#### Summary
Build "Split the MSVC static library into two projects"

#### Purpose of change
Fixes #87240. The Windows CI static library crossed the 4GB COFF archive cap (LNK1248) once the new debug console translation units landed, since `/Z7` bakes full debug info into every object.

#### Describe the solution
Split the Cataclysm lib into two static libs by source filename: `libAL` (a-l) and `libMZ` (m-z), each linked into the game, test, and JsonFormatter exes. I picked the a-l/m-z boundary by adding up source and object sizes from my Linux dev build, which lands near a clean 50/50, so each archive sits around 2GB with room to spare. New files auto-route by first letter and full debug info is kept everywhere. `libMZ` is the renamed original and still owns the prebuild, version.h, shader, and natvis steps; `libAL` is compile-only.

#### Describe alternatives you've considered
Thin archives, but the lld shipping with VS doesn't play nicely with them and it'd force everyone to install clang alongside VS (https://github.com/CleverRaven/Cataclysm-DDA/pull/87098#issuecomment-4531648259).

Dropping debug info from the heaviest TUs also works but loses symbols, the opposite of what you want.

#### Testing
CI + reviews

#### Additional context
A no-brainer uuidgen plus grep plus sed job; I don't do Windows sorry!