### PR TITLE
Fix: AIM `examine menu > activate` overlaps item selection

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2264,7 +2264,13 @@ int game::inventory_item_menu( item_location locThisItem,
                     if( locThisItem.get_item()->type->has_use() &&
                         !locThisItem.get_item()->item_has_uses_recursive( true ) ) { // NOLINT(bugprone-branch-clone)
                         // Item has uses and none of its contents (if any) has uses.
+#if defined(TILES)
+                        action_menu.set_hide( true );
+#endif
                         avatar_action::use_item( u, locThisItem );
+#if defined(TILES)
+                        action_menu.set_hide( false );
+#endif
                     } else if( locThisItem.get_item()->item_has_uses_recursive() ) {
                         game::item_action_menu( locThisItem );
                     } else if( locThisItem.get_item()->has_relic_activation() &&

--- a/src/uilist.cpp
+++ b/src/uilist.cpp
@@ -37,6 +37,7 @@
 void uilist_impl::draw_controls()
 {
 #if defined(TILES)
+    hide_if_hidden();
     using cata::options::mouse;
     bool cursor_shown = IsCursorVisible();
     if( mouse.hidekb && !cursor_shown ) {
@@ -1055,6 +1056,17 @@ void uilist::query_once( input_context &ctxt, int timeout,
 }
 
 ///@}
+#if defined(TILES)
+void uilist::set_hide( bool val )
+{
+    create_or_get_ui()->hide_ui = val;
+}
+
+void uilist::hide_if_hidden()
+{
+    create_or_get_ui()->hide_if_hidden();
+}
+#endif
 /**
  * cleanup
  */

--- a/src/uilist.h
+++ b/src/uilist.h
@@ -429,6 +429,16 @@ class uilist // NOLINT(cata-xy)
 
         void reset();
 
+#if defined(TILES)
+        void set_hide( bool val );
+        /**
+         * Used to hide ImGui menu under old menu.
+         *
+         * FIXME: Remove after complete ImGui migration.
+         */
+        void hide_if_hidden();
+#endif
+
         shared_ptr_fast<uilist_impl> create_or_get_ui();
         // NOLINTNEXTLINE(google-explicit-constructor)
         operator int() const;
@@ -542,6 +552,9 @@ class uilist // NOLINT(cata-xy)
 
 class uilist_impl : public cataimgui::window
 {
+#if defined(TILES)
+        friend class uilist;
+#endif
         uilist &parent;
     public:
         explicit uilist_impl( uilist &parent ) : cataimgui::window( "UILIST",


### PR DESCRIPTION
#### Summary
Bugfixes "AIM `examine menu > activate` overlaps item selection"

#### Purpose of change

 - Fixes #87232.

#### Describe the solution

 - Needs #87259 merged. Will not compile otherwise.

Hide `AIM > examine item` created `uilist` behind non-ImGui menu, once action `activate` (specifically) is selected.

#### Describe alternatives you've considered

 - Migrate item selector to ImGui (everything in CDDA uses item selector!).
 - Make `cataimgui:window:hide_ui` & `hide_if_hidden` public.
 - use the member variable `weak_ptr_fast<uilist_impl> ui` instead of `create_or_get_ui()`. Then `uilist::hide_if_hidden` could be `const`.

#### Testing

setup (then press enter):

<img width="966" height="439" alt="image" src="https://github.com/user-attachments/assets/1d12530b-7362-40b4-b6b7-667deb70055d" />

MOLLE issue (before):
<img width="375" height="402" alt="image" src="https://github.com/user-attachments/assets/552a4f71-5bb5-4f31-bc7b-5c5d16efe2c0" />

<img width="731" height="437" alt="image" src="https://github.com/user-attachments/assets/2e5cc9fe-c9d5-4c1e-9941-ff774f9c1ac6" />




MOLLE fixed (after):
<img width="371" height="420" alt="image" src="https://github.com/user-attachments/assets/4467f697-e570-4f17-b16b-dbc84677eae7" />

<img width="730" height="429" alt="image" src="https://github.com/user-attachments/assets/8b518e2b-8176-4285-bb90-589dd16edb7a" />

Also works, for example, for `pocket knife > activate > write on item`, since it also is an item selection triggered from AIM (before pic, after just hides the ui):

<img width="827" height="431" alt="image" src="https://github.com/user-attachments/assets/d95a0a99-5e16-4072-bb8e-67afa7a160ce" />



#### Additional context
