### PR TITLE
[XedraWood] Add some mod identity around evolution and zombification

### DIFF
--- a/data/mods/XedraWood/external_options_and_monster_adjustments.json
+++ b/data/mods/XedraWood/external_options_and_monster_adjustments.json
@@ -1,0 +1,57 @@
+[
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "CBM_SLOTS_ENABLED",
+    "//": "Used here to enable body slots for magical tattoos",
+    "stype": "bool",
+    "value": true
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "SPAWN_ANIMAL_DENSITY",
+    "stype": "float",
+    "value": 1.5
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "DISABLE_ANIMAL_CLASH",
+    "stype": "bool",
+    "value": true
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "INT_BASED_LEARNING_FOCUS_ADJUSTMENT",
+    "stype": "int",
+    "value": 6
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "ZOMBIFY_INTO_ENABLED",
+    "stype": "bool",
+    "value": false
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "EVOLUTION_INVERSE_MULTIPLIER",
+    "//": "Higher-evo monsters should mostly be spawned through mapgen or map extras, so just crank this up so we don't have to edit a ton of monsters to turn evolution off",
+    "stype": "float",
+    "value": 99.0
+  }
+  {
+    "type": "monster_adjustment",
+    "species": "ZOMBIE",
+    "flag": { "name": "REVIVES", "value": false },
+    "stat": { "name": "speed", "modifier": 0.9 }
+  },
+  {
+    "type": "monster_adjustment",
+    "species": "ZOMBIE",
+    "flag": { "name": "WARM", "value": false },
+    "stat": { "name": "hp", "modifier": 4 }
+  },
+  {
+    "type": "monster_adjustment",
+    "species": "ZOMBIE",
+    "stat": { "name": "bleed_rate", "modifier": 0 }
+  }
+]

--- a/data/mods/XedraWood/external_options_and_monster_adjustments.json
+++ b/data/mods/XedraWood/external_options_and_monster_adjustments.json
@@ -36,7 +36,7 @@
     "//": "Higher-evo monsters should mostly be spawned through mapgen or map extras, so just crank this up so we don't have to edit a ton of monsters to turn evolution off",
     "stype": "float",
     "value": 99.0
