### PR TITLE
Bump android release workflow java version to 17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -591,8 +591,8 @@ jobs:
         if: runner.os == 'Linux' && matrix.android != 'none'
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
-          java-version: '11'
-          distribution: 'adopt'   
+          java-version: '17'
+          distribution: 'temurin'   
       - name: Setup Build and Dependencies (android)
         if: runner.os == 'Linux' && matrix.android != 'none'
         run: |


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #87317

#### Describe the solution

Bump the version like it was bumped for CI workflows in #87290 

#### Describe alternatives you've considered



#### Testing



#### Additional context

