### PR TITLE
Fix search field not losing focus in keybinds menu

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -1078,6 +1078,13 @@ void cataimgui::window::clear_filter()
     }
 }
 
+void cataimgui::window::defocus_filter()
+{
+    if( filter_impl && filter_impl->id != 0 && GImGui->ActiveId == filter_impl->id ) {
+        ImGui::ClearActiveID();
+    }
+}
+
 bool cataimgui::InputFloat( const char *label, float *v, float step, float step_fast,
                             const char *format, ImGuiInputTextFlags flags )
 {

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -155,6 +155,7 @@ class window
         size_t str_height_to_pixels( size_t len );
         std::string get_filter();
         void clear_filter();
+        void defocus_filter();
         void mark_resized();
 
     protected:

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -1080,8 +1080,10 @@ action_id input_context::display_menu( bool permit_execute_action )
             if( action == "QUIT" ) {
                 kb_menu.clear_filter();
                 kb_menu.status = kb_menu_status::show;
+                kb_menu.defocus_filter();
             } else if( action == "TEXT.CONFIRM" ) {
                 kb_menu.status = kb_menu_status::show;
+                kb_menu.defocus_filter();
             }
         } else if( action == "ADD_LOCAL"
                    || raw_input_char == fallback_keys.at( fallback_action::add_local ) ) {

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -738,6 +738,7 @@ void keybindings_ui::draw_controls()
     ImGui::Separator();
 
     if( last_status != status && status == kb_menu_status::show ) {
+        defocus_filter();
         ImGui::SetNextWindowFocus();
     }
     if( ImGui::BeginTable( "KB_KEYS", 4, ImGuiTableFlags_ScrollY ) ) {
@@ -1080,10 +1081,8 @@ action_id input_context::display_menu( bool permit_execute_action )
             if( action == "QUIT" ) {
                 kb_menu.clear_filter();
                 kb_menu.status = kb_menu_status::show;
-                kb_menu.defocus_filter();
             } else if( action == "TEXT.CONFIRM" ) {
                 kb_menu.status = kb_menu_status::show;
-                kb_menu.defocus_filter();
             }
         } else if( action == "ADD_LOCAL"
                    || raw_input_char == fallback_keys.at( fallback_action::add_local ) ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix search field not losing focus in keybinds menu"

#### Purpose of change
In the keybinds menu the search input can remain active after exiting filter mode. This causes further key presses to continue going to the search field instead of menu actions.

#### Describe the solution
Add function to `cata_imgui` for removing focus to the search input when it is active; apply to when you confirm or quit the search field.

#### Describe alternatives you've considered
None.

#### Testing
Compiled in Windows.
Opened up the settings menu and confirmed the search bar loses focus on confirm and quit.

#### Additional context
Fixes #87257