### PR TITLE
Migrate minesweeper to ImGui number_input_popup

### DIFF
--- a/src/iuse_software_minesweeper.cpp
+++ b/src/iuse_software_minesweeper.cpp
@@ -11,11 +11,11 @@
 #include "coordinates.h"
 #include "cursesdef.h"
 #include "input_context.h"
+#include "input_popup.h"
 #include "output.h"
 #include "point.h"
 #include "rng.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "translations.h"
 #include "ui_helpers.h"
 #include "ui_manager.h"
@@ -38,11 +38,9 @@ void minesweeper_game::new_level()
                 iVal = iMin;
             }
 
-            string_input_popup()
-            .title( sType )
-            .width( 5 )
-            .description( desc )
-            .edit( iVal );
+            number_input_popup<int> popup( 0, iVal, sType );
+            popup.set_description( desc );
+            iVal = popup.query();
         } while( iVal < iMin || iVal > iMax );
     };
 


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Part of #78465 — migrating away from the legacy `string_input_popup` to the ImGui-based popups in `input_popup.h`. This converts the minesweeper software game's custom-difficulty number entry (level width, level height, bomb count).

#### Describe the solution
- Replace `string_input_popup().title( sType ).width( 5 ).description( desc ).edit( iVal )` with `number_input_popup<int>` + `set_description()` + `query()`.
- Swap `#include "string_input_popup.h"` for `#include "input_popup.h"`.
- Pass width `0` so the popup auto-sizes to its description, matching the other migrated numeric popups.

Behavior is preserved: integer-only entry, the "Min: X Max: Y" hint as the description, the value left unchanged on cancel (`query()` returns the old value), and the surrounding `do/while` still re-validates the `[min, max]` range.

#### Describe alternatives you've considered
n/a

#### Testing
Compiles cleanly with `make TILES=1 RELEASE=1` (clang, `-Werror`). The migrated prompts are the three custom-difficulty inputs reached via Minesweeper → Custom.

#### Additional context
One of the files that still included `string_input_popup.h`.