### PR TITLE
Fix SDL3 zoom crash from tint mask render target switch

### DIFF
--- a/src/cata_shader.cpp
+++ b/src/cata_shader.cpp
@@ -592,23 +592,78 @@ bool variant_pass::end()
     return true;
 }
 
-void variant_pass::flush()
+bool variant_pass::flush()
 {
     if( !currently_bound_ ) {
-        return;
+        return true;
     }
-    currently_bound_.reset();
     if( !SDL_SetGPURenderState( renderer_, nullptr ) ) {
         DebugLog( D_ERROR, DC_ALL )
                 << "cata_shader::variant_pass: SDL_SetGPURenderState(NULL) failed: "
                 << SDL_GetError();
         session_disabled_ = true;
+        return false;
     }
+    currently_bound_.reset();
+    return true;
 }
 
 void variant_pass::select_memory_preset( std::optional<memory_preset> preset )
 {
     active_memory_preset_ = preset;
+}
+
+render_target_scope::render_target_scope( SDL_Renderer *renderer, SDL_Texture *target,
+        variant_pass *vp )
+    : renderer_( renderer )
+{
+    if( !renderer_ ) {
+        return;
+    }
+    prior_target_ = SDL_GetRenderTarget( renderer_ );
+    if( vp && !vp->flush() ) {
+        return;
+    }
+    if( !SDL_SetRenderTarget( renderer_, target ) ) {
+        DebugLog( D_ERROR, DC_ALL )
+                << "cata_shader::render_target_scope: SDL_SetRenderTarget failed: "
+                << SDL_GetError();
+        return;
+    }
+    valid_ = true;
+}
+
+bool render_target_scope::restore()
+{
+    if( restored_ ) {
+        return true;
+    }
+    if( !renderer_ || !valid_ ) {
+        return false;
+    }
+    if( !SDL_SetRenderTarget( renderer_, prior_target_ ) ) {
+        DebugLog( D_ERROR, DC_ALL )
+                << "cata_shader::render_target_scope::restore: SDL_SetRenderTarget failed: "
+                << SDL_GetError();
+        return false;
+    }
+    restored_ = true;
+    return true;
+}
+
+render_target_scope::~render_target_scope()
+{
+    if( restored_ || !valid_ ) {
+        return;
+    }
+    // Fallback for early exit. Mark restored regardless to avoid
+    // retry loops; double failure means the invariant is lost.
+    restored_ = true;
+    if( !SDL_SetRenderTarget( renderer_, prior_target_ ) ) {
+        DebugLog( D_ERROR, DC_ALL )
+                << "cata_shader::~render_target_scope: SDL_SetRenderTarget failed: "
+                << SDL_GetError();
+    }
 }
 
 } // namespace cata_shader

--- a/src/cata_shader.h
+++ b/src/cata_shader.h
@@ -214,7 +214,10 @@ class variant_pass
         bool try_begin( variant_kind v );
         bool end();
 
-        void flush();
+        // Returns false on SDL_SetGPURenderState(NULL) failure; pass
+        // stays flagged bound so callers can refuse to cross a
+        // render-target boundary.
+        bool flush();
 
         void select_memory_preset( std::optional<memory_preset> preset );
 
@@ -234,6 +237,39 @@ class variant_pass
         bool probe_attempted_ = false;
         bool probed_ok_ = false;
         bool session_disabled_ = false;
+};
+
+// RAII guard for SDL_SetRenderTarget. Flushes variant_pass before
+// switching targets - SDL3 has been observed to crash inside
+// SDL_SetRenderTarget when variant GPU state is bound across the
+// transition. Pass nullptr if no variant_pass is involved.
+// Caller checks is_valid() before drawing and restore() before
+// continuing on the prior target.
+class render_target_scope
+{
+    public:
+        render_target_scope( SDL_Renderer *renderer, SDL_Texture *target,
+                             variant_pass *vp );
+        ~render_target_scope();
+
+        render_target_scope( const render_target_scope & ) = delete;
+        render_target_scope &operator=( const render_target_scope & ) = delete;
+        render_target_scope( render_target_scope && ) = delete;
+        render_target_scope &operator=( render_target_scope && ) = delete;
+
+        bool is_valid() const {
+            return valid_;
+        }
+
+        // Returns false if the scope is invalid or SDL_SetRenderTarget
+        // fails; failure leaves restored_ unset so the destructor retries.
+        bool restore();
+
+    private:
+        SDL_Renderer *renderer_ = nullptr;
+        SDL_Texture *prior_target_ = nullptr;
+        bool valid_ = false;
+        bool restored_ = false;
 };
 
 } // namespace cata_shader

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1079,42 +1079,72 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                             return;
                         }
                         ensure_tint_mask_texture( batch_union.w, batch_union.h );
+                        if( !tint_mask_tex ) {
+                            batch_tiles.clear();
+                            batch_sum_area = 0;
+                            return;
+                        }
 
