### PR TITLE
Tileset loader parse/upload split and scoped render-target helpers

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -306,6 +306,8 @@ void tileset::clear()
     overexposed_tile_values.clear();
     memory_tile_values.clear();
     silhouette_tile_values.clear();
+    atlas_descriptors.clear();
+    default_item_highlight_index.reset();
     duplicate_ids.clear();
     tile_ids.clear();
     for( std::unordered_map<std::string, season_tile_value> &m : tile_ids_by_season ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -308,6 +308,8 @@ void tileset::clear()
     silhouette_tile_values.clear();
     atlas_descriptors.clear();
     default_item_highlight_index.reset();
+    renderer_instance_generation_at_upload = 0;
+    gpu_textures_generation_at_upload = 0;
     duplicate_ids.clear();
     tile_ids.clear();
     for( std::unordered_map<std::string, season_tile_value> &m : tile_ids_by_season ) {
@@ -315,6 +317,30 @@ void tileset::clear()
     }
     item_layer_data.clear();
     field_layer_data.clear();
+}
+
+uint64_t compute_tileset_filter_fingerprint( const std::string &memory_map_mode )
+{
+    auto mix = []( uint64_t &h, uint64_t v ) {
+        h ^= v + 0x9e3779b97f4a7c15ULL + ( h << 6 ) + ( h >> 2 );
+    };
+    uint64_t h = 0;
+    // SCALING_MODE is stamped onto every texture at CreateTexture time via
+    // the SDL default scale quality.
+    mix( h, std::hash<std::string> {}( get_option<std::string>( "SCALING_MODE" ) ) );
+    if( memory_map_mode == "color_pixel_custom" ) {
+        mix( h, static_cast<uint64_t>( get_option<int>( "MEMORY_RGB_DARK_RED" ) ) );
+        mix( h, static_cast<uint64_t>( get_option<int>( "MEMORY_RGB_DARK_GREEN" ) ) );
+        mix( h, static_cast<uint64_t>( get_option<int>( "MEMORY_RGB_DARK_BLUE" ) ) );
+        mix( h, static_cast<uint64_t>( get_option<int>( "MEMORY_RGB_BRIGHT_RED" ) ) );
+        mix( h, static_cast<uint64_t>( get_option<int>( "MEMORY_RGB_BRIGHT_GREEN" ) ) );
+        mix( h, static_cast<uint64_t>( get_option<int>( "MEMORY_RGB_BRIGHT_BLUE" ) ) );
+        const float gamma = get_option<float>( "MEMORY_GAMMA" );
+        uint32_t gamma_bits = 0;
+        std::memcpy( &gamma_bits, &gamma, sizeof( gamma_bits ) );
+        mix( h, static_cast<uint64_t>( gamma_bits ) );
+    }
+    return h;
 }
 
 const tile_type *tileset::find_tile_type( const std::string &id ) const
@@ -391,7 +417,7 @@ void cata_tiles::load_tileset( const std::string &tileset_id, const bool prechec
     tileset_mutation_overlay_ordering.clear();
 
     tileset_ptr = cache.load_tileset( tileset_id, renderer, precheck, force, pump_events, terrain,
-                                      memory_map_mode );
+                                      memory_map_mode, 0, 0 );
 
     set_draw_scale( 16 );
 
@@ -3959,18 +3985,31 @@ bool cata_tiles::draw_item_highlight( const tripoint_bub_ms &pos, int &height_3d
 
 std::shared_ptr<const tileset> tileset_cache::load_tileset( const std::string &tileset_id,
         const SDL_Renderer_Ptr &renderer, const bool precheck, const bool force, const bool pump_events,
-        const bool terrain, const std::string &memory_map_mode )
+        const bool terrain, const std::string &memory_map_mode,
+        const uint64_t current_renderer_instance_gen, const uint64_t current_gpu_textures_gen )
 {
+    const tileset_cache_key key {
+        tileset_id, memory_map_mode, compute_tileset_filter_fingerprint( memory_map_mode )
+    };
+
     const auto get_or_create_tileset = [&]() {
-        const auto it = tilesets_.find( tileset_id );
-        if( it == tilesets_.end() || it->second.expired() ) {
-            std::shared_ptr<tileset> new_ts = std::make_shared<tileset>();
-            loader loader( *new_ts, renderer, memory_map_mode );
-            loader.load( tileset_id, precheck, pump_events, terrain );
-            tilesets_.emplace( tileset_id, new_ts );
-            return new_ts;
+        const auto it = tilesets_.find( key );
+        if( it != tilesets_.end() ) {
+            std::shared_ptr<tileset> cached = it->second.lock();
+            if( cached
+                && cached->get_renderer_instance_generation_at_upload() == current_renderer_instance_gen
+                && cached->get_gpu_textures_generation_at_upload() == current_gpu_textures_gen ) {
+                return cached;
+            }
         }
-        return it->second.lock();
+        std::shared_ptr<tileset> new_ts = std::make_shared<tileset>();
+        loader loader( *new_ts, renderer, memory_map_mode );
+        loader.load( tileset_id, precheck, pump_events, terrain );
+        new_ts->set_upload_generations( current_renderer_instance_gen, current_gpu_textures_gen );
+        // insert_or_assign so an expired weak_ptr at this key is replaced
+        // instead of being kept alongside a duplicate emplace attempt.
+        tilesets_.insert_or_assign( key, new_ts );
+        return new_ts;
     };
 
     std::shared_ptr<tileset> ts = get_or_create_tileset();
@@ -3978,6 +4017,7 @@ std::shared_ptr<const tileset> tileset_cache::load_tileset( const std::string &t
     if( force || ( ts->get_tileset_id().empty() && !precheck ) ) {
         loader loader( *ts, renderer, memory_map_mode );
         loader.load( tileset_id, precheck, pump_events, terrain );
+        ts->set_upload_generations( current_renderer_instance_gen, current_gpu_textures_gen );
     }
     return ts;
 }

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -211,6 +211,20 @@ class layer_context_sprites
         std::string append_suffix;
 };
 
+// Inputs needed to re-upload one atlas after renderer recreate or
+// device-texture reset. image_path_u8 is a UTF-8 byte sequence so the
+// descriptor avoids a cata_path dependency.
+struct atlas_replay_descriptor {
+    std::string image_path_u8;
+    int color_key_r = -1;
+    int color_key_g = -1;
+    int color_key_b = -1;
+    int sprite_width = 0;
+    int sprite_height = 0;
+    int atlas_offset = 0;
+    int expected_tilecount = 0;
+};
+
 class tileset
 {
     private:
@@ -242,6 +256,12 @@ class tileset
         std::vector<texture> overexposed_tile_values;
         std::vector<texture> memory_tile_values;
         std::vector<texture> silhouette_tile_values;
+
+        // Descriptors recorded during JSON parsing; replayed by upload_atlases.
+        std::vector<atlas_replay_descriptor> atlas_descriptors;
+        // Sprite index of the synthetic highlight overlay, or nullopt when
+        // the tileset defines its own ITEM_HIGHLIGHT.
+        std::optional<int> default_item_highlight_index;
 
         std::unordered_set<std::string> duplicate_ids;
 
@@ -314,6 +334,19 @@ class tileset
 
         const std::unordered_set<std::string> &get_duplicate_ids() const {
             return duplicate_ids;
+        }
+
+        const std::vector<atlas_replay_descriptor> &get_atlas_descriptors() const {
+            return atlas_descriptors;
+        }
+        void append_atlas_descriptor( atlas_replay_descriptor desc ) {
+            atlas_descriptors.push_back( std::move( desc ) );
+        }
+        std::optional<int> get_default_item_highlight_index() const {
+            return default_item_highlight_index;
+        }
+        void set_default_item_highlight_index( std::optional<int> idx ) {
+            default_item_highlight_index = idx;
         }
 
         tile_type &create_tile_type( const std::string &id, tile_type &&new_tile_type );

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -387,9 +387,10 @@ class tileset
                 season_type season ) const;
 };
 
