### PR TITLE
New Hoarder morale calculations

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1763,8 +1763,8 @@
     "type": "mutation",
     "id": "HOARDER",
     "name": { "str": "Hoarder" },
-    "description": "You don't feel right unless you're carrying as much as you can.  You suffer morale penalties for carrying less than maximum volume (weight is ignored).  Xanax can help control this anxiety.",
-    "points": -4,
+    "description": "You don't feel right unless you're carrying a bunch of stuff. You want to always have the right tool for every occasion, whether that's a knife, a gas mask, fresh water, a crowbar, or jelly babies. If you can't be well stocked, then even carrying junk helps keep the horrible thoughts quiet.  Xanax can help control this anxiety.",
+    "points": -2,
     "starting_trait": true,
     "valid": false
   },

--- a/src/character_morale.cpp
+++ b/src/character_morale.cpp
@@ -55,9 +55,8 @@ void Character::update_morale()
 
 void Character::hoarder_morale_penalty()
 {
-    // For hoarders holsters count as a flat -1 penalty for being empty, we also give them a 25% allowance on their pockets below 1000_ml
-    int empty_holsters = 0;
-    units::volume penalty_volume = 0_ml;
+    units::volume no_penalty_volume = 8000_ml;
+    units::volume total_volume = 0_ml;
 
     std::vector<item_pocket *> top_pockets = weapon.get_container_pockets();
     for( item &it : worn.worn ) {
@@ -65,29 +64,24 @@ void Character::hoarder_morale_penalty()
         top_pockets.insert( top_pockets.end(), worn_pockets.begin(), worn_pockets.end() );
     }
     for( const item_pocket *pocket : top_pockets ) {
-        if( pocket->is_forbidden() ) {
+        // Ablative stuff isn't gear, it is armor
+        if( pocket->is_ablative() ) {
             continue;
         }
-        if( pocket->is_holster() ) {
-            if( pocket->empty() ) {
-                empty_holsters++;
-            }
-        } else {
-            if( units::volume capacity = pocket->volume_capacity(); capacity <= 1000_ml ) {
-                penalty_volume += std::max( 0_ml, pocket->remaining_volume() - capacity / 4 );
-            } else {
-                penalty_volume += pocket->remaining_volume();
-            }
-        }
+        total_volume += pocket->contents_volume();
     }
-    int pen = penalty_volume / 125_ml;
-    pen += empty_holsters;
-    if( pen > 70 ) {
-        pen = 70;
-    }
-    if( pen <= 0 ) {
+    int pen = ( no_penalty_volume - total_volume ) / 100_ml;
+    if( pen >= 80 ) {
+        pen = 60;
+    } else if( pen <= 0 ) {
         pen = 0;
+    } else if( pen <= 40 ) {
+        // first 4L counts 10 per, next 4L is only 5 per
+        pen = pen / 2 ;
+    } else {
+        pen = pen - 20 ;
     }
+
     if( has_effect( effect_took_xanax ) ) {
         pen = pen / 7;
     } else if( has_trait( trait_THRESH_SPECIES_RAVENFOLK ) ) {


### PR DESCRIPTION
Summary
Bugfixes "Hoarder rework"

The existing 'Hoarder' is actually 'fear of empty pockets', which conflicts with any attempts at hoarding goods, as backpacks are depressing. This PR changes the calculation to rely on how much gear you're carrying rather than how much empty pocket volume you have. It will actually encourage picking up more stuff, including potentially junk early on.

Purpose of change
Issue #87369

I found the existing hoarder trait created a character who hoarded less than I normally do. The trait simply adds up empty volume, and at 9L or so you hit the maximum of a whopping 70 morale penalty. This made putting on a backpack to go pick up loot the most depressing thing ever, actively discouraging it.

Describe the solution
The new calculation doesn't care about how much pocket space you have in general, just how much stuff is in that space. So a naked character has max penalty and a character with a large half full backpack has no penalty, which is the opposite of the current trait.

I dropped the max penalty to 60. The first 4L of stuff you carry drops that penalty by 10 for each liter. The next 4 L drops it by 5 for each liter.

Ablative armor is not counted, or else a ballistic vest would easily allow you to avoid a penalty.

Now it will basically not affect a character wearing their backpack with supplies. Combat gearouts are impacted though. You will either have a morale penalty, an encumbrance penalty, or some combination of each. It increases the desirability of armor with good pocket space at minimal encumbrance, but that seems reasonable.

In the first day or two picking up outright junk is likely a good idea.

As it is now relatively easy to avoid the penalty out of combat, I lowered the point cost from -4 to -2. In combat gear it is roughly twice as bad as Bad Temper (worse before good molle pocket gear).

Describe alternatives you've considered
No change. But I found playing a hoarder as it currently stands made no sense. The only way I could at all wrap my head around my character was to completely reflavor the penalty as 'intrusive thought at seemingly random times'. A character that doesn't want to put on a backpack is not going to gather a hoard.

Different numbers. The 8L limit is somewhat arbitrary, and I could see it changed. I even contemplated having those 5 morale increments need more and more gear to satisfy. But the increased math load didn't seem worthwhile.

A different name. 'Packrat' is possibly more fitting than 'Hoarder', as hoarder implies a home full of junk rather than carrying it all around. However that would either take a substantial code change that would probably create upgrade issues, or it would leave odd cruft behind in the code. As cruft has been left before, I still consider the name change an option. If people don't like the hoarder name for the new trait it could be changed in the future.

Testing
A number of test characters picked things up and put them down. (Waiting a minute to ensure the penalty reset.)

I also played two different characters for a while with this change. It seemed far more coherent as a character trait then 'fear of backpacks'. By the time I got molle gear my combat morale penalty was often in the 10-20 range, and having a bit more encumbrance than I would have normally. Not punishing, but game play affecting.

Additional context