-                        // Save and remove clip rect -- the mask texture has its own
-                        // coordinate space unrelated to the display viewport.
+                        // Save display-buffer clip so Phase 2 can restore it.
                         if( !clip_saved ) {
                             RenderGetClipRect( renderer, &saved_clip );
                             clip_saved = true;
                         }
-                        RenderSetClipRect( renderer, nullptr );
 
                         // Phase 1: build the silhouette mask.
-                        SetRenderTarget( renderer, tint_mask_tex );
-                        SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
-                        SetRenderDrawColor( renderer, 0, 0, 0, 0 );
-                        const SDL_Rect clear_rect = { 0, 0, batch_union.w, batch_union.h };
-                        RenderFillRect( renderer, &clear_rect );
-
-                        for( const tile_render_info *bp : batch_tiles ) {
-                            for( const tint_sprite_record &rec : bp->com.tint_sprites ) {
-                                const texture *sil = tileset_ptr->get_silhouette_tile( rec.sprite_index );
-                                if( !sil ) {
-                                    continue;
-                                }
-                                // Translate to mask-local coordinates.
-                                SDL_Rect mask_dest = {
-                                    rec.destination.x - batch_union.x,
-                                    rec.destination.y - batch_union.y,
-                                    rec.destination.w,
-                                    rec.destination.h
-                                };
-                                sil->render_copy_ex( renderer, &mask_dest, rec.angle, nullptr,
-                                                     static_cast<CataFlipMode>( rec.flip ) );
+                        {
+#if SDL_MAJOR_VERSION >= 3
+                            cata_shader::render_target_scope mask_scope(
+                                renderer.get(), tint_mask_tex.get(), m_variant_pass.get() );
+                            if( !mask_scope.is_valid() ) {
+                                // variant_pass may have failed to unbind; later
+                                // target switches would cross with shader bound.
+                                batch_tiles.clear();
+                                batch_sum_area = 0;
+                                throw std::runtime_error(
+                                    "cata_tiles::flush_tint_batch: render_target_scope construction failed" );
                             }
+#else
+                            SetRenderTarget( renderer, tint_mask_tex );
+#endif
+                            // Clip is per-target; clear defensively for reused mask.
+                            RenderSetClipRect( renderer, nullptr );
+                            SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
+                            SetRenderDrawColor( renderer, 0, 0, 0, 0 );
+                            const SDL_Rect clear_rect = { 0, 0, batch_union.w, batch_union.h };
+                            RenderFillRect( renderer, &clear_rect );
+
+                            for( const tile_render_info *bp : batch_tiles ) {
+                                for( const tint_sprite_record &rec : bp->com.tint_sprites ) {
+                                    const texture *sil = tileset_ptr->get_silhouette_tile( rec.sprite_index );
+                                    if( !sil ) {
+                                        continue;
+                                    }
+                                    // Translate to mask-local coordinates.
+                                    SDL_Rect mask_dest = {
+                                        rec.destination.x - batch_union.x,
+                                        rec.destination.y - batch_union.y,
+                                        rec.destination.w,
+                                        rec.destination.h
+                                    };
+                                    sil->render_copy_ex( renderer, &mask_dest, rec.angle, nullptr,
+                                                         static_cast<CataFlipMode>( rec.flip ) );
+                                }
+                            }
+#if SDL_MAJOR_VERSION >= 3
+                            if( !mask_scope.restore() ) {
+                                // Subsequent draws would land in the mask.
+                                batch_tiles.clear();
+                                batch_sum_area = 0;
+                                throw std::runtime_error(
+                                    "cata_tiles::flush_tint_batch: failed to restore display_buffer render target" );
+                            }
+#else
+                            set_displaybuffer_rendertarget();
+#endif
                         }
 
                         // Phase 2: composite the mask to the display buffer.
-                        set_displaybuffer_rendertarget();
                         RenderSetClipRect( renderer, &saved_clip );
 
                         const SDL_Rect comp_src = { 0, 0, batch_union.w, batch_union.h };


### PR DESCRIPTION
#### Summary
Bugfixes "Fix SDL3 zoom crash from tint mask render target switch"

#### Purpose of change

Zooming on SDL3 builds can SIGSEGV inside `SDL_SetRenderTarget` when the complex tint path swaps render targets for the silhouette mask. The `variant_pass` GPU shader state stays bound across the target switch and SDL3 dereferences stale internal state.

#### Describe the solution

New `cata_shader::render_target_scope` RAII guard. Ctor flushes the variant_pass first, then calls `SDL_SetRenderTarget`; dtor restores the prior target. `variant_pass::flush()` now returns bool so the scope can refuse to cross the boundary if unbind fails. `flush_tint_batch` uses the scope around its mask draw; ctor or restore failure throws.

#### Describe alternatives you've considered

N/A

#### Testing

Verified in-game by zooming repeatedly in a save that hits the complex tint path.

#### Additional context

N/A