### PR TITLE
Fix `rot_spawn_data` inheritance overriding unset values

### DIFF
--- a/data/json/items/comestibles/egg.json
+++ b/data/json/items/comestibles/egg.json
@@ -28,7 +28,7 @@
     "copy-from": "egg_chicken",
     "name": { "str": "unfertilized bird egg" },
     "description": "A nutritious egg laid by a bird.  This one is unfertilized and probably from a farm.",
-    "rot_spawn": { "chance": 0 }
+    "extend": { "rot_spawn": { "chance": 0 } }
   },
   {
     "type": "ITEM",
@@ -38,7 +38,7 @@
     "spoils_in": "13 days",
     "copy-from": "egg_chicken",
     "proportional": { "volume": 0.73, "weight": 0.73, "calories": 0.73 },
-    "rot_spawn": { "monster": "mon_grouse_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_grouse_chick" } }
   },
   {
     "type": "ITEM",
@@ -48,7 +48,7 @@
     "spoils_in": "9 days",
     "copy-from": "egg_chicken",
     "proportional": { "volume": 0.3, "weight": 0.3, "calories": 0.3 },
-    "rot_spawn": { "monster": "mon_pigeon_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_pigeon_chick" } }
   },
   {
     "type": "ITEM",
@@ -58,7 +58,7 @@
     "spoils_in": "9 days",
     "copy-from": "egg_chicken",
     "proportional": { "volume": 0.34, "weight": 0.34, "calories": 0.34 },
-    "rot_spawn": { "monster": "mon_crow_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_crow_chick" } }
   },
   {
     "type": "ITEM",
@@ -67,7 +67,7 @@
     "name": { "str": "raven egg" },
     "spoils_in": "11 days",
     "copy-from": "egg_crow",
-    "rot_spawn": { "monster": "mon_raven_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_raven_chick" } }
   },
   {
     "type": "ITEM",
@@ -77,7 +77,7 @@
     "spoils_in": "9 days",
     "copy-from": "egg_chicken",
     "proportional": { "volume": 0.18, "weight": 0.18, "calories": 0.18 },
-    "rot_spawn": { "monster": "mon_bluejay_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_bluejay_chick" } }
   },
   {
     "type": "ITEM",
@@ -87,7 +87,7 @@
     "spoils_in": "7 days",
     "copy-from": "egg_chicken",
     "proportional": { "volume": 0.09, "weight": 0.09, "calories": 0.09 },
-    "rot_spawn": { "monster": "mon_cardinal_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_cardinal_chick" } }
   },
   {
     "type": "ITEM",
@@ -99,7 +99,7 @@
     "description": "A nutritious egg laid by a robin.  The shell is colored a distinctive light blue.",
     "color": "light_blue",
     "proportional": { "volume": 0.15, "weight": 0.15, "calories": 0.15 },
-    "rot_spawn": { "monster": "mon_robin_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_robin_chick" } }
   },
   {
     "type": "ITEM",
@@ -109,7 +109,7 @@
     "spoils_in": "7 days",
     "copy-from": "egg_chicken",
     "proportional": { "volume": 0.06, "weight": 0.06, "calories": 0.06 },
-    "rot_spawn": { "monster": "mon_sparrow_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_sparrow_chick" } }
   },
   {
     "type": "ITEM",
@@ -119,7 +119,7 @@
     "spoils_in": "6 days",
     "copy-from": "egg_chicken",
     "proportional": { "volume": 0.03, "weight": 0.03, "calories": 0.03 },
-    "rot_spawn": { "monster": "mon_chickadee_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_chickadee_chick" } }
   },
   {
     "type": "ITEM",
@@ -129,7 +129,7 @@
     "spoils_in": "8 days",
     "copy-from": "egg_chicken",
     "proportional": { "volume": 0.06, "weight": 0.06, "calories": 0.06 },
-    "rot_spawn": { "monster": "mon_waxwing_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_waxwing_chick" } }
   },
   {
     "type": "ITEM",
@@ -141,7 +141,7 @@
     "proportional": { "volume": 1.4, "weight": 1.4 },
     "calories": 130,
     "vitamins": [ [ "iron", "3 mg" ], [ "calcium", "45 mg" ], [ "egg_allergen", 1 ] ],
-    "rot_spawn": { "monster": "mon_duck_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_duck_chick" } }
   },
   {
     "type": "ITEM",
@@ -149,7 +149,7 @@
     "id": "egg_duck_domestic",
     "name": { "str": "domestic duck egg" },
     "copy-from": "egg_duck",
-    "rot_spawn": { "monster": "mon_duck_domestic_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_duck_domestic_chick" } }
   },
   {
     "type": "ITEM",
@@ -161,7 +161,7 @@
     "proportional": { "volume": 3.26, "weight": 3.26 },
     "calories": 302,
     "vitamins": [ [ "iron", "6 mg" ], [ "calcium", "98 mg" ], [ "egg_allergen", 1 ] ],
-    "rot_spawn": { "monster": "mon_goose_canadian_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_goose_canadian_chick" } }
   },
   {
     "type": "ITEM",
@@ -173,7 +173,7 @@
     "proportional": { "volume": 1.58, "weight": 1.58 },
     "calories": 135,
     "vitamins": [ [ "iron", "3 mg" ], [ "calcium", "78 mg" ], [ "egg_allergen", 1 ] ],
-    "rot_spawn": { "monster": "mon_turkey_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_turkey_chick" } }
   },
   {
     "type": "ITEM",
@@ -181,7 +181,7 @@
     "id": "egg_turkey_domestic",
     "name": { "str": "domestic turkey egg" },
     "copy-from": "egg_turkey",
-    "rot_spawn": { "monster": "mon_turkey_domestic_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_turkey_domestic_chick" } }
   },
   {
     "type": "ITEM",
@@ -190,7 +190,7 @@
     "name": { "str": "ring-necked pheasant egg" },
     "spoils_in": "14 days",
     "copy-from": "egg_chicken",
-    "rot_spawn": { "monster": "mon_pheasant_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_pheasant_chick" } }
   },
   {
     "type": "ITEM",
@@ -200,7 +200,7 @@
     "spoils_in": "14 days",
     "copy-from": "egg_chicken",
     "proportional": { "volume": 0.9, "weight": 0.9, "calories": 0.9 },
-    "rot_spawn": { "monster": "mon_guinea_fowl_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_guinea_fowl_chick" } }
   },
   {
     "type": "ITEM",
@@ -210,7 +210,7 @@
     "spoils_in": "23 days",
     "copy-from": "egg_chicken",
     "proportional": { "volume": 0.06, "weight": 0.06, "calories": 0.06 },
-    "rot_spawn": { "monster": "mon_wormsnake_baby" }
+    "extend": { "rot_spawn": { "monster": "mon_wormsnake_baby" } }
   },
   {
     "type": "ITEM",
@@ -220,7 +220,7 @@
     "spoils_in": "40 days",
     "copy-from": "egg_chicken",
     "proportional": { "volume": 0.25, "weight": 0.25, "calories": 0.25 },
-    "rot_spawn": { "monster": "mon_turtle_painted_baby" }
+    "extend": { "rot_spawn": { "monster": "mon_turtle_painted_baby" } }
   },
   {
     "type": "ITEM",
@@ -230,7 +230,7 @@
     "spoils_in": "51 days",
     "copy-from": "egg_chicken",
     "proportional": { "volume": 0.25, "weight": 0.25, "calories": 0.25 },
-    "rot_spawn": { "monster": "mon_turtle_snapping_common_baby" }
+    "extend": { "rot_spawn": { "monster": "mon_turtle_snapping_common_baby" } }
   },
   {
     "type": "ITEM",
@@ -240,7 +240,7 @@
     "spoils_in": "28 days",
     "copy-from": "egg_chicken",
     "proportional": { "volume": 0.06, "weight": 0.06, "calories": 0.06 },
-    "rot_spawn": { "monster": "mon_skink_fivelined_baby" }
+    "extend": { "rot_spawn": { "monster": "mon_skink_fivelined_baby" } }
   },
   {
     "type": "ITEM",
@@ -274,7 +274,7 @@
     "price_postapoc": "5 USD",
     "proportional": { "weight": 4, "calories": 4, "volume": 4 },
     "vitamins": [ [ "calcium", 28 ], [ "iron", 72 ], [ "mutant_toxin", 100 ], [ "egg_allergen", 1 ] ],
-    "rot_spawn": { "monster": "mon_ant_larva", "chance": 100 }
+    "extend": { "rot_spawn": { "monster": "mon_ant_larva", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -283,7 +283,7 @@
     "name": { "str": "acid ant egg" },
     "copy-from": "ant_egg",
     "description": "A large, heavy acid ant egg, the size of a softball.  Extremely nutritious, but incredibly gross.",
-    "rot_spawn": { "monster": "mon_ant_acid_larva" }
+    "extend": { "rot_spawn": { "monster": "mon_ant_acid_larva" } }
   },
   {
     "type": "ITEM",
@@ -292,7 +292,7 @@
     "name": { "str": "roach egg" },
     "description": "A fist-sized egg from a giant roach.  Incredibly gross.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_giant_cockroach_nymph", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_giant_cockroach_nymph", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -301,7 +301,7 @@
     "name": { "str": "plague vector egg" },
     "description": "A fist-sized egg from a plague vector.  Incredibly gross.",
     "copy-from": "egg_roach",
-    "rot_spawn": { "monster": "mon_plague_nymph" }
+    "extend": { "rot_spawn": { "monster": "mon_plague_nymph" } }
   },
   {
     "type": "ITEM",
@@ -311,7 +311,7 @@
     "description": "A fist-sized egg from a locust.",
     "copy-from": "egg_insect",
     "color": "green",
-    "rot_spawn": { "monster": "mon_locust_nymph", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_locust_nymph", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -321,7 +321,7 @@
     "description": "The still-wet egg of a mutated dragonfly.  Serves as a disgusting substitute for the real thing, just don't let it hatch in the water.",
     "copy-from": "egg_insect",
     "color": "light_green",
-    "rot_spawn": { "monster": "mon_dragonfly_naiad", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_dragonfly_naiad", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -331,7 +331,7 @@
     "description": "The fist-sized egg of a mutant firefly.  Glows faintly in the dark.",
     "copy-from": "egg_insect",
     "color": "yellow",
-    "rot_spawn": { "monster": "mon_firefly_larva", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_firefly_larva", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -343,7 +343,7 @@
     "color": "light_green",
     "proportional": { "weight": 2, "calories": 2, "volume": 2 },
     "vitamins": [ [ "calcium", 14 ], [ "iron", 36 ], [ "mutant_toxin", 50 ], [ "egg_allergen", 1 ] ],
-    "rot_spawn": { "monster": "mon_centipede_larva", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_centipede_larva", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -354,7 +354,7 @@
     "copy-from": "egg_insect",
     "color": "white",
     "spoils_in": "2 days",
-    "rot_spawn": { "monster": "mon_wasp_larva", "chance": 100 }
+    "extend": { "rot_spawn": { "monster": "mon_wasp_larva", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -367,7 +367,7 @@
     "spoils_in": "20 days",
     "proportional": { "weight": 5, "calories": 5, "volume": 5 },
     "vitamins": [ [ "calcium", 35 ], [ "iron", 90 ], [ "mutant_toxin", 125 ], [ "egg_allergen", 1 ] ],
-    "rot_spawn": { "monster": "mon_stag_beetle_larva", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_stag_beetle_larva", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -379,7 +379,7 @@
     "color": "yellow",
     "proportional": { "weight": 2, "calories": 2, "volume": 2 },
     "vitamins": [ [ "calcium", 14 ], [ "iron", 36 ], [ "mutant_toxin", 50 ], [ "egg_allergen", 1 ] ],
-    "rot_spawn": { "monster": "mon_antlion_larva", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_antlion_larva", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -388,7 +388,7 @@
     "name": { "str": "water strider egg" },
     "description": "A large, sticky, and wet water strider egg.  You should probably put it back in the water.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_strider_nymph", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_strider_nymph", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -398,7 +398,7 @@
     "description": "A long, white, pill-shaped grasshopper egg.  Inside you can see two twitching legs.",
     "copy-from": "egg_insect",
     "color": "light_green",
-    "rot_spawn": { "monster": "mon_grasshopper_nymph", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_grasshopper_nymph", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -408,7 +408,7 @@
     "description": "A ladybug egg.  It looks like a huge yellow rice grain.  You can see a translucent, hungry larva inside.",
     "copy-from": "egg_insect",
     "color": "light_red",
-    "rot_spawn": { "monster": "mon_lady_bug_larva", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_lady_bug_larva", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -418,7 +418,7 @@
     "description": "A mole cricket egg covered in bits of sand and dirt.  It's brown with a few black dots on it.",
     "copy-from": "egg_insect",
     "color": "brown",
-    "rot_spawn": { "monster": "mon_mole_cricket_nymph", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_mole_cricket_nymph", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -431,7 +431,7 @@
     "spoils_in": "10 days",
     "proportional": { "weight": 5, "calories": 5, "volume": 5 },
     "vitamins": [ [ "calcium", 35 ], [ "iron", 90 ], [ "mutant_toxin", 125 ], [ "egg_allergen", 1 ] ],
-    "rot_spawn": { "monster": "mon_mantis_nymph", "chance": 50, "amount": [ 1, 3 ] }
+    "extend": { "rot_spawn": { "monster": "mon_mantis_nymph", "chance": 50, "amount": [ 1, 3 ] } }
   },
   {
     "type": "ITEM",
@@ -440,7 +440,7 @@
     "name": { "str": "fly egg" },
     "description": "The egg of a fly.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_fly_larva", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_fly_larva", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -449,7 +449,7 @@
     "name": { "str": "moth fly egg" },
     "description": "The egg of a moth fly.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_moth_fly_larva", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_moth_fly_larva", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -458,7 +458,7 @@
     "name": { "str": "silverfish egg" },
     "description": "The egg of a silverfish.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_silverfish_nymph", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_silverfish_nymph", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -467,7 +467,7 @@
     "name": { "str": "house centipede egg" },
     "description": "The egg of a house centipede.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_centipede_house_larva", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_centipede_house_larva", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -476,7 +476,7 @@
     "name": { "str": "mosquito egg" },
     "description": "The egg of a mosquito.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_mosquito_larva", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_mosquito_larva", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -485,7 +485,7 @@
     "name": { "str": "cellar spider egg" },
     "description": "The egg of a cellar spider.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_spider_cellar_giant_s", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_spider_cellar_giant_s", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -494,7 +494,7 @@
     "name": { "str": "jumping spider egg" },
     "description": "The egg of a jumping spider.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_spider_jumping_giant_s", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_spider_jumping_giant_s", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -503,7 +503,7 @@
     "name": { "str": "trapdoor spider egg" },
     "description": "The egg of a trapdoor spider.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_spider_trapdoor_s", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_spider_trapdoor_s", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -512,7 +512,7 @@
     "name": { "str": "web spider egg" },
     "description": "The egg of a web spider.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_spider_web_s", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_spider_web_s", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -521,7 +521,7 @@
     "name": { "str": "black widow egg" },
     "description": "The egg of a black widow.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_spider_widow_giant_s", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_spider_widow_giant_s", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -530,7 +530,7 @@
     "name": { "str": "wolf spider egg" },
     "description": "The egg of a wolf spider.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_spider_wolf_giant_s", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_spider_wolf_giant_s", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -542,7 +542,7 @@
     "spoils_in": "10 days",
     "proportional": { "weight": 5, "calories": 5, "volume": 5 },
     "vitamins": [ [ "calcium", 35 ], [ "iron", 90 ], [ "mutant_toxin", 125 ], [ "egg_allergen", 1 ] ],
-    "rot_spawn": { "monster": "mon_worm_larva", "chance": 50, "amount": [ 1, 3 ] }
+    "extend": { "rot_spawn": { "monster": "mon_worm_larva", "chance": 50, "amount": [ 1, 3 ] } }
   },
   {
     "type": "ITEM",
@@ -551,7 +551,7 @@
     "name": { "str": "slug egg" },
     "description": "The egg of a slug.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_slug_larva", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_slug_larva", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -560,7 +560,7 @@
     "name": { "str": "snail egg" },
     "description": "The egg of a snail.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_snail_larva", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_snail_larva", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -610,7 +610,7 @@
     "id": "egg_brown_trout",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_brown_trout", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_brown_trout", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -618,7 +618,7 @@
     "id": "egg_brook_trout",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_brook_trout", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_brook_trout", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -626,7 +626,7 @@
     "id": "egg_lake_trout",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_lake_trout", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_lake_trout", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -634,7 +634,7 @@
     "id": "egg_rainbow_trout",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_rainbow_trout", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_rainbow_trout", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -642,7 +642,7 @@
     "id": "egg_salmon",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_salmon", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_salmon", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -650,7 +650,7 @@
     "id": "egg_cod",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_cod", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_cod", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -658,7 +658,7 @@
     "id": "egg_haddock",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_haddock", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_haddock", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -666,7 +666,7 @@
     "id": "egg_bluefin_tuna",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_bluefin_tuna", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_bluefin_tuna", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -674,7 +674,7 @@
     "id": "egg_halibut",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_halibut", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_halibut", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -682,7 +682,7 @@
     "id": "egg_pollock",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_pollock", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_pollock", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -690,7 +690,7 @@
     "id": "egg_flounder",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_flounder", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_flounder", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -698,7 +698,7 @@
     "id": "egg_mackerel",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_mackerel", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_mackerel", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -706,7 +706,7 @@
     "id": "egg_bluefish",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_bluefish", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_bluefish", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -714,7 +714,7 @@
     "id": "egg_blackfish",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_blackfish", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_blackfish", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -722,7 +722,7 @@
     "id": "egg_porgy",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_porgy", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_porgy", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -730,7 +730,7 @@
     "id": "egg_kokanee_salmon",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_kokanee_salmon", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_kokanee_salmon", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -738,7 +738,7 @@
     "id": "egg_whitefish",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_whitefish", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_whitefish", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -746,7 +746,7 @@
     "id": "egg_whitefish_round",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_whitefish_round", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_whitefish_round", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -754,7 +754,7 @@
     "id": "egg_lbass",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_lbass", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_lbass", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -762,7 +762,7 @@
     "id": "egg_sbass",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_sbass", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_sbass", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -770,7 +770,7 @@
     "id": "egg_pbass",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_pbass", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_pbass", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -778,7 +778,7 @@
     "id": "egg_perch",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_perch", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_perch", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -786,7 +786,7 @@
     "id": "egg_walleye",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_walleye", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_walleye", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -794,7 +794,7 @@
     "id": "egg_sunfish",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_sunfish", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_sunfish", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -802,7 +802,7 @@
     "id": "egg_pumpkinseed",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_pumpkinseed", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_pumpkinseed", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -810,7 +810,7 @@
     "id": "egg_bluegill",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_bluegill", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_bluegill", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -818,7 +818,7 @@
     "id": "egg_redbreast",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_redbreast", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_redbreast", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -826,7 +826,7 @@
     "id": "egg_green_sunfish",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_green_sunfish", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_green_sunfish", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -834,7 +834,7 @@
     "id": "egg_rock_bass",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_rock_bass", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_rock_bass", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -842,7 +842,7 @@
     "id": "egg_calico_bass",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_calico_bass", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_calico_bass", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -850,7 +850,7 @@
     "id": "egg_warmouth",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_warmouth", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_warmouth", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -858,7 +858,7 @@
     "id": "egg_bullhead",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_bullhead", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_bullhead", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -866,7 +866,7 @@
     "id": "egg_bullhead_yellow",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_bullhead_yellow", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_bullhead_yellow", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -874,7 +874,7 @@
     "id": "egg_channel_catfish",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_channel_catfish", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_channel_catfish", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -882,7 +882,7 @@
     "id": "egg_white_catfish",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_white_catfish", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_white_catfish", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -890,7 +890,7 @@
     "id": "egg_pike",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_pike", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_pike", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -898,7 +898,7 @@
     "id": "egg_pickerel",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_pickerel", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_pickerel", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -906,7 +906,7 @@
     "id": "egg_pickerel_american",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_pickerel_american", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_pickerel_american", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -914,7 +914,7 @@
     "id": "egg_muskellunge",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_muskellunge", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_muskellunge", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -922,7 +922,7 @@
     "id": "egg_white_sucker",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_white_sucker", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_white_sucker", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -930,7 +930,7 @@
     "id": "egg_carp",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_carp", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_carp", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -938,7 +938,7 @@
     "id": "egg_grass_carp",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_grass_carp", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_grass_carp", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -946,7 +946,7 @@
     "id": "egg_goldfish",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_goldfish", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_goldfish", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -954,7 +954,7 @@
     "id": "egg_bowfin",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_bowfin", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_bowfin", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -964,7 +964,7 @@
     "copy-from": "egg_fish",
     "use_action": [ "POISON" ],
     "//": "Gar eggs are poisonous - this is not an oversight. This is also why these are omitted from the cooking requirement group.",
-    "rot_spawn": { "monster": "mon_fry_gar_longnose", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_gar_longnose", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -972,7 +972,7 @@
     "id": "egg_burbot",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_burbot", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_burbot", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -980,7 +980,7 @@
     "id": "egg_sturgeon_lake",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_sturgeon_lake", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_sturgeon_lake", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -988,7 +988,7 @@
     "id": "egg_sturgeon_shortnose",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_sturgeon_shortnose", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_sturgeon_shortnose", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -996,7 +996,7 @@
     "id": "egg_fallfish",
     "name": { "str_sp": "roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "monster": "mon_fry_fallfish", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_fallfish", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -1025,7 +1025,7 @@
     "id": "egg_mutant_salmon",
     "name": { "str_sp": "mutant fish roe" },
     "copy-from": "egg_fish_mutant",
-    "rot_spawn": { "monster": "mon_fry_mutant_salmon", "chance": 45 }
+    "extend": { "rot_spawn": { "monster": "mon_fry_mutant_salmon", "chance": 45 } }
   },
   {
     "type": "ITEM",
@@ -1065,7 +1065,7 @@
     "price_postapoc": "25 cent",
     "flags": [  ],
     "fun": -2,
-    "rot_spawn": { "chance": 0 }
+    "extend": { "rot_spawn": { "chance": 0 } }
   },
   {
     "type": "ITEM",
@@ -1083,8 +1083,8 @@
     "volume": "125 ml",
     "flags": [ "EATEN_HOT", "FREEZERBURN" ],
     "fun": 3,
-    "rot_spawn": { "chance": 0 },
-    "vitamins": [ [ "egg_allergen", 1 ] ]
+    "vitamins": [ [ "egg_allergen", 1 ] ],
+    "extend": { "rot_spawn": { "chance": 0 } }
   },
   {
     "type": "ITEM",
@@ -1110,8 +1110,8 @@
     "material": [ "egg" ],
     "fun": 2,
     "flags": [ "FREEZERBURN" ],
-    "rot_spawn": { "chance": 0 },
-    "vitamins": [ [ "egg_allergen", 1 ] ]
+    "vitamins": [ [ "egg_allergen", 1 ] ],
+    "extend": { "rot_spawn": { "chance": 0 } }
   },
   {
     "type": "ITEM",
@@ -1341,7 +1341,7 @@
     "proportional": { "volume": 2.88, "weight": 2.88 },
     "calories": 266,
     "vitamins": [ [ "iron", "5 mg" ], [ "calcium", "86 mg" ], [ "egg_allergen", 1 ] ],
-    "rot_spawn": { "monster": "mon_goose_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_goose_chick" } }
   },
   {
     "type": "ITEM",
@@ -1354,7 +1354,7 @@
     "volume": "1 ml",
     "calories": 1,
     "//": "Volume and calories defined manually because proportional rounded them down to 0",
-    "rot_spawn": { "monster": "mon_hummingbird_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_hummingbird_chick" } }
   },
   {
     "type": "ITEM",
@@ -1364,7 +1364,7 @@
     "spoils_in": "6 days",
     "copy-from": "egg_chicken",
     "proportional": { "volume": 0.06, "weight": 0.06, "calories": 0.06 },
-    "rot_spawn": { "monster": "mon_woodpecker_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_woodpecker_chick" } }
   },
   {
     "type": "ITEM",
@@ -1374,7 +1374,7 @@
     "spoils_in": "13 days",
     "copy-from": "egg_chicken",
     "proportional": { "volume": 0.73, "weight": 0.73, "calories": 0.73 },
-    "rot_spawn": { "monster": "mon_coot_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_coot_chick" } }
   },
   {
     "type": "ITEM",
@@ -1383,7 +1383,7 @@
     "name": { "str": "double-crested cormorant egg" },
     "spoils_in": "14 days",
     "copy-from": "egg_chicken",
-    "rot_spawn": { "monster": "mon_cormorant_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_cormorant_chick" } }
   },
   {
     "type": "ITEM",
@@ -1392,7 +1392,7 @@
     "name": { "str": "common gallinule egg" },
     "copy-from": "egg_chicken",
     "proportional": { "volume": 0.73, "weight": 0.73, "calories": 0.73 },
-    "rot_spawn": { "monster": "mon_moorhen_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_moorhen_chick" } }
   },
   {
     "type": "ITEM",
@@ -1401,7 +1401,7 @@
     "name": { "str": "horned grebe egg" },
     "spoils_in": "12 days",
     "copy-from": "egg_chicken",
-    "rot_spawn": { "monster": "mon_grebe_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_grebe_chick" } }
   },
   {
     "type": "ITEM",
@@ -1410,7 +1410,7 @@
     "name": "water beetle egg",
     "description": "The egg of a water beetle, usually found near aquatic grass.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_diving_larva", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_diving_larva", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -1419,7 +1419,7 @@
     "name": "water scorpion egg",
     "copy-from": "egg_insect",
     "description": "The egg of a water scorpion, usually found near aquatic grass.",
-    "rot_spawn": { "monster": "mon_water_scorpion_larva", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_water_scorpion_larva", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -1428,7 +1428,7 @@
     "name": "butterfly egg",
     "description": "The egg of a butterfly.  They are usually found clustered on leaves.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_caterpillar_butterfly", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_caterpillar_butterfly", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -1437,7 +1437,7 @@
     "name": "moth egg",
     "description": "The egg of a moth.  They are usually found clustered on leaves.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_caterpillar_moth", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_caterpillar_moth", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -1446,7 +1446,7 @@
     "name": "cicada egg",
     "description": "The egg of a cicada.  They are usually found near trees.",
     "copy-from": "egg_insect",
-    "rot_spawn": { "monster": "mon_cicada_nymph", "chance": 50 }
+    "extend": { "rot_spawn": { "monster": "mon_cicada_nymph", "chance": 50 } }
   },
   {
     "type": "ITEM",
@@ -1486,7 +1486,7 @@
     "copy-from": "egg_proxy_frog",
     "name": { "str": "cluster of frog's eggs", "str_pl": "clusters of frog's eggs" },
     "description": "This is a dense cluster of dark frog's eggs, not dissimilar in appearance to caviar.",
-    "rot_spawn": { "monster": "mon_leo_tadpole", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_leo_tadpole", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -1495,7 +1495,7 @@
     "copy-from": "egg_proxy_frog",
     "name": { "str": "cluster of frog's eggs", "str_pl": "clusters of frog's eggs" },
     "description": "A thin film of frog eggs floats together atop the water in a roughly circular mass.",
-    "rot_spawn": { "monster": "mon_bullfrog_tadpole", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_bullfrog_tadpole", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -1505,7 +1505,7 @@
     "name": { "str": "cluster of frog's eggs", "str_pl": "clusters of frog's eggs" },
     "description": "These eggs float in long strands, drifting in the still water.",
     "use_action": [ "POISON" ],
-    "rot_spawn": { "monster": "mon_fowler_tadpole", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_fowler_tadpole", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -1515,7 +1515,7 @@
     "name": { "str": "cluster of frog's eggs", "str_pl": "clusters of frog's eggs" },
     "description": "A spiral strand of frog eggs adorns a patch of underwater vegetation.",
     "use_action": [ "POISON" ],
-    "rot_spawn": { "monster": "mon_freedom_tadpole", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_freedom_tadpole", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -1524,7 +1524,7 @@
     "copy-from": "egg_proxy_frog",
     "name": { "str": "cluster of frog's eggs", "str_pl": "clusters of frog's eggs" },
     "description": "A loose grouping of surprisingly few frog's eggs, anchored to submerged vegetation.",
-    "rot_spawn": { "monster": "mon_peeper_tadpole", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_peeper_tadpole", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -1533,7 +1533,7 @@
     "copy-from": "egg_proxy_frog",
     "name": { "str": "cluster of frog's eggs", "str_pl": "clusters of frog's eggs" },
     "description": "A small patch of frog's eggs rests on the water's surface.",
-    "rot_spawn": { "monster": "mon_gray_tadpole", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_gray_tadpole", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -1542,7 +1542,7 @@
     "copy-from": "egg_proxy_frog",
     "name": { "str": "cluster of frog's eggs", "str_pl": "clusters of frog's eggs" },
     "description": "A tight, spherical cluster of eggs, often found near submerged vegetation.  This cluster is polar, with dark pigment collected near the tops of the eggs and white left on the underside.",
-    "rot_spawn": { "monster": "mon_mink_tadpole", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_mink_tadpole", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -1552,7 +1552,7 @@
     "name": { "str": "cluster of frog's eggs", "str_pl": "clusters of frog's eggs" },
     "description": "A globular mass of frog's eggs.  The individual eggs are colored a dark brown on top and a yellow-cream on the bottom.",
     "use_action": [ "POISON" ],
-    "rot_spawn": { "monster": "mon_pickerel_tadpole", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_pickerel_tadpole", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -1561,7 +1561,7 @@
     "copy-from": "egg_proxy_frog",
     "name": { "str": "cluster of frog's eggs", "str_pl": "clusters of frog's eggs" },
     "description": "A thin sheet of clear, gelatinous eggs with dark embryos peppered throughout.",
-    "rot_spawn": { "monster": "mon_green_tadpole", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_green_tadpole", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -1570,7 +1570,7 @@
     "copy-from": "egg_proxy_frog",
     "name": { "str": "cluster of frog's eggs", "str_pl": "clusters of frog's eggs" },
     "description": "This softball-sized mass of gooey eggs clings together like a bunch of soft, transparent grapes.  The \"seeds\" inside these appear to be growing legs.",
-    "rot_spawn": { "monster": "mon_wood_tadpole", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_wood_tadpole", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -1580,7 +1580,7 @@
     "name": { "str": "cluster of frog's eggs", "str_pl": "clusters of frog's eggs" },
     "description": "Several short strands of tightly clustered black eggs connected together by their viscous coverings.",
     "use_action": [ "POISON" ],
-    "rot_spawn": { "monster": "mon_spade_tadpole", "chance": 20 }
+    "extend": { "rot_spawn": { "monster": "mon_spade_tadpole", "chance": 20 } }
   },
   {
     "type": "ITEM",
@@ -1606,7 +1606,7 @@
     "copy-from": "egg_proxy_bigfrog",
     "name": { "str": "cluster of giant frog's eggs", "str_pl": "clusters of giant frog's eggs" },
     "description": "From a distance you could mistake it for a cluster of gigantic caviar.  It is only on close inspection that you can make out the faint translucence of these softball-sized frog eggs.",
-    "rot_spawn": { "monster": "mon_pattern_bigtad", "chance": 45 }
+    "extend": { "rot_spawn": { "monster": "mon_pattern_bigtad", "chance": 45 } }
   },
   {
     "type": "ITEM",
@@ -1615,7 +1615,7 @@
     "copy-from": "egg_proxy_bigfrog",
     "name": { "str": "cluster of giant frog's eggs", "str_pl": "clusters of giant frog's eggs" },
     "description": "A thick flotilla of enormous frog eggs floats together atop the water in a roughly circular mass.",
-    "rot_spawn": { "monster": "mon_strange_bigtad", "chance": 45 }
+    "extend": { "rot_spawn": { "monster": "mon_strange_bigtad", "chance": 45 } }
   },
   {
     "type": "ITEM",
@@ -1625,7 +1625,7 @@
     "name": { "str": "cluster of giant frog's eggs", "str_pl": "clusters of giant frog's eggs" },
     "description": "Looking like a submerged buoy-line, this long strand of softball-sized, gelatinous eggs floats gently in the still water.",
     "use_action": [ "POISON" ],
-    "rot_spawn": { "monster": "mon_foul_bigtad", "chance": 45 }
+    "extend": { "rot_spawn": { "monster": "mon_foul_bigtad", "chance": 45 } }
   },
   {
     "type": "ITEM",
@@ -1635,7 +1635,7 @@
     "name": { "str": "cluster of giant frog's eggs", "str_pl": "clusters of giant frog's eggs" },
     "description": "This is a spiral strand of giant frog eggs.  Its increased weight and size nearly smothers the submerged vegetation it clings to.",
     "use_action": [ "POISON" ],
-    "rot_spawn": { "monster": "mon_odd_bigtad", "chance": 45 }
+    "extend": { "rot_spawn": { "monster": "mon_odd_bigtad", "chance": 45 } }
   },
   {
     "type": "ITEM",
@@ -1644,7 +1644,7 @@
     "copy-from": "egg_proxy_bigfrog",
     "name": { "str": "cluster of giant frog's eggs", "str_pl": "clusters of giant frog's eggs" },
     "description": "A patch of giant frog's eggs resembling a very thick, clear sack of oranges.",
-    "rot_spawn": { "monster": "mon_vocal_bigtad", "chance": 45 }
+    "extend": { "rot_spawn": { "monster": "mon_vocal_bigtad", "chance": 45 } }
   },
   {
     "type": "ITEM",
@@ -1654,6 +1654,6 @@
     "name": { "str": "cluster of giant frog's eggs", "str_pl": "clusters of giant frog's eggs" },
     "description": "These golfball-sized frog eggs cling together by their sticky membranes.",
     "use_action": [ "POISON" ],
-    "rot_spawn": { "monster": "mon_shift_bigtad", "chance": 45 }
+    "extend": { "rot_spawn": { "monster": "mon_shift_bigtad", "chance": 45 } }
   }
 ]

--- a/data/mods/DinoMod/items/egg.json
+++ b/data/mods/DinoMod/items/egg.json
@@ -37,8 +37,8 @@
     "description": "Pale, round egg laid by a smaller dinosaur.",
     "material": [ "egg" ],
     "volume": "12 ml",
-    "rot_spawn": { "group": "GROUP_EGG_DINO_SMALL" },
-    "vitamins": [ [ "egg_allergen", 1 ] ]
+    "vitamins": [ [ "egg_allergen", 1 ] ],
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_DINO_SMALL" } }
   },
   {
     "type": "ITEM",
@@ -53,8 +53,8 @@
     "description": "Pale, round egg laid by a larger dinosaur.",
     "material": [ "egg" ],
     "volume": "3400 ml",
-    "rot_spawn": { "group": "GROUP_EGG_DINO_LARGE" },
-    "vitamins": [ [ "egg_allergen", 1 ] ]
+    "vitamins": [ [ "egg_allergen", 1 ] ],
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_DINO_LARGE" } }
   },
   {
     "type": "ITEM",
@@ -89,8 +89,8 @@
     "comestible_type": "FOOD",
     "description": "Pale, football-shaped egg laid by a smaller dinosaur.",
     "material": [ "egg" ],
-    "rot_spawn": { "group": "GROUP_EGG_THEROPOD_SMALL" },
-    "vitamins": [ [ "egg_allergen", 1 ] ]
+    "vitamins": [ [ "egg_allergen", 1 ] ],
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_THEROPOD_SMALL" } }
   },
   {
     "type": "ITEM",
@@ -105,8 +105,8 @@
     "description": "Pale, football-shaped egg laid by a larger dinosaur.",
     "material": [ "egg" ],
     "volume": "3400 ml",
-    "rot_spawn": { "group": "GROUP_EGG_THEROPOD_LARGE" },
-    "vitamins": [ [ "egg_allergen", 1 ] ]
+    "vitamins": [ [ "egg_allergen", 1 ] ],
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_THEROPOD_LARGE" } }
   },
   {
     "type": "ITEM",
@@ -114,7 +114,7 @@
     "id": "egg_tawa",
     "name": "tawa egg",
     "copy-from": "egg_dino_theropod_small",
-    "rot_spawn": { "monster": "mon_tawa_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_tawa_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -122,7 +122,7 @@
     "id": "egg_coelophysis",
     "name": "coelophysis egg",
     "copy-from": "egg_dino_theropod_small",
-    "rot_spawn": { "monster": "mon_coelophysis_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_coelophysis_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -130,7 +130,7 @@
     "id": "egg_dilophosaurus",
     "name": "dilophosaurus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_dilophosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_dilophosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -138,7 +138,7 @@
     "id": "egg_ceratosaurus",
     "name": "ceratosaurus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_ceratosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_ceratosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -146,7 +146,7 @@
     "id": "egg_spinosaurus",
     "name": "spinosaurus egg",
     "copy-from": "egg_dino_theropod_large",
-    "rot_spawn": { "monster": "mon_spinosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_spinosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -154,7 +154,7 @@
     "id": "egg_torvosaurus",
     "name": "torvosaurus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_torvosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_torvosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -162,7 +162,7 @@
     "id": "egg_allosaurus",
     "name": "allosaurus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_allosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_allosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -170,7 +170,7 @@
     "id": "egg_acrocanthosaurus",
     "name": "acrocanthosaurus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_acrocanthosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_acrocanthosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -178,7 +178,7 @@
     "id": "egg_giganotosaurus",
     "name": "giganotosaurus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_giganotosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_giganotosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -186,7 +186,7 @@
     "id": "egg_siats",
     "name": "siats egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_siats_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_siats_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -194,7 +194,7 @@
     "id": "egg_dryptosaurus",
     "name": "dryptosaurus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_dryptosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_dryptosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -202,7 +202,7 @@
     "id": "egg_nanotyrannus",
     "name": "nanotyrannus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_nanotyrannus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_nanotyrannus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -210,7 +210,7 @@
     "id": "egg_appalachiosaurus",
     "name": "appalachiosaurus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_appalachiosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_appalachiosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -218,7 +218,7 @@
     "id": "egg_gorgosaurus",
     "name": "gorgosaurus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_gorgosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_gorgosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -226,7 +226,7 @@
     "id": "egg_albertosaurus",
     "name": "albertosaurus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_albertosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_albertosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -234,7 +234,7 @@
     "id": "egg_qianzhousaurus",
     "name": "qianzhousaurus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_qianzhousaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_qianzhousaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -242,7 +242,7 @@
     "id": "egg_nanuqsaurus",
     "name": "nanuqsaurus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_nanuqsaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_nanuqsaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -250,7 +250,7 @@
     "id": "egg_daspletosaurus",
     "name": "daspletosaurus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_daspletosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_daspletosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -258,7 +258,7 @@
     "id": "egg_tyrannosaurus",
     "name": "tyrannosaurus egg",
     "copy-from": "egg_dino_theropod_large",
-    "rot_spawn": { "monster": "mon_tyrannosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_tyrannosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -266,7 +266,7 @@
     "id": "egg_compsognathus",
     "name": "compsognathus egg",
     "copy-from": "egg_dino_theropod_small",
-    "rot_spawn": { "monster": "mon_compsognathus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_compsognathus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -274,7 +274,7 @@
     "id": "egg_nedcolbertia",
     "name": "nedcolbertia egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_nedcolbertia_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_nedcolbertia_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -282,7 +282,7 @@
     "id": "egg_gallimimus",
     "name": "gallimimus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_gallimimus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_gallimimus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -290,7 +290,7 @@
     "id": "egg_struthiomimus",
     "name": "struthiomimus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_struthiomimus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_struthiomimus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -298,7 +298,7 @@
     "id": "egg_ornithomimus",
     "name": "ornithomimus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_ornithomimus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_ornithomimus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -306,7 +306,7 @@
     "id": "egg_albertonykus",
     "name": "albertonykus egg",
     "copy-from": "egg_dino_theropod_small",
-    "rot_spawn": { "monster": "mon_albertonykus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_albertonykus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -314,7 +314,7 @@
     "id": "egg_falcarius",
     "name": "falcarius egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_falcarius_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_falcarius_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -322,7 +322,7 @@
     "id": "egg_therizinosaurus",
     "name": "therizinosaurus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_therizinosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_therizinosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -330,7 +330,7 @@
     "id": "egg_nothronychus",
     "name": "nothronychus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_nothronychus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_nothronychus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -338,7 +338,7 @@
     "id": "egg_anzu",
     "name": "anzu egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_anzu_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_anzu_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -346,7 +346,7 @@
     "id": "egg_saurornitholestes",
     "name": "saurornitholestes egg",
     "copy-from": "egg_dino_theropod_small",
-    "rot_spawn": { "monster": "mon_saurornitholestes_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_saurornitholestes_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -354,7 +354,7 @@
     "id": "egg_velociraptor",
     "name": "velociraptor egg",
     "copy-from": "egg_dino_theropod_small",
-    "rot_spawn": { "monster": "mon_velociraptor_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_velociraptor_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -362,7 +362,7 @@
     "id": "egg_deinonychus",
     "name": "deinonychus egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_deinonychus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_deinonychus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -370,7 +370,7 @@
     "id": "egg_utahraptor",
     "name": "utahraptor egg",
     "copy-from": "egg_dino_theropod",
-    "rot_spawn": { "monster": "mon_utahraptor_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_utahraptor_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -378,7 +378,7 @@
     "id": "egg_dromaeosaurus",
     "name": "dromaeosaurus egg",
     "copy-from": "egg_dino_theropod_small",
-    "rot_spawn": { "monster": "mon_dromaeosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_dromaeosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -386,7 +386,7 @@
     "id": "egg_stenonychosaurus",
     "name": "stenonychosaurus egg",
     "copy-from": "egg_dino_theropod_small",
-    "rot_spawn": { "monster": "mon_stenonychosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_stenonychosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -394,7 +394,7 @@
     "id": "egg_eoraptor",
     "name": "eoraptor egg",
     "copy-from": "egg_dino_small",
-    "rot_spawn": { "monster": "mon_eoraptor_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_eoraptor_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -402,7 +402,7 @@
     "id": "egg_sarahsaurus",
     "name": "sarahsaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_sarahsaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_sarahsaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -410,7 +410,7 @@
     "id": "egg_anchisaurus",
     "name": "anchisaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_anchisaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_anchisaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -418,7 +418,7 @@
     "id": "egg_issi",
     "name": "issi egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_issi_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_issi_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -426,7 +426,7 @@
     "id": "egg_moabosaurus",
     "name": "moabosaurus egg",
     "copy-from": "egg_dino_large",
-    "rot_spawn": { "monster": "mon_moabosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_moabosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -434,7 +434,7 @@
     "id": "egg_haplocanthosaurus",
     "name": "haplocanthosaurus egg",
     "copy-from": "egg_dino_large",
-    "rot_spawn": { "monster": "mon_haplocanthosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_haplocanthosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -442,7 +442,7 @@
     "id": "egg_amargasaurus",
     "name": "amargasaurus egg",
     "copy-from": "egg_dino_large",
-    "rot_spawn": { "monster": "mon_amargasaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_amargasaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -450,7 +450,7 @@
     "id": "egg_apatosaurus",
     "name": "apatosaurus egg",
     "copy-from": "egg_dino_large",
-    "rot_spawn": { "monster": "mon_apatosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_apatosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -458,7 +458,7 @@
     "id": "egg_brontosaurus",
     "name": "brontosaurus egg",
     "copy-from": "egg_dino_large",
-    "rot_spawn": { "monster": "mon_brontosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_brontosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -466,7 +466,7 @@
     "id": "egg_diplodocus",
     "name": "diplodocus egg",
     "copy-from": "egg_dino_large",
-    "rot_spawn": { "monster": "mon_diplodocus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_diplodocus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -474,7 +474,7 @@
     "id": "egg_barosaurus",
     "name": "barosaurus egg",
     "copy-from": "egg_dino_large",
-    "rot_spawn": { "monster": "mon_barosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_barosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -482,7 +482,7 @@
     "id": "egg_camarasaurus",
     "name": "camarasaurus egg",
     "copy-from": "egg_dino_large",
-    "rot_spawn": { "monster": "mon_camarasaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_camarasaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -490,7 +490,7 @@
     "id": "egg_brachiosaurus",
     "name": "brachiosaurus egg",
     "copy-from": "egg_dino_large",
-    "rot_spawn": { "monster": "mon_brachiosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_brachiosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -498,7 +498,7 @@
     "id": "egg_astrodon",
     "name": "astrodon egg",
     "copy-from": "egg_dino_large",
-    "rot_spawn": { "monster": "mon_astrodon_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_astrodon_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -506,7 +506,7 @@
     "id": "egg_alamosaurus",
     "name": "alamosaurus egg",
     "copy-from": "egg_dino_large",
-    "rot_spawn": { "monster": "mon_alamosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_alamosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -514,7 +514,7 @@
     "id": "egg_scutellosaurus",
     "name": "scutellosaurus egg",
     "copy-from": "egg_dino_small",
-    "rot_spawn": { "monster": "mon_scutellosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_scutellosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -522,7 +522,7 @@
     "id": "egg_stegosaurus",
     "name": "stegosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_stegosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_stegosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -530,7 +530,7 @@
     "id": "egg_hesperosaurus",
     "name": "hesperosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_hesperosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_hesperosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -538,7 +538,7 @@
     "id": "egg_gastonia",
     "name": "gastonia egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_gastonia_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_gastonia_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -546,7 +546,7 @@
     "id": "egg_gargoyleosaurus",
     "name": "gargoyleosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_gargoyleosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_gargoyleosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -554,7 +554,7 @@
     "id": "egg_sauropelta",
     "name": "sauropelta egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_sauropelta_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_sauropelta_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -562,7 +562,7 @@
     "id": "egg_nodosaurus",
     "name": "nodosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_nodosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_nodosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -570,7 +570,7 @@
     "id": "egg_panoplosaurus",
     "name": "panoplosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_panoplosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_panoplosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -578,7 +578,7 @@
     "id": "egg_edmontonia",
     "name": "edmontonia egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_edmontonia_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_edmontonia_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -586,7 +586,7 @@
     "id": "egg_zuul",
     "name": "zuul egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_zuul_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_zuul_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -594,7 +594,7 @@
     "id": "egg_dyoplosaurus",
     "name": "dyoplosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_dyoplosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_dyoplosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -602,7 +602,7 @@
     "id": "egg_ankylosaurus",
     "name": "ankylosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_ankylosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_ankylosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -610,7 +610,7 @@
     "id": "egg_euoplocephalus",
     "name": "euoplocephalus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_euoplocephalus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_euoplocephalus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -618,7 +618,7 @@
     "id": "egg_scolosaurus",
     "name": "scolosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_scolosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_scolosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -626,7 +626,7 @@
     "id": "egg_tenontosaurus",
     "name": "tenontosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_tenontosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_tenontosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -634,7 +634,7 @@
     "id": "egg_dryosaurus",
     "name": "dryosaurus egg",
     "copy-from": "egg_dino_small",
-    "rot_spawn": { "monster": "mon_dryosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_dryosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -642,7 +642,7 @@
     "id": "egg_camptosaurus",
     "name": "camptosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_camptosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_camptosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -650,7 +650,7 @@
     "id": "egg_iguanodon",
     "name": "iguanodon egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_iguanodon_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_iguanodon_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -658,7 +658,7 @@
     "id": "egg_eolambia",
     "name": "eolambia egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_eolambia_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_eolambia_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -666,7 +666,7 @@
     "id": "egg_hadrosaurus",
     "name": "hadrosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_hadrosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_hadrosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -674,7 +674,7 @@
     "id": "egg_maiasaura",
     "name": "maiasaura egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_maiasaura_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_maiasaura_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -682,7 +682,7 @@
     "id": "egg_gryposaurus",
     "name": "gryposaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_gryposaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_gryposaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -690,7 +690,7 @@
     "id": "egg_prosaurolophus",
     "name": "prosaurolophus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_prosaurolophus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_prosaurolophus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -698,7 +698,7 @@
     "id": "egg_saurolophus",
     "name": "saurolophus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_saurolophus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_saurolophus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -706,7 +706,7 @@
     "id": "egg_edmontosaurus",
     "name": "edmontosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_edmontosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_edmontosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -714,7 +714,7 @@
     "id": "egg_parasaurolophus",
     "name": "parasaurolophus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_parasaurolophus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_parasaurolophus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -722,7 +722,7 @@
     "id": "egg_lambeosaurus",
     "name": "lambeosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_lambeosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_lambeosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -730,7 +730,7 @@
     "id": "egg_corythosaurus",
     "name": "corythosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_corythosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_corythosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -738,7 +738,7 @@
     "id": "egg_hypacrosaurus",
     "name": "hypacrosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_hypacrosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_hypacrosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -746,7 +746,7 @@
     "id": "egg_stegoceras",
     "name": "stegoceras egg",
     "copy-from": "egg_dino_small",
-    "rot_spawn": { "monster": "mon_stegoceras_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_stegoceras_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -754,7 +754,7 @@
     "id": "egg_pachycephalosaurus",
     "name": "pachycephalosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_pachycephalosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_pachycephalosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -762,7 +762,7 @@
     "id": "egg_aquilops",
     "name": "aquilops egg",
     "copy-from": "egg_dino_small",
-    "rot_spawn": { "monster": "mon_aquilops_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_aquilops_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -770,7 +770,7 @@
     "id": "egg_leptoceratops",
     "name": "leptoceratops egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_leptoceratops_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_leptoceratops_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -778,7 +778,7 @@
     "id": "egg_zuniceratops",
     "name": "zuniceratops egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_zuniceratops_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_zuniceratops_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -786,7 +786,7 @@
     "id": "egg_lokiceratops",
     "name": "lokiceratops egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_lokiceratops_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_lokiceratops_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -794,7 +794,7 @@
     "id": "egg_styracosaurus",
     "name": "styracosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_styracosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_styracosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -802,7 +802,7 @@
     "id": "egg_centrosaurus",
     "name": "centrosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_centrosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_centrosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -810,7 +810,7 @@
     "id": "egg_einiosaurus",
     "name": "einiosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_einiosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_einiosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -818,7 +818,7 @@
     "id": "egg_achelousaurus",
     "name": "achelousaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_achelousaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_achelousaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -826,7 +826,7 @@
     "id": "egg_pachyrhinosaurus",
     "name": "pachyrhinosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_pachyrhinosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_pachyrhinosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -834,7 +834,7 @@
     "id": "egg_chasmosaurus",
     "name": "chasmosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_chasmosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_chasmosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -842,7 +842,7 @@
     "id": "egg_pentaceratops",
     "name": "pentaceratops egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_pentaceratops_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_pentaceratops_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -850,7 +850,7 @@
     "id": "egg_kosmoceratops",
     "name": "kosmoceratops egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_kosmoceratops_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_kosmoceratops_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -858,7 +858,7 @@
     "id": "egg_torosaurus",
     "name": "torosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_torosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_torosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -866,7 +866,7 @@
     "id": "egg_triceratops",
     "name": "triceratops egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_triceratops_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_triceratops_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -874,7 +874,7 @@
     "id": "egg_nanosaurus",
     "name": "nanosaurus egg",
     "copy-from": "egg_dino_small",
-    "rot_spawn": { "monster": "mon_nanosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_nanosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -882,7 +882,7 @@
     "id": "egg_fona",
     "name": "fona egg",
     "copy-from": "egg_dino_small",
-    "rot_spawn": { "monster": "mon_fona_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_fona_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -890,7 +890,7 @@
     "id": "egg_oryctodromeus",
     "name": "oryctodromeus egg",
     "copy-from": "egg_dino_small",
-    "rot_spawn": { "monster": "mon_oryctodromeus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_oryctodromeus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -898,7 +898,7 @@
     "id": "egg_thescelosaurus",
     "name": "thescelosaurus egg",
     "copy-from": "egg_dino",
-    "rot_spawn": { "monster": "mon_thescelosaurus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_thescelosaurus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -906,7 +906,7 @@
     "id": "egg_dimorphodon",
     "name": "dimorphodon egg",
     "copy-from": "egg_chicken",
-    "rot_spawn": { "monster": "mon_dimorphodon_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_dimorphodon_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -914,7 +914,7 @@
     "id": "egg_pteranodon",
     "name": "pteranodon egg",
     "copy-from": "egg_chicken",
-    "rot_spawn": { "monster": "mon_pteranodon_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_pteranodon_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -922,7 +922,7 @@
     "id": "egg_quetzalcoatlus",
     "name": "quetzalcoatlus egg",
     "copy-from": "egg_chicken",
-    "rot_spawn": { "monster": "mon_quetzalcoatlus_hatchling" }
+    "extend": { "rot_spawn": { "monster": "mon_quetzalcoatlus_hatchling" } }
   },
   {
     "type": "ITEM",
@@ -939,8 +939,8 @@
     "material": [ "egg" ],
     "fun": 2,
     "flags": [ "FREEZERBURN" ],
-    "rot_spawn": { "group": "GROUP_NULL", "chance": 0 },
-    "vitamins": [ [ "egg_allergen", 1 ] ]
+    "vitamins": [ [ "egg_allergen", 1 ] ],
+    "extend": { "rot_spawn": { "group": "GROUP_NULL", "chance": 0 } }
   },
   {
     "type": "ITEM",
@@ -957,8 +957,8 @@
     "material": [ "egg" ],
     "fun": 10,
     "flags": [ "FREEZERBURN" ],
-    "rot_spawn": { "group": "GROUP_NULL", "chance": 0 },
-    "vitamins": [ [ "egg_allergen", 1 ] ]
+    "vitamins": [ [ "egg_allergen", 1 ] ],
+    "extend": { "rot_spawn": { "group": "GROUP_NULL", "chance": 0 } }
   },
   {
     "type": "ITEM",
@@ -975,7 +975,7 @@
     "material": [ "egg" ],
     "fun": 20,
     "flags": [ "FREEZERBURN" ],
-    "rot_spawn": { "group": "GROUP_NULL", "chance": 0 },
-    "vitamins": [ [ "egg_allergen", 1 ] ]
+    "vitamins": [ [ "egg_allergen", 1 ] ],
+    "extend": { "rot_spawn": { "group": "GROUP_NULL", "chance": 0 } }
   }
 ]

--- a/data/mods/Magiclysm/items/comestibles.json
+++ b/data/mods/Magiclysm/items/comestibles.json
@@ -32,7 +32,7 @@
     "quench": 14,
     "calories": 2100,
     "volume": "1800 ml",
-    "rot_spawn": { "monster": "mon_giant_heron_ridable_chick", "chance": 75 }
+    "extend": { "rot_spawn": { "monster": "mon_giant_heron_ridable_chick", "chance": 75 } }
   },
   {
     "type": "ITEM",

--- a/data/mods/Megafauna/items/animal_products.json
+++ b/data/mods/Megafauna/items/animal_products.json
@@ -29,7 +29,7 @@
     "quench": 9,
     "calories": 140,
     "volume": "90 ml",
-    "rot_spawn": { "group": "GROUP_EGG_AUK" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_AUK" } }
   },
   {
     "type": "ITEM",
@@ -41,7 +41,7 @@
     "quench": 14,
     "calories": 2100,
     "volume": "1800 ml",
-    "rot_spawn": { "group": "GROUP_EGG_TITANIS_WALLERI" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_TITANIS_WALLERI" } }
   },
   {
     "type": "ITEM",

--- a/data/mods/MindOverMatter/items/comestible_overrides.json
+++ b/data/mods/MindOverMatter/items/comestible_overrides.json
@@ -5,7 +5,7 @@
     "id": "egg_chicken",
     "copy-from": "egg_chicken",
     "name": { "str": "chicken egg" },
-    "rot_spawn": { "group": "GROUP_EGG_CHICKEN", "chance": 70 }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_CHICKEN", "chance": 70 } }
   },
   {
     "type": "ITEM",
@@ -13,7 +13,7 @@
     "id": "egg_pigeon",
     "name": { "str": "feral pigeon egg" },
     "copy-from": "egg_pigeon",
-    "rot_spawn": { "group": "GROUP_EGG_PIGEON" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_PIGEON" } }
   },
   {
     "type": "ITEM",

--- a/data/mods/MindOverMatter/items/comestibles.json
+++ b/data/mods/MindOverMatter/items/comestibles.json
@@ -229,7 +229,7 @@
     "id": "egg_cockatrice",
     "name": { "str": "cockatrice egg" },
     "copy-from": "egg_chicken",
-    "rot_spawn": { "group": "GROUP_EGG_COCKATRICE" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_COCKATRICE" } }
   },
   {
     "id": "black_nether_water",
@@ -258,6 +258,6 @@
     "id": "egg_pigeon_passenger",
     "name": { "str": "feral pigeon egg" },
     "copy-from": "egg_pigeon",
-    "rot_spawn": { "monster": "mon_pigeon_passenger", "chance": 70 }
+    "extend": { "rot_spawn": { "monster": "mon_pigeon_passenger", "chance": 70 } }
   }
 ]

--- a/data/mods/My_Sweet_Cataclysm/sweet_comestibles.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_comestibles.json
@@ -30,8 +30,8 @@
     "container": "null",
     "description": "A handful of squishy, fluffy, puffy, delicious marshmallows.  They feel oddly warm…",
     "copy-from": "marshmallow",
-    "rot_spawn": { "group": "GROUP_EGG_MARSHMALLOW", "chance": 100 },
-    "spoils_in": "15 days"
+    "spoils_in": "15 days",
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_MARSHMALLOW", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -42,8 +42,8 @@
     "container": "null",
     "copy-from": "smores",
     "description": "A pair of graham crackers with some chocolate and a marshmallow between them.  Warmth radiates from it as if it is… alive?",
-    "rot_spawn": { "group": "GROUP_EGG_SMORES", "chance": 100 },
-    "spoils_in": "15 days"
+    "spoils_in": "15 days",
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_SMORES", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -54,8 +54,8 @@
     "symbol": "%",
     "container": "null",
     "copy-from": "candy3",
-    "rot_spawn": { "group": "GROUP_EGG_GUMMY", "chance": 100 },
-    "spoils_in": "15 days"
+    "spoils_in": "15 days",
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_GUMMY", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -66,8 +66,8 @@
     "symbol": "%",
     "container": "null",
     "copy-from": "candy3",
-    "rot_spawn": { "group": "GROUP_EGG_GUMMY_GATOR", "chance": 100 },
-    "spoils_in": "15 days"
+    "spoils_in": "15 days",
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_GUMMY_GATOR", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -78,8 +78,8 @@
     "container": "null",
     "description": "Dry and sugary, these crackers will leave you thirsty, but go good with some chocolate and marshmallows.  They shiver under your touch.  Weird!",
     "copy-from": "grahmcrackers",
-    "rot_spawn": { "group": "GROUP_EGG_CRACKER", "chance": 100 },
-    "spoils_in": "20 days"
+    "spoils_in": "20 days",
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_CRACKER", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -90,8 +90,8 @@
     "container": "null",
     "description": "Dry and sugary, these cracker pellets will leave you thirsty, but go good with some chocolate and marshmallows.  They shiver under your touch.  Weird!",
     "copy-from": "grahmcrackers",
-    "rot_spawn": { "group": "GROUP_EGG_CRACKER_ROE", "chance": 100 },
-    "spoils_in": "20 days"
+    "spoils_in": "20 days",
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_CRACKER_ROE", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -102,8 +102,8 @@
     "container": "null",
     "description": "Sweet and delicious cookies, just like grandma used to bake.  They shiver under your touch.  Weird!",
     "copy-from": "cookies",
-    "rot_spawn": { "group": "GROUP_EGG_COOKIE", "chance": 100 },
-    "spoils_in": "10 days"
+    "spoils_in": "10 days",
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_COOKIE", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -114,8 +114,8 @@
     "container": "null",
     "description": "Sweet and delicious cookies, shaped like eggs.  They shiver under your touch as if something is inside.  Weird!",
     "copy-from": "cookies",
-    "rot_spawn": { "group": "GROUP_EGG_COOKIE_EGG", "chance": 100 },
-    "spoils_in": "10 days"
+    "spoils_in": "10 days",
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_COOKIE_EGG", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -126,8 +126,8 @@
     "description": "Bright pink chewing gum.  Sugary, sweet, and bad for your teeth.  It's oddly warm to the touch…",
     "symbol": "*",
     "copy-from": "gum",
-    "rot_spawn": { "group": "GROUP_EGG_GUM", "chance": 100 },
-    "spoils_in": "5 days"
+    "spoils_in": "5 days",
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_GUM", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -138,8 +138,8 @@
     "description": "Chewing gum with added caffeine.  Sugary and bad for your teeth, but it's a nice pick-me-up.  It's oddly warm to the touch…",
     "symbol": "*",
     "copy-from": "caff_gum",
-    "rot_spawn": { "group": "GROUP_EGG_CAFFGUM", "chance": 100 },
-    "spoils_in": "7 days"
+    "spoils_in": "7 days",
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_CAFFGUM", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -150,8 +150,8 @@
     "symbol": "*",
     "copy-from": "cow_candy",
     "color": "brown",
-    "rot_spawn": { "group": "GROUP_EGG_CHOC_COW", "chance": 100 },
-    "spoils_in": "10 days"
+    "spoils_in": "10 days",
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_CHOC_COW", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -223,9 +223,9 @@
     "name": { "str_sp": "licorice" },
     "symbol": "%",
     "copy-from": "licorice",
-    "rot_spawn": { "group": "GROUP_EGG_LICORICE", "chance": 100 },
     "container": "null",
     "color": "red",
-    "description": "A swirly confectionary treat in strings of sweet tasting candy.  You think you've seen them wriggle a bit.  How strange…"
+    "description": "A swirly confectionary treat in strings of sweet tasting candy.  You think you've seen them wriggle a bit.  How strange…",
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_LICORICE", "chance": 100 } }
   }
 ]

--- a/data/mods/Tamable_Wildlife/items/comestibles/eggs.json
+++ b/data/mods/Tamable_Wildlife/items/comestibles/eggs.json
@@ -6,7 +6,7 @@
     "name": { "str": "tame dragonfly egg" },
     "copy-from": "egg_dragonfly",
     "description": "The still-wet egg of a mutated dragonfly.  This one has been carefully tended for.  The dragonfly inside seems more timid and calmer upon touch.",
-    "rot_spawn": { "monster": "mon_dragonfly_naiad_friendly", "chance": 100 }
+    "extend": { "rot_spawn": { "monster": "mon_dragonfly_naiad_friendly", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -15,7 +15,7 @@
     "name": { "str": "tame mantis egg" },
     "copy-from": "egg_mantis",
     "description": "Praying mantis eggs glued to each other inside a strange-looking case.  These ones have been carefully tended for.  The mantis inside seems more timid and calmer upon touch.",
-    "rot_spawn": { "monster": "mon_mantis_nymph_friendly", "chance": 100 }
+    "extend": { "rot_spawn": { "monster": "mon_mantis_nymph_friendly", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -24,7 +24,7 @@
     "name": { "str": "tame ladybug egg" },
     "copy-from": "egg_lady_bug",
     "description": "A ladybug egg.  You can see a translucent, happy looking larva inside.  This one has been carefully tended for.  The larva inside seems more timid and calmer upon touch.",
-    "rot_spawn": { "monster": "mon_lady_bug_larva_friendly", "chance": 100 }
+    "extend": { "rot_spawn": { "monster": "mon_lady_bug_larva_friendly", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -33,7 +33,7 @@
     "name": { "str": "tame antlion egg" },
     "copy-from": "egg_antlion",
     "description": "A large, white antlion egg.  This one has been carefully tended for.  The larva inside seems more timid and calmer upon touch.",
-    "rot_spawn": { "monster": "mon_antlion_larva_friendly", "chance": 100 }
+    "extend": { "rot_spawn": { "monster": "mon_antlion_larva_friendly", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -42,7 +42,7 @@
     "name": { "str": "tame cicada egg" },
     "copy-from": "egg_cicada",
     "description": "The egg of a cicada.  This one has been carefully tended for.  The cicada inside seems more timid and calmer upon touch.",
-    "rot_spawn": { "monster": "mon_cicada_nymph_friendly", "chance": 100 }
+    "extend": { "rot_spawn": { "monster": "mon_cicada_nymph_friendly", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -51,7 +51,7 @@
     "name": { "str": "tame water beetle egg" },
     "copy-from": "egg_water_beetle",
     "description": "The egg of a water beetle.  This one has been carefully tended for.  The larva inside seems more timid and calmer upon touch.",
-    "rot_spawn": { "monster": "mon_diving_larva_friendly", "chance": 100 }
+    "extend": { "rot_spawn": { "monster": "mon_diving_larva_friendly", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -60,7 +60,7 @@
     "name": { "str": "tame water scorpion egg" },
     "copy-from": "egg_water_bug",
     "description": "The egg of a water scorpion.  This one has been carefully tended for.  The water scorpion inside seems more timid and calmer upon touch.",
-    "rot_spawn": { "monster": "mon_water_scorpion_larva_friendly", "chance": 100 }
+    "extend": { "rot_spawn": { "monster": "mon_water_scorpion_larva_friendly", "chance": 100 } }
   },
   {
     "type": "ITEM",
@@ -69,6 +69,6 @@
     "name": { "str": "tame centipede egg" },
     "copy-from": "egg_centipede",
     "description": "The egg of a centipede.  This one has been carefully tended for.  The centipede larva inside seems more timid and calmer upon touch.",
-    "rot_spawn": { "monster": "mon_centipede_larva_friendly", "chance": 100 }
+    "extend": { "rot_spawn": { "monster": "mon_centipede_larva_friendly", "chance": 100 } }
   }
 ]

--- a/data/mods/TropiCataclysm/items/comestibles/egg.json
+++ b/data/mods/TropiCataclysm/items/comestibles/egg.json
@@ -7,7 +7,7 @@
     "spoils_in": "25 days",
     "copy-from": "egg_chicken",
     "proportional": { "volume": 12, "weight": 12, "calories": 12 },
-    "rot_spawn": { "monster": "mon_rhea_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_rhea_chick" } }
   },
   {
     "type": "ITEM",
@@ -16,7 +16,7 @@
     "name": { "str": "toco toucan egg" },
     "spoils_in": "9 days",
     "copy-from": "egg_crow",
-    "rot_spawn": { "monster": "mon_toucan_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_toucan_chick" } }
   },
   {
     "type": "ITEM",
@@ -25,7 +25,7 @@
     "name": { "str": "white-eyed parakeet egg" },
     "spoils_in": "13 days",
     "copy-from": "egg_bluejay",
-    "rot_spawn": { "monster": "mon_parrot_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_parrot_chick" } }
   },
   {
     "type": "ITEM",
@@ -34,7 +34,7 @@
     "name": { "str": "blue-and-yellow macaw egg" },
     "spoils_in": "13 days",
     "copy-from": "egg_crow",
-    "rot_spawn": { "monster": "mon_macaw_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_macaw_chick" } }
   },
   {
     "type": "ITEM",
@@ -42,7 +42,7 @@
     "id": "egg_finch_saffron",
     "name": { "str": "saffron finch egg" },
     "copy-from": "egg_waxwing",
-    "rot_spawn": { "monster": "mon_finch_saffron_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_finch_saffron_chick" } }
   },
   {
     "type": "ITEM",
@@ -50,7 +50,7 @@
     "id": "egg_great_kiskadee",
     "name": { "str": "great kiskadee egg" },
     "copy-from": "egg_bluejay",
-    "rot_spawn": { "monster": "mon_great_kiskadee_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_great_kiskadee_chick" } }
   },
   {
     "type": "ITEM",
@@ -58,7 +58,7 @@
     "id": "egg_rufous_hornero",
     "name": { "str": "rufous hornero egg" },
     "copy-from": "egg_waxwing",
-    "rot_spawn": { "monster": "mon_rufous_hornero_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_rufous_hornero_chick" } }
   },
   {
     "type": "ITEM",
@@ -66,7 +66,7 @@
     "id": "egg_tinamou",
     "name": { "str": "small-billed tinamou egg" },
     "copy-from": "egg_bluejay",
-    "rot_spawn": { "monster": "mon_tinamou_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_tinamou_chick" } }
   },
   {
     "type": "ITEM",
@@ -75,7 +75,7 @@
     "name": { "str": "red-legged seriema egg" },
     "spoils_in": "15 days",
     "copy-from": "egg_guinea_fowl",
-    "rot_spawn": { "monster": "mon_seriema_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_seriema_chick" } }
   },
   {
     "type": "ITEM",
@@ -84,7 +84,7 @@
     "name": { "str": "Chaco chachalaca egg" },
     "spoils_in": "12 days",
     "copy-from": "egg_crow",
-    "rot_spawn": { "monster": "mon_chachalaca_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_chachalaca_chick" } }
   },
   {
     "type": "ITEM",
@@ -93,7 +93,7 @@
     "name": { "str": "dusky-legged guan egg" },
     "spoils_in": "14 days",
     "copy-from": "egg_chicken",
-    "rot_spawn": { "monster": "mon_guan_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_guan_chick" } }
   },
   {
     "type": "ITEM",
@@ -101,7 +101,7 @@
     "id": "egg_curassow",
     "name": { "str": "bare-faced curassow egg" },
     "copy-from": "egg_crow",
-    "rot_spawn": { "monster": "mon_curassow_chick" }
+    "extend": { "rot_spawn": { "monster": "mon_curassow_chick" } }
   },
   {
     "type": "ITEM",
@@ -110,7 +110,7 @@
     "name": "snake egg",
     "copy-from": "egg_chicken",
     "description": "The egg of a tropical snake.",
-    "rot_spawn": { "group": "GROUP_EGG_CONSTRICTOR" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_CONSTRICTOR" } }
   },
   {
     "type": "ITEM",
@@ -127,7 +127,7 @@
     "name": "iguana egg",
     "copy-from": "egg_chicken",
     "description": "The egg of an iguana.",
-    "rot_spawn": { "group": "GROUP_EGG_IGUANA" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_IGUANA" } }
   },
   {
     "type": "ITEM",
@@ -136,7 +136,7 @@
     "name": "turtle egg",
     "copy-from": "egg_chicken",
     "description": "The round egg of a turtle.  It is covered in leaves.",
-    "rot_spawn": { "group": "GROUP_EGG_TURTLE" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_TURTLE" } }
   },
   {
     "type": "ITEM",
@@ -145,7 +145,7 @@
     "name": "tortoise egg",
     "copy-from": "egg_chicken",
     "description": "The round egg of a tortoise.  It is covered in dirt.",
-    "rot_spawn": { "group": "GROUP_EGG_TORTOISE" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_TORTOISE" } }
   },
   {
     "type": "ITEM",
@@ -154,7 +154,7 @@
     "name": "termite egg",
     "copy-from": "ant_egg",
     "description": "The small translucent egg of a termite.  It will grow quickly into a nymph if allowed.",
-    "rot_spawn": { "monster": "mon_termite_nymph" }
+    "extend": { "rot_spawn": { "monster": "mon_termite_nymph" } }
   },
   {
     "type": "ITEM",
@@ -219,7 +219,7 @@
     "name": { "str": "cluster of tadfish eggs", "str_pl": "clusters of tadfish eggs" },
     "copy-from": "egg_proxy_frog",
     "description": "A large clump of tadfish eggs.  Very similar to other amphibian eggs.",
-    "rot_spawn": { "group": "GROUP_EGG_TADFISH" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_TADFISH" } }
   },
   {
     "type": "ITEM",
@@ -227,7 +227,7 @@
     "id": "egg_lungfish",
     "name": { "str_sp": "lungfish roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_LUNGFISH" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_LUNGFISH" } }
   },
   {
     "type": "ITEM",
@@ -235,7 +235,7 @@
     "id": "egg_eel_electric",
     "name": { "str_sp": "electric eel roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_EEL_ELECTRIC" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_EEL_ELECTRIC" } }
   },
   {
     "type": "ITEM",
@@ -243,7 +243,7 @@
     "id": "egg_pacu",
     "name": { "str_sp": "pacu roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_PACU" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_PACU" } }
   },
   {
     "type": "ITEM",
@@ -251,7 +251,7 @@
     "id": "egg_tambaqui",
     "name": { "str_sp": "tambaqui roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_TAMBAQUI" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_TAMBAQUI" } }
   },
   {
     "type": "ITEM",
@@ -259,7 +259,7 @@
     "id": "egg_piranha",
     "name": { "str_sp": "piranha roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_PIRANHA" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_PIRANHA" } }
   },
   {
     "type": "ITEM",
@@ -267,7 +267,7 @@
     "id": "egg_arowana",
     "name": { "str_sp": "arowana roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_AROWANA" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_AROWANA" } }
   },
   {
     "type": "ITEM",
@@ -275,7 +275,7 @@
     "id": "egg_arapaima",
     "name": { "str_sp": "arapaima roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_ARAPAIMA" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_ARAPAIMA" } }
   },
   {
     "type": "ITEM",
@@ -283,7 +283,7 @@
     "id": "egg_piraiba",
     "name": { "str_sp": "piraiba roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_PIRAIBA" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_PIRAIBA" } }
   },
   {
     "type": "ITEM",
@@ -291,7 +291,7 @@
     "id": "egg_pleco",
     "name": { "str_sp": "pleco roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_PLECO" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_PLECO" } }
   },
   {
     "type": "ITEM",
@@ -300,7 +300,7 @@
     "name": { "str_sp": "gar roe" },
     "copy-from": "egg_fish",
     "//": "gar eggs seem to be poisonous to consume according to Wikipedia, but poison tag didn't seem to work on this item",
-    "rot_spawn": { "group": "GROUP_EGG_GAR" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_GAR" } }
   },
   {
     "type": "ITEM",
@@ -308,7 +308,7 @@
     "id": "egg_tucunare",
     "name": { "str_sp": "tucunaré roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_TUCUNARE" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_TUCUNARE" } }
   },
   {
     "type": "ITEM",
@@ -316,7 +316,7 @@
     "id": "egg_discus",
     "name": { "str_sp": "discus roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_DISCUS" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_DISCUS" } }
   },
   {
     "type": "ITEM",
@@ -324,7 +324,7 @@
     "id": "egg_angelfish",
     "name": { "str_sp": "angelfish roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_ANGELFISH" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_ANGELFISH" } }
   },
   {
     "type": "ITEM",
@@ -332,7 +332,7 @@
     "id": "egg_koi",
     "name": { "str_sp": "koi roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_KOI" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_KOI" } }
   },
   {
     "type": "ITEM",
@@ -340,7 +340,7 @@
     "id": "egg_tilapia",
     "name": { "str_sp": "tilapia roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_TILAPIA" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_TILAPIA" } }
   },
   {
     "type": "ITEM",
@@ -348,7 +348,7 @@
     "id": "egg_sabalo",
     "name": { "str_sp": "sabalo roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_SABALO" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_SABALO" } }
   },
   {
     "type": "ITEM",
@@ -356,7 +356,7 @@
     "id": "egg_oscar",
     "name": { "str_sp": "oscar roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_OSCAR" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_OSCAR" } }
   },
   {
     "type": "ITEM",
@@ -364,7 +364,7 @@
     "id": "egg_guapote",
     "name": { "str_sp": "guapote roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_GUAPOTE" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_GUAPOTE" } }
   },
   {
     "type": "ITEM",
@@ -372,6 +372,6 @@
     "id": "egg_mayaheros",
     "name": { "str_sp": "mayaheros roe" },
     "copy-from": "egg_fish",
-    "rot_spawn": { "group": "GROUP_EGG_MAYAHEROS" }
+    "extend": { "rot_spawn": { "group": "GROUP_EGG_MAYAHEROS" } }
   }
 ]

--- a/src/item_degrade.cpp
+++ b/src/item_degrade.cpp
@@ -34,6 +34,7 @@
 #include "fault.h"
 #include "fire.h"
 #include "flag.h"
+#include "flexbuffer_json.h"
 #include "game.h"
 #include "game_constants.h"
 #include "generic_factory.h"
@@ -62,8 +63,6 @@
 
 static const item_category_id item_category_drugs( "drugs" );
 static const item_category_id item_category_food( "food" );
-
-class JsonObject;
 
 namespace item_internal
 {
@@ -1469,10 +1468,22 @@ void item::set_birthday( const time_point &bday )
     this->bday = std::max( calendar::turn_zero, bday );
 }
 
+void rot_spawn_data::load( const JsonObject &jo, bool was_loaded )
+{
+    optional( jo, was_loaded, "monster", rot_spawn_monster, mtype_id::NULL_ID() );
+    optional( jo, was_loaded, "group", rot_spawn_group, mongroup_id::NULL_ID() );
+    optional( jo, was_loaded, "chance", rot_spawn_chance );
+    optional( jo, was_loaded, "amount", rot_spawn_monster_amount, { 1, 1 } );
+}
+
+bool rot_spawn_data::handle_extend( const JsonValue &jv )
+{
+    JsonObject jo = jv.get_object();
+    load( jo, true );
+    return true;
+}
+
 void rot_spawn_data::deserialize( const JsonObject &jo )
 {
-    optional( jo, false, "monster", rot_spawn_monster, mtype_id::NULL_ID() );
-    optional( jo, false, "group", rot_spawn_group, mongroup_id::NULL_ID() );
-    optional( jo, false, "chance", rot_spawn_chance );
-    optional( jo, false, "amount", rot_spawn_monster_amount, {1, 1} );
+    load( jo, false );
 }

--- a/src/itype.h
+++ b/src/itype.h
@@ -171,6 +171,9 @@ struct rot_spawn_data {
     /** Range of monsters spawned */
     std::pair<int, int> rot_spawn_monster_amount;
 
+    // supports was_loaded
+    void load( const JsonObject &jo, bool was_loaded );
+    bool handle_extend( const JsonValue &jv );
     void deserialize( const JsonObject &jo );
 };
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "fix `rot_spawn_data` inheritance overriding unset values"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Fixes #86438

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

"rot_spawn" COMESTIBLE fields now inherit from their parent object using "extend", which will not overwrite unset values with defaults.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Making `rot_spawn_data` a `generic_factory`-supported type seemed excessive for a 4-field object.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Hatched 20 chicken eggs (base case) and 20 grouse eggs (copy-from `egg_chicken`), and confirmed that `egg_bird_unfert` does not hatch anything.

<img width="879" height="362" alt="image" src="https://github.com/user-attachments/assets/cfb9db73-2619-4601-9cf5-b218ae7cb0f9" />
<img width="850" height="275" alt="image" src="https://github.com/user-attachments/assets/18203825-2a8e-43a4-a79e-696b882b8af2" />


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Thanks again abadams for the very concise bug report.

Yet another mechanic that needs a proper test case. This has probably been broken for over a year!

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
