### PR TITLE
[XEDRA Evolved] Fix XE dream snippets not appearing

### DIFF
--- a/data/mods/Xedra_Evolved/eocs/eoc_conditions.json
+++ b/data/mods/Xedra_Evolved/eocs/eoc_conditions.json
@@ -133,7 +133,7 @@
     "condition": { "or": [ { "one_in_chance": 2 }, { "u_has_effect": "effect_hedge_no_nightmares" } ] },
     "effect": [
       { "u_message": "You have a good dream.", "type": "neutral" },
-      { "u_message": "sweet_dreams", "snippet": true, "type": "good" },
+      { "u_message": "XE_SWEET_DREAMS", "snippet": true, "type": "good" },
       { "u_add_morale": "morale_sweet_dreams", "bonus": [ 15, 40 ], "max_bonus": 40 },
       { "math": [ "dream_counter = 1" ] },
       { "u_cast_spell": { "id": "dream_mana_gain" } },
@@ -141,7 +141,7 @@
     ],
     "false_effect": [
       { "u_message": "You have a bad dream.", "type": "neutral" },
-      { "u_message": "nightmares", "snippet": true, "type": "bad" },
+      { "u_message": "XE_BAD_DREAMS", "snippet": true, "type": "bad" },
       { "u_add_morale": "morale_nightmare", "bonus": [ -15, -40 ], "max_bonus": -40 },
       { "math": [ "dream_counter = 1" ] },
       { "u_cast_spell": { "id": "nightmare_mana_gain" } },


### PR DESCRIPTION


#### Summary
None

#### Purpose of change

Fix the issue of XE good dreams not receiving a snippet. also changes the nightmare's snippet to the XE one for consistency's sake.
#### Describe the solution

`sweet_dreams` -> `XE_SWEET_DREAMS`
`nightmares` -> `XE_BAD_DREAMS`

#### Describe alternatives you've considered

Not changing the nightmare to the XE made one?

#### Testing
<img width="303" height="205" alt="Screenshot_20260531_122004" src="https://github.com/user-attachments/assets/9701a3a5-6d4c-4997-a2f8-7f3d77fdac89" />

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
