### PR TITLE
Fix crafting performance

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6427,8 +6427,20 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     craft.item_counter = std::min( craft.item_counter, 10000000 );
 
     // Step transitions: accumulate work and advance through step boundaries.
+    // Each closing step gets a final non-charged tool sweep before its index
+    // is incremented; a missing tool rewinds the whole turn.
     int old_step = 0;
     double old_step_progress = 0.0;
+    const auto rewind_turn = [&]() {
+        if( rec.has_steps() ) {
+            craft.set_current_step( old_step );
+            craft.set_step_progress( old_step_progress );
+        }
+        craft.item_counter = old_counter;
+        crafter.set_moves( old_moves );
+        craft.erase_var( "crafter" );
+        crafter.cancel_activity();
+    };
     if( rec.has_steps() ) {
         old_step = craft.get_current_step();
         old_step_progress = craft.get_step_progress();
@@ -6441,22 +6453,28 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
             if( craft.get_step_progress() < budget ) {
                 break;
             }
+            if( !crafter.verify_step_tools( craft, craft.get_current_step(),
+                                            crafter.pos_bub(), PICKUP_RANGE, /*pin_to_map=*/false ) ) {
+                rewind_turn();
+                return;
+            }
             craft.set_step_progress( craft.get_step_progress() - budget );
             craft.set_current_step( craft.get_current_step() + 1 );
         }
     }
