### PR TITLE
Multimag PAPRs

### DIFF
--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -561,6 +561,11 @@
   },
   {
     "type": "item_action",
+    "id": "PAPR_MASK_ACTIVATE",
+    "name": { "str": "Attach to PAPR blower, pressurise, and suction test" }
+  },
+  {
+    "type": "item_action",
     "id": "DIVE_TANK_ACTIVATE",
     "name": { "str": "Use regulator" }
   },

--- a/data/json/items/armor/bespoke_armor/custom_headgear.json
+++ b/data/json/items/armor/bespoke_armor/custom_headgear.json
@@ -312,17 +312,8 @@
     "material_thickness": 3,
     "environmental_protection": 4,
     "environmental_protection_with_filter": 16,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "flag_restriction": [ "GASFILTER_SM" ],
-        "default_magazine": "gasfilter_sm"
-      }
-    ],
-    "use_action": [ "GASMASK_ACTIVATE" ],
-    "tick_action": [ "GASMASK" ],
-    "flags": [ "VARSIZE", "SUN_GLASSES", "RAINPROOF", "PADDED", "SLEEP_IGNORE", "PAPR_MASK" ],
-    "tool_ammo": "gasfilter_s"
+    "use_action": [ "PAPR_MASK_ACTIVATE" ],
+    "tick_action": [ "PAPR_MASK" ],
+    "flags": [ "VARSIZE", "SUN_GLASSES", "RAINPROOF", "PADDED", "SLEEP_IGNORE", "PAPR_MASK" ]
   }
 ]

--- a/data/json/items/armor/bespoke_armor/utility.json
+++ b/data/json/items/armor/bespoke_armor/utility.json
@@ -206,7 +206,7 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR", "TOOL" ],
     "name": { "str": "nomad utility belt" },
-    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side is lined with 10 cartridge loops fit for 27.3x110 Diyua shotshells.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  Paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  Activate it to turn it on.",
+    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side has a custom open-top pouch lined with 10 cartridge loops fit for 27.3x110 Diyua shotshells.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  If loaded with a filter and paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  Activate it to turn it on.",
     "weight": "1549 g",
     "volume": "2250 ml",
     "price": "150 USD",
@@ -218,6 +218,13 @@
     "material_thickness": 2,
     "pocket_data": [
       {
+        "id": "papr_blower_filter",
+        "pocket_type": "MAGAZINE_WELL",
+        "flag_restriction": [ "GASFILTER_MED" ],
+        "default_magazine": "gasfilter_med",
+        "rigid": true
+      },
+      {
         "holster": true,
         "max_contains_volume": "1 L",
         "max_contains_weight": "2 kg",
@@ -225,9 +232,17 @@
         "moves": 20,
         "flag_restriction": [ "SHEATH_KNIFE" ]
       },
-      { "ammo_restriction": { "273x110": 10 }, "moves": 25, "volume_encumber_modifier": 0.3 }
+      {
+        "pocket_type": "CONTAINER",
+        "max_item_length": "120 mm",
+        "max_contains_volume": "2840 ml",
+        "max_contains_weight": "2260 g",
+        "moves": 25,
+        "item_restriction": [ "273x110flock", "273x110canister", "273x110slugheavy", "273x110sluglight", "273x110slugmedium" ],
+        "volume_encumber_modifier": 0.3
+      }
     ],
