### PR TITLE
Migrate zone manager faction filter to ImGui input_popup

### DIFF
--- a/src/zone_manager_ui.cpp
+++ b/src/zone_manager_ui.cpp
@@ -12,6 +12,7 @@
 #include "game.h"
 #include "line.h"
 #include "input_context.h"
+#include "input_popup.h"
 #include "map.h"
 #include "options.h"
 #include "output.h"
@@ -19,7 +20,6 @@
 #include "panels.h"
 #include "popup.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "translations.h"
 #include "uilist.h"
 #include "ui_manager.h"
@@ -620,11 +620,10 @@ void zone_manager_ui::display_zone_manager()
         } else if( action == "CHANGE_FACTION" ) {
             ui.invalidate_ui();
             std::string facname = zones_faction.str();
-            string_input_popup()
-            .description( _( "Show zones for faction:" ) )
-            .width( 55 )
-            .max_length( 256 )
-            .edit( facname );
+            string_input_popup_imgui popup( 55, facname );
+            popup.set_description( _( "Show zones for faction:" ) );
+            popup.set_max_input_length( 256 );
+            facname = popup.query();
             zones_faction = faction_id( facname );
             zones = get_zones();
         } else if( action == "QUIT" ) {


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Part of #78465 — migrating away from the legacy `string_input_popup` to the ImGui-based popups in `input_popup.h`. This converts the "Show zones for faction" text entry in the zone manager (the `CHANGE_FACTION` action).

#### Describe the solution
- Replace `string_input_popup().description(...).width(55).max_length(256).edit(facname)` with `string_input_popup_imgui` + `set_description()` + `set_max_input_length()` + `query()`.
- Swap `#include "string_input_popup.h"` for `#include "input_popup.h"`.

Behavior is preserved: the description prompt, the 256-character limit, and the value being left unchanged on cancel (`query()` returns the old input).

#### Describe alternatives you've considered
n/a

#### Testing
Compiles cleanly with `make TILES=1 RELEASE=1` (clang, `-Werror`).

#### Additional context
One of the files that still included `string_input_popup.h` (#78465).