### PR TITLE
[Bombastic Perks] Add more perks

### DIFF
--- a/data/mods/BombasticPerks/perkdata/hive_queen.json
+++ b/data/mods/BombasticPerks/perkdata/hive_queen.json
@@ -1,0 +1,38 @@
+[
+  {
+    "type": "effect_type",
+    "id": "effect_hive_queen_canceller",
+    "//": "Hidden effect, cancels Hive Queen briefly",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
+    "type": "mutation",
+    "id": "TRAIT_HIVE_QUEEN",
+    "name": { "str": "Insect Ignoring", "//~": "NO_I18N" },
+    "points": 0,
+    "description": { "str": "Need this trait for anger relations.", "//~": "NO_I18N" },
+    "valid": false,
+    "purifiable": false,
+    "player_display": false,
+    "ignored_by": [ "INSECT", "INSECT_FLYING" ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HIVE_QUEEN_ATTACK_INSECT_SUPPRESSOR",
+    "eoc_type": "EVENT",
+    "required_event": "monster_takes_damage",
+    "condition": "has_beta",
+    "effect": [
+      {
+        "if": {
+          "and": [
+            { "or": [ { "u_has_species": "INSECT" }, { "u_has_species": "INSECT_FLYING" } ] },
+            { "npc_has_trait": "perk_hive_queen" }
+          ]
+        },
+        "then": [ { "npc_add_effect": "effect_hive_queen_canceller", "duration": 120 } ]
+      }
+    ]
+  }
+]

--- a/data/mods/BombasticPerks/perkdata/soothing_the_savage_beast.json
+++ b/data/mods/BombasticPerks/perkdata/soothing_the_savage_beast.json
@@ -1,0 +1,48 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BOMBASTIC_PERKS_SOOTHING_THE_SAVAGE_BEAST",
+    "effect": [
+      {
+        "run_eocs": "EOC_GENERIC_SPELL_MUTATION",
+        "variables": {
+          "prep_time": 3,
+          "spell_to_cast": "soothing_the_savage_beast_spell",
+          "message_success": { "i18n": true, "str": "You sing a song to charm the most wild heart." }
+        }
+      }
+    ]
+  },
+  {
+    "id": "soothing_the_savage_beast_spell",
+    "type": "SPELL",
+    "name": { "str": "Soothing the Savage Beast Perk Spell", "//~": "NO_I18N" },
+    "description": { "str": "Soothes the savage beast if you have the perk.  You shouldn't have this.", "//~": "NO_I18N" },
+    "message": "",
+    "teachable": false,
+    "valid_targets": [ "hostile" ],
+    "skill": "survival",
+    "flags": [ "VERBAL", "RANDOM_DAMAGE", "RANDOM_DURATION", "NO_HANDS", "NO_LEGS", "NO_EXPLOSION_SFX" ],
+    "effect": "charm_monster",
+    "shape": "blast",
+    "min_damage": 800,
+    "max_damage": 800,
+    "min_duration": 180000,
+    "max_duration": 540000,
+    "min_aoe": 6,
+    "max_aoe": 6,
+    "targeted_monster_species": [ "MAMMAL", "BIRD", "AMPHIBIAN", "REPTILE", "FISH" ],
+    "ignored_monster_species": [
+      "ZOMBIE",
+      "ROBOT",
+      "ROBOT_FLYING",
+      "NETHER",
+      "NETHER_EMANATION",
+      "LEECH_PLANT",
+      "WORM",
+      "FUNGUS",
+      "SLIME",
+      "PSI_NULL"
+    ]
+  }
+]

--- a/data/mods/BombasticPerks/perkdata/soothing_the_savage_beast.json
+++ b/data/mods/BombasticPerks/perkdata/soothing_the_savage_beast.json
@@ -8,7 +8,8 @@
         "variables": {
           "prep_time": 3,
           "spell_to_cast": "soothing_the_savage_beast_spell",
-          "message_success": { "i18n": true, "str": "You sing a song to charm the most wild heart." }
+          "message_success": { "i18n": true, "str": "You sing a song to charm the most wild heart." },
+          "message_fail": { "i18n": true, "str": "Your song has no effect!" }
         }
       }
     ]