-    "tool_ammo": [ "battery" ],
+    "tool_ammo": [ "battery", "gasfilter_m" ],
     "use_action": [
       { "type": "holster", "holster_prompt": "Store item", "holster_msg": "You put your %1$s in your %2$s" },
       {
@@ -245,7 +260,7 @@
     "subtypes": [ "ARMOR", "TOOL" ],
     "copy-from": "nomad_papr_blower_273diyua_off",
     "name": { "str": "nomad utility belt (on)", "str_pl": "nomad utility belts (on)" },
-    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side is lined with 10 cartridge loops fit for 27.3x110 Diyua shotshells.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  Paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  The blower is active and draining power.  Activate it to turn it off.",
+    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side has a custom open-top pouch lined with 10 cartridge loops fit for 27.3x110 Diyua shotshells.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  If loaded with a filter and paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  The blower is active and draining power.  Activate it to turn it off.",
     "use_action": [
       { "type": "holster", "holster_prompt": "Store item", "holster_msg": "You put your %1$s in your %2$s" },
       {
@@ -258,14 +273,17 @@
     ],
     "power_draw": "4000 mW",
     "revert_to": "nomad_papr_blower_273diyua_off",
-    "tick_action": {
-      "type": "sound",
-      "sound_type": "movement",
-      "sound_message": "whooooo…",
-      "sound_id": "humming",
-      "sound_variant": "machinery",
-      "sound_volume": 12
-    },
+    "tick_action": [
+      "PAPR_BLOWER",
+      {
+        "type": "sound",
+        "sound_type": "movement",
+        "sound_message": "whooooo…",
+        "sound_id": "humming",
+        "sound_variant": "machinery",
+        "sound_volume": 12
+      }
+    ],
     "extend": { "flags": [ "PAPR_BLOWER", "TRADER_AVOID", "SPAWN_ACTIVE" ] }
   },
   {
@@ -274,7 +292,7 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR", "TOOL" ],
     "name": { "str": "nomad utility belt" },
-    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side has three pouches, each fit for a 26-round PA md. 68 box magazine (although anything that size or smaller will fit).  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  Paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  Activate it to turn it on.",
+    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side has three pouches, each fit for a 26-round PA md. 68 box magazine (although anything that size or smaller will fit).  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  If loaded with a filter and paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  Activate it to turn it on.",
     "weight": "1549 g",
     "volume": "2250 ml",
     "price": "150 USD",
@@ -285,6 +303,13 @@
     "color": "brown",
     "material_thickness": 2,
     "pocket_data": [
+      {
+        "id": "papr_blower_filter",
+        "pocket_type": "MAGAZINE_WELL",
+        "flag_restriction": [ "GASFILTER_MED" ],
+        "default_magazine": "gasfilter_med",
+        "rigid": true
+      },
       {
         "holster": true,
         "max_contains_volume": "1 L",
@@ -321,7 +346,7 @@
         "volume_encumber_modifier": 0.3
       }
     ],
-    "tool_ammo": [ "battery" ],
+    "tool_ammo": [ "battery", "gasfilter_m" ],
     "use_action": [
       { "type": "holster", "holster_prompt": "Store item", "holster_msg": "You put your %1$s in your %2$s" },
       {
@@ -339,7 +364,7 @@
     "subtypes": [ "ARMOR", "TOOL" ],
     "copy-from": "nomad_papr_blower_magpouch_off",
     "name": { "str": "nomad utility belt (on)", "str_pl": "nomad utility belts (on)" },
-    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side has three pouches made to snugly and securely hold 26-round PA md. 68 box magazines, although anything that size or smaller will fit.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  Paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  The blower is active and draining power.  Activate it to turn it off.",
+    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side has three pouches made to snugly and securely hold 26-round PA md. 68 box magazines, although anything that size or smaller will fit.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  If loaded with a filter and paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  The blower is active and draining power.  Activate it to turn it off.",
     "use_action": [
       { "type": "holster", "holster_prompt": "Store item", "holster_msg": "You put your %1$s in your %2$s" },
       {
@@ -352,14 +377,17 @@
     ],
     "power_draw": "4000 mW",
     "revert_to": "nomad_papr_blower_magpouch_off",
-    "tick_action": {
-      "type": "sound",
-      "sound_type": "movement",
-      "sound_message": "whooooo…",
-      "sound_id": "humming",
-      "sound_variant": "machinery",
-      "sound_volume": 12
-    },
+    "tick_action": [
+      "PAPR_BLOWER",
+      {
+        "type": "sound",
+        "sound_type": "movement",
+        "sound_message": "whooooo…",
+        "sound_id": "humming",
+        "sound_variant": "machinery",
+        "sound_volume": 12
+      }
+    ],
     "extend": { "flags": [ "PAPR_BLOWER", "TRADER_AVOID", "SPAWN_ACTIVE" ] }
   },
   {
@@ -368,7 +396,7 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR", "TOOL" ],
     "name": { "str": "nomad utility belt" },
-    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side is lined with 10 leather and plastic clips fit for 27.3x Diyua grenades.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  Paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  Activate it to turn it on.",
+    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side has a custom open-top pouch lined with 10 cartridge loops fit for 27.3x Diyua grenades.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  If loaded with a filter and paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  Activate it to turn it on.",
     "weight": "1549 g",
     "volume": "2250 ml",
     "price": "150 USD",
@@ -380,6 +408,13 @@
     "material_thickness": 2,
     "pocket_data": [
       {
+        "id": "papr_blower_filter",
+        "pocket_type": "MAGAZINE_WELL",
+        "flag_restriction": [ "GASFILTER_MED" ],
+        "default_magazine": "gasfilter_med",
+        "rigid": true
+      },
+      {
         "holster": true,
         "max_contains_volume": "1 L",
         "max_contains_weight": "2 kg",
@@ -387,9 +422,17 @@
         "moves": 20,
         "flag_restriction": [ "SHEATH_KNIFE" ]
       },
-      { "ammo_restriction": { "273x44": 10 }, "moves": 25, "volume_encumber_modifier": 0.3 }
+      {
+        "pocket_type": "CONTAINER",
+        "max_item_length": "120 mm",
+        "max_contains_volume": "1760 ml",
+        "max_contains_weight": "1760 g",
+        "moves": 25,
+        "item_restriction": [ "273x44HE", "273x44flare", "273x44trainer", "273x44thermobaric" ],
+        "volume_encumber_modifier": 0.3
+      }
     ],
-    "tool_ammo": [ "battery" ],
+    "tool_ammo": [ "battery", "gasfilter_m" ],
     "use_action": [
       { "type": "holster", "holster_prompt": "Store item", "holster_msg": "You put your %1$s in your %2$s" },
       {
@@ -407,7 +450,7 @@
     "subtypes": [ "ARMOR", "TOOL" ],
     "copy-from": "nomad_papr_blower_273grenade_off",
     "name": { "str": "nomad utility belt (on)", "str_pl": "nomad utility belts (on)" },
-    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side is lined with 10 leather and plastic clips fit for 27.3x Diyua grenades.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  Paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  The blower is active and draining power.  Activate it to turn it off.",
+    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side has a custom open-top pouch lined with 10 cartridge loops fit for 27.3x Diyua grenades.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  If loaded with a filter and paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  The blower is active and draining power.  Activate it to turn it off.",
     "use_action": [
       { "type": "holster", "holster_prompt": "Store item", "holster_msg": "You put your %1$s in your %2$s" },
       {
@@ -420,14 +463,17 @@
     ],
     "power_draw": "4000 mW",
     "revert_to": "nomad_papr_blower_273grenade_off",
-    "tick_action": {
-      "type": "sound",
-      "sound_type": "movement",
-      "sound_message": "whooooo…",
-      "sound_id": "humming",
-      "sound_variant": "machinery",
-      "sound_volume": 12
-    },
+    "tick_action": [
+      "PAPR_BLOWER",
+      {
+        "type": "sound",
+        "sound_type": "movement",
+        "sound_message": "whooooo…",
+        "sound_id": "humming",
+        "sound_variant": "machinery",
+        "sound_volume": 12
+      }
+    ],
     "extend": { "flags": [ "PAPR_BLOWER", "TRADER_AVOID", "SPAWN_ACTIVE" ] }
   }
 ]

--- a/data/json/items/armor/robofac_armor.json
+++ b/data/json/items/armor/robofac_armor.json
@@ -1533,7 +1533,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "category": "armor",
     "name": { "str": "Hub 01 LENS PAPR mask" },
-    "description": "A ballistic powered air purifying respirator mask, designed form a tight seal with a Hub 01 LENS helmet.  Once activated it will comfortably protect against chemical, biological, radiological, and nuclear threats.  Like a standard gas mask it must be loaded with a filter and prepared before use; unlike a standard gas mask, or any other LENS mask, easy airflow keeps it relatively cool and comfortable.  However, it will only function to filter air when paired with an active PAPR blower unit.",
+    "description": "A ballistic powered air purifying respirator mask, designed form a tight seal with a Hub 01 LENS helmet.  Once activated it will comfortably protect against chemical, biological, radiological, and nuclear threats.  Like a standard gas mask it must be prepared before use; unlike a standard gas mask, or any other LENS mask, easy airflow keeps it relatively cool and comfortable.  However, it will only function to filter air when paired with an active PAPR blower unit.",
     "weight": "512 g",
     "volume": "750 ml",
     "price": "200 USD",
@@ -1552,16 +1552,7 @@
     "armor": [ { "encumbrance": 5, "coverage": 100, "covers": [ "mouth" ] } ],
     "environmental_protection": 4,
     "environmental_protection_with_filter": 16,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "flag_restriction": [ "GASFILTER_MED" ],
-        "default_magazine": "gasfilter_med"
-      }
-    ],
-    "use_action": [ "GASMASK_ACTIVATE" ],
-    "tick_action": [ "GASMASK" ],
-    "tool_ammo": "gasfilter_m"
+    "use_action": [ "PAPR_MASK_ACTIVATE" ],
+    "tick_action": [ "PAPR_MASK" ]
   }
 ]

--- a/data/json/items/armor/robofac_armor.json
+++ b/data/json/items/armor/robofac_armor.json
@@ -1533,7 +1533,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "category": "armor",
     "name": { "str": "Hub 01 LENS PAPR mask" },
-    "description": "A ballistic powered air purifying respirator mask, designed form a tight seal with a Hub 01 LENS helmet.  Once activated it will comfortably protect against chemical, biological, radiological, and nuclear threats.  Like a standard gas mask it must be prepared before use; unlike a standard gas mask, or any other LENS mask, easy airflow keeps it relatively cool and comfortable.  However, it will only function to filter air when paired with an active PAPR blower unit.",
+    "description": "A ballistic powered air purifying respirator mask, designed to form a tight seal with a Hub 01 LENS helmet.  Once activated it will comfortably protect against chemical, biological, radiological, and nuclear threats.  Like a standard gas mask it must be prepared before use; unlike a standard gas mask, or any other LENS mask, easy airflow keeps it relatively cool and comfortable.  However, it will only function to filter air when paired with an active PAPR blower unit.",
     "weight": "512 g",
     "volume": "750 ml",
     "price": "200 USD",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -2769,7 +2769,7 @@
     "category": "armor",
     "name": { "str": "PAPR helmet" },
     "looks_like": "flight_helmet",
-    "description": "A helmet fit with a transparent full-face mask.  On the back of the helmet is a long tube which attaches to a powered air purifying respirator system.  Once activated it will comfortably protect against chemical, biological, radiological, and nuclear threats.  Like a standard gas mask it must be loaded with a filter and prepared before use; unlike a standard gas mask, it is relatively cool and comfortable, but will only function when paired with an active PAPR blower unit.",
+    "description": "A helmet fit with a transparent full-face mask.  On the back of the helmet is a long tube which attaches to a powered air purifying respirator system.  Once activated it will comfortably protect against chemical, biological, radiological, and nuclear threats.  Like a standard gas mask it must be prepared before use; unlike a standard gas mask, it is relatively cool and comfortable, but will only function when paired with an active PAPR blower unit.",
     "weight": "857 g",
     "volume": "2250 ml",
     "price": "700 USD",
@@ -2861,7 +2861,7 @@
     "category": "clothing",
     "name": { "str": "military PAPR mask" },
     "looks_like": "mask_gas",
-    "description": "A black, full-face military respirator made from a silicon and butyl rubber blend, providing decent user comfort in addition to a clear field of view and a secure fit thanks to the mask's single-element visor and 6-point head harness.  The mask has pre-installed tubing which attaches to a powered air purifying respirator system.  Once activated it will comfortably protect against chemical, biological, radiological, and nuclear threats.  Like a standard gas mask it must be loaded with a filter and prepared before use; unlike a standard gas mask it will only function when paired with an active PAPR blower unit.  Unlike large commercial and industrial models, this respirator sits close to the face and can accommodate various attachments.",
+    "description": "A black, full-face military respirator made from a silicon and butyl rubber blend, providing decent user comfort in addition to a clear field of view and a secure fit thanks to the mask's single-element visor and 6-point head harness.  The mask has pre-installed tubing which attaches to a powered air purifying respirator system.  Once activated it will comfortably protect against chemical, biological, radiological, and nuclear threats.  Like a standard gas mask it must be prepared before use; unlike a standard gas mask it will only function when paired with an active PAPR blower unit.  Unlike large commercial and industrial models, this respirator sits close to the face and can accommodate various attachments.",
     "weight": "490 g",
     "volume": "1536 ml",
     "longest_side": "27 cm",
@@ -2927,7 +2927,6 @@
     "environmental_protection": 4,
     "environmental_protection_with_filter": 16,
     "pocket_data": [
-      { "pocket_type": "MAGAZINE_WELL", "flag_restriction": [ "GASFILTER_MED" ], "default_magazine": "gasfilter_med" },
       {
         "pocket_type": "CONTAINER",
         "ablative": true,
@@ -2954,10 +2953,9 @@
         "inherits_flags": true
       }
     ],
-    "use_action": [ "GASMASK_ACTIVATE" ],
-    "tick_action": [ "GASMASK" ],
-    "flags": [ "SKINTIGHT", "NORMAL", "SLEEP_IGNORE", "VARSIZE", "PADDED", "PAPR_MASK" ],
-    "tool_ammo": "gasfilter_m"
+    "use_action": [ "PAPR_MASK_ACTIVATE" ],
+    "tick_action": [ "PAPR_MASK" ],
+    "flags": [ "SKINTIGHT", "NORMAL", "SLEEP_IGNORE", "VARSIZE", "PADDED", "PAPR_MASK" ]
   },
   {
     "id": "basic_papr_helmet_xedra_mark",
@@ -2967,7 +2965,7 @@
     "category": "armor",
     "name": { "str": "shielded PAPR-EEG helmet" },
     "looks_like": "flight_helmet",
-    "description": "A white plastic helmet fit with a transparent full-face mask.  It has been modified for some unknown purpose.  On the back of the helmet is a long tube which attaches to a powered air purifying respirator system.  Once activated it will comfortably protect against chemical, biological, radiological, and nuclear threats.  Like a standard gas mask it must be loaded with a filter and prepared before use; unlike a standard gas mask it will only function when paired with an active PAPR blower unit.  A cotton cap covered in electrodes and wires, like those used to make electroencephalogram recordings, has been integrated as an underlayer, with a thick connection cable exiting a grommeted and sealed hole in the back.  A layer of shiny metallized polyethylene terephthalate has been glued to the interior of the helmet itself.  A tinfoil hat for a prepper with class.",
+    "description": "A white plastic helmet fit with a transparent full-face mask.  It has been modified for some unknown purpose.  On the back of the helmet is a long tube which attaches to a powered air purifying respirator system.  Once activated it will comfortably protect against chemical, biological, radiological, and nuclear threats.  Like a standard gas mask it must be prepared before use; unlike a standard gas mask it will only function when paired with an active PAPR blower unit.  A cotton cap covered in electrodes and wires, like those used to make electroencephalogram recordings, has been integrated as an underlayer, with a thick connection cable exiting a grommeted and sealed hole in the back.  A layer of shiny metallized polyethylene terephthalate has been glued to the interior of the helmet itself.  A tinfoil hat for a prepper with class.",
     "weight": "950 g",
     "volume": "2250 ml",
     "price": "700 USD",
@@ -3024,12 +3022,6 @@
     "flags": [ "WATERPROOF", "PADDED", "OVERSIZE", "SLEEP_IGNORE", "PAPR_MASK", "PSYSHIELD_PARTIAL" ],
     "pocket_data": [
       {
-        "pocket_type": "MAGAZINE_WELL",
-        "flag_restriction": [ "GASFILTER_MED" ],
-        "default_magazine": "gasfilter_med",
-        "rigid": true
-      },
-      {
         "pocket_type": "CONTAINER",
         "ablative": true,
         "volume_encumber_modifier": 0,
@@ -3071,9 +3063,8 @@
         "transparent": true
       }
     ],
-    "use_action": [ "GASMASK_ACTIVATE" ],
-    "tick_action": [ "GASMASK" ],
-    "tool_ammo": "gasfilter_m"
+    "use_action": [ "PAPR_MASK_ACTIVATE" ],
+    "tick_action": [ "PAPR_MASK" ]
   },
   {
     "id": "papr_half_mask",
@@ -3082,7 +3073,7 @@
     "//": "Based on Optrel Swiss Air",
     "name": { "str": "half-face PAPR mask" },
     "category": "clothing",
-    "description": "A lightweight, form-fitting mask that straps over your mouth and nose.  The mask has pre-installed tubing which attaches to a powered air purifying respirator system.  Once activated it will comfortably protect against chemical, biological, radiological, and nuclear threats.  Like a standard gas mask it must be loaded with a filter and prepared before use; unlike a standard gas mask, it will only function when paired with an active PAPR blower unit.  Safety goggles are advised!  It must be prepared before use.",
+    "description": "A lightweight, form-fitting mask that straps over your mouth and nose.  The mask has pre-installed tubing which attaches to a powered air purifying respirator system.  Once activated it will comfortably protect against chemical, biological, radiological, and nuclear threats.  Like a standard gas mask it must be prepared before use; unlike a standard gas mask, it will only function when paired with an active PAPR blower unit.  Safety goggles are advised!",
     "flags": [ "SLEEP_IGNORE", "PAPR_MASK" ],
     "weight": "400 g",
     "volume": "500 ml",
@@ -3096,18 +3087,9 @@
     "material_thickness": 2,
     "environmental_protection": 3,
     "environmental_protection_with_filter": 16,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "flag_restriction": [ "GASFILTER_MED" ],
-        "default_magazine": "gasfilter_med"
-      }
-    ],
-    "use_action": [ "GASMASK_ACTIVATE" ],
-    "tick_action": [ "GASMASK" ],
-    "armor": [ { "encumbrance": 10, "rigid_layer_only": true, "coverage": 100, "covers": [ "mouth" ] } ],
-    "tool_ammo": "gasfilter_m"
+    "use_action": [ "PAPR_MASK_ACTIVATE" ],
+    "tick_action": [ "PAPR_MASK" ],
+    "armor": [ { "encumbrance": 10, "rigid_layer_only": true, "coverage": 100, "covers": [ "mouth" ] } ]
   },
   {
     "id": "welding_papr_helmet",
@@ -3117,7 +3099,7 @@
     "category": "armor",
     "name": { "str": "PAPR welding helmet" },
     "looks_like": "welding_mask",
-    "description": "A helmet fit with a welding mask over a transparent full-face mask.  On the back of the helmet is a long tube which attaches to a powered air purifying respirator system.  Once activated it will comfortably protect against chemical, biological, radiological, and nuclear threats.  Like a standard gas mask it must be loaded with a filter and prepared before use; unlike a standard gas mask, it is relatively cool and comfortable, but will only function when paired with an active PAPR blower unit.  The welding shield is separate from the PAPR mask itself, so can be raised safely with compromising its ability to filter air.  Activate it to prepare it, or to push the welding mask up onto your head.",
+    "description": "A helmet fit with a welding mask over a transparent full-face mask.  On the back of the helmet is a long tube which attaches to a powered air purifying respirator system.  Once activated it will comfortably protect against chemical, biological, radiological, and nuclear threats.  Like a standard gas mask it must be prepared before use; unlike a standard gas mask, it is relatively cool and comfortable, but will only function when paired with an active PAPR blower unit.  The welding shield is separate from the PAPR mask itself, so can be raised safely without compromising its ability to filter air.  Activate it to prepare it, or to push the welding mask up onto your head.",
     "weight": "857 g",
     "volume": "2250 ml",
     "price": "700 USD",
@@ -3158,12 +3140,6 @@
     "flags": [ "WATERPROOF", "PADDED", "OVERSIZE", "SLEEP_IGNORE", "PAPR_MASK", "SUN_GLASSES", "FLASH_PROTECTION" ],
     "pocket_data": [
       {
-        "pocket_type": "MAGAZINE_WELL",
-        "flag_restriction": [ "GASFILTER_MED" ],
-        "default_magazine": "gasfilter_med",
-        "rigid": true
-      },
-      {
         "pocket_type": "CONTAINER",
         "ablative": true,
         "volume_encumber_modifier": 0,
@@ -3206,7 +3182,7 @@
       }
     ],
     "use_action": [
-      "GASMASK_ACTIVATE",
+      "PAPR_MASK_ACTIVATE",
       {
         "type": "transform",
         "msg": "You raise the welding shield.",
@@ -3214,8 +3190,7 @@
         "menu_text": "Raise welding shield"
       }
     ],
-    "tick_action": [ "GASMASK" ],
-    "tool_ammo": "gasfilter_m"
+    "tick_action": [ "PAPR_MASK" ]
   },
   {
     "id": "welding_papr_helmet_raised",
@@ -3226,7 +3201,7 @@
     "copy-from": "welding_papr_helmet",
     "name": { "str": "PAPR welding helmet (raised)", "str_pl": "PAPR welding helmets (raised)" },
     "looks_like": "welding_mask_raised",
-    "description": "A helmet fit with a welding mask over a transparent full-face mask.  On the back of the helmet is a long tube which attaches to a powered air purifying respirator system.  Once activated it will comfortably protect against chemical, biological, radiological, and nuclear threats.  Like a standard gas mask it must be loaded with a filter and prepared before use; unlike a standard gas mask, it is relatively cool and comfortable, but will only function when paired with an active PAPR blower unit.  The welding shield is separate from the PAPR mask itself, so can be raised safely with compromising its ability to filter air.  The welding mask it raised.  Activate it to prepare it, or to push the welding mask back down over your face.",
+    "description": "A helmet fit with a welding mask over a transparent full-face mask.  On the back of the helmet is a long tube which attaches to a powered air purifying respirator system.  Once activated it will comfortably protect against chemical, biological, radiological, and nuclear threats.  Like a standard gas mask it must be prepared before use; unlike a standard gas mask, it is relatively cool and comfortable, but will only function when paired with an active PAPR blower unit.  The welding shield is separate from the PAPR mask itself, so can be raised safely without compromising its ability to filter air.  The welding mask it raised.  Activate it to prepare it, or to push the welding mask back down over your face.",
     "flags": [ "WATERPROOF", "PADDED", "OVERSIZE", "SLEEP_IGNORE", "PAPR_MASK" ],
     "armor": [
       {
@@ -3255,14 +3230,15 @@
       }
     ],
     "use_action": [
-      "GASMASK_ACTIVATE",
+      "PAPR_MASK_ACTIVATE",
       {
         "type": "transform",
         "msg": "You lower the welding shield.",
         "target": "welding_papr_helmet",
         "menu_text": "Lower welding shield"
       }
-    ]
+    ],
+    "tick_action": [ "PAPR_MASK" ]
   },
   {
     "id": "basic_papr_belt_off",
@@ -3270,7 +3246,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "PAPR blower (off)", "str_pl": "PAPR blowers (off)" },
-    "description": "A blower unit for a powered air purifying respirator system.  It has been attached to a basic rubber and plastic belt.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.",
+    "description": "A blower unit for a powered air purifying respirator system.  It has been attached to a basic rubber and plastic belt.  When active and loaded with a charged battery and a filter canister, it can be paired with a prepared PAPR mask to provide excellent protection against chemical, biological, radiological, and nuclear threats.",
     "weight": "918 g",
     "volume": "1000 ml",
     "price": "300 USD",
