### PR TITLE
Sort ammotype declarations in multimag_matrix_test

### DIFF
--- a/tests/multimag_matrix_test.cpp
+++ b/tests/multimag_matrix_test.cpp
@@ -43,9 +43,9 @@
 
 static const ammotype ammo_9mm( "9mm" );
 static const ammotype ammo_battery( "battery" );
-static const ammotype ammo_test_graphite( "test_graphite" );
 static const ammotype ammo_lamp_oil( "lamp_oil" );
 static const ammotype ammo_oxygen( "oxygen" );
+static const ammotype ammo_test_graphite( "test_graphite" );
 static const ammotype ammo_water( "water" );
 
 static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

#87332 renamed `ammo_graphite` to `ammo_test_graphite`, breaking sort order. Slipped through while clang-tidy CI was broken.

#### Describe the solution

Reorder to alphabetical.

#### Testing

Ran clang-tidy on the file, clean.

#### Additional context

N/A