### PR TITLE
Update Rubber Dissasembly results

### DIFF
--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -1905,7 +1905,7 @@
     "latent_heat": 165,
     "chip_resist": 8,
     "repaired_with": "plastic_chunk",
-    "salvaged_into": "chunk_rubber",
+    "salvaged_into": "rubber_tire_chunk",
     "dmg_adj": [ "worn", "stressed", "shredded", { "ctxt": "adjective", "str": "ruined" } ],
     "bash_dmg_verb": "stressed",
     "cut_dmg_verb": "slashed",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Replace what rubber items are cut up into"

#### Purpose of change
Changes rubber item's cut up  recults from small rubber chunks to Thick Rubber Chunks, which can still be dissasembled into the smaller version and are more useful generally. Also will allow survivors to actually make tire armor without having to find a specific piece of specialized equipment, luck into finding a tire bereft of rims, or smashing vehicle mounted tires for an hour to get tire chunk drops.

#### Describe the solution
Change a single line so that rubber is cut up into Thick rubber chunks if sizeable enough.
#### Describe alternatives you've considered
Make a new material specifically for car tires so that they can be cut up into tire parts while other rubber items still produce small parts.
 Make some sort of 'makeshift tire changing kit' featuring equipment similar to the stuff featured in this video https://www.youtube.com/watch?v=ii8PtW8lDWY .
#### Testing
Loaded in with the new code, cut up a few tires and other stuff, saw a handy amount of thick chunks.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