@@ -3323,7 +3299,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "PAPR blower (on)", "str_pl": "PAPR blowers (on)" },
-    "description": "A blower unit for a powered air purifying respirator system.  It has been attached to a basic rubber and plastic belt.  If paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.  The fan is audibly blowing.",
+    "description": "An active blower unit for a powered air purifying respirator system.  It has been attached to a basic rubber and plastic belt.  If paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.  The fan is audibly blowing.",
     "weight": "918 g",
     "volume": "1000 ml",
     "material": [ { "type": "plastic", "portion": 2 }, { "type": "rubber", "portion": 1 } ],
@@ -3386,7 +3362,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "military PAPR blower (off)", "str_pl": "military PAPR blowers (off)" },
-    "description": "A sturdy blower unit for a powered air purifying respirator system.  Its large triangular body is designed to be worn on the back.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.",
+    "description": "A sturdy blower unit for a powered air purifying respirator system.  Its large triangular body is designed to be worn on the back.  When active and loaded with a charged battery and a filter canister, it can be paired with a prepared PAPR mask to provide excellent protection against chemical, biological, radiological, and nuclear threats.",
     "weight": "653 g",
     "volume": "3589 ml",
     "price": "1400 USD",
@@ -3398,13 +3374,21 @@
     "material_thickness": 2,
     "pocket_data": [
       {
+        "id": "papr_blower_filter",
+        "pocket_type": "MAGAZINE_WELL",
+        "flag_restriction": [ "GASFILTER_MED" ],
+        "default_magazine": "gasfilter_med",
+        "rigid": true
+      },
+      {
+        "id": "papr_blower_battery",
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
         "flag_restriction": [ "BATTERY_HEAVY" ],
         "default_magazine": "heavy_plus_battery_cell"
       }
     ],