@@ -22,7 +23,7 @@
     "teachable": false,
     "valid_targets": [ "hostile" ],
     "skill": "survival",
-    "flags": [ "VERBAL", "RANDOM_DAMAGE", "RANDOM_DURATION", "NO_HANDS", "NO_LEGS", "NO_EXPLOSION_SFX" ],
+    "flags": [ "VERBAL", "RANDOM_DAMAGE", "RANDOM_DURATION", "NO_HANDS", "NO_LEGS", "NO_EXPLOSION_SFX", "SILENT" ],
     "effect": "charm_monster",
     "shape": "blast",
     "min_damage": 800,

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1201,6 +1201,30 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_fencing_footwork" } },
+        "text": "Gain [<trait_name:perk_fencing_footwork>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_fencing_footwork>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_fencing_footwork>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_fencing_footwork", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must have melee 5 and dexterity 10",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "and": [ { "math": [ "u_skill('melee') >= 5" ] }, { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus') >= 10" ] } ]
+            }
+          }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_artifact_resonance_detection" } },
         "text": "Gain [<trait_name:perk_artifact_resonance_detection>]",
         "effect": [

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1230,11 +1230,46 @@
           },
           { "set_string_var": "perk_artifact_resonance_reduction", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have <trait_name:perk_artifact_resonance_detection>",
+            "set_string_var": "Must have <trait_name:perk_artifact_resonance_detection>.  Cannot have <trait_name:perk_artifact_resonance_exploitation>",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_artifact_resonance_detection" } }
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "and": [
+                { "u_has_trait": "perk_artifact_resonance_detection" },
+                { "not": { "u_has_trait": "perk_artifact_resonance_exploitation" } }
+              ]
+            }
+          }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_artifact_resonance_exploitation" } },
+        "text": "Gain [<trait_name:perk_artifact_resonance_exploitation>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_artifact_resonance_exploitation>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_artifact_resonance_exploitation>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_artifact_resonance_exploitation", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must have <trait_name:perk_artifact_resonance_detection>.  Cannot have <trait_name:perk_artifact_resonance_reduction>",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "and": [
+                { "u_has_trait": "perk_artifact_resonance_detection" },
+                { "not": { "u_has_trait": "perk_artifact_resonance_reduction" } }
+              ]
+            }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -2318,6 +2318,28 @@
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_soothing_the_savage_beast" } },
+        "text": "Gain [<trait_name:perk_soothing_the_savage_beast>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_soothing_the_savage_beast>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_soothing_the_savage_beast>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_soothing_the_savage_beast", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires social 4 and survival 8",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "math": [ "u_skill('speech') >= 4" ] }, { "math": [ "u_skill('survival') >= 8" ] } ] }
+          }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_dexterous_speed" } },
         "text": "Gain [<trait_name:perk_dexterous_speed>]",
         "effect": [

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1211,7 +1211,7 @@
           },
           { "set_string_var": "perk_fencing_footwork", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have melee 5,  dexterity 10, and fencing weapon proficiency",
+            "set_string_var": "Must have melee 5, dexterity 10, and fencing weapon proficiency",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -1225,6 +1225,25 @@
               ]
             }
           }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_fish_in_water" } },
