### PR TITLE
make water boiling recipe unattended

### DIFF
--- a/data/json/recipes/food/drinks.json
+++ b/data/json/recipes/food/drinks.json
@@ -1,18 +1,25 @@
 [
   {
     "type": "recipe",
-    "activity_level": "NO_EXERCISE",
     "result": "water_clean",
     "charges": 1,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_DRINKS",
     "skill_used": "cooking",
-    "time": "5 m",
     "autolearn": true,
-    "batch_time_factors": [ 20, 1 ],
-    "qualities": [ { "id": "BOIL", "level": 1 } ],
-    "//": "1u of water_boiling_heat takes 5 m minimum, heat at full power",
-    "tools": [ [ [ "water_boiling_heat", 1, "LIST" ] ] ],
+    "steps": [
+      {
+        "name": "Boiling",
+        "time": "5 m",
+        "//": "1u of water_boiling_heat takes 5 m minimum, heat at full power",
+        "activity_level": "NO_EXERCISE",
+        "qualities": [ { "id": "BOIL", "level": 1 } ],
+        "tools": [ [ [ "water_boiling_heat", 1, "LIST" ] ] ],
+        "batch_time_factors": [ 20, 1 ],
+        "attention": "unattended",
+        "max_time": "30 m"
+      }
+    ],
     "components": [ [ [ "water", 1 ] ] ]
   },
   {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Water boiling is one of the few tasks that people do all the time, so it is a good candidate to make it unattended
#### Describe the solution
Adjust recipe in a way that makes it unattended
#### Describe alternatives you've considered
Remove grace period? i assume leaving boiling water for a while will evaporate it; i was pointed that boiling water in something like microwave do not tend to do this, but i am not sure if `water_boiling_heat` accomodate it

make tablet purification tablets work via unattended crafting - desirable, but requires work
#### Testing
Lot of boiling of water
#### Additional context
Noticed that setting timer for recipe do not actually set anything, at least i never received a message about it when i was outside of reality bub, and just being within reality bub sent a notification even if i didn't ask to set a notification

i kinda do not like that craft of liquids like boiling water spawns solid in-progress item, so, firstly, you can boil 12L of water out of 1L pan in one go, and secondly, because of it, the in-progress item has to be parked and wait for user activation to be poured into bottles, instead of automatically transforming into clean water in whatever pot you boiled it