-    "charges_per_use": 1,
+    "consumption_per_use": [ { "pocket": "papr_blower_battery", "qty": 1 } ],
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s and the fan starts to audibly whoosh.",
@@ -3431,7 +3415,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "military PAPR blower (on)", "str_pl": "military PAPR blowers (on)" },
-    "description": "A sturdy blower unit for a powered air purifying respirator system.  Its large triangular body is designed to be worn on the back.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.  The fan is audibly blowing.",
+    "description": "An active, sturdy blower unit for a powered air purifying respirator system.  Its large triangular body is designed to be worn on the back.  When paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.  The fan is audibly blowing.",
     "weight": "653 g",
     "volume": "3589 ml",
     "material": [ { "type": "plastic", "portion": 2 }, { "type": "rubber", "portion": 1 } ],
@@ -3441,13 +3425,22 @@
     "material_thickness": 2,
     "pocket_data": [
       {
+        "id": "papr_blower_filter",
+        "pocket_type": "MAGAZINE_WELL",
+        "flag_restriction": [ "GASFILTER_MED" ],
+        "default_magazine": "gasfilter_med",
+        "rigid": true
+      },
+      {
+        "id": "papr_blower_battery",
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
         "flag_restriction": [ "BATTERY_HEAVY" ],
         "default_magazine": "heavy_plus_battery_cell"
       }
     ],