+        "text": "Gain [<trait_name:perk_fish_in_water>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_fish_in_water>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_fish_in_water>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_fish_in_water", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must have athletics 4",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('swimming') >= 4" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1211,14 +1211,18 @@
           },
           { "set_string_var": "perk_fencing_footwork", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have melee 5 and dexterity 10",
+            "set_string_var": "Must have melee 5,  dexterity 10, and fencing weapon proficiency",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
           {
             "set_condition": "perk_condition",
             "condition": {
-              "and": [ { "math": [ "u_skill('melee') >= 5" ] }, { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus') >= 10" ] } ]
+              "and": [
+                { "math": [ "u_skill('melee') >= 5" ] },
+                { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus') >= 10" ] },
+                { "math": [ "u_proficiency('prof_fencing_weapons_pro', 'format': 'percent') >= 100" ] }
+              ]
             }
           }
         ],

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -2328,13 +2328,41 @@
           },
           { "set_string_var": "perk_soothing_the_savage_beast", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires social 4 and survival 8",
+            "set_string_var": "Requires social 4 and survival 8.  Must not have <trait_name:perk_hive_queen>",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
           {
             "set_condition": "perk_condition",
-            "condition": { "and": [ { "math": [ "u_skill('speech') >= 4" ] }, { "math": [ "u_skill('survival') >= 8" ] } ] }
+            "condition": {
+              "and": [
+                { "math": [ "u_skill('speech') >= 4" ] },
+                { "math": [ "u_skill('survival') >= 8" ] },
+                { "not": { "u_has_trait": "perk_hive_queen" } }
+              ]
+            }
+          }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_hive_queen" } },
+        "text": "Gain [<trait_name:perk_hive_queen>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_hive_queen>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_hive_queen>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_hive_queen", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires social 9.  Must not have <trait_name:perk_soothing_the_savage_beast>",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "math": [ "u_skill('speech') >= 9" ] }, { "not": { "u_has_trait": "perk_soothing_the_savage_beast" } } ] }
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1588,13 +1588,15 @@
     "type": "mutation",
     "id": "perk_hive_queen",
     "name": { "str": "Hive Queen" },
-    "description": "The insects have accepted you as one of their own. You are neutral with eusocial insects, including giant ones, but your presence is a little unnerving to animals and people.",
+    "description": "The insects have accepted you as one of their own.  You are neutral with eusocial insects, including giant ones, but your presence is a little unnerving to animals and people.",
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "ignored_by": [ "INSECT_FLYING", "INSECT" ],
     "anger_relations": [ [ "MAMMAL", 5 ], [ "BIRD", 5 ] ],
-    "enchantments": [ { "values": [ { "value": "SOCIAL_PERSUADE", "add": -5 }, { "value": "SOCIAL_INTIMIDATE", "add": -5 } ] } ],
+    "enchantments": [
+      { "condition": { "not": { "u_has_effect": "effect_hive_queen_canceller" } }, "mutations": [ "TRAIT_HIVE_QUEEN" ] },
+      { "values": [ { "value": "SOCIAL_PERSUADE", "add": -5 }, { "value": "SOCIAL_INTIMIDATE", "add": -5 } ] }
+    ],
     "flags": [ "ANIMALDISCORD" ]
   }
 ]

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -730,7 +730,7 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "description": "Your frequent handling of artifacts has allowed you to redirect some of the otherworldly power they carry.  When suffering from resonance effects, you gain a variety of minor bonuses such as resistance to fire, electricity, or cold, increased dodge, or increased stamina regen.",
+    "description": "Your frequent handling of artifacts has allowed you to redirect some of the otherworldly power they carry.  When suffering from resonance effects, you gain a variety of minor bonuses such as resistance to fire, electricity, or cold, increased dodge, or increased stamina regeneration.",
     "enchantments": [
       {
         "condition": { "math": [ "u_artifact_resonance() > 2000" ] },
@@ -1583,5 +1583,18 @@
     "valid": false,
     "active": true,
     "activated_eocs": [ "EOC_BOMBASTIC_PERKS_SOOTHING_THE_SAVAGE_BEAST" ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_hive_queen",
+    "name": { "str": "Hive Queen" },
+    "description": "The insects have accepted you as one of their own. You are neutral with eusocial insects, including giant ones, but your presence is a little unnerving to animals and people.",
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "ignored_by": [ "INSECT_FLYING", "INSECT" ],
+    "anger_relations": [ [ "MAMMAL", 5 ], [ "BIRD", 5 ] ],
+    "enchantments": [ { "values": [ { "value": "SOCIAL_PERSUADE", "add": -5 }, { "value": "SOCIAL_INTIMIDATE", "add": -5 } ] } ],
+    "flags": [ "ANIMALDISCORD" ]
   }
 ]

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -725,6 +725,32 @@
   },
   {
     "type": "mutation",
+    "id": "perk_artifact_resonance_exploitation",
+    "name": { "str": "Resonating Empowerment" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": "Your frequent handling of artifacts has allowed you to redirect some of the otherworldly power they carry.  When suffering from resonance effects, you gain a variety of minor bonuses such as resistance to fire, electricity, or cold, increased dodge, or increased stamina regen.",
+    "enchantments": [
+      {
+        "condition": { "math": [ "u_artifact_resonance() > 2000" ] },
+        "incoming_damage_mod": [
+          { "type": "heat", "add": { "math": [ "rand(8) + 2" ] } },
+          { "type": "electric", "add": { "math": [ "rand(8) + 2" ] } },
+          { "type": "cold", "add": { "math": [ "rand(8) + 2" ] } }
+        ],
+        "values": [
+          { "value": "BONUS_DODGE", "add": { "math": [ "rand(1)" ] } },
+          { "value": "REGEN_STAMINA", "multiply": { "math": [ "rng(0.1,0.3)" ] } },
+          { "value": "FORCEFIELD", "multiply": { "math": [ "rng(0,0.1)" ] } },
+          { "value": "MOVE_COST", "multiply": { "math": [ "rng(-0.05,0)" ] } },
+          { "value": "PAIN", "multiply": { "math": [ "rng(-0.15,0)" ] } }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_frakenstein",
     "name": { "str": "Playing God" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -721,6 +721,21 @@
   },
   {
     "type": "mutation",
+    "id": "perk_fish_in_water",
+    "name": { "str": "Like a Fish in the Water" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": "So unremarkable that there's no proverb about it.  When in deep water, your stamina regeneration is doubled, and you can swim 25% faster.",
+    "enchantments": [
+      {
+        "condition": { "and": [ { "u_is_on_terrain_with_flag": "SWIMMABLE" }, { "u_is_on_terrain_with_flag": "DEEP_WATER" } ] },
+        "values": [ { "value": "REGEN_STAMINA", "multiply": 1 }, { "value": "MOVECOST_SWIM_MOD", "multiply": -0.25 } ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_artifact_resonance_detection",
     "name": { "str": "Nether Resonator" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -992,7 +992,10 @@
     "valid": false,
     "description": "Smoking is bad, but damn it's badass.  You deal more damage and shoot more accurately when you smoke.",
     "enchantments": [
-      { "condition": { "u_has_effect": "cig" }, "values": [ { "value": "MELEE_DAMAGE", "multiply": 0.25 } ] },
+      {
+        "condition": { "u_has_effect": "cig" },
+        "melee_damage_bonus": [ { "type": "bash", "multiply": 0.25 }, { "type": "stab", "multiply": 0.25 }, { "type": "cut", "multiply": 0.25 } ]
+      },
       { "condition": { "u_has_effect": "cig" }, "values": [ { "value": "WEAPON_DISPERSION", "multiply": -0.25 } ] }
     ]
   },
@@ -1144,7 +1147,8 @@
             { "not": { "u_has_effect": "effect_perk_rage_against_the_unnatural_penalty" } }
           ]
         },
-        "values": [ { "value": "MELEE_DAMAGE", "multiply": 0.35 }, { "value": "ARMOR_ALL", "multiply": -0.15 } ]
+        "melee_damage_bonus": [ { "type": "bash", "multiply": 0.35 }, { "type": "stab", "multiply": 0.35 }, { "type": "cut", "multiply": 0.35 } ],
+        "values": [ { "value": "ARMOR_ALL", "multiply": -0.15 } ]
       }
     ]
   },
@@ -1307,7 +1311,11 @@
     "enchantments": [
       {
         "condition": "ALWAYS",
-        "values": [ { "value": "MELEE_DAMAGE", "multiply": { "math": [ "u_effect_intensity('bleed') * 0.05" ] } } ]
+        "melee_damage_bonus": [
+          { "type": "bash", "multiply": { "math": [ "u_effect_intensity('bleed') * 0.05" ] } },
+          { "type": "stab", "multiply": { "math": [ "u_effect_intensity('bleed') * 0.05" ] } },
+          { "type": "cut", "multiply": { "math": [ "u_effect_intensity('bleed') * 0.05" ] } }
+        ]
       }
     ]
   },

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1572,5 +1572,16 @@
     "points": 0,
     "purifiable": false,
     "valid": false
+  },
+  {
+    "type": "mutation",
+    "id": "perk_soothing_the_savage_beast",
+    "name": { "str": "Soothing the Savage Beast" },
+    "description": "Disney princesses stand back!  You have learned the secret tongues of bird and beast, or at least, you can howl or chirp in such a way that they consider it an offer of friendship.  Activate this perk to charm any nearby mammals, birds, amphibians, reptiles, or fish (not insects or spiders).",
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "active": true,
+    "activated_eocs": [ "EOC_BOMBASTIC_PERKS_SOOTHING_THE_SAVAGE_BEAST" ]
   }
 ]

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -703,6 +703,24 @@
   },
   {
     "type": "mutation",
+    "id": "perk_fencing_footwork",
+    "name": { "str": "Fancy Footwork" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": {
+      "str": "Ho!  Ha-Ha!  Guard!  Turn!  Parry!  Dodge!  Spin!  Ha!  Thrust!  When wielding a fencing weapon, you gain +1 bonus dodge and slightly reduced move cost on flat terrain.",
+      "//~": "The beginning of this description is a reference to the Looney Tunes short 'Robin Hood Daffy' "
+    },
+    "enchantments": [
+      {
+        "condition": { "u_has_wielded_with_weapon_category": "FENCING" },
+        "values": [ { "value": "BONUS_DODGE", "add": 1 }, { "value": "MOVECOST_FLATGROUND_MOD", "multiply": -0.05 } ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_artifact_resonance_detection",
     "name": { "str": "Nether Resonator" },
     "points": 0,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Bombastic Perks] Add more perks"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Adding more perks.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the following perks:

1. Fancy Footwork (Must have Melee 5, Dexterity 10, and fencing proficiency):  Ho!  Ha-Ha!  Guard!  Turn!  Parry!  Dodge!  Spin!  Ha!  Thrust!  When wielding a fencing weapon, you gain +1 bonus dodge and slightly reduced move cost on flat terrain.
2. Like a Fish in the Water (Must have Athletics 4): You regenerate stamina twice as fast in water, and swim 25% faster.
3. Resonating Empowerment (must not have Relic Wielder): Adds a variety of minor bonuses if you have enough artifact resonance to be suffering from resonance effects (e.g. heat/electricity/cold resistance, chance to avoid damage, stamina regen, etc. These bonuses fluctuate from turn to turn.

And the following playstyle perks:

1. Soothing the Savage Beast (requires Social 4, Survival 8, must not have Hive Queen): Disney Princesses stand back. You can sing a short song and charm any nearby animals, making them friendly to you for a period. Only works on mammals, birds, reptiles, amphibians, etc (_not_ insects)
2. Hive Queen (requires Social 9, must not have Soothing the Savage Beast): The insects have accepted you as one of them. You are neutral with eusocial insects, including giant ones (ants, bees, wasps, etc), but your presence is a little unnerving to animals and people (slight morale penalty with mammals and birds, persuade penalty with humans). 

While in here I also replaced all the `MELEE_DAMAGE` perks with `melee_damage_bonus`

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Fancy Footwork: works
Resonating Empowerment: works
Like a Fish in the Water: works
Hive Queen: works
Soothing the Savage Beast: works

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
