### PR TITLE
Fix vehicle shape preview not working when installing adjacent to a frame

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -11391,6 +11391,7 @@ void vehicle_activity_actor::complete_vehicle( player_activity &act, Character &
                 break;
             }
             ::vehicle_part &vp_new = veh.part( partnum );
+            here.add_vehicle_to_cache( &veh );
             if( vp_new.info().variants.size() > 1 ) {
                 veh_shape( here, veh ).change_part_shape( vpart_reference( veh, partnum ) );
             }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix vehicle shape preview not working when installing adjacent to a frame"

#### Purpose of change
When installing a vehicle part adjacent to an existing frame, the shape variant preview doesn't work.

#### Describe the solution
Update the vehicle map cache immediately after installing the part before opening the preview menu. Previously the cache had `veh_exists_at` set to false for the new part's position so `veh_at()` returned null and the tile rendered as plain terrain during the preview.

#### Describe alternatives you've considered
None.

#### Testing
Compiled on Windows.
Installed a new frame adjacent to an existing frame. Verified the shape preview worked.
Installed a ram adjacent to a frame. Verified the shape preview worked.

#### Additional context