-  }
+  },
   {
     "type": "monster_adjustment",
     "species": "ZOMBIE",

--- a/data/mods/XedraWood/monstergroups/default_additions.json
+++ b/data/mods/XedraWood/monstergroups/default_additions.json
@@ -3,7 +3,7 @@
     "type": "monstergroup",
     "id": "GROUP_FOREST",
     "monsters": [
-       {
+      {
         "group": "GROUP_WILDERNESS_FOREST_MAMMAL",
         "weight": 75,
         "starts": "12 days",
@@ -105,7 +105,7 @@
     "id": "GROUP_WILDERNESS_FOREST_MAMMAL_MUTANT",
     "override": true,
     "monsters": [ { "monster": "mon_null", "weight": 1 } ]
-  }, 
+  },
   {
     "type": "monstergroup",
     "id": "GROUP_MUTAFROGS_SWAMP",

--- a/data/mods/XedraWood/monstergroups/default_additions.json
+++ b/data/mods/XedraWood/monstergroups/default_additions.json
@@ -3,6 +3,54 @@
     "type": "monstergroup",
     "id": "GROUP_FOREST",
     "monsters": [
+       {
+        "group": "GROUP_WILDERNESS_FOREST_MAMMAL",
+        "weight": 75,
+        "starts": "12 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_MAMMAL",
+        "weight": 75,
+        "starts": "28 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_MAMMAL",
+        "weight": 75,
+        "starts": "112 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_MAMMAL",
+        "weight": 75,
+        "starts": "360 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_MAMMAL_WINTER",
+        "weight": 75,
+        "starts": "12 days",
+        "conditions": [ "WINTER" ]
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_MAMMAL_WINTER",
+        "weight": 75,
+        "starts": "28 days",
+        "conditions": [ "WINTER" ]
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_MAMMAL_WINTER",
+        "weight": 75,
+        "starts": "112 days",
+        "conditions": [ "WINTER" ]
+      },
+      {
+        "group": "GROUP_WILDERNESS_FOREST_MAMMAL_WINTER",
+        "weight": 75,
+        "starts": "360 days",
+        "conditions": [ "WINTER" ]
+      },
       { "monster": "mon_claw_runner", "weight": 9, "cost_multiplier": 4 },
       { "monster": "mon_claw_runner", "weight": 3, "cost_multiplier": 4, "pack_size": [ 2, 5 ] },
       { "monster": "mon_claw_hunter", "weight": 3, "cost_multiplier": 30 },
@@ -22,6 +70,13 @@
     "type": "monstergroup",
     "id": "GROUP_SWAMP",
     "monsters": [
+      {
+        "monster": "mon_lemming",
+        "weight": 50,
+        "pack_size": [ 2, 7 ],
+        "starts": "360 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
       { "monster": "mon_claw_runner", "weight": 15, "cost_multiplier": 4 },
       { "monster": "mon_claw_runner", "weight": 5, "cost_multiplier": 4, "pack_size": [ 2, 5 ] },
       { "monster": "mon_claw_hunter", "weight": 6, "cost_multiplier": 30 },
@@ -38,6 +93,24 @@
       { "group": "GROUP_HOLLOW_ZOMBIES", "weight": 5 },
       { "group": "GROUP_HOLLOW_ZOMBIES", "weight": 1, "pack_size": [ 2, 5 ] }
     ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_WILDERNESS_FOREST_ZOMBIE",
+    "override": true,
+    "monsters": [ { "monster": "mon_null", "weight": 1 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_WILDERNESS_FOREST_MAMMAL_MUTANT",
+    "override": true,
+    "monsters": [ { "monster": "mon_null", "weight": 1 } ]
+  }, 
+  {
+    "type": "monstergroup",
+    "id": "GROUP_MUTAFROGS_SWAMP",
+    "override": true,
+    "monsters": [ { "monster": "mon_null", "weight": 1 } ]
   },
   {
     "type": "monstergroup",

--- a/data/mods/XedraWood/monstergroups/monster_blacklist.json
+++ b/data/mods/XedraWood/monstergroups/monster_blacklist.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "MONSTER_BLACKLIST",
+    "monsters": [
+      "mon_beaver_mutant_huge",
+      "mon_beaver_mutant_avian",
+      "mon_mutant_experimental",
+      "mon_crow_mutant_small",
+      "mon_zhark",
+      "mon_ocean_zhark"
+    ]
+  }
+]

--- a/data/mods/XedraWood/monsters/weakpoints.json
+++ b/data/mods/XedraWood/monsters/weakpoints.json
@@ -1,0 +1,174 @@
+[
+  {
+    "type": "weakpoint_set",
+    "id": "wps_humanoid_zombie_body",
+    "weakpoints": [
+      {
+        "id": "arm",
+        "name": "the arm",
+        "crit_mult": { "all": 0.75 },
+        "difficulty": { "ranged": 4, "melee": 1 },
+        "coverage_mult": { "point": 0.75 },
+        "damage_mult": { "all": 0.5 },
+        "effects": [
+          { "effect": "staggered", "chance": 20, "message": "The %s is knocked off-balance!", "damage_required": [ 0, 3 ] },
+          {
+            "effect": "staggered",
+            "chance": 40,
+            "message": "The %s is knocked off-balance!",
+            "damage_required": [ 4, 100 ]
+          }
+        ],
+        "coverage": 8
+      },
+      {
+        "id": "part_grabbing",
+        "name": "the arm",
+        "//": "Gives you a higher chance of hitting the arm if the enemy is grabbing you.",
+        "crit_mult": { "all": 0.75 },
+        "damage_mult": { "all": 0.5 },
+        "effects": [
+          { "effect": "staggered", "chance": 30, "message": "The %s is knocked off-balance!", "damage_required": [ 0, 3 ] },
+          {
+            "effect": "staggered",
+            "chance": 50,
+            "message": "The %s is knocked off-balance!",
+            "damage_required": [ 4, 100 ]
+          }
+        ],
+        "condition": { "npc_has_any_effect": [ "grabbing" ] },
+        "coverage": 8
+      },
+      {
+        "id": "leg",
+        "name": "the leg",
+        "crit_mult": { "all": 0.75 },
+        "difficulty": { "ranged": 3, "melee": 1 },
+        "coverage_mult": { "point": 0.75 },
+        "damage_mult": { "all": 0.5 },
+        "effects": [
+          { "effect": "downed", "chance": 10, "message": "The %s is knocked down!", "damage_required": [ 0, 3 ] },
+          { "effect": "downed", "chance": 20, "message": "The %s is knocked down!", "damage_required": [ 4, 7 ] },
+          { "effect": "downed", "chance": 40, "message": "The %s is knocked down!", "damage_required": [ 8, 100 ] }
+        ],
+        "coverage": 15
+      },
+      {
+        "id": "leg_mangled",
+        "//": "until we can represent chopping off legs, this is a good way to handle a similar effect.  Can mainly only be done with swinging/slashing weaponry.",
+        "name": "the leg",
+        "difficulty": { "ranged": 3, "melee": 1 },
+        "coverage_mult": { "point": 0.1 },
+        "damage_mult": { "all": 0.5 },
+        "effects": [
+          {
+            "effect": "downed",
+            "chance": 40,
+            "permanent": true,
+            "message": "The %s is knocked down, and doesn't look like it can get back up!",
+            "damage_required": [ 3, 6 ]
+          },
+          {
+            "effect": "downed",
+            "chance": 80,
+            "permanent": true,
+            "message": "The %s is knocked down, and doesn't look like it can get back up!",
+            "damage_required": [ 7, 100 ]
+          }
+        ],
+        "coverage": 10
+      },
+      {
+        "id": "head",
+        "name": "the head",
+        "is_head": true,
+        "coverage": 8,
+        "crit_mult": { "all": 2 },
+        "armor_mult": { "physical": 0.75 },
+        "difficulty": { "melee": 1, "ranged": 5 },
+        "coverage_mult": { "melee": 2 },
+        "damage_mult": { "all": 10 },
+        "effects": [
+          {
+            "effect": "stunned",
+            "duration": [ 1, 2 ],
+            "chance": 5,
+            "message": "The %s is stunned!",
+            "damage_required": [ 1, 10 ]
+          },
+          {
+            "effect": "stunned",
+            "duration": [ 1, 2 ],
+            "chance": 25,
+            "message": "The %s is stunned!",
+            "damage_required": [ 11, 50 ]
+          },
+          {
+            "effect": "stunned",
+            "duration": [ 1, 2 ],
+            "chance": 45,
+            "message": "The %s is stunned!",
+            "damage_required": [ 51, 100 ]
+          }
+        ]
+      },
+      {
+        "id": "eye",
+        "name": "the eye",
+        "is_head": true,
+        "armor_mult": { "physical": 0 },
+        "coverage": 1,
+        "crit_mult": { "all": 2.5 },
+        "difficulty": { "ranged": 8, "melee": 6 },
+        "coverage_mult": { "broad": 0.5 },
+        "damage_mult": { "all": 10 },
+        "effects": [
+          { "effect": "blind", "duration": [ 1, 2 ], "chance": 40, "message": "The %s is blinded!", "damage_required": [ 1, 25 ] },
+          {
+            "effect": "blind",
+            "permanent": true,
+            "chance": 30,
+            "message": "The %s's eyes are obliterated!",
+            "damage_required": [ 26, 100 ]
+          }
+        ]
+      },
+      {
+        "id": "head_coup",
+        "name": "the head",
+        "is_head": true,
+        "//": "If a zombie is downed, it's way easier to get a headshot.",
+        "coverage": 25,
+        "crit_mult": { "all": 2 },
+        "armor_mult": { "physical": 0.75 },
+        "difficulty": { "ranged": 5 },
+        "coverage_mult": { "melee": 2 },
+        "damage_mult": { "all": 15 },
+        "effects": [
+          {
+            "effect": "stunned",
+            "duration": [ 1, 2 ],
+            "chance": 5,
+            "message": "The %s is stunned!",
+            "damage_required": [ 1, 10 ]
+          },
+          {
+            "effect": "stunned",
+            "duration": [ 1, 2 ],
+            "chance": 25,
+            "message": "The %s is stunned!",
+            "damage_required": [ 11, 50 ]
+          },
+          {
+            "effect": "stunned",
+            "duration": [ 1, 2 ],
+            "chance": 45,
+            "message": "The %s is stunned!",
+            "damage_required": [ 51, 100 ]
+          }
+        ],
+        "condition": { "npc_has_any_effect": [ "downed" ] }
+      }
+    ]
+  }
+]

--- a/data/mods/XedraWood/monsters/zombies.json
+++ b/data/mods/XedraWood/monsters/zombies.json
@@ -95,7 +95,10 @@
     "id": "mon_zombie_rot",
     "type": "MONSTER",
     "copy-from": "mon_zombie_rot",
+    "description": "A once-dead human corpse.  Its discolored, swollen flesh is riddled with festering wounds and open sores.  Even at a distance, the smell nearly makes you gag.",
     "weakpoint_sets": [ "wps_humanoid_zombie_body" ],
+    "attack_effs": [ { "id": "pre_flu", "duration": 432000, "chance": 2 }, { "id": "rat_bite_fever", "duration": 345600, "chance": 3 } ],
+    "emit_fields": [ { "emit_id": "emit_nauseating_smell", "delay": "1 s" } ],
     "upgrades": false,
     "death_drops": "hollow_one_death_drops_zombie"
   },

--- a/data/mods/XedraWood/monsters/zombies.json
+++ b/data/mods/XedraWood/monsters/zombies.json
@@ -5,7 +5,7 @@
     "copy-from": "mon_zombie",
     "description": "A human body, skin a sickly grayish color, moving with a slow shuffling motion.",
     "upgrades": false,
-    "death_drops": "hollow_one_death_drops_zombie"
+    "death_drops": "hollow_one_death_drops_zombie",
     "weakpoint_sets": [ "wps_humanoid_zombie_body" ],
     "extend": {
       "flags": [ "CLUMSY_ATTACKS" ],

--- a/data/mods/XedraWood/monsters/zombies.json
+++ b/data/mods/XedraWood/monsters/zombies.json
@@ -3,28 +3,108 @@
     "id": "mon_zombie",
     "type": "MONSTER",
     "copy-from": "mon_zombie",
-    "upgrades": { "half_life": 30, "into_group": "GROUP_ZOMBIE_INNAWOOD_UPGRADE" },
+    "description": "A human body, skin a sickly grayish color, moving with a slow shuffling motion.",
+    "upgrades": false,
     "death_drops": "hollow_one_death_drops_zombie"
+    "weakpoint_sets": [ "wps_humanoid_zombie_body" ],
+    "extend": {
+      "flags": [ "CLUMSY_ATTACKS" ],
+      "special_attacks": [
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "zombie_drag_down",
+          "cooldown": 15,
+          "accuracy": 5,
+          "move_cost": 100,
+          "dodgeable": true,
+          "blockable": false,
+          "condition": {
+            "and": [
+              {
+                "or": [
+                  { "npc_has_effect": "grabbed", "bodypart": "arm_r" },
+                  { "npc_has_effect": "grabbed", "bodypart": "arm_l" },
+                  { "npc_has_effect": "grabbed", "bodypart": "head" },
+                  { "npc_has_effect": "grabbed", "bodypart": "torso" },
+                  { "npc_has_effect": "grabbed", "bodypart": "leg_l" },
+                  { "npc_has_effect": "grabbed", "bodypart": "leg_r" }
+                ]
+              },
+              { "math": [ "n_mon_species_nearby('ZOMBIE', 'radius': 1) >= 3" ] },
+              { "not": { "npc_has_effect": "downed" } }
+            ]
+          },
+          "damage_max_instance": [ { "damage_type": "bash", "amount": 0 } ],
+          "effects": [ { "id": "downed", "duration": 3 } ],
+          "effects_require_dmg": false,
+          "hit_dmg_u": "%1$s drags you down to the ground!",
+          "hit_dmg_npc": "%1$s drags <npcname> down to the ground!",
+          "no_dmg_msg_u": "%1$s drags you down to the ground!",
+          "no_dmg_msg_npc": "%1$s drags <npcname> down to the ground!",
+          "miss_msg_u": "",
+          "miss_msg_npc": ""
+        },
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "zombie_pile_on",
+          "cooldown": 15,
+          "accuracy": 5,
+          "move_cost": 100,
+          "dodgeable": true,
+          "blockable": false,
+          "condition": {
+            "and": [
+              {
+                "or": [
+                  { "npc_has_effect": "grabbed", "bodypart": "arm_r" },
+                  { "npc_has_effect": "grabbed", "bodypart": "arm_l" },
+                  { "npc_has_effect": "grabbed", "bodypart": "head" },
+                  { "npc_has_effect": "grabbed", "bodypart": "torso" },
+                  { "npc_has_effect": "grabbed", "bodypart": "leg_l" },
+                  { "npc_has_effect": "grabbed", "bodypart": "leg_r" }
+                ]
+              },
+              { "npc_has_effect": "downed" }
+            ]
+          },
+          "damage_max_instance": [ { "damage_type": "bash", "amount": 0 } ],
+          "effects": [ { "id": "downed", "duration": 3 }, { "id": "effect_zombie_pile_on", "duration": 10 } ],
+          "self_effects_always": [ { "id": "downed", "duration": 3 } ],
+          "effects_require_dmg": false,
+          "hit_dmg_u": "%1$s piles on while you're down!",
+          "hit_dmg_npc": "%1$s piles on <npcname> while they're down!",
+          "no_dmg_msg_u": "%1$s piles on while you're down!",
+          "no_dmg_msg_npc": "%1$s piles on <npcname> while they're down!",
+          "miss_msg_u": "",
+          "miss_msg_npc": ""
+        }
+      ]
+    }
   },
   {
     "id": "mon_zombie_crawler",
     "type": "MONSTER",
     "copy-from": "mon_zombie_crawler",
-    "upgrades": { "half_life": 30, "into_group": "GROUP_ZOMBIE_CRAWLER_INNAWOOD_UPGRADE" },
+    "weakpoint_sets": [ "wps_humanoid_zombie_body" ],
+    "upgrades": false,
     "death_drops": "hollow_one_death_drops_zombie"
   },
   {
     "id": "mon_zombie_rot",
     "type": "MONSTER",
     "copy-from": "mon_zombie_rot",
-    "upgrades": { "half_life": 43, "into": "mon_devourer" },
+    "weakpoint_sets": [ "wps_humanoid_zombie_body" ],
+    "upgrades": false,
     "death_drops": "hollow_one_death_drops_zombie"
   },
   {
     "id": "mon_zombie_tough",
     "type": "MONSTER",
     "copy-from": "mon_zombie_tough",
-    "upgrades": { "half_life": 30, "into_group": "GROUP_ZOMBIE_INNAWOOD_UPGRADE" },
+    "weakpoint_sets": [ "wps_humanoid_zombie_body" ],
+    "upgrades": false,
     "death_drops": "hollow_warrior_death_drops"
   },
   {
@@ -37,14 +117,14 @@
     "id": "mon_zombie_acidic",
     "type": "MONSTER",
     "copy-from": "mon_zombie_acidic",
-    "upgrades": { "half_life": 30, "into": "mon_zombie_spitter" },
+    "upgrades": false,
     "death_drops": "hollow_one_death_drops_zombie"
   },
   {
     "id": "mon_zombie_spitter",
     "type": "MONSTER",
     "copy-from": "mon_zombie_spitter",
-    "upgrades": { "half_life": 42, "into": "mon_zombie_corrosive" },
+    "upgrades": false,
     "death_drops": "hollow_one_death_drops_zombie"
   },
   {
@@ -75,7 +155,7 @@
     "id": "mon_zombie_grabber",
     "type": "MONSTER",
     "copy-from": "mon_zombie_grabber",
-    "upgrades": { "half_life": 30, "into_group": "GROUP_ZOMBIE_GRAB_INNAWOOD" },
+    "upgrades": false,
     "death_drops": "hollow_one_death_drops_zombie"
   },
   {
@@ -172,7 +252,7 @@
     "id": "mon_skeleton",
     "type": "MONSTER",
     "copy-from": "mon_skeleton",
-    "upgrades": { "half_life": 32, "into_group": "GROUP_SKELETON_UPGRADE_INNAWOOD" },
+    "upgrades": false,
     "death_drops": "hollow_one_death_drops_zombie"
   },
   {

--- a/data/mods/XedraWood/recipes/occult_knowledge.json
+++ b/data/mods/XedraWood/recipes/occult_knowledge.json
@@ -32,7 +32,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "name": "study occult research notes",
     "id": "study_occult_research",
-    "description": "There's more you could learn from those notes you took.  You just need to go over them again and separate the truth from the nonsense.",
+    "description": "There's more you could learn from those notes you took.  You just need to go over them again and separate the truth from the lies.",
     "category": "CC_XEDRA",
     "subcategory": "CSC_XEDRA_RESEARCH",
     "difficulty": 3,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[XedraWood] Add some mod identity around evolution and zombification"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The creeping evolution clock is an important part of base DDA, but in a low-tech sword and sorcery world we have other ways to provide end-game threats to the player. You have to fight groups of Fair Folk, mi-go psychics, triffid sorcerers, liches in tombs, etc.

Giant spiders, giant snakes, etc are a critical part of sword and sorcery but I can add lairs for them, they don't need to be everywhere as the game goes on.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

A number of changes:

- Port over a bunch of the zombie adjustments from DDotD: Zombies have much larger HP pools, they don't bleed, they don't revive, they aren't warm, they can overwhelm you and drag you down to the ground, they're slower, and you can easily kill them with a headshot. They do **not** have the deadly zombie virus
- Decaying zombies have the disgusting stench mechanic and diseased attacks from the base-game plaguebearer
- Set the evolution timer so high (99) that it basically won't matter
- Zero out several evolution-based monsters groups like `GROUP_WILDERNESS_FOREST_ZOMBIE` and `GROUP_WILDERNESS_FOREST_MAMMAL_MUTANT` so they don't spawn anything
- Add extra normal animal spawns on timers to counteract the base-game decrease in normal animals over time. 
- Add some external options: turn off Zombifies Into, slightly increase the focus benefit from Intelligence, increase wilderness animal spawns, disable the extra warring spawns in swamps (turns out swamp deathzone rumbles are an External Option), and enable CBM slots (to be used for magical tattoos when those are added). 

To-do:

- [X] individually blacklist monsters like mutant crows that show up on normal spawnlists

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Fought a zombie, it took a ton of damage before dying and did not try to rise again
Waited a year, teleported around, no zombie evolution occurred. 
Mass-killed everything in a swamp, nothing tried to rise. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

A lot of insects have `age_grow` so I'll need another PR to override all of that. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
