### PR TITLE
Compound Eyes is now a bodypart

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -2448,7 +2448,7 @@
       },
       {
         "material": [ { "type": "hard_plastic_transp", "covered_by_mat": 100, "thickness": 5 } ],
-        "covers": [ "eyes" ],
+        "covers": [ "eyes", "eyes_compound" ],
         "coverage": 100,
         "encumbrance": 25
       }
@@ -2565,7 +2565,7 @@
           { "type": "hard_plastic_transp", "covered_by_mat": 100, "thickness": 5 },
           { "type": "lc_steel", "covered_by_mat": 15, "thickness": 1 }
         ],
-        "covers": [ "eyes" ],
+        "covers": [ "eyes", "eyes_compound" ],
         "layers": [ "SKINTIGHT", "NORMAL" ],
         "rigid_layer_only": true,
         "coverage": 100,
@@ -2683,13 +2683,13 @@
     "armor": [
       {
         "material": [ { "type": "leather_treated", "covered_by_mat": 100, "thickness": 4 } ],
-        "covers": [ "mouth" ],
+        "covers": [ "mouth", "beak", "muzzle", "insect_proboscis" ],
         "coverage": 100,
         "encumbrance": 35
       },
       {
         "material": [ { "type": "hard_plastic_transp", "covered_by_mat": 100, "thickness": 5 } ],
-        "covers": [ "eyes" ],
+        "covers": [ "eyes", "eyes_compound" ],
         "layers": [ "SKINTIGHT", "NORMAL" ],
         "rigid_layer_only": true,
         "coverage": 100,

--- a/data/json/mutations/limbs_body_parts.json
+++ b/data/json/mutations/limbs_body_parts.json
@@ -165,8 +165,7 @@
     "hit_size": 7,
     "ugliness": 8,
     "drench_capacity": 5,
-    "drying_chance": 60,
-    "drying_increment": 3,
+    "drying_rate": 0.4,
     "limb_scores": [ [ "vision", 0.65 ], [ "night_vis", 0.8 ], [ "reaction", 1.0 ] ],
     "sub_parts": [ "eyes_compound_left", "eyes_compound_right" ],
     "flags": [ "IGNORE_TEMP", "SEESLEEP", "LIMB_UPPER" ]

--- a/data/json/mutations/limbs_body_parts.json
+++ b/data/json/mutations/limbs_body_parts.json
@@ -154,6 +154,24 @@
     "flags": [ "IGNORE_TEMP", "LIMB_UPPER" ]
   },
   {
+    "type": "body_part",
+    "id": "eyes_compound",
+    "name": "compound eyes",
+    "accusative": { "ctxt": "bodypart_accusative", "str": "compound eyes" },
+    "heading": "eyes",
+    "heading_multiple": "eyes",
+    "copy-from": "eyes",
+    "opposite_part": "eyes_compound",
+    "hit_size": 7,
+    "ugliness": 8,
+    "drench_capacity": 5,
+    "drying_chance": 60,
+    "drying_increment": 3,
+    "limb_scores": [ [ "vision", 0.65 ], [ "night_vis", 0.8 ], [ "reaction", 1.0 ] ],
+    "sub_parts": [ "eyes_compound_left", "eyes_compound_right" ],
+    "flags": [ "IGNORE_TEMP", "SEESLEEP", "LIMB_UPPER" ]
+  },
+  {
     "id": "muzzle",
     "//": "Used as a default for similar_bodypart to work for armor.",
     "type": "body_part",

--- a/data/json/mutations/limbs_sublimbs.json
+++ b/data/json/mutations/limbs_sublimbs.json
@@ -139,7 +139,7 @@
     "side": "left",
     "opposite": "eyes_avian_right",
     "name_multiple": "eyes",
-    "name": "right eye",
+    "name": "left eye",
     "similar_bodypart": "eyes_left"
   },
   {
@@ -236,6 +236,26 @@
     "opposite": "eyes_crab_left",
     "name_multiple": "eyestalks",
     "name": "right eyestalk"
+  },
+  {
+    "id": "eyes_compound_left",
+    "type": "sub_body_part",
+    "max_coverage": 50,
+    "parent": "eyes_compound",
+    "side": "left",
+    "opposite": "eyes_compound_right",
+    "name_multiple": "eyes",
+    "name": "left eye"
+  },
+  {
+    "id": "eyes_compound_right",
+    "type": "sub_body_part",
+    "max_coverage": 50,
+    "parent": "eyes_compound",
+    "side": "right",
+    "opposite": "eyes_compound_left",
+    "name_multiple": "eyes",
+    "name": "right eye"
   },
   {
     "id": "muzzle_lips",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5974,14 +5974,15 @@
     "type": "mutation",
     "id": "COMPOUND_EYES",
     "name": { "str": "Compound Eyes" },
-    "description": "Your eyes are compound, like those of an insect.  This increases your Perception by 2 whenever you aren't wearing eyewear.",
+    "description": "Your eyes are compound, like those of an insect.  This increases your reaction time, but your fine detailed vision isn't as acute.",
     "category": [ "INSECT" ],
     "types": [ "EYES" ],
     "prereqs": [ "EYEBULGE" ],
     "points": 2,
     "vitamin_cost": 160,
     "visibility": 9,
-    "ugliness": 5
+    "ugliness": 5,
+    "enchantments": [ { "condition": "ALWAYS", "modified_bodyparts": [ { "lose": "eyes" }, { "gain": "eyes_compound" } ] } ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5982,7 +5982,14 @@
     "vitamin_cost": 160,
     "visibility": 9,
     "ugliness": 5,
-    "enchantments": [ { "condition": "ALWAYS", "modified_bodyparts": [ { "lose": "eyes" }, { "gain": "eyes_compound" } ] } ]
+    "restricts_gear": [ "eyes" ],
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [ { "value": "BONUS_DODGE", "add": 1 } ],
+        "modified_bodyparts": [ { "lose": "eyes" }, { "gain": "eyes_compound" } ]
+      }
+    ]
   },
   {
     "type": "mutation",

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -124,7 +124,6 @@ static const trait_id trait_ARACHNID_ARMS_OK( "ARACHNID_ARMS_OK" );
 static const trait_id trait_CHITIN2( "CHITIN2" );
 static const trait_id trait_CHITIN3( "CHITIN3" );
 static const trait_id trait_CHITIN_FUR3( "CHITIN_FUR3" );
-static const trait_id trait_COMPOUND_EYES( "COMPOUND_EYES" );
 static const trait_id trait_DEBUG_CLOAK( "DEBUG_CLOAK" );
 static const trait_id trait_INSECT_ARMS( "INSECT_ARMS" );
 static const trait_id trait_INSECT_ARMS_OK( "INSECT_ARMS_OK" );
@@ -1014,9 +1013,6 @@ void avatar::reset_stats()
     }
     if( has_trait( trait_CHITIN2 ) || has_trait( trait_CHITIN3 ) || has_trait( trait_CHITIN_FUR3 ) ) {
         add_miss_reason( _( "Your chitin gets in the way." ), 1 );
-    }
-    if( has_trait( trait_COMPOUND_EYES ) && !wearing_something_on( bodypart_id( "eyes" ) ) ) {
-        mod_per_bonus( 2 );
     }
     if( has_trait( trait_INSECT_ARMS ) ) {
         add_miss_reason( _( "Your insect limbs get in the way." ), 2 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Compound Eyes is now a bodypart"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Companion to #87286

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Turns compound eyes into a bodypart.  They now restrict gear on your eyes (oversize gear like the survivor gasmask works on them). They have much better reaction time than human eyes--add in the dragonfly head and you'll have almost double the reaction score. 

Compound eyes also provide 1 bonus dodge (to go with dragonfly head's Balance score bonus). 

They no longer provide a Perception bonus. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Built game without perception bonus. Ran game, mutated compound eyes, had eyes. 

Put on a handmade gas mask, it covered the eyes. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