-    "power_draw": "4000 mW",
+    "consumption_per_use": [ { "pocket": "papr_blower_battery", "qty": 1 } ],
+    "turns_per_charge": 240,
     "revert_to": "military_papr_blower_off",
     "use_action": {
       "menu_text": "Turn off",
@@ -3456,14 +3449,17 @@
       "target": "military_papr_blower_off",
       "ammo_scale": 0
     },
-    "tick_action": {
-      "type": "sound",
-      "sound_type": "movement",
-      "sound_message": "whooooo…",
-      "sound_id": "humming",
-      "sound_variant": "machinery",
-      "sound_volume": 12
-    },
+    "tick_action": [
+      "PAPR_BLOWER",
+      {
+        "type": "sound",
+        "sound_type": "movement",
+        "sound_message": "whooooo…",
+        "sound_id": "humming",
+        "sound_variant": "machinery",
+        "sound_volume": 12
+      }
+    ],
     "tool_ammo": [ "battery", "gasfilter_m" ],
     "flags": [ "BELTED", "OVERSIZE", "ELECTRONIC", "TRADER_AVOID", "SPAWN_ACTIVE", "PAPR_BLOWER" ],
     "armor": [
@@ -3482,7 +3478,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "modular PAPR blower (off)", "str_pl": "modular PAPR blowers (off)" },
-    "description": "A blower unit for a powered air purifying respirator system, built from a flexible silicon and butyl rubber blend.  Its components are arranged linearly in a narrow strip close to the body and is outfitted with straps to wear it about the waist.  If paired with the appropriate straps, it can also attached to any compatible MOLLE system.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.",
+    "description": "A blower unit for a powered air purifying respirator system, built from a flexible silicon and butyl rubber blend.  Its components are arranged linearly in a narrow strip close to the body and is outfitted with straps to wear it about the waist.  If paired with the appropriate straps, it can also attached to any compatible MOLLE system.  When active and loaded with a charged battery and a filter canister, it can be paired with a prepared PAPR mask to provide excellent protection against chemical, biological, radiological, and nuclear threats.",
     "weight": "920 g",
     "volume": "3000 ml",
     "price": "1600 USD",
