### PR TITLE
Migrate remaining simple string_input_popup uses and drop stale includes

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -195,7 +195,6 @@
 #include "start_location.h"
 #include "stats_tracker.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "surroundings_menu.h"
 #include "talker.h"
 #include "text_snippets.h"

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -34,7 +34,6 @@
 #include "sdltiles.h" // IWYU pragma: keep
 #include "cursesport.h" // IWYU pragma: keep
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "translations.h"
 #include "ui_manager.h"
 #include "sdl_gamepad.h"

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -33,7 +33,6 @@
 #include "sdlsound.h"
 #include "sounds.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "system_locale.h"
 #include "translations.h"
 #include "try_parse_integer.h"
@@ -972,11 +971,11 @@ void options_manager::cOpt::setNext()
 
     } else if( sType == "string_input" ) {
         int iMenuTextLength = utf8_width( sMenuText.translated() );
-        string_input_popup()
-        .width( iMaxLength > 80 ? 80 : iMaxLength < iMenuTextLength ? iMenuTextLength : iMaxLength + 1 )
-        .title( sMenuText.translated() )
-        .max_length( iMaxLength )
-        .edit( sSet );
+        string_input_popup_imgui popup(
+            iMaxLength > 80 ? 80 : iMaxLength < iMenuTextLength ? iMenuTextLength : iMaxLength + 1,
+            sSet, sMenuText.translated() );
+        popup.set_max_input_length( iMaxLength );
+        sSet = popup.query();
 
     } else if( sType == "bool" ) {
         bSet = !bSet;


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Part of #78465 — working toward zero `#include "string_input_popup.h"`. This cleans up the remaining straightforward cases.

#### Describe the solution
- **options.cpp**: migrate the `"string_input"` option-value editor from `string_input_popup().width(...).title(...).max_length(...).edit(sSet)` to `string_input_popup_imgui` + `set_max_input_length()` + `query()`. `query()` returns the old value on cancel, matching the previous `.edit()`; the width expression already accounts for the menu-text length so the popup won't clip.
- **game.cpp**: drop the now-unused `#include "string_input_popup.h"` — its popup already uses `string_input_popup_imgui`.
- **input_context.cpp**: drop the `#include "string_input_popup.h"`, which was unused.

Left for separate, individually-tested PRs: shared helpers (`output.cpp`'s `query_int`) and the popups held as `unique_ptr` members wired into custom UI (`inventory_ui.cpp`, `advanced_inv.cpp`, `messages.cpp`, etc.).

#### Describe alternatives you've considered
n/a

#### Testing
Compiles cleanly with `make TILES=1 RELEASE=1` (clang, `-Werror`).

#### Additional context
Part of #78465.