-// Hash of color-filter configuration that affects pre-baked texture variants.
-// Currently covers MEMORY_RGB_{DARK,BRIGHT}_{R,G,B} and MEMORY_GAMMA when
-// MEMORY_MAP_MODE is "color_pixel_custom"; zero otherwise.
+// Hashes the options baked into tileset textures so changing any of them
+// invalidates the cache key and forces a reupload. Always folds in
+// SCALING_MODE; adds MEMORY_RGB_{DARK,BRIGHT}_{R,G,B} and MEMORY_GAMMA under
+// the "color_pixel_custom" memory map mode.
 uint64_t compute_tileset_filter_fingerprint( const std::string &memory_map_mode );
 
 struct tileset_cache_key {

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -263,6 +263,12 @@ class tileset
         // the tileset defines its own ITEM_HIGHLIGHT.
         std::optional<int> default_item_highlight_index;
 
+        // Renderer-instance and device-texture epochs the textures were
+        // uploaded against. A bundle whose epochs differ from the live ones
+        // is stale and must be reuploaded before use.
+        uint64_t renderer_instance_generation_at_upload = 0;
+        uint64_t gpu_textures_generation_at_upload = 0;
+
         std::unordered_set<std::string> duplicate_ids;
 
         std::unordered_map<std::string, tile_type> tile_ids;
@@ -348,6 +354,16 @@ class tileset
         void set_default_item_highlight_index( std::optional<int> idx ) {
             default_item_highlight_index = idx;
         }
+        uint64_t get_renderer_instance_generation_at_upload() const {
+            return renderer_instance_generation_at_upload;
+        }
+        uint64_t get_gpu_textures_generation_at_upload() const {
+            return gpu_textures_generation_at_upload;
+        }
+        void set_upload_generations( uint64_t renderer_instance_gen, uint64_t gpu_textures_gen ) {
+            renderer_instance_generation_at_upload = renderer_instance_gen;
+            gpu_textures_generation_at_upload = gpu_textures_gen;
+        }
 
         tile_type &create_tile_type( const std::string &id, tile_type &&new_tile_type );
         const tile_type *find_tile_type( const std::string &id ) const;
@@ -371,17 +387,53 @@ class tileset
                 season_type season ) const;
 };
 
+// Hash of color-filter configuration that affects pre-baked texture variants.
+// Currently covers MEMORY_RGB_{DARK,BRIGHT}_{R,G,B} and MEMORY_GAMMA when
+// MEMORY_MAP_MODE is "color_pixel_custom"; zero otherwise.
+uint64_t compute_tileset_filter_fingerprint( const std::string &memory_map_mode );
+
+struct tileset_cache_key {
+    std::string tileset_id;
+    std::string memory_preset;
+    uint64_t filter_fingerprint = 0;
+
+    bool operator==( const tileset_cache_key &other ) const {
+        return tileset_id == other.tileset_id
+               && memory_preset == other.memory_preset
+               && filter_fingerprint == other.filter_fingerprint;
+    }
+};
+
+struct tileset_cache_key_hash {
+    std::size_t operator()( const tileset_cache_key &key ) const noexcept {
+        const std::size_t h1 = std::hash<std::string> {}( key.tileset_id );
+        const std::size_t h2 = std::hash<std::string> {}( key.memory_preset );
+        const std::size_t h3 = std::hash<uint64_t> {}( key.filter_fingerprint );
+        std::size_t h = h1;
+        h ^= h2 + 0x9e3779b97f4a7c15ULL + ( h << 6 ) + ( h >> 2 );
+        h ^= h3 + 0x9e3779b97f4a7c15ULL + ( h << 6 ) + ( h >> 2 );
+        return h;
+    }
+};
+
 class tileset_cache
 {
     public:
+        // Look up or load a tileset bundle. current_renderer_instance_gen and
+        // current_gpu_textures_gen are compared against the bundle's recorded
+        // generations; a mismatch on either treats the cached entry as stale
+        // and reloads.
         std::shared_ptr<const tileset> load_tileset( const std::string &tileset_id,
                 const SDL_Renderer_Ptr &renderer, bool precheck,
                 bool force, bool pump_events, bool terrain,
-                const std::string &memory_map_mode );
+                const std::string &memory_map_mode,
+                uint64_t current_renderer_instance_gen,
+                uint64_t current_gpu_textures_gen );
     private:
         class loader;
 
-        std::unordered_map<std::string, std::weak_ptr<tileset>> tilesets_;
+        std::unordered_map<tileset_cache_key, std::weak_ptr<tileset>, tileset_cache_key_hash>
+        tilesets_;
 };
 
 

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -259,7 +259,6 @@ void pixel_minimap::clear_unused_cache()
 }
 
 //draws individual updates to the submap cache texture