@@ -3494,13 +3490,21 @@
     "material_thickness": 2,
     "pocket_data": [
       {
+        "id": "papr_blower_filter",
+        "pocket_type": "MAGAZINE_WELL",
+        "flag_restriction": [ "GASFILTER_MED" ],
+        "default_magazine": "gasfilter_med",
+        "rigid": true
+      },
+      {
+        "id": "papr_blower_battery",
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
         "flag_restriction": [ "BATTERY_HEAVY" ],
         "default_magazine": "heavy_plus_battery_cell"
       }
     ],
-    "charges_per_use": 1,
+    "consumption_per_use": [ { "pocket": "papr_blower_battery", "qty": 1 } ],
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s and the fan starts to audibly whoosh.",
@@ -3508,7 +3512,7 @@
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead."
     },
-    "tool_ammo": [ "battery" ],
+    "tool_ammo": [ "battery", "gasfilter_m" ],
     "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "ELECTRONIC" ],
     "armor": [
       {
@@ -3527,7 +3531,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "modular PAPR blower (on)", "str_pl": "modular PAPR blowers (on)" },
-    "description": "A blower unit for a powered air purifying respirator system, built from a flexible silicon and butyl rubber blend.  Its components are arranged linearly in a narrow strip close to the body and is outfitted with straps to wear it about the waist.  If paired with the appropriate straps, it can also attached to any compatible MOLLE system.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.  The fan is quietly blowing.",
+    "description": "An active blower unit for a powered air purifying respirator system, built from a flexible silicon and butyl rubber blend.  Its components are arranged linearly in a narrow strip close to the body and is outfitted with straps to wear it about the waist.  If paired with the appropriate straps, it can also attached to any compatible MOLLE system.  When paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.  The fan is quietly blowing.",
     "weight": "920 g",
     "volume": "3000 ml",
     "material": [ { "type": "plastic", "portion": 2 }, { "type": "butyl_rubber", "portion": 1 } ],
@@ -3537,13 +3541,22 @@
     "material_thickness": 2,
     "pocket_data": [
       {
+        "id": "papr_blower_filter",
+        "pocket_type": "MAGAZINE_WELL",
+        "flag_restriction": [ "GASFILTER_MED" ],
+        "default_magazine": "gasfilter_med",
+        "rigid": true
+      },
+      {
+        "id": "papr_blower_battery",
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
         "flag_restriction": [ "BATTERY_HEAVY" ],
         "default_magazine": "heavy_plus_battery_cell"
       }
     ],
-    "power_draw": "4000 mW",
+    "consumption_per_use": [ { "pocket": "papr_blower_battery", "qty": 1 } ],
+    "turns_per_charge": 240,
     "revert_to": "molle_papr_blower_off",
     "use_action": {
       "menu_text": "Turn off",
@@ -3552,15 +3565,18 @@
       "target": "molle_papr_blower_off",
       "ammo_scale": 0
     },
-    "tick_action": {
-      "type": "sound",
-      "sound_type": "movement",
-      "sound_message": "whooooo…",
-      "sound_id": "humming",
-      "sound_variant": "machinery",
-      "sound_volume": 8
-    },
-    "tool_ammo": [ "battery" ],
+    "tick_action": [
+      "PAPR_BLOWER",
+      {
+        "type": "sound",
+        "sound_type": "movement",
+        "sound_message": "whooooo…",
+        "sound_id": "humming",
+        "sound_variant": "machinery",
+        "sound_volume": 12
+      }
+    ],
+    "tool_ammo": [ "battery", "gasfilter_m" ],
     "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "ELECTRONIC", "TRADER_AVOID", "SPAWN_ACTIVE", "PAPR_BLOWER" ],
     "armor": [
       {

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -2809,12 +2809,6 @@
     "flags": [ "WATERPROOF", "PADDED", "OVERSIZE", "SLEEP_IGNORE", "PAPR_MASK" ],
     "pocket_data": [
       {
-        "pocket_type": "MAGAZINE_WELL",
-        "flag_restriction": [ "GASFILTER_MED" ],
-        "default_magazine": "gasfilter_med",
-        "rigid": true
-      },
-      {
         "pocket_type": "CONTAINER",
         "ablative": true,
         "volume_encumber_modifier": 0,
@@ -2856,9 +2850,8 @@
         "transparent": true
       }
     ],
-    "use_action": [ "GASMASK_ACTIVATE" ],
-    "tick_action": [ "GASMASK" ],
-    "tool_ammo": "gasfilter_m"
+    "use_action": [ "PAPR_MASK_ACTIVATE" ],
+    "tick_action": [ "PAPR_MASK" ]
   },
   {
     "id": "military_papr_mask",
@@ -3289,13 +3282,21 @@
     "material_thickness": 1,
     "pocket_data": [
       {
+        "id": "papr_blower_filter",
+        "pocket_type": "MAGAZINE_WELL",
+        "flag_restriction": [ "GASFILTER_MED" ],
+        "default_magazine": "gasfilter_med",
+        "rigid": true
+      },
+      {
+        "id": "papr_blower_battery",
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
         "flag_restriction": [ "BATTERY_MEDIUM" ],
         "default_magazine": "medium_battery_cell"
       }
     ],
-    "charges_per_use": 1,
+    "consumption_per_use": [ { "pocket": "papr_blower_battery", "qty": 1 } ],
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s and the fan starts to audibly whoosh.",
@@ -3303,7 +3304,7 @@
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead."
     },
-    "tool_ammo": [ "battery" ],
+    "tool_ammo": [ "battery", "gasfilter_m" ],
     "flags": [ "BELTED", "OVERSIZE", "ELECTRONIC", "WATER_BREAK_ACTIVE" ],
     "armor": [
       {
@@ -3332,13 +3333,22 @@
     "material_thickness": 1,
     "pocket_data": [
       {
+        "id": "papr_blower_filter",
+        "pocket_type": "MAGAZINE_WELL",
+        "flag_restriction": [ "GASFILTER_MED" ],
+        "default_magazine": "gasfilter_med",
+        "rigid": true
+      },
+      {
+        "id": "papr_blower_battery",
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
         "flag_restriction": [ "BATTERY_MEDIUM" ],
         "default_magazine": "medium_battery_cell"
       }
     ],
-    "power_draw": "4000 mW",
+    "consumption_per_use": [ { "pocket": "papr_blower_battery", "qty": 1 } ],
+    "turns_per_charge": 240,
     "revert_to": "basic_papr_belt_off",
     "use_action": {
       "menu_text": "Turn off",
@@ -3347,15 +3357,18 @@
       "target": "basic_papr_belt_off",
       "ammo_scale": 0
     },
-    "tick_action": {
-      "type": "sound",
-      "sound_type": "movement",
-      "sound_message": "whooooo…",
-      "sound_id": "humming",
-      "sound_variant": "machinery",
-      "sound_volume": 12
-    },
-    "tool_ammo": [ "battery" ],
+    "tick_action": [
+      "PAPR_BLOWER",
+      {
+        "type": "sound",
+        "sound_type": "movement",
+        "sound_message": "whooooo…",
+        "sound_id": "humming",
+        "sound_variant": "machinery",
+        "sound_volume": 12
+      }
+    ],
+    "tool_ammo": [ "battery", "gasfilter_m" ],
     "flags": [ "BELTED", "OVERSIZE", "ELECTRONIC", "TRADER_AVOID", "WATER_BREAK", "SPAWN_ACTIVE", "PAPR_BLOWER" ],
     "armor": [
       {
@@ -3399,7 +3412,7 @@
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead."
     },
-    "tool_ammo": [ "battery" ],
+    "tool_ammo": [ "battery", "gasfilter_m" ],
     "flags": [ "BELTED", "OVERSIZE", "ELECTRONIC" ],
     "armor": [
       {
@@ -3451,7 +3464,7 @@
       "sound_variant": "machinery",
       "sound_volume": 12
     },
-    "tool_ammo": [ "battery" ],
+    "tool_ammo": [ "battery", "gasfilter_m" ],
     "flags": [ "BELTED", "OVERSIZE", "ELECTRONIC", "TRADER_AVOID", "SPAWN_ACTIVE", "PAPR_BLOWER" ],
     "armor": [
       {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2148,6 +2148,9 @@ void Item_factory::init()
     add_iuse( "OXYTORCH", &iuse::oxytorch );
     add_iuse( "PACK_CBM", &iuse::pack_cbm );
     add_iuse( "PACK_ITEM", &iuse::pack_item );
+    add_iuse( "PAPR_BLOWER", &iuse::papr_blower );
+    add_iuse( "PAPR_MASK", &iuse::papr_mask );
+    add_iuse( "PAPR_MASK_ACTIVATE", &iuse::papr_mask_activate );
     add_iuse( "PETFOOD", &iuse::petfood );
     add_iuse( "PICK_LOCK", &iuse::pick_lock );
     add_iuse( "PICKAXE", &iuse::pickaxe );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3973,13 +3973,23 @@ std::optional<int> iuse::gasmask_activate( Character *p, item *it, const tripoin
         it->set_var( "overwrite_env_resist", it->get_base_env_resist_w_filter() );
     }
 
-    if( it->has_flag( flag_PAPR_MASK ) ) {
-        if( !p->has_item_with_flag( flag_PAPR_BLOWER ) ) {
-            p->add_msg_if_player( m_bad,
-                                  _( "You don't have an active PAPR blower unit so the %s fails to function." ), it->tname() );
-            it->set_var( "overwrite_env_resist", 0 );
-            it->active = false;
-        }
+    return 0;
+}
+
+std::optional<int> iuse::papr_mask_activate ( Character *p, item *it, const tripoint_bub_ms & )
+{
+    if( !p->has_item_with_flag( flag_PAPR_BLOWER ) ) {
+        p->add_msg_if_player( m_bad,
+                              _( "You don't have an active PAPR blower unit so the %s fails to function." ), it->tname() );
+    } else if( !it->activation_success() ) {
+        p->add_msg_if_player( m_bad, _( "You fail to adjust your damaged %s so it doesn't leak." ),
+                              it->tname() );
+        return std::nullopt;
+
+    } else {
+        p->add_msg_if_player( _( "You prepare your %s." ), it->tname() );
+        it->active = true;
+        it->set_var( "overwrite_env_resist", it->get_base_env_resist_w_filter() );
     }
 
     return 0;
@@ -4045,14 +4055,74 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint_bub_ms 
         it->active = false;
     }
 
-    if( it->has_flag( flag_PAPR_MASK ) ) {
-        if( !p->has_item_with_flag( flag_PAPR_BLOWER ) ) {
+    return 0;
+}
+
+std::optional<int> iuse::papr_mask( Character *p, item *it, const tripoint_bub_ms &pos )
+{        
+    if( p && p->is_worn( *it ) ) {    
+        if( it->activation_success() ) {
+            // In case if failed the previous tick.
+            it->set_var( "overwrite_env_resist", it->get_base_env_resist_w_filter() );
+        } else {
+            p->add_msg_if_player( m_bad, _( "Your damaged %s is leaking." ), it->tname() );
+            it->set_var( "overwrite_env_resist", 0 );
+            return std::nullopt;
+        }
+        if( p && !p->has_item_with_flag( flag_PAPR_BLOWER ) ) {
             p->add_msg_if_player( m_bad, _( "Your PAPR system stops working!" ) );
             it->set_var( "overwrite_env_resist", 0 );
             it->active = false;
         }
     }
+    
+    return 0;
+}
 
+std::optional<int> iuse::papr_blower( Character *p, item *it, const tripoint_bub_ms &pos )
+{        
+    map &here = get_map();
+    // calculate amount of absorbed gas per filter charge
+    const field &gasfield = here.field_at( pos );
+    for( const auto &dfield : gasfield ) {
+        const field_entry &entry = dfield.second;
+        int gas_abs_factor = to_turns<int>( entry.get_field_type()->gas_absorption_factor );
+        // Not set, skip this field
+        if( gas_abs_factor == 0 ) {
+            continue;
+        }
+        const field_intensity_level &int_level = entry.get_intensity_level();
+        // 6000 is the amount of "gas absorbed" charges in a full 100 capacity gas mask cartridge.
+        // factor/concentration gives an amount of seconds the cartidge is expected to last in current conditions.
+        /// 6000/that is the amount of "gas absorbed" charges to tick up every second in order to reach that number.
+        float gas_absorbed = 6000 / ( static_cast<float>( gas_abs_factor ) / static_cast<float>
+                                      ( int_level.concentration ) );
+        add_msg_debug( debugmode::DF_IUSE, "Absorbing %g/60 from field: 6000 / (%d * %d)", gas_absorbed,
+                       gas_abs_factor, int_level.concentration );
+        if( gas_absorbed > 0 ) {
+            it->set_var( "gas_absorbed", it->get_var( "gas_absorbed", 0 ) + gas_absorbed );
+        }
+    }
+    if( it->get_var( "gas_absorbed", 0 ) >= 60 ) {
+        it->ammo_consume_in_pocket( "papr_blower_filter", 1, here, pos );
+        it->set_var( "gas_absorbed", 0 );
+        if( it->ammo_remaining_in_pocket( "papr_blower_filter" ) < 10 ) {
+            p->add_msg_player_or_npc(
+                m_bad,
+                _( "Your %s is struggling to filter gas!" ),
+                _( "<npcname>'s PAPR blower is struggling to filter gas!" )
+                , it->tname() );
+        }
+    }
+    if( it->ammo_remaining_in_pocket( "papr_blower_filter" ) == 0 ) {
+        p->add_msg_player_or_npc(
+            m_bad,
+            _( "Your %s requires new filters!" ),
+            _( "<npcname> needs new PAPR blower filters!" )
+            , it->tname() );
+        it->deactivate();
+    }
+    
     return 0;
 }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3976,7 +3976,7 @@ std::optional<int> iuse::gasmask_activate( Character *p, item *it, const tripoin
     return 0;
 }
 
-std::optional<int> iuse::papr_mask_activate ( Character *p, item *it, const tripoint_bub_ms & )
+std::optional<int> iuse::papr_mask_activate( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( !p->has_item_with_flag( flag_PAPR_BLOWER ) ) {
         p->add_msg_if_player( m_bad,
@@ -4059,8 +4059,8 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint_bub_ms 
 }
 
 std::optional<int> iuse::papr_mask( Character *p, item *it, const tripoint_bub_ms &pos )
-{        
-    if( p && p->is_worn( *it ) ) {    
+{
+    if( p && p->is_worn( *it ) ) {
         if( it->activation_success() ) {
             // In case if failed the previous tick.
             it->set_var( "overwrite_env_resist", it->get_base_env_resist_w_filter() );
@@ -4075,12 +4075,11 @@ std::optional<int> iuse::papr_mask( Character *p, item *it, const tripoint_bub_m
             it->active = false;
         }
     }
-    
     return 0;
 }
 
 std::optional<int> iuse::papr_blower( Character *p, item *it, const tripoint_bub_ms &pos )
-{        
+{
     map &here = get_map();
     // calculate amount of absorbed gas per filter charge
     const field &gasfield = here.field_at( pos );
@@ -4122,7 +4121,6 @@ std::optional<int> iuse::papr_blower( Character *p, item *it, const tripoint_bub
             , it->tname() );
         it->deactivate();
     }
-    
     return 0;
 }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4058,7 +4058,7 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint_bub_ms 
     return 0;
 }
 
-std::optional<int> iuse::papr_mask( Character *p, item *it, const tripoint_bub_ms &pos )
+std::optional<int> iuse::papr_mask( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p && p->is_worn( *it ) ) {
         if( it->activation_success() ) {

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -151,6 +151,9 @@ std::optional<int> binder_add_recipe( Character *, item *, const tripoint_bub_ms
 std::optional<int> binder_manage_recipe( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> pack_cbm( Character *p, item *it, const tripoint_bub_ms & );
 std::optional<int> pack_item( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> papr_blower( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> papr_mask( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> papr_mask_activate( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> pick_lock( Character *p, item *it, const tripoint_bub_ms &pos );
 std::optional<int> pickaxe( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> play_game( Character *, item *, const tripoint_bub_ms & );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "PAPR blowers are now loaded with filters and batteries; PAPR masks simply need to be attached and activated"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

With the glory of multimage we can have more realistic PAPR systems.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Filters and batteries are now loaded into the PAPR blowers themselves.  The masks/helmets no longer accept filters.

The blower must be activated to activate the masks.  Both must be activated to filter air.

Active blowers dropped on the ground will continue to filter air, and consume charges if necessary.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Filter consumption is tied to a MAGAZINE_WELL that must have the id `papr_blower_filter`.  If someone smarter than me has a better solution, happy to see it.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked all the masks/helmets and blowers.  Loaded, unloaded.  Activated and deactivated in various configurations.  Unloaded mid use, and the whole thing deactivates.  Used it to filter gas in the scarlet sea.  When a filter canister expires, the entire system shuts down.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<img width="517" height="150" alt="PAPRs" src="https://github.com/user-attachments/assets/4bde6eca-fa87-4c1e-9123-1dd1d7d11ff1" />


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
