### PR TITLE
Use safe_reference for deferred explosion source

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -202,6 +202,11 @@ Creature &Creature::operator=( Creature && ) noexcept = default;
 
 Creature::~Creature() = default;
 
+safe_reference<Creature> Creature::get_safe_reference()
+{
+    return anchor->reference_to( this );
+}
+
 tripoint_bub_ms Creature::pos_bub() const
 {
     return get_map().get_bub( location );

--- a/src/creature.h
+++ b/src/creature.h
@@ -18,6 +18,7 @@
 
 #include "bodypart.h"
 #include "calendar.h"
+#include "cata_lazy.h"
 #include "character_id.h"
 #include "compatibility.h"
 #include "coordinates.h"
@@ -28,6 +29,7 @@
 #include "global_vars.h"
 #include "math_parser_diag_value.h"
 #include "pimpl.h"
+#include "safe_reference.h"
 #include "string_formatter.h"
 #include "translation.h"
 #include "type_id.h"
@@ -807,6 +809,7 @@ class Creature : public viewer
 
         /** The creature's position in absolute coordinates */
         tripoint_abs_ms location;
+        lazy<safe_reference_anchor> anchor;
     protected:
         // Sets the creature's position without any side-effects.
         void set_pos_bub_only( const map &here, const tripoint_bub_ms &p );
@@ -814,6 +817,7 @@ class Creature : public viewer
     public:
         // Sets the creature's position without any side-effects.
         void set_pos_abs_only( const tripoint_abs_ms &loc );
+        safe_reference<Creature> get_safe_reference();
     protected:
         // Invoked when the creature's position changes.
         virtual void on_move( const tripoint_abs_ms &old_pos );

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -541,6 +541,13 @@ bool explosion_processing_active()
     return process_explosions_in_progress;
 }
 
+queued_explosion::queued_explosion( const Creature *source, const tripoint_abs_ms &pos,
+                                    const explosion_data &data )
+    : source( source ? const_cast<Creature *>( source )->get_safe_reference()
+              : safe_reference<Creature>() )
+    , pos( pos )
+    , data( data ) {}
+
 void explosion( const Creature *source, const tripoint_bub_ms &p, const explosion_data &ex )
 {
     _explosions.emplace_back( source, get_map().get_abs( p ), ex );
@@ -1015,10 +1022,10 @@ void process_explosions()
             m.spawn_monsters( true, true );
             g->load_npcs( &m );
             process_explosions_in_progress = false;
-            _make_explosion( &m, ex.source, m.get_bub( ex.pos ), ex.data );
+            _make_explosion( &m, ex.source.get(), m.get_bub( ex.pos ), ex.data );
             m.process_falling();
         } else {
-            _make_explosion( bubble_map, ex.source, bubble_map->get_bub( ex.pos ), ex.data );
+            _make_explosion( bubble_map, ex.source.get(), bubble_map->get_bub( ex.pos ), ex.data );
         }
     }
 }

--- a/src/explosion.h
+++ b/src/explosion.h
@@ -9,6 +9,7 @@
 
 #include "coordinates.h"
 #include "point.h"
+#include "safe_reference.h"
 #include "type_id.h"
 
 class Creature;
@@ -67,12 +68,11 @@ struct explosion_data {
 namespace explosion_handler
 {
 struct queued_explosion {
-    const Creature *source;
+    safe_reference<Creature> source;
     const tripoint_abs_ms pos;
     const explosion_data data;
 
-    queued_explosion( const Creature *source, const tripoint_abs_ms &pos, const explosion_data &data )
-        : source( source ), pos( pos ), data( data ) {}
+    queued_explosion( const Creature *source, const tripoint_abs_ms &pos, const explosion_data &data );
 };
 inline std::vector<queued_explosion> _explosions;
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix heap-buffer-overflow when explosion source dies before deferred flush"

#### Purpose of change
`queued_explosion::source` stored a raw `const Creature *`. The source can die between enqueue and `process_explosions()` flush, and `do_blast` / `shrapnel` dereference it through `pos_abs()`. Observed in https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/26599714280/job/78379945585: ASan heap-buffer-overflow in `monster_can_navigate_from_anywhere_in_reality_bubble`.

#### Describe the solution
Added a `lazy<safe_reference_anchor>` and `get_safe_reference()` to `Creature`, switched `queued_explosion::source` to `safe_reference<Creature>`, and resolved it with `.get()` at flush. Expired refs become `nullptr`, matching the existing no-source path.

#### Describe alternatives you've considered
Storing just `tripoint_abs_ms source_pos` and re-resolving via `creature_at` was tempting but loses attribution if the source moved before flush.

#### Testing
Compiles, game starts. The rest is on CI.

#### Additional context
N/A