-    // Consume tools to match progress: per recipe step, or the whole recipe as a
-    // single implicit step for stepless recipes.  A charge shortfall rewinds this
-    // turn's step and counter state before any skill gain.
-    if( !crafter.craft_consume_step_tools( craft ) ) {
-        if( rec.has_steps() ) {
-            craft.set_current_step( old_step );
-            craft.set_step_progress( old_step_progress );
+    // Verify before debit so a rejected closure does not burn charges first.
+    if( craft.item_counter >= 10000000 ) {
+        const int closing_step = rec.has_steps()
+                                 ? static_cast<int>( rec.steps().size() ) - 1 : 0;
+        if( !crafter.verify_step_tools( craft, closing_step,
+                                        crafter.pos_bub(), PICKUP_RANGE, /*pin_to_map=*/false ) ) {
+            rewind_turn();
+            return;
         }
-        craft.item_counter = old_counter;
-        crafter.set_moves( old_moves );
-        craft.erase_var( "crafter" );
-        crafter.cancel_activity();
+    }
+    // Charge shortfall rewinds the turn before any skill gain.
+    if( !crafter.craft_consume_step_tools( craft ) ) {
+        rewind_turn();
         return;
     }
 

--- a/src/character.h
+++ b/src/character.h
@@ -3851,12 +3851,14 @@ class Character : public Creature, public visitable
          *  wall-clock progress.  Returns false (consuming nothing) if charges are short. */
         bool craft_consume_passive_step_tools( item &craft, time_point now, const item_location &loc );
         /** Consume each step's tool allocations up to its 5% bucket target.
-         *  active_step is the in-progress step, whose non-charged selected tools are
-         *  re-checked for presence every call (even once their buckets are full) so a
-         *  tool removed before completion cannot finish the step.  When pin_to_map is
-         *  set, usage_from::player and usage_from::both allocations draw from the map
-         *  at origin instead of the crafter.  Returns false (consuming nothing) on a
-         *  shortfall. */
+         *  active_step is the in-progress step; its non-charged selected tools
+         *  are re-checked for presence on bucket transitions and during the
+         *  step's final 5% drift (once buckets are full but the step has not
+         *  completed) so a tool removed in that window cannot finish the step.
+         *  Mid-bucket turns skip the check to avoid rebuilding a nearby-item
+         *  inventory each tick.  When pin_to_map is set, usage_from::player and
+         *  usage_from::both allocations draw from the map at origin instead of
+         *  the crafter.  Returns false (consuming nothing) on a shortfall. */
         bool consume_step_tool_targets( item &craft, const std::vector<int> &targets,
                                         int active_step, const tripoint_bub_ms &origin, int radius,
                                         bool pin_to_map );

--- a/src/character.h
+++ b/src/character.h
@@ -3851,17 +3851,24 @@ class Character : public Creature, public visitable
          *  wall-clock progress.  Returns false (consuming nothing) if charges are short. */
         bool craft_consume_passive_step_tools( item &craft, time_point now, const item_location &loc );
         /** Consume each step's tool allocations up to its 5% bucket target.
-         *  active_step is the in-progress step; its non-charged selected tools
-         *  are re-checked for presence on bucket transitions and during the
-         *  step's final 5% drift (once buckets are full but the step has not
-         *  completed) so a tool removed in that window cannot finish the step.
-         *  Mid-bucket turns skip the check to avoid rebuilding a nearby-item
-         *  inventory each tick.  When pin_to_map is set, usage_from::player and
-         *  usage_from::both allocations draw from the map at origin instead of
-         *  the crafter.  Returns false (consuming nothing) on a shortfall. */
+         *  Non-charged selected tools are re-checked for presence on bucket
+         *  transitions only; verify_step_tools catches tools removed within a
+         *  bucket when the step closes.  When pin_to_map is set,
+         *  usage_from::player and usage_from::both allocations draw from the
+         *  map at origin instead of the crafter.  Returns false (consuming
+         *  nothing) on a shortfall. */
         bool consume_step_tool_targets( item &craft, const std::vector<int> &targets,
-                                        int active_step, const tripoint_bub_ms &origin, int radius,
+                                        const tripoint_bub_ms &origin, int radius,
                                         bool pin_to_map );
+        /** Verify that every non-charged tool selected for a recipe step is
+         *  present at the source the step draws from.  Emits a player-visible
+         *  message naming the missing tool on failure and clears the craft's
+         *  tools_to_continue flag so resume re-validates and reselects.
+         *  Charged tools are outside the scope: their availability is enforced
+         *  when consumed.  When pin_to_map is set, presence is checked against
+         *  the map at origin instead of the crafter. */
+        bool verify_step_tools( item &craft, int step_idx,
+                                const tripoint_bub_ms &origin, int radius, bool pin_to_map );
         void consume_tools( const comp_selection<tool_comp> &tool, int batch );
         void consume_tools( map &m, const comp_selection<tool_comp> &tool, int batch,
                             const tripoint_bub_ms &origin = tripoint_bub_ms::zero, int radius = PICKUP_RANGE,

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1619,11 +1619,22 @@ static void craft_actualize_ready( item &craft, time_point now, const item_locat
         return;
     }
 
+    // Verify before debit so a rejected closure does not burn charges first.
+    Character *consumer = resolve_consume_crafter( craft, loc );
+    if( consumer != nullptr ) {
+        const step_source_context src = resolve_step_source( craft, loc );
+        if( !consumer->verify_step_tools( craft, step_idx, src.origin, src.radius,
+                                          /*pin_to_map=*/src.present_char == nullptr ) ) {
+            craft_enter_env_pause( craft, now, loc );
+            return;
+        }
+    }
+
     // Drain the step's charged tools to current progress (the full allocation at
     // completion); a shortfall re-pauses.  Runs before the restored-but-not-ready
     // return below, since craft_check_env_step only restores on qualities: a pause
     // for missing charges must not clear while the charges are still short.
-    if( Character *consumer = resolve_consume_crafter( craft, loc ) ) {
+    if( consumer != nullptr ) {
         if( !consumer->craft_consume_passive_step_tools( craft, now, loc ) ) {
             craft_enter_env_pause( craft, now, loc );
             return;
@@ -3571,7 +3582,7 @@ static int step_buckets_for_fraction( double f )
 }
 
 bool Character::consume_step_tool_targets( item &craft, const std::vector<int> &targets,
-        int active_step, const tripoint_bub_ms &origin, int radius, bool pin_to_map )
+        const tripoint_bub_ms &origin, int radius, bool pin_to_map )
 {
     std::vector<std::vector<step_tool_alloc>> allocs = craft.get_step_tool_allocs();
 
@@ -3599,13 +3610,10 @@ bool Character::consume_step_tool_targets( item &craft, const std::vector<int> &
         for( int a = 0; a < static_cast<int>( allocs[s].size() ); ++a ) {
             step_tool_alloc &alloc = allocs[s][a];
             if( alloc.sel.comp.count <= 0 ) {
-                // Re-check non-charged tool presence on bucket transitions, and
-                // also during the active step's final 5% drift (buckets full but
-                // step not yet complete) so a tool removed in that window cannot
-                // finish the step.  Skipping the mid-bucket case avoids
-                // rebuilding nearby-item inventory each tick.
-                const bool active_drift = s == active_step && alloc.consumed_buckets >= 20;
-                if( tgt > alloc.consumed_buckets || active_drift ) {
+                // Re-check non-charged tool presence on bucket transitions only;
+                // verify_step_tools sweeps the step at completion to catch a
+                // tool removed within the final bucket.
+                if( tgt > alloc.consumed_buckets ) {
                     presence.push_back( { alloc.sel.comp.type, s, a, tgt } );
                 }
                 continue;
@@ -3724,6 +3732,44 @@ bool Character::consume_step_tool_targets( item &craft, const std::vector<int> &
     return true;
 }
 
+bool Character::verify_step_tools( item &craft, int step_idx,
+                                   const tripoint_bub_ms &origin, int radius, bool pin_to_map )
+{
+    if( has_trait( trait_DEBUG_HS ) ) {
+        return true;
+    }
+    const std::vector<std::vector<step_tool_alloc>> &allocs = craft.get_step_tool_allocs();
+    if( step_idx < 0 || step_idx >= static_cast<int>( allocs.size() ) ) {
+        return true;
+    }
+    std::optional<inventory> map_inv;
+    const auto get_map_inv = [&]() -> const inventory & {
+        if( !map_inv )
+        {
+            map_inv.emplace();
+            map_inv->form_from_map( origin, radius, this );
+        }
+        return *map_inv;
+    };
+    for( const step_tool_alloc &alloc : allocs[step_idx] ) {
+        if( alloc.sel.comp.count > 0 ) {
+            continue;
+        }
+        const bool present = pin_to_map ? get_map_inv().has_tools( alloc.sel.comp.type, 1 )
+                             : crafting_inventory().has_tools( alloc.sel.comp.type, 1 );
+        if( !present ) {
+            add_msg_player_or_npc(
+                _( "You no longer have the %s and can't continue crafting." ),
+                _( "<npcname> no longer has the %s and can't continue crafting." ),
+                item::nname( alloc.sel.comp.type ) );
+            // Resume must reselect; otherwise an OR alternative is unreachable.
+            craft.set_tools_to_continue( false );
+            return false;
+        }
+    }
+    return true;
+}
+
 bool Character::craft_consume_step_tools( item &craft )
 {
     if( has_trait( trait_DEBUG_HS ) ) {
@@ -3753,7 +3799,7 @@ bool Character::craft_consume_step_tools( item &craft )
             targets[s] = step_buckets_for_fraction( budget > 0.0 ? cur_progress / budget : 1.0 );
         }
     }
-    return consume_step_tool_targets( craft, targets, rec.has_steps() ? cur_step : 0,
+    return consume_step_tool_targets( craft, targets,
                                       pos_bub(), PICKUP_RANGE, /*pin_to_map=*/false );
 }
 
@@ -3797,7 +3843,7 @@ bool Character::craft_consume_passive_step_tools( item &craft, time_point now,
         }
     }
     const step_source_context src = resolve_step_source( craft, loc );
-    return consume_step_tool_targets( craft, targets, cur_step, src.origin, src.radius,
+    return consume_step_tool_targets( craft, targets, src.origin, src.radius,
                                       /*pin_to_map=*/src.present_char == nullptr );
 }
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -3599,10 +3599,13 @@ bool Character::consume_step_tool_targets( item &craft, const std::vector<int> &
         for( int a = 0; a < static_cast<int>( allocs[s].size() ); ++a ) {
             step_tool_alloc &alloc = allocs[s][a];
             if( alloc.sel.comp.count <= 0 ) {
-                // step_buckets_for_fraction reaches 20 before the step is ready,
-                // so a tool removed after its last bucket must still be re-checked
-                // here or the final true-up would finish using a tool that is gone.
-                if( s == active_step ? tgt > 0 : tgt > alloc.consumed_buckets ) {
+                // Re-check non-charged tool presence on bucket transitions, and
+                // also during the active step's final 5% drift (buckets full but
+                // step not yet complete) so a tool removed in that window cannot
+                // finish the step.  Skipping the mid-bucket case avoids
+                // rebuilding nearby-item inventory each tick.
+                const bool active_drift = s == active_step && alloc.consumed_buckets >= 20;
+                if( tgt > alloc.consumed_buckets || active_drift ) {
                     presence.push_back( { alloc.sel.comp.type, s, a, tgt } );
                 }
                 continue;
@@ -3638,8 +3641,6 @@ bool Character::consume_step_tool_targets( item &craft, const std::vector<int> &
 
     // Aggregate the required charges per tool type, then preflight, so shared
     // pools cannot pass per-alloc yet fail in total.
-    inventory map_inv;
-    map_inv.form_from_map( origin, radius, this );
     std::map<itype_id, int> need_player;
     std::map<itype_id, int> need_map;
     std::map<itype_id, int> need_both;
@@ -3659,11 +3660,23 @@ bool Character::consume_step_tool_targets( item &craft, const std::vector<int> &
                 break;
         }
     }
+    // form_from_map is expensive in dense areas; defer it until a map-sourced
+    // check actually needs it.  Active crafts with player-held tools never hit
+    // need_map and pin_to_map=false, so the inventory is never built.
+    std::optional<inventory> map_inv;
+    const auto get_map_inv = [&]() -> const inventory & {
+        if( !map_inv )
+        {
+            map_inv.emplace();
+            map_inv->form_from_map( origin, radius, this );
+        }
+        return *map_inv;
+    };
     const auto shortfall = [&]( const std::map<itype_id, int> &need, int which ) -> bool {
         for( const std::pair<const itype_id, int> &n : need )
         {
             bool ok = which == 0 ? has_charges( n.first, n.second )
-            : which == 1 ? map_inv.has_charges( n.first, n.second )
+            : which == 1 ? get_map_inv().has_charges( n.first, n.second )
             : crafting_inventory().has_charges( n.first, n.second );
             if( !ok ) {
                 add_msg_player_or_npc(
@@ -3679,7 +3692,7 @@ bool Character::consume_step_tool_targets( item &craft, const std::vector<int> &
     for( const pending_presence &p : presence ) {
         // Source the presence check the same way charges are: from the craft tile
         // when the crafter is out of reach, otherwise from the crafter.
-        const bool present = pin_to_map ? map_inv.has_tools( p.type, 1 )
+        const bool present = pin_to_map ? get_map_inv().has_tools( p.type, 1 )
                              : crafting_inventory().has_tools( p.type, 1 );
         if( !present ) {
             add_msg_player_or_npc(

--- a/tests/craft_attention_test.cpp
+++ b/tests/craft_attention_test.cpp
@@ -15,6 +15,7 @@
 #include "crafting.h"
 #include "crafting_enums.h"
 #include "flexbuffer_json.h"
+#include "game_constants.h"
 #include "item.h"
 #include "item_components.h"
 #include "item_location.h"
@@ -1276,10 +1277,32 @@ TEST_CASE( "craft_unattended_noncharged_tool_offset_crafter_uses_map_source",
 
         WHEN( "the tool is gone at the completion true-up" ) {
             here.i_rem( craft_pos, &tool );
+            on_map.set_tools_to_continue( true );
 
-            THEN( "completion re-checks presence and the step does not finish free" ) {
-                CHECK_FALSE( u.craft_consume_passive_step_tools(
-                                 on_map, calendar::turn + 10_minutes, loc ) );
+            THEN( "the verifier fails and clears tools_to_continue" ) {
+                CHECK_FALSE( u.verify_step_tools( on_map, 1, craft_pos, PICKUP_RANGE,
+                                                  /*pin_to_map=*/true ) );
+                CHECK_FALSE( on_map.has_tools_to_continue() );
+            }
+        }
+    }
+
+    GIVEN( "ready dispatch fires with the non-charged tool missing" ) {
+        on_map.set_step_plans( std::vector<attention_plan>( 2 ) );
+        on_map.set_tools_to_continue( true );
+        std::vector<std::vector<step_tool_alloc>> drift_allocs = on_map.get_step_tool_allocs();
+        drift_allocs[1][0].consumed_buckets = 20;
+        on_map.set_step_tool_allocs( drift_allocs );
+
+        WHEN( "craft_actualize_scheduled runs the ready_check handler" ) {
+            craft_actualize_scheduled( on_map, item_wakeup_kind::ready_check,
+                                       calendar::turn + 10_minutes, loc );
+
+            THEN( "the step pauses without closing and tools_to_continue clears" ) {
+                REQUIRE( loc.get_item() != nullptr );
+                CHECK( on_map.get_current_step() == 1 );
+                CHECK( on_map.get_pause_started_at() == calendar::turn + 10_minutes );
+                CHECK_FALSE( on_map.has_tools_to_continue() );
             }
         }
     }

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -175,6 +175,7 @@ recipe_cudgel_test_charged_fast_stepless( "cudgel_test_charged_fast_stepless" );
 static const recipe_id recipe_cudgel_test_steps_basic( "cudgel_test_steps_basic" );
 static const recipe_id recipe_cudgel_test_steps_charged( "cudgel_test_steps_charged" );
 static const recipe_id recipe_cudgel_test_steps_dual_charged( "cudgel_test_steps_dual_charged" );
+static const recipe_id recipe_cudgel_test_steps_two_tools( "cudgel_test_steps_two_tools" );
 static const recipe_id recipe_dry_meat( "dry_meat" );
 static const recipe_id recipe_fishing_hook_basic( "fishing_hook_basic" );
 static const recipe_id recipe_helmet_kabuto( "helmet_kabuto" );
@@ -1398,6 +1399,68 @@ TEST_CASE( "craft_step_charge_shortfall_rewinds_turn_progress",
     CHECK( u.get_moves() == 100 );
 }
 
+TEST_CASE( "craft_terminal_verifier_cancels_on_missing_noncharged_tool",
+           "[crafting][charge][steps]" )
+{
+    std::vector<item> tools;
+    tools.emplace_back( itype_2x4 );
+    tools.emplace_back( itype_soldering_iron_portable );
+    tools.emplace_back( itype_hammer );
+    prep_craft( recipe_cudgel_test_steps_two_tools, tools, true );
+    setup_test_craft( recipe_cudgel_test_steps_two_tools );
+
+    avatar &u = get_avatar();
+
+    // Drive into the final 5% drift window so every bucket has already been
+    // credited with both tools present.
+    int guard = 0;
+    while( u.activity.id() == ACT_CRAFT ) {
+        item_location craft = u.get_wielded_item();
+        REQUIRE( craft );
+        REQUIRE( craft->is_craft() );
+        if( craft->item_counter >= 9500000 ) {
+            break;
+        }
+        REQUIRE( ++guard < 100000 );
+        u.set_moves( 100 );
+        u.activity.do_turn( u );
+    }
+    REQUIRE( u.activity.id() == ACT_CRAFT );
+    {
+        item_location craft = u.get_wielded_item();
+        REQUIRE( craft );
+        REQUIRE( craft->is_craft() );
+        const std::vector<std::vector<step_tool_alloc>> &allocs = craft->get_step_tool_allocs();
+        REQUIRE( allocs.size() == 1 );
+        REQUIRE( allocs[0].size() == 2 );
+        for( const step_tool_alloc &a : allocs[0] ) {
+            REQUIRE( a.consumed_buckets == 20 );
+        }
+        craft->set_tools_to_continue( true );
+    }
+
+    // Remove the hammer in the drift window; the terminal sweep at completion
+    // must reject the craft even though every bucket has already been credited.
+    for( item *it : u.items_with( []( const item & i ) {
+    return i.typeId() == itype_hammer;
+    } ) ) {
+        u.i_rem( it );
+    }
+    u.invalidate_crafting_inventory();
+
+    while( u.activity.id() == ACT_CRAFT ) {
+        REQUIRE( ++guard < 100000 );
+        u.set_moves( 100 );
+        u.activity.do_turn( u );
+    }
+
+    item_location after = u.get_wielded_item();
+    REQUIRE( after );
+    REQUIRE( after->is_craft() );
+    CHECK( after->item_counter < 10000000 );
+    CHECK_FALSE( after->has_tools_to_continue() );
+}
+
 TEST_CASE( "craft_step_consume_requires_selected_noncharged_tool",
            "[crafting][charge][steps]" )
 {
@@ -1444,14 +1507,18 @@ TEST_CASE( "craft_step_consume_requires_selected_noncharged_tool",
 
     GIVEN( "the tool's buckets are full but the craft is not done" ) {
         // Buckets filled earlier with the tool present, then it was removed
-        // before completion; the active step must re-check, not free-finish.
+        // before completion; the step-completion verifier must catch the
+        // absence so the step does not finish on a missing tool.
         allocs[0][0].consumed_buckets = 20;
         craft.set_step_tool_allocs( allocs );
         craft.item_counter = 0;
+        craft.set_tools_to_continue( true );
         u.invalidate_crafting_inventory();
 
-        THEN( "the active step re-checks presence and fails" ) {
-            CHECK_FALSE( u.craft_consume_step_tools( craft ) );
+        THEN( "the verifier fails and clears tools_to_continue" ) {
+            CHECK_FALSE( u.verify_step_tools( craft, 0, u.pos_bub(), PICKUP_RANGE,
+                                              /*pin_to_map=*/false ) );
+            CHECK_FALSE( craft.has_tools_to_continue() );
         }
     }
 

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -1454,6 +1454,46 @@ TEST_CASE( "craft_step_consume_requires_selected_noncharged_tool",
             CHECK_FALSE( u.craft_consume_step_tools( craft ) );
         }
     }
+
+    GIVEN( "the tool is removed within a bucket that has already been credited" ) {
+        // Presence is sampled on bucket boundaries (matching charge-debit
+        // semantics), so a tool removed mid-bucket is tolerated until the
+        // next bucket boundary aborts the step.
+        const recipe &rec = craft.get_making();
+        const double budget = rec.step_budget_moves( u, 0, 1, {} );
+        REQUIRE( budget > 0.0 );
+        allocs[0][0].consumed_buckets = 5;
+        craft.set_step_tool_allocs( allocs );
+        craft.set_current_step( 0 );
+        // Place progress comfortably inside bucket 5 (fraction ~0.22) so the
+        // step's target is also 5: no boundary to cross this turn.
+        craft.set_step_progress( budget * 0.22 );
+        craft.item_counter = 2200000;
+        u.invalidate_crafting_inventory();
+
+        THEN( "the mid-bucket call does not abort" ) {
+            CHECK( u.craft_consume_step_tools( craft ) );
+            CHECK( craft.get_step_tool_allocs()[0][0].consumed_buckets == 5 );
+        }
+    }
+
+    GIVEN( "the tool is gone when progress crosses into the next bucket" ) {
+        const recipe &rec = craft.get_making();
+        const double budget = rec.step_budget_moves( u, 0, 1, {} );
+        REQUIRE( budget > 0.0 );
+        allocs[0][0].consumed_buckets = 5;
+        craft.set_step_tool_allocs( allocs );
+        craft.set_current_step( 0 );
+        // Fraction ~0.30 puts the target at bucket 6, one past consumed_buckets.
+        craft.set_step_progress( budget * 0.30 );
+        craft.item_counter = 3000000;
+        u.invalidate_crafting_inventory();
+
+        THEN( "the boundary crossing re-checks presence and aborts" ) {
+            CHECK_FALSE( u.craft_consume_step_tools( craft ) );
+            CHECK( craft.get_step_tool_allocs()[0][0].consumed_buckets == 5 );
+        }
+    }
 }
 
 TEST_CASE( "tool_use", "[crafting][tool]" )


### PR DESCRIPTION
#### Summary
Performance "Stop rebuilding nearby-item inventory every craft tick"

#### Purpose of change
Fixes #87316. `consume_step_tool_targets` ran `form_from_map` every craft tick, which dominates crafting time when the player is near dense item caches.

#### Describe the solution
First commit narrows when the inventory rebuild fires. Lazy-init the nearby-item inventory only when a map-sourced check actually needs it, and restrict the active step's per-turn non-charged presence sweep to bucket transitions.

Second commit moves the drift safeguard out of the per-tick path. New `verify_step_tools` sweeps the closing step's non-charged tools, called from `activity_actor` at the step boundary and pre-completion, and from `craft_actualize_ready` before the passive debit. Verifier runs before any charge debit so a rejected closure does not burn charges, and clears `tools_to_continue` so resume reselects through OR alternatives instead of looping on the same shortfall.

#### Describe alternatives you've considered
Caching the surrounding inventory across ticks. Invalidation surface (movement, drops) outweighs the win for a check that really only matters at step close.

#### Testing
Drift unit tests redirected to call the verifier. Added a terminal-completion integration test driving the active actor through step close with a missing non-charged tool, and a ready-dispatch test driving `craft_actualize_scheduled` with the same scenario for the passive path. Existing crafting and attention tests pass. Verified in game too.

#### Additional context
N/A