### PR TITLE
Invalidate clang-tidy plugin cache on LLVM patch bumps

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -45,21 +45,34 @@ jobs:
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         persist-credentials: false
-    - name: cache clang-tidy plugin
-      id: plugin-cache
-      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      with:
-        path: build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so
-        key: clang-tidy-plugin-llvm22-ubuntu2404-${{ hashFiles('tools/clang-tidy-plugin/**', 'build-scripts/clang-tidy-build.sh', 'CMakeLists.txt', 'CMakeModules/**') }}
     - name: install LLVM 22
-      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && steps.plugin-cache.outputs.cache-hit != 'true' }}
+      id: install-llvm
+      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
       run: |
           wget -O llvm.sh https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 22 all
           sudo apt-get install -y python3-pip ninja-build cmake
           pip3 install --user lit
+          # Plugin .so ABI is tied to the exact LLVM patch version it links
+          # against; feeding the installed version into the cache key forces
+          # a rebuild on apt point releases (e.g. 22.1.6 -> 22.1.7) and
+          # avoids "clang version mismatch in CataTidyModule" at run time.
+          llvm_full_version="$(clang-tidy-22 --version | sed -n 's/.*LLVM version \([0-9.]*\).*/\1/p' | head -1)"
+          if [ -z "$llvm_full_version" ]; then
+              echo "Failed to parse clang-tidy-22 version" >&2
+              clang-tidy-22 --version
+              exit 1
+          fi
+          echo "llvm_full_version=$llvm_full_version" >> "$GITHUB_OUTPUT"
+          echo "Installed LLVM $llvm_full_version"
+    - name: cache clang-tidy plugin
+      id: plugin-cache
+      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so
+        key: clang-tidy-plugin-llvm${{ steps.install-llvm.outputs.llvm_full_version }}-ubuntu2404-${{ hashFiles('tools/clang-tidy-plugin/**', 'build-scripts/clang-tidy-build.sh', 'CMakeLists.txt', 'CMakeModules/**') }}
     - uses: ammaraskar/gcc-problem-matcher@0f9c86f9e693db67dacf53986e1674de5f2e5f28 # master
     - name: build clang-tidy plugin
       if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && steps.plugin-cache.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
#### Summary
Infrastructure "Invalidate clang-tidy plugin cache on LLVM patch bumps"

#### Purpose of change
CI clang-tidy runs are failing with

> LLVM ERROR: clang version mismatch in CataTidyModule. Compiled against 22.1.6 but loaded by Ubuntu clang version 22.1.7

The cached plugin .so is ABI-tied to the exact LLVM patch version it linked against, but the cache key only hashed plugin sources, so apt.llvm.org point releases poisoned the cache across workflow runs.

#### Describe the solution
In `build-clang-tidy`, install LLVM unconditionally (was: only on cache miss), parse `clang-tidy-22 --version`, and append the patch version to the plugin cache key. Patch bumps now produce a new key, miss the cache, and rebuild the plugin.

#### Describe alternatives you've considered
Configuring the apt repo without installing and using `apt-cache policy` to get the candidate version into the cache key would avoid the extra install on cache hits, but the matching pin in `run-clang-tidy` adds complexity for a small saving. Maybe later.

#### Testing
N/A, CI-only change. Next clang-tidy run will exercise it.

#### Additional context