-//the render target will be set back to display_buffer after all submaps are updated
 void pixel_minimap::flush_cache_updates()
 {
     for( auto &mcp : cache ) {
@@ -267,7 +266,10 @@ void pixel_minimap::flush_cache_updates()
             continue;
         }
 
-        SetRenderTarget( renderer, mcp.second.chunk_tex );
+        scoped_render_target chunk_scope( renderer, mcp.second.chunk_tex.get() );
+        if( !chunk_scope.is_valid() ) {
+            continue;
+        }
 
         if( !mcp.second.ready ) {
             mcp.second.ready = true;
@@ -440,15 +442,18 @@ void pixel_minimap::reset()
 
 void pixel_minimap::render( const tripoint_bub_ms &center )
 {
-    SetRenderTarget( renderer, main_tex );
-    SetRenderDrawColor( renderer, pixel_minimap_r, pixel_minimap_g, pixel_minimap_b, pixel_minimap_a );
-    RenderClear( renderer );
+    {
+        scoped_render_target main_scope( renderer, main_tex.get() );
+        if( !main_scope.is_valid() ) {
+            return;
+        }
+        SetRenderDrawColor( renderer, pixel_minimap_r, pixel_minimap_g, pixel_minimap_b,
+                            pixel_minimap_a );
+        RenderClear( renderer );
 
-    render_cache( center );
-    render_critters( center );
-
-    //set display buffer to main screen
-    set_displaybuffer_rendertarget();
+        render_cache( center );
+        render_critters( center );
+    }
     //paint intermediate texture to screen
     RenderCopy( renderer, main_tex, &main_tex_clip_rect, &screen_clip_rect );
 }

--- a/src/sdl_wrappers.cpp
+++ b/src/sdl_wrappers.cpp
@@ -9,6 +9,9 @@
 #include <string>
 
 #include "cata_assert.h"
+#if SDL_MAJOR_VERSION >= 3
+#include "cata_shader.h"
+#endif
 #include "debug.h"
 #include "point.h"
 
@@ -320,6 +323,78 @@ bool SetRenderTarget( const SDL_Renderer_Ptr &renderer, const SDL_Texture_Ptr &t
                                       "SDL_SetRenderTarget failed" );
 #else
     const bool failed = printErrorIf( SDL_SetRenderTarget( renderer.get(), texture.get() ) != 0,
+                                      "SDL_SetRenderTarget failed" );
+#endif
+    return !failed;
+}
+
+scoped_render_target::scoped_render_target( const SDL_Renderer_Ptr &renderer,
+        SDL_Texture *target, cata_shader::variant_pass *vp )
+{
+    if( !renderer ) {
+        dbg( D_ERROR ) << "scoped_render_target: null renderer";
+        return;
+    }
+    renderer_ = renderer.get();
+#if SDL_MAJOR_VERSION >= 3
+    prior_target_ = SDL_GetRenderTarget( renderer_ );
+    if( vp && !vp->flush() ) {
+        renderer_ = nullptr;
+        prior_target_ = nullptr;
+        return;
+    }
+    if( !SDL_SetRenderTarget( renderer_, target ) ) {
+        dbg( D_ERROR ) << "scoped_render_target: SDL_SetRenderTarget failed: " << SDL_GetError();
+        renderer_ = nullptr;
+        prior_target_ = nullptr;
+        return;
+    }
+#else
+    ( void )vp;
+    prior_target_ = SDL_GetRenderTarget( renderer_ );
+    if( SDL_SetRenderTarget( renderer_, target ) != 0 ) {
+        dbg( D_ERROR ) << "scoped_render_target: SDL_SetRenderTarget failed: " << SDL_GetError();
+        renderer_ = nullptr;
+        prior_target_ = nullptr;
+        return;
+    }
+#endif
+    valid_ = true;
+}
+
+scoped_render_target::~scoped_render_target()
+{
+    if( restored_ || !valid_ || !renderer_ ) {
+        return;
+    }
+    restored_ = true;
+#if SDL_MAJOR_VERSION >= 3
+    if( !SDL_SetRenderTarget( renderer_, prior_target_ ) ) {
+        dbg( D_ERROR ) << "~scoped_render_target: SDL_SetRenderTarget failed: " << SDL_GetError();
+    }
+#else
+    if( SDL_SetRenderTarget( renderer_, prior_target_ ) != 0 ) {
+        dbg( D_ERROR ) << "~scoped_render_target: SDL_SetRenderTarget failed: " << SDL_GetError();
+    }
+#endif
+}
+
+bool permanent_render_target_bind( const SDL_Renderer_Ptr &renderer, SDL_Texture *target,
+                                   cata_shader::variant_pass *vp )
+{
+    if( !renderer ) {
+        dbg( D_ERROR ) << "permanent_render_target_bind: null renderer";
+        return false;
+    }
+#if SDL_MAJOR_VERSION >= 3
+    if( vp && !vp->flush() ) {
+        return false;
+    }
+    const bool failed = printErrorIf( !SDL_SetRenderTarget( renderer.get(), target ),
+                                      "SDL_SetRenderTarget failed" );
+#else
+    ( void )vp;
+    const bool failed = printErrorIf( SDL_SetRenderTarget( renderer.get(), target ) != 0,
                                       "SDL_SetRenderTarget failed" );
 #endif
     return !failed;

--- a/src/sdl_wrappers.h
+++ b/src/sdl_wrappers.h
@@ -123,6 +123,44 @@ void SetRenderDrawBlendMode( const SDL_Renderer_Ptr &renderer, SDL_BlendMode ble
 void GetRenderDrawBlendMode( const SDL_Renderer_Ptr &renderer, SDL_BlendMode &blend_mode );
 SDL_Surface_Ptr load_image( const char *path );
 bool SetRenderTarget( const SDL_Renderer_Ptr &renderer, const SDL_Texture_Ptr &texture );
+
+namespace cata_shader
+{
+class variant_pass;
+} // namespace cata_shader
+
+// RAII render-target swap: binds `target`, restores the prior target on
+// destruction. On SDL3 a non-null `vp` is flushed before the swap so shader
+// GPU state is not left bound across the SetRenderTarget transition. Check
+// is_valid() before issuing draws.
+class scoped_render_target
+{
+    public:
+        scoped_render_target( const SDL_Renderer_Ptr &renderer, SDL_Texture *target,
+                              cata_shader::variant_pass *vp = nullptr );
+        ~scoped_render_target();
+
+        scoped_render_target( const scoped_render_target & ) = delete;
+        scoped_render_target &operator=( const scoped_render_target & ) = delete;
+        scoped_render_target( scoped_render_target && ) = delete;
+        scoped_render_target &operator=( scoped_render_target && ) = delete;
+
+        bool is_valid() const {
+            return valid_;
+        }
+
+    private:
+        SDL_Renderer *renderer_ = nullptr;
+        SDL_Texture *prior_target_ = nullptr;
+        bool valid_ = false;
+        bool restored_ = false;
+};
+
+// Bind a render target permanently, with no auto-restore, for transitions
+// where the prior target is not meaningful. Flushes variant_pass on SDL3
+// when `vp` is non-null.
+bool permanent_render_target_bind( const SDL_Renderer_Ptr &renderer, SDL_Texture *target,
+                                   cata_shader::variant_pass *vp = nullptr );
 void RenderClear( const SDL_Renderer_Ptr &renderer );
 SDL_Surface_Ptr CreateRGBSurface( Uint32 flags, int width, int height, int depth, Uint32 Rmask,
                                   Uint32 Gmask, Uint32 Bmask, Uint32 Amask );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1369,6 +1369,13 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     }
 
     RenderSetClipRect( renderer, nullptr );
+#if SDL_MAJOR_VERSION >= 3
+    // Flush so GPU shader state from sprite draws is not left bound across a
+    // following ImGui pass or target switch.
+    if( m_variant_pass ) {
+        m_variant_pass->flush();
+    }
+#endif
 }
 
 static bool draw_window( Font_Ptr &font, const catacurses::window &w, const point &offset )

--- a/src/tileset_loader.cpp
+++ b/src/tileset_loader.cpp
@@ -212,9 +212,11 @@ void tileset_cache::loader::copy_surface_to_texture( const SDL_Surface_Ptr &surf
 }
 
 void tileset_cache::loader::create_textures_from_tile_atlas( const SDL_Surface_Ptr &tile_atlas,
-        const point &offset )
+        const point &offset, const tile_value_targets &targets )
 {
     cata_assert( tile_atlas );
+    cata_assert( targets.normal && targets.shadow && targets.night && targets.overexposed
+                 && targets.memory && targets.silhouette );
 
     // Compute per-sprite opaque bounds once from the unfiltered atlas.
     // Color filter variants preserve the alpha channel, so rescanning is unnecessary.
@@ -243,12 +245,12 @@ void tileset_cache::loader::create_textures_from_tile_atlas( const SDL_Surface_P
     /** perform color filter conversion here */
     using tiles_pixel_color_entry = std::tuple<std::vector<texture>*, std::string>;
     std::array<tiles_pixel_color_entry, 6> tile_values_data = {{
-            { std::make_tuple( &ts.tile_values, "color_pixel_none" ) },
-            { std::make_tuple( &ts.shadow_tile_values, "color_pixel_grayscale" ) },
-            { std::make_tuple( &ts.night_tile_values, "color_pixel_nightvision" ) },
-            { std::make_tuple( &ts.overexposed_tile_values, "color_pixel_overexposed" ) },
-            { std::make_tuple( &ts.memory_tile_values, memory_map_mode ) },
-            { std::make_tuple( &ts.silhouette_tile_values, "color_pixel_silhouette" ) }
+            { std::make_tuple( targets.normal, "color_pixel_none" ) },
+            { std::make_tuple( targets.shadow, "color_pixel_grayscale" ) },
+            { std::make_tuple( targets.night, "color_pixel_nightvision" ) },
+            { std::make_tuple( targets.overexposed, "color_pixel_overexposed" ) },
+            { std::make_tuple( targets.memory, memory_map_mode ) },
+            { std::make_tuple( targets.silhouette, "color_pixel_silhouette" ) }
         }
     };
     for( tiles_pixel_color_entry &entry : tile_values_data ) {
@@ -271,73 +273,14 @@ static void extend_vector_by( std::vector<T> &vec, const size_t additional_size 
     vec.resize( vec.size() + additional_size );
 }
 
-void tileset_cache::loader::load_tileset( const cata_path &img_path, const bool pump_events )
+void tileset_cache::loader::read_image_dimensions( const cata_path &img_path,
+        const int kr, const int kg, const int kb )
 {
     cata_assert( sprite_width > 0 );
     cata_assert( sprite_height > 0 );
     const SDL_Surface_Ptr tile_atlas = load_image( img_path.get_unrelative_path().u8string().c_str() );
     cata_assert( tile_atlas );
     tile_atlas_width = tile_atlas->w;
-
-    if( R >= 0 && R <= 255 && G >= 0 && G <= 255 && B >= 0 && B <= 255 ) {
-        const Uint32 key = MapRGB( tile_atlas, 0, 0, 0 );
-        throwErrorIf( SetColorKey( tile_atlas, 1, key ) != 0,
-                      "SDL_SetColorKey failed" );
-        throwErrorIf( SetSurfaceRLE( tile_atlas, 1 ), "SDL_SetSurfaceRLE failed" );
-    }
-
-    int max_tex_w = 0;
-    int max_tex_h = 0;
-    throwErrorIf( !GetRendererMaxTextureSize( renderer, &max_tex_w, &max_tex_h ),
-                  "GetRendererMaxTextureSize failed" );
-    // Software rendering stores textures as surfaces with run-length encoding, which makes
-    // extracting a part in the middle of the texture slow. Therefore this "simulates" that the
-    // renderer only supports one tile per texture.
-    if( IsRendererSoftware( renderer ) ) {
-        max_tex_w = sprite_width;
-        max_tex_h = sprite_height;
-    }
-    // for debugging only: force a very small maximal texture size, as to trigger
-    // splitting the tile atlas.
-#if 0
-    // +1 to check correct rounding
-    max_tex_w = sprite_width * 10 + 1;
-    max_tex_h = sprite_height * 20 + 1;
-#endif
-
-    const int min_tile_xcount = 128;
-    const int min_tile_ycount = min_tile_xcount * 2;
-
-    if( max_tex_w == 0 ) {
-        max_tex_w = sprite_width * min_tile_xcount;
-        DebugLog( D_INFO, DC_ALL ) << "Renderer max_texture_width was 0. "
-                                   << "Changed to " << max_tex_w;
-    } else {
-        throwErrorIf( max_tex_w < sprite_width,
-                      "Maximal texture width is smaller than tile width" );
-    }
-
-    if( max_tex_h == 0 ) {
-        max_tex_h = sprite_height * min_tile_ycount;
-        DebugLog( D_INFO, DC_ALL ) << "Renderer max_texture_height was 0. "
-                                   << "Changed to " << max_tex_h;
-    } else {
-        throwErrorIf( max_tex_h < sprite_height,
-                      "Maximal texture height is smaller than tile height" );
-    }
-
-    // Number of tiles in each dimension that fits into a (maximal) SDL texture.
-    // If the tile atlas contains more than that, we have to split it.
-    const int max_tile_xcount = max_tex_w / sprite_width;
-    const int max_tile_ycount = max_tex_h / sprite_height;
-    // Range over the tile atlas, wherein each rectangle fits into the maximal
-    // SDL texture size. In other words: a range over the parts into which the
-    // tile atlas needs to be split.
-    const rect_range<SDL_Rect> output_range(
-        max_tile_xcount * sprite_width,
-        max_tile_ycount * sprite_height,
-        point( divide_round_up( tile_atlas->w, max_tex_w ),
-               divide_round_up( tile_atlas->h, max_tex_h ) ) );
 
     const int expected_tilecount = ( tile_atlas->w / sprite_width ) *
                                    ( tile_atlas->h / sprite_height );
@@ -348,35 +291,16 @@ void tileset_cache::loader::load_tileset( const cata_path &img_path, const bool 
     extend_vector_by( ts.memory_tile_values, expected_tilecount );
     extend_vector_by( ts.silhouette_tile_values, expected_tilecount );
 
-    for( const SDL_Rect sub_rect : output_range ) {
-        cata_assert( sub_rect.x % sprite_width == 0 );
-        cata_assert( sub_rect.y % sprite_height == 0 );
-        cata_assert( sub_rect.w % sprite_width == 0 );
-        cata_assert( sub_rect.h % sprite_height == 0 );
-        SDL_Surface_Ptr smaller_surf;
-
-        if( is_contained( SDL_Rect{ 0, 0, tile_atlas->w, tile_atlas->h }, sub_rect ) ) {
-            // can use tile_atlas directly, it is completely contained in the output rectangle
-        } else {
-            // Need a temporary surface that contains the parts of the tile atlas that fit
-            // into sub_rect. But doesn't always need to be as large as sub_rect.
-            const int w = std::min( tile_atlas->w - sub_rect.x, sub_rect.w );
-            const int h = std::min( tile_atlas->h - sub_rect.y, sub_rect.h );
-            smaller_surf = ::create_surface_32( w, h );
-            cata_assert( smaller_surf );
-            const SDL_Rect inp{ sub_rect.x, sub_rect.y, w, h };
-            throwErrorIf( BlitSurface( tile_atlas, &inp, smaller_surf,
-                                       nullptr ) != 0, "SDL_BlitSurface failed" );
-        }
-        const SDL_Surface_Ptr &surf_to_use = smaller_surf ? smaller_surf : tile_atlas;
-        cata_assert( surf_to_use );
-
-        create_textures_from_tile_atlas( surf_to_use, point( sub_rect.x, sub_rect.y ) );
-
-        if( pump_events ) {
-            inp_mngr.pump_events();
-        }
-    }
+    atlas_replay_descriptor desc;
+    desc.image_path_u8 = img_path.get_unrelative_path().u8string();
+    desc.color_key_r = kr;
+    desc.color_key_g = kg;
+    desc.color_key_b = kb;
+    desc.sprite_width = sprite_width;
+    desc.sprite_height = sprite_height;
+    desc.atlas_offset = offset;
+    desc.expected_tilecount = expected_tilecount;
+    ts.append_atlas_descriptor( std::move( desc ) );
 
     size = expected_tilecount;
 }
@@ -453,9 +377,10 @@ void tileset_cache::loader::load( const std::string &tileset_id, const bool prec
 
     ts.clear();
 
-    // Load tile information if available.
+    // Parse pass: record atlas descriptors and tile mappings, no GPU work.
+    // Texture upload happens later in upload_atlases.
     offset = 0;
-    load_internal( config, tileset_root, img_path, pump_events );
+    parse_atlases( config, tileset_root, img_path, pump_events );
 
     // Load mod tilesets if available
     for( const mod_tileset &mts : all_mod_tilesets ) {
@@ -494,7 +419,7 @@ void tileset_cache::loader::load( const std::string &tileset_id, const bool prec
                         if( mod_config.has_member( "compatibility" ) ) {
                             mod_config.get_member( "compatibility" );
                         }
-                        load_internal( mod_config, tileset_root, img_path, pump_events );
+                        parse_atlases( mod_config, tileset_root, img_path, pump_events );
                         break;
                     }
                     num_in_file++;
@@ -503,7 +428,7 @@ void tileset_cache::loader::load( const std::string &tileset_id, const bool prec
         } else {
             JsonObject mod_config = mod_config_json.get_object();
             mark_visited( mod_config );
-            load_internal( mod_config, tileset_root, img_path, pump_events );
+            parse_atlases( mod_config, tileset_root, img_path, pump_events );
         }
     }
 
@@ -526,7 +451,17 @@ void tileset_cache::loader::load( const std::string &tileset_id, const bool prec
         dbg( D_ERROR ) << "The tileset you're using has no '" << ( terrain ? "unknown_terrain" : "unknown" )
                        << "' tile defined!";
     }
-    ensure_default_item_highlight();
+
+    // When the tileset lacks ITEM_HIGHLIGHT, reserve the next free slot for
+    // the synthetic overlay. upload_atlases fills it on every upload, so the
+    // slot stays stable across device-reset replay.
+    if( !ts.find_tile_type( ITEM_HIGHLIGHT ) ) {
+        const int reserved_index = offset;
+        ts.set_default_item_highlight_index( reserved_index );
+        ts.tile_ids[ITEM_HIGHLIGHT].fg.add( std::vector<int>( {reserved_index} ), 1 );
+    } else {
+        ts.set_default_item_highlight_index( std::nullopt );
+    }
 
     ts.tileset_id = tileset_id;
 
@@ -544,9 +479,11 @@ void tileset_cache::loader::load( const std::string &tileset_id, const bool prec
         load_layers( layer_config );
     }
 
+    upload_atlases( ts, renderer, memory_map_mode, ts.get_atlas_descriptors(),
+                    0, 0, pump_events );
 }
 
-void tileset_cache::loader::load_internal( const JsonObject &config,
+void tileset_cache::loader::parse_atlases( const JsonObject &config,
         const cata_path &tileset_root,
         const cata_path &img_path, const bool pump_events )
 {
@@ -585,10 +522,10 @@ void tileset_cache::loader::load_internal( const JsonObject &config,
                               sprite_height + std::max( sprite_offset.y, sprite_offset_retracted.y ) ),
                 }
             };
-            // First load the tileset image to get the number of available tiles.
+            // First read the tileset image header to count tiles.
             dbg( D_INFO ) << "Attempting to Load Tileset file " << tileset_image_path;
-            load_tileset( tileset_image_path, pump_events );
-            load_tilejson_from_file( tile_part_def );
+            read_image_dimensions( tileset_image_path, R, G, B );
+            parse_mappings( tile_part_def );
             if( tile_part_def.has_member( "ascii" ) ) {
                 load_ascii( tile_part_def );
             }
@@ -610,9 +547,9 @@ void tileset_cache::loader::load_internal( const JsonObject &config,
         B = -1;
         // old system, no tile file path entry, only one array of tiles
         dbg( D_INFO ) << "Attempting to Load Tileset file " << img_path;
-        load_tileset( img_path, pump_events );
-        load_tilejson_from_file( config );
-        offset = size;
+        read_image_dimensions( img_path, R, G, B );
+        parse_mappings( config );
+        offset += size;
     }
 
     // allows a tileset to override the order of mutation images being applied to a character
@@ -900,7 +837,7 @@ void tileset_cache::loader::load_ascii_set( const JsonObject &entry )
     }
 }
 
-void tileset_cache::loader::load_tilejson_from_file( const JsonObject &config )
+void tileset_cache::loader::parse_mappings( const JsonObject &config )
 {
     if( !config.has_member( "tiles" ) ) {
         config.throw_error( "\"tiles\" section missing" );
@@ -1035,22 +972,171 @@ void tileset_cache::loader::load_tile_spritelists( const JsonObject &entry,
         vs.add( std::vector<int>( {entry.get_int( objname ) + sprite_id_offset} ), 1 );
     }
 }
-void tileset_cache::loader::ensure_default_item_highlight()
+void tileset_cache::loader::upload_atlases( tileset &ts, const SDL_Renderer_Ptr &renderer,
+        const std::string &memory_map_mode,
+        const std::vector<atlas_replay_descriptor> &descriptors,
+        uint64_t /*renderer_instance_generation*/,
+        uint64_t /*gpu_textures_generation*/,
+        const bool pump_events )
 {
-    if( ts.find_tile_type( ITEM_HIGHLIGHT ) ) {
-        return;
+    int total = 0;
+    for( const atlas_replay_descriptor &d : descriptors ) {
+        total += d.expected_tilecount;
     }
-    const Uint8 highlight_alpha = 127;
+    const std::optional<int> highlight_idx = ts.get_default_item_highlight_index();
+    const int highlight_extra = highlight_idx ? 1 : 0;
 
-    int index = ts.tile_values.size();
+    // Variant vectors size to the atlas tilecount; the synthetic highlight
+    // adds a slot only to the normal vector so the draw path's range check
+    // returns nullptr for variants at that index and falls back to normal.
+    std::vector<texture> cand_normal( total + highlight_extra );
+    std::vector<texture> cand_shadow( total );
+    std::vector<texture> cand_night( total );
+    std::vector<texture> cand_overexposed( total );
+    std::vector<texture> cand_memory( total );
+    std::vector<texture> cand_silhouette( total );
 
-    const SDL_Surface_Ptr surface = create_surface_32( ts.tile_width, ts.tile_height );
-    cata_assert( surface );
-    throwErrorIf( FillRect( surface, nullptr, MapRGBA( surface, 0, 0, 127,
-                            highlight_alpha ) ) != 0, "SDL_FillRect failed" );
-    ts.tile_values.emplace_back( CreateTextureFromSurface( renderer, surface ),
-                                 SDL_Rect{ 0, 0, ts.tile_width, ts.tile_height } );
-    ts.tile_ids[ITEM_HIGHLIGHT].fg.add( std::vector<int>( {index} ), 1 );
+    loader uploader( ts, renderer, memory_map_mode );
+    tile_value_targets targets;
+    targets.normal = &cand_normal;
+    targets.shadow = &cand_shadow;
+    targets.night = &cand_night;
+    targets.overexposed = &cand_overexposed;
+    targets.memory = &cand_memory;
+    targets.silhouette = &cand_silhouette;
+
+    for( const atlas_replay_descriptor &desc : descriptors ) {
+        uploader.upload_one_atlas( desc, targets, pump_events );
+    }
+
+    if( highlight_idx ) {
+        const Uint8 highlight_alpha = 127;
+        const SDL_Surface_Ptr surface = create_surface_32( ts.tile_width, ts.tile_height );
+        cata_assert( surface );
+        throwErrorIf( FillRect( surface, nullptr, MapRGBA( surface, 0, 0, 127,
+                                highlight_alpha ) ) != 0, "SDL_FillRect failed" );
+        const int idx = *highlight_idx;
+        cata_assert( idx >= 0 && idx < static_cast<int>( cand_normal.size() ) );
+        cand_normal[idx] = texture( CreateTextureFromSurface( renderer, surface ),
+                                    SDL_Rect{ 0, 0, ts.tile_width, ts.tile_height } );
+    }
+
+    // Commit candidates atomically so a partial upload is never observable.
+    ts.tile_values = std::move( cand_normal );
+    ts.shadow_tile_values = std::move( cand_shadow );
+    ts.night_tile_values = std::move( cand_night );
+    ts.overexposed_tile_values = std::move( cand_overexposed );
+    ts.memory_tile_values = std::move( cand_memory );
+    ts.silhouette_tile_values = std::move( cand_silhouette );
+}
+
+void tileset_cache::loader::upload_one_atlas( const atlas_replay_descriptor &desc,
+        const tile_value_targets &targets, const bool pump_events )
+{
+    cata_assert( desc.sprite_width > 0 );
+    cata_assert( desc.sprite_height > 0 );
+
+    SDL_Surface_Ptr tile_atlas = load_image( desc.image_path_u8.c_str() );
+    cata_assert( tile_atlas );
+
+    if( desc.color_key_r >= 0 && desc.color_key_r <= 255
+        && desc.color_key_g >= 0 && desc.color_key_g <= 255
+        && desc.color_key_b >= 0 && desc.color_key_b <= 255 ) {
+        const Uint32 key = MapRGB( tile_atlas, 0, 0, 0 );
+        throwErrorIf( SetColorKey( tile_atlas, 1, key ) != 0,
+                      "SDL_SetColorKey failed" );
+        throwErrorIf( SetSurfaceRLE( tile_atlas, 1 ), "SDL_SetSurfaceRLE failed" );
+    }
+
+    int max_tex_w = 0;
+    int max_tex_h = 0;
+    throwErrorIf( !GetRendererMaxTextureSize( renderer, &max_tex_w, &max_tex_h ),
+                  "GetRendererMaxTextureSize failed" );
+    // Software rendering stores textures as surfaces with run-length encoding, which makes
+    // extracting a part in the middle of the texture slow. Therefore this "simulates" that the
+    // renderer only supports one tile per texture.
+    if( IsRendererSoftware( renderer ) ) {
+        max_tex_w = desc.sprite_width;
+        max_tex_h = desc.sprite_height;
+    }
+    // for debugging only: force a very small maximal texture size, as to trigger
+    // splitting the tile atlas.
+#if 0
+    // +1 to check correct rounding
+    max_tex_w = desc.sprite_width * 10 + 1;
+    max_tex_h = desc.sprite_height * 20 + 1;
+#endif
+
+    const int min_tile_xcount = 128;
+    const int min_tile_ycount = min_tile_xcount * 2;
+
+    if( max_tex_w == 0 ) {
+        max_tex_w = desc.sprite_width * min_tile_xcount;
+        DebugLog( D_INFO, DC_ALL ) << "Renderer max_texture_width was 0. "
+                                   << "Changed to " << max_tex_w;
+    } else {
+        throwErrorIf( max_tex_w < desc.sprite_width,
+                      "Maximal texture width is smaller than tile width" );
+    }
+
+    if( max_tex_h == 0 ) {
+        max_tex_h = desc.sprite_height * min_tile_ycount;
+        DebugLog( D_INFO, DC_ALL ) << "Renderer max_texture_height was 0. "
+                                   << "Changed to " << max_tex_h;
+    } else {
+        throwErrorIf( max_tex_h < desc.sprite_height,
+                      "Maximal texture height is smaller than tile height" );
+    }
+
+    // Number of tiles in each dimension that fits into a (maximal) SDL texture.
+    // If the tile atlas contains more than that, we have to split it.
+    const int max_tile_xcount = max_tex_w / desc.sprite_width;
+    const int max_tile_ycount = max_tex_h / desc.sprite_height;
+    // Range over the tile atlas, wherein each rectangle fits into the maximal
+    // SDL texture size. In other words: a range over the parts into which the
+    // tile atlas needs to be split.
+    const rect_range<SDL_Rect> output_range(
+        max_tile_xcount * desc.sprite_width,
+        max_tile_ycount * desc.sprite_height,
+        point( divide_round_up( tile_atlas->w, max_tex_w ),
+               divide_round_up( tile_atlas->h, max_tex_h ) ) );
+
+    // Mirror the per-atlas state that create_textures_from_tile_atlas reads
+    // off the loader instance.
+    sprite_width = desc.sprite_width;
+    sprite_height = desc.sprite_height;
+    offset = desc.atlas_offset;
+    tile_atlas_width = tile_atlas->w;
+
+    for( const SDL_Rect sub_rect : output_range ) {
+        cata_assert( sub_rect.x % desc.sprite_width == 0 );
+        cata_assert( sub_rect.y % desc.sprite_height == 0 );
+        cata_assert( sub_rect.w % desc.sprite_width == 0 );
+        cata_assert( sub_rect.h % desc.sprite_height == 0 );
+        SDL_Surface_Ptr smaller_surf;
+
+        if( is_contained( SDL_Rect{ 0, 0, tile_atlas->w, tile_atlas->h }, sub_rect ) ) {
+            // can use tile_atlas directly, it is completely contained in the output rectangle
+        } else {
+            // Need a temporary surface that contains the parts of the tile atlas that fit
+            // into sub_rect. But doesn't always need to be as large as sub_rect.
+            const int w = std::min( tile_atlas->w - sub_rect.x, sub_rect.w );
+            const int h = std::min( tile_atlas->h - sub_rect.y, sub_rect.h );
+            smaller_surf = ::create_surface_32( w, h );
+            cata_assert( smaller_surf );
+            const SDL_Rect inp{ sub_rect.x, sub_rect.y, w, h };
+            throwErrorIf( BlitSurface( tile_atlas, &inp, smaller_surf,
+                                       nullptr ) != 0, "SDL_BlitSurface failed" );
+        }
+        const SDL_Surface_Ptr &surf_to_use = smaller_surf ? smaller_surf : tile_atlas;
+        cata_assert( surf_to_use );
+
+        create_textures_from_tile_atlas( surf_to_use, point( sub_rect.x, sub_rect.y ), targets );
+
+        if( pump_events ) {
+            inp_mngr.pump_events();
+        }
+    }
 }
 
 #endif // defined(TILES)

--- a/src/tileset_loader.cpp
+++ b/src/tileset_loader.cpp
@@ -975,8 +975,8 @@ void tileset_cache::loader::load_tile_spritelists( const JsonObject &entry,
 void tileset_cache::loader::upload_atlases( tileset &ts, const SDL_Renderer_Ptr &renderer,
         const std::string &memory_map_mode,
         const std::vector<atlas_replay_descriptor> &descriptors,
-        uint64_t /*renderer_instance_generation*/,
-        uint64_t /*gpu_textures_generation*/,
+        const uint64_t renderer_instance_generation,
+        const uint64_t gpu_textures_generation,
         const bool pump_events )
 {
     int total = 0;
@@ -1028,6 +1028,8 @@ void tileset_cache::loader::upload_atlases( tileset &ts, const SDL_Renderer_Ptr 
     ts.overexposed_tile_values = std::move( cand_overexposed );
     ts.memory_tile_values = std::move( cand_memory );
     ts.silhouette_tile_values = std::move( cand_silhouette );
+
+    ts.set_upload_generations( renderer_instance_generation, gpu_textures_generation );
 }
 
 void tileset_cache::loader::upload_one_atlas( const atlas_replay_descriptor &desc,

--- a/src/tileset_loader.h
+++ b/src/tileset_loader.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_TILESET_LOADER_H
 #define CATA_SRC_TILESET_LOADER_H
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -17,6 +18,19 @@ template <typename T> struct weighted_int_list;
 
 class tileset_cache::loader
 {
+    public:
+        // Destination vectors for the six color-filter variants. Lets the
+        // texture-creation path target candidate vectors instead of the live
+        // tileset.
+        struct tile_value_targets {
+            std::vector<texture> *normal = nullptr;
+            std::vector<texture> *shadow = nullptr;
+            std::vector<texture> *night = nullptr;
+            std::vector<texture> *overexposed = nullptr;
+            std::vector<texture> *memory = nullptr;
+            std::vector<texture> *silhouette = nullptr;
+        };
+
     private:
         tileset &ts;
         const SDL_Renderer_Ptr &renderer;
@@ -39,12 +53,11 @@ class tileset_cache::loader
 
         int tile_atlas_width = 0;
 
-        void ensure_default_item_highlight();
-
         void copy_surface_to_texture( const SDL_Surface_Ptr &surf, const point &offset,
                                       std::vector<texture> &target,
                                       const std::vector<SDL_Rect> &opaque_bounds );
-        void create_textures_from_tile_atlas( const SDL_Surface_Ptr &tile_atlas, const point &offset );
+        void create_textures_from_tile_atlas( const SDL_Surface_Ptr &tile_atlas, const point &offset,
+                                              const tile_value_targets &targets );
 
         void process_variations_after_loading( weighted_int_list<std::vector<int>> &v ) const;
 
@@ -60,32 +73,53 @@ class tileset_cache::loader
                                     std::string_view objname ) const;
 
         void load_ascii( const JsonObject &config );
-        // Loads the tileset image and emits texture variants. R, G, B identify
-        // the transparent color. pump_events handles window events / refreshes
-        // the screen during the load; ensure the tileset is not accessed while
-        // pump_events is true.
-        void load_tileset( const cata_path &path, bool pump_events );
-        // Load tile definitions from json. config must have a "tiles" array
-        // with definitions for the previously-loaded tileset image. Sprite
-        // indices in tile_type::fg / tile_type::bg are validated against
-        // [0,size) and adjusted by offset.
-        void load_tilejson_from_file( const JsonObject &config );
-        // Helper for load. pump_events same caveat as load_tileset.
-        void load_internal( const JsonObject &config, const cata_path &tileset_root,
+        // Read atlas image header, extend tileset value vectors, append an
+        // atlas_replay_descriptor. No GPU work. kr/kg/kb identify the
+        // transparent color; all-negative disables color keying.
+        void read_image_dimensions( const cata_path &img_path, int kr, int kg, int kb );
+        // Parse tile-id -> sprite-index mappings from a tileset JSON object.
+        // Indices in fg/bg are validated against [0,size) and shifted by
+        // offset.
+        void parse_mappings( const JsonObject &config );
+        // Walk every atlas in config (tiles-new array, or the single-atlas
+        // fallback when no tiles-new is present) running
+        // read_image_dimensions + parse_mappings on each. pump_events
+        // refreshes the screen mid-walk; do not access the tileset while it
+        // is true.
+        void parse_atlases( const JsonObject &config, const cata_path &tileset_root,
                             const cata_path &img_path, bool pump_events );
 
         // Load layering data from json.
         void load_layers( const JsonObject &config );
+
+        // Upload one atlas: split to renderer-sized chunks, apply color
+        // keying, emit all six filter variants. Mutates loader sprite-state
+        // from the descriptor.
+        void upload_one_atlas( const atlas_replay_descriptor &desc,
+                               const tile_value_targets &targets,
+                               bool pump_events );
 
     public:
         loader( tileset &ts, const SDL_Renderer_Ptr &r, std::string memory_map_mode )
             : ts( ts ), renderer( r ), memory_map_mode( std::move( memory_map_mode ) ) {
         }
         // tileset_id matches the option string. precheck only loads metadata
-        // (tile dimensions). pump_events same caveat as load_tileset. terrain
-        // marks this as an overmap/terrain tileset.
+        // (tile dimensions). pump_events handles window events / refreshes
+        // the screen during the upload pass. terrain marks this as an
+        // overmap/terrain tileset.
         void load( const std::string &tileset_id, bool precheck, bool pump_events = false,
                    bool terrain = false );
+
+        // Upload every descriptor and regenerate the default highlight when
+        // active. Builds candidate vectors and swaps them into ts on full
+        // success; ts is unchanged on failure. The two generation arguments
+        // are reserved for bundle-generation tracking.
+        static void upload_atlases( tileset &ts, const SDL_Renderer_Ptr &renderer,
+                                    const std::string &memory_map_mode,
+                                    const std::vector<atlas_replay_descriptor> &descriptors,
+                                    uint64_t renderer_instance_generation,
+                                    uint64_t gpu_textures_generation,
+                                    bool pump_events );
 };
 
 #endif // CATA_SRC_TILESET_LOADER_H

--- a/src/tileset_loader.h
+++ b/src/tileset_loader.h
@@ -112,8 +112,8 @@ class tileset_cache::loader
 
         // Upload every descriptor and regenerate the default highlight when
         // active. Builds candidate vectors and swaps them into ts on full
-        // success; ts is unchanged on failure. The two generation arguments
-        // are reserved for bundle-generation tracking.
+        // success; ts is unchanged on failure. Stamps the upload generations
+        // onto the bundle so a later cache lookup can spot a stale upload.
         static void upload_atlases( tileset &ts, const SDL_Renderer_Ptr &renderer,
                                     const std::string &memory_map_mode,
                                     const std::vector<atlas_replay_descriptor> &descriptors,


### PR DESCRIPTION
#### Summary
Infrastructure "Split tileset loading into parse and upload steps, add render-target RAII helpers"

#### Purpose of change
Hardening the SDL3 render-resource lifecycle so renderer-owned resources can survive recreation. Right now tile atlases can't be rebuilt without re-reading their JSON, and the tileset cache keys on id alone, so it serves textures baked with stale scaling or memory options. Two loosely related bits share a PR since they sit in the same files.

#### Describe the solution
Tileset loading is two steps now. Parsing just records a descriptor per atlas (image path, color key, sprite size, offset) plus the JSON mappings, no GPU work. Upload replays those descriptors, builds the six filter variants off to the side, and swaps them in all at once so you never catch a half-uploaded tileset. Re-upload after a reset doesn't touch JSON.

The cache key gains the memory map mode and a fingerprint of the options that bake into textures (scaling mode, plus memory color/gamma under color_pixel_custom). Change one and you get a fresh bundle instead of stale textures. Bundles also remember the renderer and device-texture generation they were built against, though that's wired at 0 for now since nothing bumps the counters yet.

Other bit: scoped_render_target, an RAII guard that swaps the render target and puts the old one back on destruction (flushing the SDL3 shader pass first so its GPU state doesn't leak across the swap). permanent_render_target_bind for the startup/recovery cases where there's no old target worth restoring. pixel_minimap uses the guard instead of doing it by hand, and draw_om flushes the variant pass at the end like draw already does.

Nothing changes on desktop.

#### Describe alternatives you've considered
Could just re-read the JSON on every reset and skip the split, but reparsing a whole tileset to rebuild textures that didn't change is silly. The id-only cache key is what's there today, and it's quietly wrong the moment you touch scaling or memory options.

#### Testing
Game builds and runs, no changes.

#### Additional context
First of a few SDL3 render-pipeline hardening PRs; the generation counters get wired to real reset and lifecycle events later.