### PR TITLE
labyrinth level 2 slightly less tedious to explore

### DIFF
--- a/data/json/mapgen/netherum/labyrinth2_overgrown_labyrinth.json
+++ b/data/json/mapgen/netherum/labyrinth2_overgrown_labyrinth.json
@@ -54,6 +54,55 @@
       "fill_ter": "t_nl_metal_floor",
       "rows": [
         "vvvvvvvvv#    #vvvvvvvvv",
+        "vvvvvvvvv#    #vvvvvvvvv",
+        "vvvvvvvvv#    #vvvvvvvvv",
+        "vvvvvvvvv#    #vvvvvvvvv",
+        "vvvvvvv###    #vvvvvvvvv",
+        "vvvvvvv#<o    #vvvvvvvvv",
+        "vvvvvvv###....#vvvvvvvvv",
+        "vvvvvvvvv#....#vvvvvvvvv",
+        "vvvvvvvvv#....#vvvvvvvvv",
+        "##########....##########",
+        "      ............      ",
+        "      ............      ",
+        "      ............      ",
+        "      ............      ",
+        "##########....##########",
+        "vvvvvvvvv#....#vvvvvvvvv",
+        "vvvvvvvvv#....#vvvvvvvvv",
+        "vvvvvvvvv#....#vvvvvvvvv",
+        "vvvvvvvvv#    #vvvvvvvvv",
+        "vvvvvvvvv#    #vvvvvvvvv",
+        "vvvvvvvvv#    #vvvvvvvvv",
+        "vvvvvvvvv#    #vvvvvvvvv",
+        "vvvvvvvvv#    #vvvvvvvvv",
+        "vvvvvvvvv#    #vvvvvvvvv"
+      ],
+      "palettes": [ "labyrinthine_overgrown_palette" ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "computers": {
+        "Ç": { "name": "AltarOS Console", "eocs": [ "EOC_LS_Computer" ], "chat_topics": [ "COMP_LS_Exit_Controls_Temp_overgrown" ] }
+      },
+      "terrain": { "<": "t_nl_stairs_up", "o": "t_nl_archway" },
+      "place_nested": [
+        { "chunks": [ "labyrinth_overgrown_9x9_cave_sw" ], "x": 0, "y": 15 },
+        { "chunks": [ "labyrinth_overgrown_9x9_cave_ne" ], "x": 15, "y": 0 },
+        { "chunks": [ "labyrinth_overgrown_9x9_cave_se" ], "x": 15, "y": 15 },
+        { "chunks": [ [ "null", 80 ], [ "labyrinth_9x9_grass_transition", 20 ] ], "x": 4, "y": 0 },
+        { "chunks": [ [ "null", 80 ], [ "labyrinth_9x9_grass_transition", 20 ] ], "x": 10, "y": 0 },
+        { "chunks": [ [ "null", 80 ], [ "labyrinth_9x9_grass_transition", 20 ] ], "x": 4, "y": 15 },
+        { "chunks": [ [ "null", 80 ], [ "labyrinth_9x9_grass_transition", 20 ] ], "x": 10, "y": 15 },
+        { "chunks": [ [ "labyrinth_stairs_2_to_1_teleporter", 1 ] ], "x": 6, "y": 3, "z": 1 }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": [ "labyrinth_overgrown_entrance" ],
+    "object": {
+      "fill_ter": "t_nl_metal_floor",
+      "rows": [
+        "vvvvvvvvv#    #vvvvvvvvv",
         "vvvvvvvvv#   %#vvvvvvvvv",
         "vvvvvvvvv#    #vvvvvvvvv",
         "vvvvvvvvv# %  #vvvvvvvvv",

--- a/data/json/mapgen/netherum/labyrinth2_rooms_large_nests.json
+++ b/data/json/mapgen/netherum/labyrinth2_rooms_large_nests.json
@@ -28,6 +28,29 @@
       "rotation": [ 0, 3 ],
       "rows": [
         "         ",
+        "         ",
+        "         ",
+        "   ###   ",
+        "   #<o   ",
+        "   ###   ",
+        "         ",
+        "         ",
+        "         "
+      ],
+      "palettes": [ "labyrinth2_nest_palette" ],
+      "terrain": { "<": "t_nl_stairs_up", "o": "t_nl_archway" },
+      "place_nested": [ { "chunks": [ [ "labyrinth_stairs_2_to_1_teleporter", 1 ] ], "x": 2, "y": 2, "z": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "labyrinth2_9x9_square_room_nest",
+    "object": {
+      "mapgensize": [ 9, 9 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "         ",
         " ÇÇÇ ÇÇÇ ",
         "         ",
         " ϴÇÇÇÇϴ  ",
@@ -1100,6 +1123,31 @@
         "           "
       ],
       "palettes": [ "labyrinth2_nest_palette" ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "labyrinth2_9x9_circle_room_nest",
+    "object": {
+      "mapgensize": [ 11, 11 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "           ",
+        "           ",
+        "           ",
+        "           ",
+        "    ###    ",
+        "    #<o    ",
+        "    ###    ",
+        "           ",
+        "           ",
+        "           ",
+        "           "
+      ],
+      "palettes": [ "labyrinth2_nest_palette" ],
+      "terrain": { "<": "t_nl_stairs_up", "o": "t_nl_archway" },
+      "place_nested": [ { "chunks": [ [ "labyrinth_stairs_2_to_1_teleporter", 1 ] ], "x": 3, "y": 3, "z": 1 } ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   }

--- a/data/json/overmap/overmap_terrain/overmap_terrain_netherum_labyrinth.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_netherum_labyrinth.json
@@ -13,7 +13,6 @@
     "type": "overmap_terrain",
     "name": "bosky labyrinth",
     "id": "labyrinth_overgrown_hall",
-    "sym": "_",
     "color": "light_green",
     "see_cost": "high",
     "travel_cost_type": "impassable",
@@ -30,7 +29,7 @@
   },
   {
     "type": "overmap_terrain",
-    "name": "terminal",
+    "name": "root",
     "id": "labyrinth_overgrown_entrance",
     "sym": "O",
     "color": "light_red",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Labyrinth level 2 is _very_ difficult to explore.  I wanted to reduce some of the tedium.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. Changed the overgrown labyrinth to be properly linear, so you can more easily make out entry/exit points
<img width="392" height="267" alt="navigability" src="https://github.com/user-attachments/assets/06418888-d68f-47ca-b263-3f0104a90254" />

2. Renamed the center to "root," since it's not always a terminal.

3. Added some extra stairs back to level 1.  One labyrinth finale has stairs.  Two nested rooms have stairs.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

explored labyrinths with debug

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
