### PR TITLE
Migrate appliance rename to ImGui input_popup

### DIFF
--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -19,6 +19,7 @@
 #include "game.h"
 #include "handle_liquid.h"
 #include "input_enums.h"
+#include "input_popup.h"
 #include "inventory.h"
 #include "item_location.h"
 #include "itype.h"
@@ -32,7 +33,6 @@
 #include "requirements.h"
 #include "ret_val.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "translations.h"
 #include "ui_manager.h"
 #include "uilist.h"
@@ -522,10 +522,8 @@ void veh_app_interact::siphon( map &here )
 
 void veh_app_interact::rename()
 {
-    std::string name = string_input_popup()
-                       .title( _( "Enter new appliance name:" ) )
-                       .width( 20 )
-                       .query_string();
+    string_input_popup_imgui popup( 0, "", _( "Enter new appliance name:" ) );
+    std::string name = popup.query();
     if( !name.empty() ) {
         veh->name = name;
         if( veh->tracking_on ) {


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Part of #78465 — migrating away from the legacy `string_input_popup` to the ImGui-based popups in `input_popup.h`. This converts the "Enter new appliance name" entry in `veh_app_interact::rename()`.

#### Describe the solution
- Replace `string_input_popup().title(...).width(20).query_string()` with `string_input_popup_imgui` + `query()`.
- Swap `#include "string_input_popup.h"` for `#include "input_popup.h"`.

Behavior is preserved: on cancel the old `query_string()` cleared its text and returned `""`, and the new `query()` returns the (empty) old input, so the `!name.empty()` guard still skips the rename. Width `0` auto-sizes the popup to fit the prompt (the old `.width(20)` was the field width; in the new API width is the window width).

#### Describe alternatives you've considered
n/a

#### Testing
Compiles cleanly with `make TILES=1 RELEASE=1` (clang, `-Werror`).

#### Additional context
One of the files that still included `string_input_popup.h` (#78465).