### PR TITLE
fix: compare menu shown under crafting menu

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -834,6 +834,14 @@ cataimgui::window::~window()
     }
 }
 
+void cataimgui::window::hide_if_hidden() const
+{
+    if( hide_ui ) {
+        ImGuiWindow *w = ImGui::GetCurrentWindowRead();
+        ImGui::SetWindowHiddenAndSkipItemsForCurrentFrame( w );
+    }
+}
+
 bool cataimgui::window::is_bounds_changed()
 {
     return p_impl->is_resized;

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -159,6 +159,7 @@ class window
 
     protected:
         bool force_to_back = false;
+        bool hide_ui = false;
         bool is_open;
         std::string id;
         int window_flags;
@@ -166,6 +167,7 @@ class window
         virtual bounds get_bounds();
         virtual void draw_controls() = 0;
         void draw_filter( const input_context &ctxt, bool filtering_active );
+        void hide_if_hidden() const;
 };
 
 #ifdef TUI

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -613,6 +613,7 @@ cataimgui::bounds crafting_ui_impl::get_bounds()
 
 void crafting_ui_impl::draw_controls()
 {
+    hide_if_hidden();
     // Debug: set to true to show borders around all child regions and table cells
     static constexpr bool debug_layout = false;
     if( debug_layout ) {
@@ -2786,8 +2787,10 @@ void crafting_ui_impl::process_action( const std::string &action_in,
             recalc_unread = highlight_unread;
         }
     } else if( action == "COMPARE" && selection_ok( current, line, false ) ) {
+        hide_ui = true;
         const item recipe_result = get_recipe_result_item( *current[line], *crafter );
         compare_recipe_with_item( recipe_result, *crafter );
+        hide_ui = false;
     } else if( action == "PRIORITIZE_MISSING_COMPONENTS" && selection_ok( current, line, false ) ) {
         uistate.read_recipes.insert( current[line]->ident() );
         recalc_unread = highlight_unread;

--- a/src/surroundings_menu.cpp
+++ b/src/surroundings_menu.cpp
@@ -754,10 +754,7 @@ cataimgui::bounds surroundings_menu::get_bounds()
 
 void surroundings_menu::draw_controls()
 {
-    if( hide_ui ) {
-        ImGuiWindow *w = ImGui::GetCurrentWindowRead();
-        ImGui::SetWindowHiddenAndSkipItemsForCurrentFrame( w );
-    }
+    hide_if_hidden();
     if( ImGui::BeginTabBar( "surroundings tabs" ) ) {
         draw_item_tab();
         draw_monster_tab();

--- a/src/surroundings_menu.h
+++ b/src/surroundings_menu.h
@@ -213,7 +213,6 @@ class surroundings_menu : public cataimgui::window
         surroundings_menu_tab_enum switch_tab = surroundings_menu_tab_enum::num_tabs;
         // auto scrolling when navigating by keyboard
         bool auto_scroll = false;
-        bool hide_ui = false;
 
         int max_gun_range = 0;
         bool highlight_new = false;


### PR DESCRIPTION
#### Summary
Bugfixes "Compare menu shown under crafting menu"

#### Purpose of change

- Fix #87256

#### Describe the solution

As suggested by @mqrause:

 - extract hide_if_hidden method into cataimgui::window
 - use it in crafting menu

#### Describe alternatives you've considered

Migrating inventory selector to ImGui (too much work).

#### Testing

- Look around in `V` menu still works
- Comparing in crafting menu now places menu over ImGui menu.

After the fix:
<img width="1616" height="809" alt="image" src="https://github.com/user-attachments/assets/d4a5fbb7-6650-45c6-bafb-5f3ea7fe2da7" />


#### Additional context

It's really cool, that the crafting menu stays there!