### PR TITLE
Plate hotfix

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -1283,7 +1283,7 @@
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 0.8 },
+          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 0.75 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
@@ -1413,7 +1413,7 @@
         "specifically_covers": [ "arm_lower_l", "arm_lower_r" ],
         "coverage": 100,
         "cover_vitals": 100,
-        "encumbrance": 12
+        "encumbrance": 10
       },
       {
         "material": [
@@ -1545,7 +1545,7 @@
         "specifically_covers": [ "arm_lower_l", "arm_lower_r" ],
         "cover_vitals": 100,
         "coverage": 100,
-        "encumbrance": 18
+        "encumbrance": 15
       },
       {
         "material": [

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -1570,7 +1570,8 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
         "coverage": 100,
-        "cover_vitals": 85
+        "cover_vitals": 85,
+        "encumbrance": 8
       },
       {
         "material": [
@@ -1699,7 +1700,8 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
         "coverage": 100,
-        "cover_vitals": 90
+        "cover_vitals": 90,
+        "encumbrance": 12
       },
       {
         "material": [
@@ -1827,7 +1829,8 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_knee_l", "leg_knee_r", "leg_upper_l", "leg_upper_r" ],
         "cover_vitals": 95,
-        "coverage": 96
+        "coverage": 100,
+        "encumbrance": 15
       },
       {
         "material": [

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -629,14 +629,14 @@
     "armor": [
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 1.55 },
+          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 1.5 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_upper" ],
         "coverage": 100,
-        "encumbrance": 11,
+        "encumbrance": 12,
         "cover_vitals": 92
       },
       {
@@ -652,7 +652,7 @@
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 0.8 },
+          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 0.75 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
@@ -675,7 +675,7 @@
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 88, "thickness": 1.45 },
+          { "type": "lc_steel", "covered_by_mat": 88, "thickness": 1.4 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
@@ -697,19 +697,19 @@
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 90, "thickness": 1.45 },
+          { "type": "lc_steel", "covered_by_mat": 90, "thickness": 1.4 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
         "coverage": 100,
-        "encumbrance": 8,
+        "encumbrance": 10,
         "cover_vitals": 85
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 85, "thickness": 0.75 },
+          { "type": "lc_steel", "covered_by_mat": 85, "thickness": 0.7 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
@@ -720,7 +720,7 @@
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 0.8 },
+          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 0.75 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
@@ -849,7 +849,7 @@
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 98, "thickness": 3 },
+          { "type": "lc_steel", "covered_by_mat": 98, "thickness": 2.5 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
@@ -883,7 +883,7 @@
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 3 },
+          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 2.5 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
@@ -894,14 +894,14 @@
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 3 },
+          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 2.5 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
         "coverage": 100,
-        "encumbrance": 12,
+        "encumbrance": 15,
         "cover_vitals": 90
       },
       {
@@ -1045,7 +1045,7 @@
         "cover_vitals": 100,
         "specifically_covers": [ "torso_upper" ],
         "coverage": 100,
-        "encumbrance": 21
+        "encumbrance": 23
       },
       {
         "material": [
@@ -1103,7 +1103,7 @@
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
         "coverage": 100,
         "cover_vitals": 100,
-        "encumbrance": 18
+        "encumbrance": 20
       },
       {
         "material": [
@@ -1114,7 +1114,7 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_knee_l", "leg_knee_r", "leg_upper_l", "leg_upper_r" ],
         "cover_vitals": 95,
-        "coverage": 96
+        "coverage": 100
       },
       {
         "material": [

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -704,7 +704,7 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
         "coverage": 100,
-        "encumbrance": 10,
+        "encumbrance": 9,
         "cover_vitals": 85
       },
       {

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -1783,14 +1783,14 @@
     "armor": [
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 1.55 },
+          { "type": "lc_steel", "covered_by_mat": 92, "thickness": 1.5 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_upper" ],
         "coverage": 100,
-        "encumbrance": 11,
+        "encumbrance": 12,
         "cover_vitals": 92
       },
       {
@@ -1806,14 +1806,14 @@
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 90, "thickness": 1.45 },
+          { "type": "lc_steel", "covered_by_mat": 90, "thickness": 1.4 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r", "gastropod_foot" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
         "coverage": 100,
-        "encumbrance": 8,
+        "encumbrance": 3,
         "cover_vitals": 85
       },
       {
@@ -1822,10 +1822,11 @@
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
-        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "gastropod_foot" ],
+        "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l" ],
         "coverage": 100,
-        "cover_vitals": 85
+        "cover_vitals": 85,
+        "encumbrance": 2
       }
     ],
     "melee_damage": { "bash": 8 }
@@ -1935,7 +1936,7 @@
     "armor": [
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 3.15 },
+          { "type": "lc_steel", "covered_by_mat": 95, "thickness": 3.1 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
@@ -1947,7 +1948,7 @@
       },
       {
         "material": [
-          { "type": "lc_steel", "covered_by_mat": 98, "thickness": 3 },
+          { "type": "lc_steel", "covered_by_mat": 98, "thickness": 2.5 },
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
@@ -1965,7 +1966,7 @@
         "covers": [ "leg_l", "leg_r", "gastropod_foot" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
         "coverage": 100,
-        "encumbrance": 12,
+        "encumbrance": 6,
         "cover_vitals": 90
       },
       {
@@ -1974,9 +1975,10 @@
           { "type": "lc_steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
-        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r" ],
+        "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l" ],
-        "coverage": 100
+        "coverage": 100,
+        "encumbrance": 4
       }
     ],
     "melee_damage": { "bash": 8 }
@@ -2094,7 +2096,7 @@
         "cover_vitals": 100,
         "specifically_covers": [ "torso_upper" ],
         "coverage": 100,
-        "encumbrance": 21
+        "encumbrance": 23
       },
       {
         "material": [
@@ -2118,7 +2120,7 @@
         "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_hip_gastropod_l", "leg_hip_gastropod_r" ],
         "coverage": 100,
         "cover_vitals": 100,
-        "encumbrance": 18
+        "encumbrance": 8
       },
       {
         "material": [
@@ -2129,7 +2131,8 @@
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r" ],
         "coverage": 100,
-        "cover_vitals": 100
+        "cover_vitals": 100,
+        "encumbrance": 5
       }
     ],
     "melee_damage": { "bash": 8 }


### PR DESCRIPTION
#### Summary
Balance "Add encumbrances I missed!"

#### Purpose of change

It came to my attention that I had forgotten to assign encumbrances to leg plate armor!!

#### Describe the solution

Fixed that, and adjusted some protection values and encumbrances after having had time to test plate myself through playing. Leg encumbrance increased to original values for heavy and medium plate. Medium plate lower torso made thinner. Light plate torso encumbrance increased slightly, Adjusted values of standalone armor pieces! 

#### Describe alternatives you've considered

N/A

#### Testing

Loaded up game. Works, leg plate has values it should have and the rest is adjusted appropriately.

#### Additional context

Game balance truly is a flat circle.

Sorry for all the mistakes, should have been more thorough :( 
