### PR TITLE
Lowered Synthetic Armors (and Amphibian Biology) proficiency learn to 30m

### DIFF
--- a/data/json/proficiencies/weakpoints.json
+++ b/data/json/proficiencies/weakpoints.json
@@ -62,7 +62,7 @@
     "name": { "str": "Synthetic Armors" },
     "description": "Understanding of man-made armors and ways to exploit them.  You're able to find openings in certain kinds of body armor.",
     "can_learn": true,
-    "time_to_learn": "6 h",
+    "time_to_learn": "30 m",
     "default_weakpoint_bonus": 4,
     "default_weakpoint_penalty": -4
   },
@@ -95,7 +95,7 @@
     "name": { "str": "Amphibian Biology" },
     "description": "Basic familiarity with various types of frogs and salamanders.",
     "can_learn": true,
-    "time_to_learn": "8 h",
+    "time_to_learn": "30 m",
     "required_proficiencies": [ "prof_gross_anatomy" ],
     "default_weakpoint_bonus": 1,
     "default_weakpoint_penalty": 0


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Changes the proficiency learn time for the synthetic armors and amphibian biology proficiencies to take 30m in line with other weakpoints."

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I have noticed that learning the synthetic armor proficiency takes a lot longer than other weakpoint proficiencies while logically not being that much harder to understand than something like bony body armor plates. If you can understand how to stab a skeletal zombie in order to dodge hard bony plates, you can learn as easily (or even easier) where to stab a soldier so that it doesn't get blocked by hard plates or soft kevlar. I've also noticed that the amphibian biology weakpoint proficiency is 8 whole hours while similar animal proficiencies like avian take 30m. So I have decided to put them both in line with the rest.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Lower the study time of the named weakpoint proficiencies to 30m to put them in line with other weakpoints that take one or two dissections to learn.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Dissect entire platoons of soldiers to understand where a body armor vest is weak.
Or add a practice recipe that studies a ballistic vest to learn how to pierce them effectively but that was rejected before so eh.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned two soldiers, killed them, dissected them, got the proficiency.
Spawned two zombie frogs, killed them, dissected them, got the proficiency.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
