### PR TITLE
Flip the idle render target to null and bind display_buffer per draw

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -15,6 +15,7 @@
 #include "input.h"
 #include "output.h"
 #include "path_info.h"
+#include "point.h"
 #include "ui_manager.h"
 #include "input_context.h"
 
@@ -120,13 +121,29 @@ cataimgui::client::~client()
     ImGui::Shutdown();
 }
 
-void cataimgui::client::new_frame()
+void cataimgui::client::new_frame( int display_buffer_w, int display_buffer_h )
 {
+    // TUI layout is driven by the ncurses backend, not display-buffer
+    // pixel dims.
+    ( void )display_buffer_w;
+    ( void )display_buffer_h;
     ImTui_ImplNcurses_NewFrame( imtui_events );
     imtui_events.clear();
     ImTui_ImplText_NewFrame();
 
     ImGui::NewFrame();
+}
+
+void cataimgui::client::abort_frame()
+{
+    // EndFrame finalizes the drawlist without painting it. Drain
+    // cata_input_trail like end_frame() so events do not pile up.
+    ImGui::EndFrame();
+    ImGuiIO &io = ImGui::GetIO();
+    for( const int &code : cata_input_trail ) {
+        io.AddKeyEvent( cata_key_to_imgui( code ), false );
+    }
+    cata_input_trail.clear();
 }
 
 void cataimgui::client::end_frame()
@@ -155,8 +172,12 @@ void cataimgui::client::set_alloced_pair_count( short count )
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-void cataimgui::client::process_input( void *input )
+void cataimgui::client::process_input( void *input, int display_buffer_w, int display_buffer_h )
 {
+    // TUI input is in cell coordinates from ncurses; no display-buffer
+    // pixel scaling.
+    ( void )display_buffer_w;
+    ( void )display_buffer_h;
     if( !any_window_shown() ) {
         return;
     }
@@ -470,7 +491,16 @@ struct FreeTypeTest {
 FreeTypeTest freetype_test;
 #endif
 
-void cataimgui::client::new_frame()
+point cataimgui::imgui_frame_display_size( const int display_buffer_w, const int display_buffer_h,
+        const int renderer_output_w, const int renderer_output_h )
+{
+    if( display_buffer_w > 0 && display_buffer_h > 0 ) {
+        return point{ display_buffer_w, display_buffer_h };
+    }
+    return point{ renderer_output_w, renderer_output_h };
+}
+
+void cataimgui::client::new_frame( int display_buffer_w, int display_buffer_h )
 {
 #if 0 and not TUI
     if( freetype_test.PreNewFrame() ) {
@@ -496,18 +526,20 @@ void cataimgui::client::new_frame()
     ImGui_ImplSDL2_NewFrame();
 #endif
 
-    // The game and ImGui both draw into display_buffer, whose size can differ from
-    // the window: SCALING_FACTOR shrinks the buffer on desktop, and on Android the
-    // buffer stays terminal-sized behind a fullscreen window. The SDL backend sets
-    // io.DisplaySize to the window size, which mis-centers and oversizes ImGui
-    // windows, so use the render target's output size instead.
+    // ImGui draws into display_buffer, whose size differs from the window under
+    // SCALING_FACTOR or android letterboxing. Prefer the caller's dims; fall
+    // back to the bound target's output size.
     {
         ImGuiIO &io = ImGui::GetIO();
-        int target_w = 0;
-        int target_h = 0;
-        GetRendererOutputSize( sdl_renderer, &target_w, &target_h );
-        if( target_w > 0 && target_h > 0 ) {
-            io.DisplaySize = ImVec2( static_cast<float>( target_w ), static_cast<float>( target_h ) );
+        int output_w = 0;
+        int output_h = 0;
+        if( display_buffer_w <= 0 || display_buffer_h <= 0 ) {
+            GetRendererOutputSize( sdl_renderer, &output_w, &output_h );
+        }
+        const point sz = imgui_frame_display_size( display_buffer_w, display_buffer_h,
+                         output_w, output_h );
+        if( sz.x > 0 && sz.y > 0 ) {
+            io.DisplaySize = ImVec2( static_cast<float>( sz.x ), static_cast<float>( sz.y ) );
             io.DisplayFramebufferScale = ImVec2( 1.0f, 1.0f );
         }
     }
@@ -533,12 +565,24 @@ void cataimgui::client::end_frame()
     cata_input_trail.clear();
 }
 
+void cataimgui::client::abort_frame()
+{
+    // EndFrame finalizes the drawlist without painting it. Drain
+    // cata_input_trail like end_frame() so events do not pile up.
+    ImGui::EndFrame();
+    ImGuiIO &io = ImGui::GetIO();
+    for( const int &code : cata_input_trail ) {
+        io.AddKeyEvent( cata_key_to_imgui( code ), false );
+    }
+    cata_input_trail.clear();
+}
+
 bool cataimgui::clear_pending()
 {
     return clear_screen;
 }
 
-void cataimgui::client::process_input( void *input )
+void cataimgui::client::process_input( void *input, int display_buffer_w, int display_buffer_h )
 {
     if( any_window_shown() ) {
         const SDL_Event *evt = static_cast<const SDL_Event *>( input );
@@ -552,38 +596,14 @@ void cataimgui::client::process_input( void *input )
                     return;
             }
         }
+        ( void )display_buffer_w;
+        ( void )display_buffer_h;
 #if SDL_MAJOR_VERSION >= 3
         ImGui_ImplSDL3_ProcessEvent( evt );
 #else
-        // ImGui lays out windows in render-target (display_buffer) coordinates (see
-        // new_frame), but SDL mouse events arrive in window coordinates. Scale mouse
-        // positions into buffer space so they line up; SDL3 handles this in
-        // ConvertEventCoordinates().
-        int buf_w = 0;
-        int buf_h = 0;
-        int win_w = 0;
-        int win_h = 0;
-        GetRendererOutputSize( sdl_renderer, &buf_w, &buf_h );
-        GetWindowSize( sdl_window.get(), &win_w, &win_h );
-        if( win_w > 0 && win_h > 0 && ( buf_w != win_w || buf_h != win_h ) ) {
-            SDL_Event scaled = *evt;
-            const float sx = static_cast<float>( buf_w ) / win_w;
-            const float sy = static_cast<float>( buf_h ) / win_h;
-            switch( evt->type ) {
-                case CATA_MOUSEMOTION:
-                    scaled.motion.x = static_cast<Sint32>( evt->motion.x * sx );
-                    scaled.motion.y = static_cast<Sint32>( evt->motion.y * sy );
-                    break;
-                case CATA_MOUSEBUTTONDOWN:
-                case CATA_MOUSEBUTTONUP:
-                    scaled.button.x = static_cast<Sint32>( evt->button.x * sx );
-                    scaled.button.y = static_cast<Sint32>( evt->button.y * sy );
-                    break;
-            }
-            ImGui_ImplSDL2_ProcessEvent( &scaled );
-        } else {
-            ImGui_ImplSDL2_ProcessEvent( evt );
-        }
+        // Coordinates already converted to display_buffer space by
+        // convert_event_to_display_buffer_coords in the event pump.
+        ImGui_ImplSDL2_ProcessEvent( evt );
 #endif
     }
 }

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -83,9 +83,16 @@ class client
 #endif
         ~client();
 
-        void new_frame();
+        // display_buffer_w/h drive ImGui layout (DisplaySize) and SDL2 mouse
+        // scaling. Pass 0 to fall back to the bound target's output size (only
+        // valid while a draw scope has display_buffer bound).
+        void new_frame( int display_buffer_w = 0, int display_buffer_h = 0 );
         void end_frame();
-        void process_input( void *input );
+        // Close the active ImGui frame without any backend draw commands, for
+        // aborting mid-flight when end_frame() is unsafe (renderer undefined).
+        // The next NewFrame would assert if the frame were left open.
+        void abort_frame();
+        void process_input( void *input, int display_buffer_w = 0, int display_buffer_h = 0 );
         void process_cata_input( const input_event &event );
 #ifdef TUI
         void upload_color_pair( int p, int f, int b );
@@ -103,6 +110,14 @@ class client
         // True if an ImGui text field or shortcut has keyboard focus.
         static bool want_capture_keyboard();
 };
+
+#ifndef TUI
+// Pick the ImGui DisplaySize for a frame: the explicit display-buffer dims when
+// both are positive, else the renderer's output dims. Keeps the terminal-buffer
+// sizing contract when the idle-null target leaves the output reading the window.
+point imgui_frame_display_size( int display_buffer_w, int display_buffer_h,
+                                int renderer_output_w, int renderer_output_h );
+#endif
 
 void point_to_imvec2( point *src, ImVec2 *dest );
 void imvec2_to_point( ImVec2 *src, point *dest );

--- a/src/cata_shader.cpp
+++ b/src/cata_shader.cpp
@@ -209,43 +209,18 @@ render_state &render_state::operator=( render_state &&other ) noexcept
     return *this;
 }
 
-gpu_state_scope::gpu_state_scope( SDL_Renderer *renderer, SDL_GPURenderState *state )
-    : renderer_( renderer )
-{
-    if( !renderer_ || !state ) {
-        return;
-    }
-    if( !SDL_SetGPURenderState( renderer_, state ) ) {
-        DebugLog( D_ERROR, DC_ALL )
-                << "cata_shader::gpu_state_scope: SDL_SetGPURenderState failed: "
-                << SDL_GetError();
-        return;
-    }
-    active_ = true;
-}
-
-gpu_state_scope::~gpu_state_scope()
-{
-    ( void )unbind();
-}
-
-bool gpu_state_scope::unbind()
-{
-    if( !active_ ) {
-        return true;
-    }
-    active_ = false;
-    if( !SDL_SetGPURenderState( renderer_, nullptr ) ) {
-        DebugLog( D_ERROR, DC_ALL )
-                << "cata_shader::gpu_state_scope: SDL_SetGPURenderState(NULL) failed: "
-                << SDL_GetError();
-        return false;
-    }
-    return true;
-}
-
 namespace
 {
+
+// Disposal slot for probe-owned textures left undestroyable by a failed
+// SDL_SetGPURenderState(NULL). Recovery replaces the renderer, so the gate
+// keeps teardown from destroying them on a dead renderer.
+gpu_handle_graveyard &probe_texture_graveyard()
+{
+    static gpu_handle_graveyard g;
+    return g;
+}
+
 
 const char *shader_basename_for( variant_kind v )
 {
@@ -381,38 +356,58 @@ variant_pass::~variant_pass()
 namespace
 {
 
+struct probe_result {
+    bool ok = false;
+    // False when the renderer was left with an undefined shader-state bind
+    // or with rt still active as the target. Caller must NOT destroy any
+    // resources that the renderer might still reference.
+    bool boundary_safe = true;
+};
+
 // Renders a 1x1 mid-gray sprite via state and checks readback via pred.
 // Mid-gray (128,128,128,255) gives each variant a distinctive output, so a
 // passing predicate distinguishes "shader ran" from "bind silently ignored".
-bool draw_probe( SDL_Renderer *renderer, SDL_GPURenderState *state,
-                 probe_predicate pred )
+probe_result draw_probe( SDL_Renderer *renderer, SDL_GPURenderState *state,
+                         probe_predicate pred )
 {
+    probe_result res;
     SDL_Surface *src_surf = SDL_CreateSurface( 1, 1, SDL_PIXELFORMAT_RGBA32 );
     if( !src_surf ) {
-        return false;
+        return res;
     }
     // Mid-gray opaque: 0x80, 0x80, 0x80, 0xFF in RGBA32.
     SDL_FillSurfaceRect( src_surf, nullptr, 0xFF808080u );
     SDL_Texture *src = SDL_CreateTextureFromSurface( renderer, src_surf );
     SDL_DestroySurface( src_surf );
     if( !src ) {
-        return false;
+        return res;
     }
     SDL_Texture *rt = SDL_CreateTexture( renderer, SDL_PIXELFORMAT_RGBA32,
                                          SDL_TEXTUREACCESS_TARGET, 1, 1 );
     if( !rt ) {
         SDL_DestroyTexture( src );
-        return false;
+        return res;
     }
     SDL_Texture *prior_target = SDL_GetRenderTarget( renderer );
-    bool ok = false;
-    if( SDL_SetRenderTarget( renderer, rt ) ) {
+    const bool target_bound = SDL_SetRenderTarget( renderer, rt );
+    if( !target_bound ) {
+        // SDL may mutate target state before failing, so this is not a clean
+        // no-op: mark the boundary unsafe and graveyard the probe textures.
+        DebugLog( D_ERROR, DC_ALL )
+                << "cata_shader::draw_probe: SDL_SetRenderTarget(rt) failed: "
+                << SDL_GetError();
+        res.boundary_safe = false;
+    }
+    if( target_bound ) {
         SDL_SetRenderDrawColor( renderer, 0, 0, 0, 255 );
         SDL_RenderClear( renderer );
         if( SDL_SetGPURenderState( renderer, state ) ) {
             const SDL_FRect dst{ 0.0f, 0.0f, 1.0f, 1.0f };
-            if( SDL_RenderTexture( renderer, src, nullptr, &dst ) ) {
-                SDL_SetGPURenderState( renderer, nullptr );
+            const bool drew = SDL_RenderTexture( renderer, src, nullptr, &dst );
+            // Unbind shader state before any further switch/readback. On
+            // failure the bind is still held, so skip rt + restore.
+            const bool unbound = SDL_SetGPURenderState( renderer, nullptr );
+            if( drew && unbound ) {
                 const SDL_Rect rect{ 0, 0, 1, 1 };
                 SDL_Surface *out = SDL_RenderReadPixels( renderer, &rect );
                 if( out ) {
@@ -428,19 +423,47 @@ bool draw_probe( SDL_Renderer *renderer, SDL_GPURenderState *state,
                         const int g = p[1];
                         const int b = p[2];
                         const int a = p[3];
-                        ok = a >= 250 && pred && pred( r, g, b );
+                        res.ok = a >= 250 && pred && pred( r, g, b );
                         SDL_DestroySurface( rgba );
                     }
                 }
-            } else {
-                SDL_SetGPURenderState( renderer, nullptr );
             }
+            if( !unbound ) {
+                DebugLog( D_ERROR, DC_ALL )
+                        << "cata_shader::draw_probe: SDL_SetGPURenderState(NULL) failed: "
+                        << SDL_GetError();
+                res.ok = false;
+                res.boundary_safe = false;
+            }
+        } else {
+            // Bind state undefined after a failed SDL_SetGPURenderState:
+            // assume still held, so do not ship rt/probe through teardown.
+            DebugLog( D_ERROR, DC_ALL )
+                    << "cata_shader::draw_probe: SDL_SetGPURenderState failed: "
+                    << SDL_GetError();
+            res.ok = false;
+            res.boundary_safe = false;
+        }
+        if( res.boundary_safe && !SDL_SetRenderTarget( renderer, prior_target ) ) {
+            DebugLog( D_ERROR, DC_ALL )
+                    << "cata_shader::draw_probe: SDL_SetRenderTarget restore failed: "
+                    << SDL_GetError();
+            res.ok = false;
+            // rt is still the active target: mark unsafe so neither rt nor
+            // src is destroyed and the caller refuses the still-bound state.
+            res.boundary_safe = false;
         }
     }
-    SDL_SetRenderTarget( renderer, prior_target );
-    SDL_DestroyTexture( rt );
-    SDL_DestroyTexture( src );
-    return ok;
+    // Preserve rt and src when the renderer state is undefined: destroying
+    // them here would invalidate resources the renderer still references.
+    if( res.boundary_safe ) {
+        SDL_DestroyTexture( rt );
+        SDL_DestroyTexture( src );
+    } else {
+        probe_texture_graveyard().add( rt );
+        probe_texture_graveyard().add( src );
+    }
+    return res;
 }
 
 } // namespace
@@ -448,35 +471,53 @@ bool draw_probe( SDL_Renderer *renderer, SDL_GPURenderState *state,
 namespace
 {
 
+enum class load_outcome {
+    ok,
+    failed_clean,
+    failed_unsafe,
+};
+
 // Loads shader + render_state for basename and validates via draw_probe.
-bool load_and_probe( SDL_GPUDevice *device, SDL_Renderer *renderer,
-                     const char *basename, probe_predicate pred,
-                     shader &out_shader, render_state &out_state )
+// On a probe boundary failure the local shader/state are abandoned so their
+// destructors do not release SDL handles the renderer may still reference.
+load_outcome load_and_probe( SDL_GPUDevice *device, SDL_Renderer *renderer,
+                             const char *basename, probe_predicate pred,
+                             shader &out_shader, render_state &out_state )
 {
     shader frag = shader::load_fragment( device, basename, 1, 0 );
     if( !frag.is_valid() ) {
         DebugLog( D_ERROR, DC_ALL )
                 << "cata_shader::variant_pass: shader load failed for "
                 << basename << "; shader variant path disabled";
-        return false;
+        return load_outcome::failed_clean;
     }
     render_state state = render_state::create( renderer, frag );
     if( !state.is_valid() ) {
         DebugLog( D_ERROR, DC_ALL )
                 << "cata_shader::variant_pass: render_state::create failed for "
                 << basename << "; shader variant path disabled";
-        return false;
+        return load_outcome::failed_clean;
     }
-    if( !draw_probe( renderer, state.get(), pred ) ) {
+    const probe_result res = draw_probe( renderer, state.get(), pred );
+    if( !res.boundary_safe ) {
+        DebugLog( D_ERROR, DC_ALL )
+                << "cata_shader::variant_pass: probe left renderer in undefined "
+                "state for " << basename << "; abandoning shader + render_state "
+                "to avoid destroying a bound resource";
+        state.abandon();
+        frag.abandon();
+        return load_outcome::failed_unsafe;
+    }
+    if( !res.ok ) {
         DebugLog( D_ERROR, DC_ALL )
                 << "cata_shader::variant_pass: textured-draw probe failed for "
                 << basename << " (silent miswire? readback did not match "
                 "expected variant transform); shader variant path disabled";
-        return false;
+        return load_outcome::failed_clean;
     }
     out_shader = std::move( frag );
     out_state = std::move( state );
-    return true;
+    return load_outcome::ok;
 }
 
 } // namespace
@@ -495,6 +536,7 @@ void variant_pass::reset()
     probe_attempted_ = false;
     probed_ok_ = false;
     session_disabled_ = false;
+    unbind_required_ = false;
 }
 
 void variant_pass::probe()
@@ -516,8 +558,14 @@ void variant_pass::probe()
         if( !basename ) {
             continue;
         }
-        if( !load_and_probe( device, renderer_, basename, predicate_for( v ),
-                             shaders_[i], states_[i] ) ) {
+        const load_outcome o = load_and_probe( device, renderer_, basename,
+                                               predicate_for( v ), shaders_[i], states_[i] );
+        if( o == load_outcome::failed_unsafe ) {
+            unbind_required_ = true;
+            session_disabled_ = true;
+            return;
+        }
+        if( o == load_outcome::failed_clean ) {
             return;
         }
     }
@@ -527,8 +575,14 @@ void variant_pass::probe()
         if( !basename ) {
             continue;
         }
-        if( !load_and_probe( device, renderer_, basename, predicate_for( p ),
-                             memory_shaders_[i], memory_states_[i] ) ) {
+        const load_outcome o = load_and_probe( device, renderer_, basename,
+                                               predicate_for( p ), memory_shaders_[i], memory_states_[i] );
+        if( o == load_outcome::failed_unsafe ) {
+            unbind_required_ = true;
+            session_disabled_ = true;
+            return;
+        }
+        if( o == load_outcome::failed_clean ) {
             return;
         }
     }
@@ -576,7 +630,10 @@ bool variant_pass::try_begin( variant_kind v )
                 << "cata_shader::variant_pass: SDL_SetGPURenderState failed: "
                 << SDL_GetError();
         session_disabled_ = true;
-        currently_bound_.reset();
+        // Bind state undefined after the failure: assume still held. Keep
+        // currently_bound_ so operator== rejects the boundary, and force the
+        // next flush() to call null-state even if currently_bound_ was empty.
+        unbind_required_ = true;
         return false;
     }
     if( target ) {
@@ -584,6 +641,7 @@ bool variant_pass::try_begin( variant_kind v )
     } else {
         currently_bound_.reset();
     }
+    unbind_required_ = false;
     return target != nullptr;
 }
 
@@ -594,7 +652,7 @@ bool variant_pass::end()
 
 bool variant_pass::flush()
 {
-    if( !currently_bound_ ) {
+    if( !currently_bound_ && !unbind_required_ ) {
         return true;
     }
     if( !SDL_SetGPURenderState( renderer_, nullptr ) ) {
@@ -605,6 +663,7 @@ bool variant_pass::flush()
         return false;
     }
     currently_bound_.reset();
+    unbind_required_ = false;
     return true;
 }
 

--- a/src/cata_shader.h
+++ b/src/cata_shader.h
@@ -94,6 +94,14 @@ class shader
             return ptr_;
         }
 
+        // Renounce ownership without SDL_ReleaseGPUShader, for when the
+        // renderer still references this through a stale bind we could not
+        // detach -- destroying it would invalidate live GPU pipeline state.
+        void abandon() {
+            ptr_ = nullptr;
+            device_ = nullptr;
+        }
+
     private:
         shader( SDL_GPUDevice *device, SDL_GPUShader *ptr )
             : device_( device ), ptr_( ptr ) {}
@@ -131,41 +139,16 @@ class render_state
             return ptr_;
         }
 
+        // Renounce ownership without SDL_DestroyGPURenderState. Used when a
+        // probe leaves the state bound on a renderer we cannot safely detach.
+        void abandon() {
+            ptr_ = nullptr;
+        }
+
     private:
         explicit render_state( SDL_GPURenderState *ptr ) : ptr_( ptr ) {}
 
         SDL_GPURenderState *ptr_ = nullptr;
-};
-
-// RAII bracket around SDL_SetGPURenderState. Binds the supplied state on
-// construction, clears it on destruction (or earlier via unbind()). ImGui's
-// SDL3 renderer backend does not save/restore custom GPU state; any unpaired
-// bind leaks into the next draw, so the bracket is mandatory.
-class gpu_state_scope
-{
-    public:
-        // Binds state on the renderer. is_valid() reflects whether the bind
-        // succeeded; on failure end-of-scope is a no-op.
-        gpu_state_scope( SDL_Renderer *renderer, SDL_GPURenderState *state );
-        ~gpu_state_scope();
-
-        gpu_state_scope( const gpu_state_scope & ) = delete;
-        gpu_state_scope &operator=( const gpu_state_scope & ) = delete;
-        gpu_state_scope( gpu_state_scope && ) = delete;
-        gpu_state_scope &operator=( gpu_state_scope && ) = delete;
-
-        bool is_valid() const {
-            return active_;
-        }
-
-        // Clears the bind early. Returns true on success (or no-op when
-        // already inactive), false if SDL_SetGPURenderState(NULL) failed.
-        // Subsequent destruction is a no-op.
-        bool unbind();
-
-    private:
-        SDL_Renderer *renderer_ = nullptr;
-        bool active_ = false;
 };
 
 // Owns one SDL_GPUShader + SDL_GPURenderState per supported variant and
@@ -234,6 +217,10 @@ class variant_pass
         memory_states_;
         std::optional<memory_preset> active_memory_preset_;
         std::optional<variant_kind> currently_bound_;
+        // Set after an unsafe bind transition (failed SDL_SetGPURenderState or
+        // a probe boundary loss): next flush() must call null-state regardless
+        // of currently_bound_ to clear whatever the renderer holds.
+        bool unbind_required_ = false;
         bool probe_attempted_ = false;
         bool probed_ok_ = false;
         bool session_disabled_ = false;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -430,6 +430,12 @@ void cata_tiles::load_tileset( const std::string &tileset_id, const bool prechec
 void cata_tiles::reinit()
 {
     set_draw_scale( 16 );
+    // Wrap so the clear lands on display_buffer rather than the null idle
+    // target.
+    display_buffer_draw_scope draw_scope;
+    if( display_buffer_scope_is_invalid() ) {
+        return;
+    }
     RenderClear( renderer );
 }
 
@@ -476,7 +482,8 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                        std::multimap<point, formatted_text> &overlay_strings,
                        color_block_overlay_container &color_blocks )
 {
-    if( !g ) {
+    display_buffer_draw_scope draw_scope;
+    if( display_buffer_scope_is_invalid() || !g ) {
         return;
     }
 
@@ -1121,20 +1128,24 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
 
                         // Phase 1: build the silhouette mask.
                         {
+                            scoped_render_target mask_scope( renderer, tint_mask_tex.get()
 #if SDL_MAJOR_VERSION >= 3
-                            cata_shader::render_target_scope mask_scope(
-                                renderer.get(), tint_mask_tex.get(), m_variant_pass.get() );
+                                                             , m_variant_pass.get()
+#endif
+                                                           );
                             if( !mask_scope.is_valid() ) {
                                 // variant_pass may have failed to unbind; later
                                 // target switches would cross with shader bound.
                                 batch_tiles.clear();
                                 batch_sum_area = 0;
-                                throw std::runtime_error(
-                                    "cata_tiles::flush_tint_batch: render_target_scope construction failed" );
+                                if( !mask_scope.boundary_intact() ) {
+                                    // Boundary lost: latch so the enclosing dtor skips detach.
+                                    display_buffer_scope_signal_recovery_required();
+                                }
+                                throw std::runtime_error( mask_scope.boundary_intact()
+                                                          ? "cata_tiles::flush_tint_batch: variant_pass refused boundary"
+                                                          : "cata_tiles::flush_tint_batch: scoped_render_target boundary lost" );
                             }
-#else
-                            SetRenderTarget( renderer, tint_mask_tex );
-#endif
                             // Clip is per-target; clear defensively for reused mask.
                             RenderSetClipRect( renderer, nullptr );
                             SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
@@ -1159,17 +1170,19 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                                                          static_cast<CataFlipMode>( rec.flip ) );
                                 }
                             }
-#if SDL_MAJOR_VERSION >= 3
+                            // Explicit restore before phase 2 so a failure
+                            // aborts compositing instead of leaving the draw
+                            // landing in the mask.
                             if( !mask_scope.restore() ) {
-                                // Subsequent draws would land in the mask.
                                 batch_tiles.clear();
                                 batch_sum_area = 0;
-                                throw std::runtime_error(
-                                    "cata_tiles::flush_tint_batch: failed to restore display_buffer render target" );
+                                if( !mask_scope.boundary_intact() ) {
+                                    display_buffer_scope_signal_recovery_required();
+                                }
+                                throw std::runtime_error( mask_scope.boundary_intact()
+                                                          ? "cata_tiles::flush_tint_batch: variant_pass refused boundary on restore"
+                                                          : "cata_tiles::flush_tint_batch: failed to restore display_buffer render target" );
                             }
-#else
-                            set_displaybuffer_rendertarget();
-#endif
                         }
 
                         // Phase 2: composite the mask to the display buffer.
@@ -1425,9 +1438,13 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
     RenderSetClipRect( renderer, nullptr );
 #if SDL_MAJOR_VERSION >= 3
     // Unbind any GPU render state held across sprite batches so ImGui or the
-    // next-frame draws see a clean state.
-    if( m_variant_pass ) {
-        m_variant_pass->flush();
+    // next-frame draws see clean state. On flush failure the bind boundary
+    // forbids a target switch: abort the unbind, latch recovery, and throw.
+    if( m_variant_pass && !m_variant_pass->flush() ) {
+        draw_scope.abort_unbind();
+        display_buffer_scope_signal_recovery_required();
+        throw std::runtime_error(
+            "cata_tiles::draw: variant_pass flush failed at end of frame; renderer in undefined state" );
     }
 #endif
 }

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -62,7 +62,6 @@ enum class direction : unsigned int;
 enum class lit_level : uint8_t;
 enum class visibility_type : int;
 
-extern void set_displaybuffer_rendertarget();
 
 /** Structures */
 struct tile_type {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,6 +81,10 @@ class ui_adaptor;
 #   include "sdl_version_wrappers.h"
 #endif
 
+#if defined(TILES)
+#   include "sdltiles.h"
+#endif
+
 #if defined(__ANDROID__)
 #include <android/log.h>
 #include <unistd.h>
@@ -844,11 +848,18 @@ int main( int argc, const char *argv[] )
 
 #if defined(LOCALIZE)
     if( get_option<std::string>( "USE_LANG" ).empty() && !SystemLocale::Language().has_value() ) {
-        imclient->new_frame(); // we have to prime the pump, because of reasons
-        imclient->end_frame();
-        const std::string lang = select_language();
-        get_options().get_option( "USE_LANG" ).setValue( lang );
-        set_language_from_options();
+#if defined(TILES)
+        display_buffer_draw_scope draw_scope;
+        if( !display_buffer_scope_is_invalid() ) {
+#endif
+            imclient->new_frame(); // we have to prime the pump, because of reasons
+            imclient->end_frame();
+            const std::string lang = select_language();
+            get_options().get_option( "USE_LANG" ).setValue( lang );
+            set_language_from_options();
+#if defined(TILES)
+        }
+#endif
     }
 #endif
     replay_buffered_debugmsg_prompts();

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -35,6 +35,7 @@
 #include "mtype.h"
 #include "pixel_minimap_projectors.h"
 #include "sdl_utils.h"
+#include "sdltiles.h"
 #include "type_id.h"
 #include "vehicle.h"
 #include "viewer.h"
@@ -268,7 +269,15 @@ void pixel_minimap::flush_cache_updates()
 
         scoped_render_target chunk_scope( renderer, mcp.second.chunk_tex.get() );
         if( !chunk_scope.is_valid() ) {
-            continue;
+            if( !chunk_scope.boundary_intact() ) {
+                // Boundary lost: latch so the enclosing dtor skips detach.
+                display_buffer_scope_signal_recovery_required();
+            }
+            // Chunk did not paint, so a later render would composite stale data.
+            // Throw to abort the frame, like the tint-mask path.
+            throw std::runtime_error( chunk_scope.boundary_intact()
+                                      ? "pixel_minimap::flush_cache_updates: variant_pass refused boundary"
+                                      : "pixel_minimap::flush_cache_updates: scoped_render_target boundary lost" );
         }
 
         if( !mcp.second.ready ) {
@@ -302,6 +311,17 @@ void pixel_minimap::flush_cache_updates()
         }
 
         mcp.second.update_list.clear();
+
+        // Restore failure leaves later draws landing on the chunk texture or an
+        // undefined target, so propagate like the other scoped failures.
+        if( !chunk_scope.restore() ) {
+            if( !chunk_scope.boundary_intact() ) {
+                display_buffer_scope_signal_recovery_required();
+            }
+            throw std::runtime_error( chunk_scope.boundary_intact()
+                                      ? "pixel_minimap::flush_cache_updates: variant_pass refused boundary on restore"
+                                      : "pixel_minimap::flush_cache_updates: failed to restore prior render target" );
+        }
     }
 }
 
@@ -442,19 +462,33 @@ void pixel_minimap::reset()
 
 void pixel_minimap::render( const tripoint_bub_ms &center )
 {
-    {
-        scoped_render_target main_scope( renderer, main_tex.get() );
-        if( !main_scope.is_valid() ) {
-            return;
+    scoped_render_target main_scope( renderer, main_tex.get() );
+    if( !main_scope.is_valid() ) {
+        if( !main_scope.boundary_intact() ) {
+            display_buffer_scope_signal_recovery_required();
         }
-        SetRenderDrawColor( renderer, pixel_minimap_r, pixel_minimap_g, pixel_minimap_b,
-                            pixel_minimap_a );
-        RenderClear( renderer );
-
-        render_cache( center );
-        render_critters( center );
+        // main_tex unpainted: the RenderCopy below would composite stale data.
+        throw std::runtime_error( main_scope.boundary_intact()
+                                  ? "pixel_minimap::render: variant_pass refused boundary"
+                                  : "pixel_minimap::render: scoped_render_target boundary lost" );
     }
-    //paint intermediate texture to screen
+    SetRenderDrawColor( renderer, pixel_minimap_r, pixel_minimap_g, pixel_minimap_b,
+                        pixel_minimap_a );
+    RenderClear( renderer );
+
+    render_cache( center );
+    render_critters( center );
+
+    // Restore so the compositing RenderCopy below lands on the caller's prior
+    // target, not main_tex.
+    if( !main_scope.restore() ) {
+        if( !main_scope.boundary_intact() ) {
+            display_buffer_scope_signal_recovery_required();
+        }
+        throw std::runtime_error( main_scope.boundary_intact()
+                                  ? "pixel_minimap::render: variant_pass refused boundary on restore"
+                                  : "pixel_minimap::render: failed to restore prior render target" );
+    }
     RenderCopy( renderer, main_tex, &main_tex_clip_rect, &screen_clip_rect );
 }
 

--- a/src/sdl_wrappers.cpp
+++ b/src/sdl_wrappers.cpp
@@ -143,6 +143,67 @@ SDL_Texture_Ptr CreateTextureFromSurface( const SDL_Renderer_Ptr &renderer,
     return result;
 }
 
+std::shared_ptr<SDL_Texture> make_gated_texture( SDL_Texture *raw, gpu_handle_graveyard::gate g )
+{
+    return std::shared_ptr<SDL_Texture>( raw,
+    [g = std::move( g )]( SDL_Texture * t ) {
+        if( t && ( !g || !g->load() ) ) {
+            SDL_Texture_deleter{}( t );
+        }
+    } );
+}
+
+gpu_handle_graveyard::gpu_handle_graveyard()
+    : gate_( std::make_shared<std::atomic<bool>>( false ) )
+{
+}
+
+gpu_handle_graveyard::~gpu_handle_graveyard()
+{
+    // Never SDL_DestroyTexture at teardown -- the renderer may already be gone.
+    // Inline the poison-and-clear without abandon()'s gate re-arm: a make_shared
+    // in a (noexcept) destructor could terminate on bad_alloc.
+    if( gate_ && !handles_.empty() ) {
+        gate_->store( true );
+    }
+    handles_.clear();
+}
+
+void gpu_handle_graveyard::add( SDL_Texture *raw )
+{
+    if( !raw ) {
+        return;
+    }
+    handles_.push_back( make_gated_texture( raw, gate_ ) );
+}
+
+void gpu_handle_graveyard::adopt( std::shared_ptr<SDL_Texture> handle )
+{
+    if( handle ) {
+        handles_.push_back( std::move( handle ) );
+    }
+}
+
+void gpu_handle_graveyard::drain_live_renderer()
+{
+    // Gate stays clear, so clearing the handles runs each deleter
+    // (SDL_DestroyTexture) against the still-live renderer.
+    handles_.clear();
+    gate_ = std::make_shared<std::atomic<bool>>( false );
+}
+
+void gpu_handle_graveyard::abandon()
+{
+    // Poison the gate only when this graveyard owns handles: an empty one may
+    // share its gate with handles committed elsewhere (a successful upload),
+    // which must still destroy normally.
+    if( gate_ && !handles_.empty() ) {
+        gate_->store( true );
+    }
+    handles_.clear();
+    gate_ = std::make_shared<std::atomic<bool>>( false );
+}
+
 void SetRenderDrawColor( const SDL_Renderer_Ptr &renderer, const Uint8 r, const Uint8 g,
                          const Uint8 b, const Uint8 a )
 {
@@ -311,21 +372,10 @@ SDL_Surface_Ptr load_image( const char *const path )
     return result;
 }
 
-bool SetRenderTarget( const SDL_Renderer_Ptr &renderer, const SDL_Texture_Ptr &texture )
+void scoped_render_target::mark_boundary_lost()
 {
-    if( !renderer ) {
-        dbg( D_ERROR ) << "Tried to use a null renderer";
-        return false;
-    }
-    // a null texture is fine for SDL (resets to default target)
-#if SDL_MAJOR_VERSION >= 3
-    const bool failed = printErrorIf( !SDL_SetRenderTarget( renderer.get(), texture.get() ),
-                                      "SDL_SetRenderTarget failed" );
-#else
-    const bool failed = printErrorIf( SDL_SetRenderTarget( renderer.get(), texture.get() ) != 0,
-                                      "SDL_SetRenderTarget failed" );
-#endif
-    return !failed;
+    renderer_boundary_signal_recovery_required();
+    boundary_intact_ = false;
 }
 
 scoped_render_target::scoped_render_target( const SDL_Renderer_Ptr &renderer,
@@ -335,18 +385,30 @@ scoped_render_target::scoped_render_target( const SDL_Renderer_Ptr &renderer,
         dbg( D_ERROR ) << "scoped_render_target: null renderer";
         return;
     }
-    renderer_ = renderer.get();
-#if SDL_MAJOR_VERSION >= 3
-    prior_target_ = SDL_GetRenderTarget( renderer_ );
-    if( vp && !vp->flush() ) {
-        renderer_ = nullptr;
-        prior_target_ = nullptr;
+    // Already latched (or embargoed): renderer may be dangling after a LOST
+    // handover, so even SDL_GetRenderTarget is unsafe. Refuse before any SDL call.
+    if( renderer_boundary_recovery_pending() ) {
+        boundary_intact_ = false;
         return;
     }
+    renderer_ = renderer.get();
+#if SDL_MAJOR_VERSION >= 3
+    vp_ = vp;
+    // Flush the pass FIRST so an embargoed pass refuses before any SDL call;
+    // only then capture prior_target_ and switch.
+    if( vp_ && !vp_->flush() ) {
+        mark_boundary_lost();
+        renderer_ = nullptr;
+        vp_ = nullptr;
+        return;
+    }
+    prior_target_ = SDL_GetRenderTarget( renderer_ );
     if( !SDL_SetRenderTarget( renderer_, target ) ) {
         dbg( D_ERROR ) << "scoped_render_target: SDL_SetRenderTarget failed: " << SDL_GetError();
+        mark_boundary_lost();
         renderer_ = nullptr;
         prior_target_ = nullptr;
+        vp_ = nullptr;
         return;
     }
 #else
@@ -354,6 +416,7 @@ scoped_render_target::scoped_render_target( const SDL_Renderer_Ptr &renderer,
     prior_target_ = SDL_GetRenderTarget( renderer_ );
     if( SDL_SetRenderTarget( renderer_, target ) != 0 ) {
         dbg( D_ERROR ) << "scoped_render_target: SDL_SetRenderTarget failed: " << SDL_GetError();
+        mark_boundary_lost();
         renderer_ = nullptr;
         prior_target_ = nullptr;
         return;
@@ -362,33 +425,79 @@ scoped_render_target::scoped_render_target( const SDL_Renderer_Ptr &renderer,
     valid_ = true;
 }
 
+bool scoped_render_target::restore()
+{
+    if( restore_attempted_ ) {
+        return last_restore_ok_;
+    }
+    restore_attempted_ = true;
+    last_restore_ok_ = false;
+    if( !valid_ || !renderer_ ) {
+        return false;
+    }
+    if( renderer_boundary_recovery_pending() ) {
+        // Already latched; do not issue another SDL_SetRenderTarget.
+        boundary_intact_ = false;
+        return false;
+    }
+#if SDL_MAJOR_VERSION >= 3
+    if( vp_ && !vp_->flush() ) {
+        // Undefined shader-state bind: do not switch the target.
+        dbg( D_ERROR ) << "scoped_render_target::restore: variant_pass flush failed";
+        mark_boundary_lost();
+        return false;
+    }
+    if( !SDL_SetRenderTarget( renderer_, prior_target_ ) ) {
+        dbg( D_ERROR ) << "scoped_render_target::restore: SDL_SetRenderTarget failed: "
+                       << SDL_GetError();
+        mark_boundary_lost();
+        return false;
+    }
+#else
+    if( SDL_SetRenderTarget( renderer_, prior_target_ ) != 0 ) {
+        dbg( D_ERROR ) << "scoped_render_target::restore: SDL_SetRenderTarget failed: "
+                       << SDL_GetError();
+        mark_boundary_lost();
+        return false;
+    }
+#endif
+    restored_ = true;
+    last_restore_ok_ = true;
+    return true;
+}
+
 scoped_render_target::~scoped_render_target()
 {
     if( restored_ || !valid_ || !renderer_ ) {
         return;
     }
-    restored_ = true;
-#if SDL_MAJOR_VERSION >= 3
-    if( !SDL_SetRenderTarget( renderer_, prior_target_ ) ) {
-        dbg( D_ERROR ) << "~scoped_render_target: SDL_SetRenderTarget failed: " << SDL_GetError();
+    if( restore_attempted_ ) {
+        // Explicit restore already failed and logged; the caller chose to
+        // abort. Do not retry to avoid masking the original failure.
+        return;
     }
-#else
-    if( SDL_SetRenderTarget( renderer_, prior_target_ ) != 0 ) {
-        dbg( D_ERROR ) << "~scoped_render_target: SDL_SetRenderTarget failed: " << SDL_GetError();
+    if( renderer_boundary_recovery_pending() ) {
+        // Another callsite latched recovery; suppress the implicit restore.
+        // The coordinator rebinds on rebuild.
+        boundary_intact_ = false;
+        return;
     }
-#endif
+    ( void )restore();
 }
 
-bool permanent_render_target_bind( const SDL_Renderer_Ptr &renderer, SDL_Texture *target,
-                                   cata_shader::variant_pass *vp )
+bind_result permanent_render_target_bind( const SDL_Renderer_Ptr &renderer, SDL_Texture *target,
+        cata_shader::variant_pass *vp )
 {
     if( !renderer ) {
         dbg( D_ERROR ) << "permanent_render_target_bind: null renderer";
-        return false;
+        // No SDL call issued, so no embargo: pre-switch refusal.
+        return bind_result::refused_pre_switch;
     }
 #if SDL_MAJOR_VERSION >= 3
     if( vp && !vp->flush() ) {
-        return false;
+        // Unsafe shader-state bind: do not switch the target. Latch recovery.
+        renderer_boundary_signal_recovery_required();
+        return bind_result::failed_in_switch;
     }
     const bool failed = printErrorIf( !SDL_SetRenderTarget( renderer.get(), target ),
                                       "SDL_SetRenderTarget failed" );
@@ -397,7 +506,13 @@ bool permanent_render_target_bind( const SDL_Renderer_Ptr &renderer, SDL_Texture
     const bool failed = printErrorIf( SDL_SetRenderTarget( renderer.get(), target ) != 0,
                                       "SDL_SetRenderTarget failed" );
 #endif
-    return !failed;
+    if( failed ) {
+        // SDL may have mutated target state before failing; latch recovery.
+        // Callers with a quarantine path still see the bind_result and
+        // sequence their own teardown -- the latch is additive.
+        renderer_boundary_signal_recovery_required();
+    }
+    return failed ? bind_result::failed_in_switch : bind_result::ok;
 }
 
 void RenderClear( const SDL_Renderer_Ptr &renderer )
@@ -1410,38 +1525,17 @@ SDL_Renderer_Ptr CreateRenderer( const SDL_Window_Ptr &window, const char *drive
 }
 
 
-void ConvertEventCoordinates( const SDL_Renderer_Ptr &renderer, SDL_Event *event )
-{
-#if SDL_MAJOR_VERSION >= 3
-    if( renderer && event ) {
-        SDL_ConvertEventToRenderCoordinates( renderer.get(), event );
-    }
-#else
-    ( void )renderer;
-    ( void )event;
-    // SDL2: no-op. SDL_RenderSetLogicalSize auto-scales mouse/touch events.
-#endif
-}
-
-
 float GetFingerX( const SDL_Event &ev, const int windowWidth )
 {
-#if SDL_MAJOR_VERSION >= 3
-    ( void )windowWidth;
-    return ev.tfinger.x;
-#else
+    // Both SDL2 and SDL3 deliver tfinger.x in normalized [0..1] space.
+    // Multiply by the logical window width to land in window pixel units
+    // for shortcut hit-tests and joystick math.
     return ev.tfinger.x * windowWidth;
-#endif
 }
 
 float GetFingerY( const SDL_Event &ev, const int windowHeight )
 {
-#if SDL_MAJOR_VERSION >= 3
-    ( void )windowHeight;
-    return ev.tfinger.y;
-#else
     return ev.tfinger.y * windowHeight;
-#endif
 }
 
 #endif // defined(TILES)

--- a/src/sdl_wrappers.h
+++ b/src/sdl_wrappers.h
@@ -29,8 +29,10 @@
 #endif
 // IWYU pragma: end_exports
 
+#include <atomic>
 #include <memory>
 #include <string>
+#include <vector>
 
 struct point;
 
@@ -122,7 +124,54 @@ bool SetTextureColorMod( const std::shared_ptr<SDL_Texture> &texture, Uint32 r, 
 void SetRenderDrawBlendMode( const SDL_Renderer_Ptr &renderer, SDL_BlendMode blendMode );
 void GetRenderDrawBlendMode( const SDL_Renderer_Ptr &renderer, SDL_BlendMode &blend_mode );
 SDL_Surface_Ptr load_image( const char *path );
-bool SetRenderTarget( const SDL_Renderer_Ptr &renderer, const SDL_Texture_Ptr &texture );
+
+// Deferred-disposal list for GPU texture handles that must outlive an
+// interrupted or pre-rebuild operation. Each handle's deleter consults a shared
+// gate: while the gate is set, SDL_DestroyTexture is skipped because the
+// originating renderer is being torn down and reclaims the texture itself.
+// drain_live_renderer() destroys on the live renderer; abandon() and the
+// destructor release without destroying. Single-threaded, hence a plain vector.
+class gpu_handle_graveyard
+{
+    public:
+        using gate = std::shared_ptr<std::atomic<bool>>;
+
+        gpu_handle_graveyard();
+        ~gpu_handle_graveyard();
+        gpu_handle_graveyard( const gpu_handle_graveyard & ) = delete;
+        gpu_handle_graveyard &operator=( const gpu_handle_graveyard & ) = delete;
+        gpu_handle_graveyard( gpu_handle_graveyard && ) = default;
+        gpu_handle_graveyard &operator=( gpu_handle_graveyard && ) = default;
+
+        // Adopt a raw handle, wrapping it in a shared_ptr that shares this
+        // graveyard's current gate.
+        void add( SDL_Texture *raw );
+        // Adopt a handle already wrapped against this graveyard's gate.
+        void adopt( std::shared_ptr<SDL_Texture> handle );
+        bool empty() const {
+            return handles_.empty();
+        }
+        // The gate every adopted handle's deleter consults; callers that build
+        // handles destined for this graveyard wrap them against it.
+        const gate &current_gate() const {
+            return gate_;
+        }
+        // Destroy the handles on the still-live renderer, then re-arm a fresh
+        // gate so the graveyard is reusable.
+        void drain_live_renderer();
+        // Release the handles without SDL_DestroyTexture because the originating
+        // renderer is being destroyed, then re-arm a fresh gate.
+        void abandon();
+
+    private:
+        std::vector<std::shared_ptr<SDL_Texture>> handles_;
+        gate gate_;
+};
+
+// Wrap a raw texture handle in a shared_ptr whose deleter skips
+// SDL_DestroyTexture while `g` is set. Ownership of `raw` transfers to the
+// returned handle.
+std::shared_ptr<SDL_Texture> make_gated_texture( SDL_Texture *raw, gpu_handle_graveyard::gate g );
 
 namespace cata_shader
 {
@@ -132,7 +181,9 @@ class variant_pass;
 // RAII render-target swap: binds `target`, restores the prior target on
 // destruction. On SDL3 a non-null `vp` is flushed before the swap so shader
 // GPU state is not left bound across the SetRenderTarget transition. Check
-// is_valid() before issuing draws.
+// is_valid() before drawing. On any failure here (flush or SDL_SetRenderTarget)
+// the ctor raises the global recovery latch, or observes it if another callsite
+// already did; boundary_intact() goes false and the caller must abort the frame.
 class scoped_render_target
 {
     public:
@@ -149,18 +200,61 @@ class scoped_render_target
             return valid_;
         }
 
+        // False when the renderer may be in an undefined state (see class
+        // doc). The global recovery latch is raised by the time this returns
+        // false, and the caller must abort the enclosing frame.
+        bool boundary_intact() const {
+            return boundary_intact_;
+        }
+
+        // Eagerly restore the prior target (re-flushing vp). Idempotent:
+        // caches its result. Returns false if the scope was never valid, the
+        // flush or SDL_SetRenderTarget fails, or recovery was already latched.
+        bool restore();
+
     private:
+        // Latch the global recovery embargo and clear boundary_intact_ after an
+        // unsafe SDL boundary outcome.
+        void mark_boundary_lost();
+
         SDL_Renderer *renderer_ = nullptr;
         SDL_Texture *prior_target_ = nullptr;
+#if SDL_MAJOR_VERSION >= 3
+        cata_shader::variant_pass *vp_ = nullptr;
+#endif
         bool valid_ = false;
         bool restored_ = false;
+        bool restore_attempted_ = false;
+        bool last_restore_ok_ = false;
+        bool boundary_intact_ = true;
 };
+
+// Outcome of permanent_render_target_bind. This helper does NOT short-circuit
+// on the recovery latch -- the coordinator needs it during rebuild transitions.
+// - ok: SDL accepted the bind.
+// - refused_pre_switch: a precondition (null renderer) blocked any SDL call;
+//   the prior target is still bound and intact.
+// - failed_in_switch: variant_pass::flush() failed (undefined shader bind, or
+//   the abandoned_pending_rebind_ embargo) OR SDL_SetRenderTarget returned false
+//   (SDL may have mutated target state before failing). The renderer is left
+//   undefined and the helper raises the recovery latch.
+enum class bind_result {
+    ok,
+    refused_pre_switch,
+    failed_in_switch,
+};
+
+// Sticky renderer-boundary recovery latch, mirrored here so this header's
+// helpers can consult it without the full sdltiles.h chain. Defined in sdltiles.cpp.
+bool renderer_boundary_recovery_pending();
+// Raise that latch from code without the sdltiles.h chain.
+void renderer_boundary_signal_recovery_required();
 
 // Bind a render target permanently, with no auto-restore, for transitions
 // where the prior target is not meaningful. Flushes variant_pass on SDL3
 // when `vp` is non-null.
-bool permanent_render_target_bind( const SDL_Renderer_Ptr &renderer, SDL_Texture *target,
-                                   cata_shader::variant_pass *vp = nullptr );
+bind_result permanent_render_target_bind( const SDL_Renderer_Ptr &renderer, SDL_Texture *target,
+        cata_shader::variant_pass *vp = nullptr );
 void RenderClear( const SDL_Renderer_Ptr &renderer );
 SDL_Surface_Ptr CreateRGBSurface( Uint32 flags, int width, int height, int depth, Uint32 Rmask,
                                   Uint32 Gmask, Uint32 Bmask, Uint32 Amask );
@@ -220,7 +314,8 @@ void RenderPresent( const SDL_Renderer_Ptr &renderer );
 void RenderDrawRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *rect );
 void RenderGetViewport( const SDL_Renderer_Ptr &renderer, SDL_Rect *rect );
 // SDL3: replaced by SDL_SetRenderLogicalPresentation(r, w, h, mode).
-// Callers must also use ConvertEventCoordinates (SDL3 does not auto-scale events).
+// Callers convert event coordinates explicitly (window_to_display_buffer_coords)
+// since the input pipeline runs against the window target, not the buffer.
 void RenderSetLogicalSize( const SDL_Renderer_Ptr &renderer, int w, int h );
 void RenderSetScale( const SDL_Renderer_Ptr &renderer, float scaleX, float scaleY );
 // SDL3: returns SDL_Surface* instead of filling a buffer. Wrapper copies data out.
@@ -305,12 +400,9 @@ void SetWindowTitle( SDL_Window *window, const char *title );
 SDL_Renderer_Ptr CreateRenderer( const SDL_Window_Ptr &window, const char *driver_name,
                                  bool software, bool vsync );
 
-// SDL2: no-op (logical size auto-scales events).
-// SDL3: calls SDL_ConvertEventToRenderCoordinates on all event types.
-void ConvertEventCoordinates( const SDL_Renderer_Ptr &renderer, SDL_Event *event );
-
-// SDL2: finger coords are normalized [0,1]; multiply by window dimension.
-// SDL3: after ConvertEventCoordinates, coords are already absolute render-logical.
+// Touch finger coordinates. Both SDL2 and SDL3 emit normalized [0,1] values
+// on SDL_FINGER* / SDL_EVENT_FINGER_* events; the wrappers multiply by the
+// supplied window dimension to recover window-pixel coordinates.
 float GetFingerX( const SDL_Event &ev, int windowWidth );
 float GetFingerY( const SDL_Event &ev, int windowHeight );
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -172,6 +172,10 @@ static void ClearScreen()
 
 void clear_sdl_window()
 {
+    display_buffer_draw_scope draw_scope;
+    if( display_buffer_scope_is_invalid() ) {
+        return;
+    }
     ClearScreen();
 }
 
@@ -253,20 +257,58 @@ static void InitSDL()
     }
 }
 
+namespace
+{
+// Disposal slot for staged display_buffer textures left bound after a failed
+// unbind. Destroying them would invalidate the active target; the gate keeps a
+// later SDL_DestroyRenderer (which frees them) from racing the dtor.
+gpu_handle_graveyard &setup_target_quarantine()
+{
+    static gpu_handle_graveyard q;
+    return q;
+}
+} // namespace
+
 static bool SetupRenderTarget()
 {
     SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
-    display_buffer = CreateTexture( renderer, SDL_PIXELFORMAT_ARGB8888,
-                                    SDL_TEXTUREACCESS_TARGET, WindowWidth / scaling_factor,
-                                    WindowHeight / scaling_factor );
-    if( printErrorIf( !display_buffer, "Failed to create window buffer" ) ) {
+    // Stage into a local so a failed bind leaves the previous display_buffer
+    // intact rather than orphaning a still-referenced target.
+    SDL_Texture_Ptr staged = CreateTexture( renderer, SDL_PIXELFORMAT_ARGB8888,
+                                            SDL_TEXTUREACCESS_TARGET, WindowWidth / scaling_factor,
+                                            WindowHeight / scaling_factor );
+    if( printErrorIf( !staged, "Failed to create window buffer" ) ) {
         return false;
     }
-    if( !SetRenderTarget( renderer, display_buffer ) ) {
-        return false;
+    {
+        const bind_result r = permanent_render_target_bind( renderer, staged.get() );
+        if( r == bind_result::failed_in_switch ) {
+            // Boundary undefined: quarantine staged so its dtor cannot race the
+            // active target. The previous display_buffer is untouched.
+            setup_target_quarantine().add( staged.release() );
+            return false;
+        }
+        if( r != bind_result::ok ) {
+            // Refused before binding; staged was never bound, drop it.
+            return false;
+        }
     }
     ClearScreen();
-
+    {
+        const bind_result r = permanent_render_target_bind( renderer, nullptr );
+        if( r == bind_result::failed_in_switch ) {
+            // Detach failed: staged is still the active target, so quarantine
+            // rather than destroy.
+            setup_target_quarantine().add( staged.release() );
+            return false;
+        }
+        if( r != bind_result::ok ) {
+            // Refused: staged is still bound, quarantine so the next bind wins.
+            setup_target_quarantine().add( staged.release() );
+            return false;
+        }
+    }
+    display_buffer = std::move( staged );
     return true;
 }
 
@@ -483,6 +525,9 @@ static void WinCreate()
             software_renderer = true;
             display_buffer.reset();
             renderer.reset();
+            // The poisoned accelerated renderer is destroyed; clear the latch
+            // SetupRenderTarget raised so the software fallback is not pre-refused.
+            display_buffer_scope_clear_recovery_required();
         }
     }
 
@@ -656,13 +701,31 @@ void refresh_display()
         return;
     }
 
+    if( display_buffer_scope_recovery_pending() ) {
+        // An earlier target switch latched recovery; skip the whole present so
+        // nothing runs against the undefined renderer until the rebuild clears it.
+        return;
+    }
+
 #if defined(SDL_SOUND)
     sound_backend::poll();
 #endif
 
-    // Select default target (the window), copy rendered buffer
-    // there, present it, select the buffer as target again.
-    SetRenderTarget( renderer, nullptr );
+    // Present from the window target. The buffer stays unbound; draw paths
+    // re-bind it next frame. Go through the pass-aware helper so variant_pass
+    // can flush before the switch.
+    {
+        const bind_result r = permanent_render_target_bind( renderer, nullptr );
+        if( r == bind_result::failed_in_switch ) {
+            // Helper already latched; signal again defensively and skip present.
+            display_buffer_scope_signal_recovery_required();
+            return;
+        }
+        if( r != bind_result::ok ) {
+            // Refused; skip this frame.
+            return;
+        }
+    }
     ClearScreen();
 #if defined(__ANDROID__)
     SDL_Rect dstrect = get_android_render_rect( TERMINAL_WIDTH * fontwidth,
@@ -681,7 +744,6 @@ void refresh_display()
 #endif
     draw_gamepad_radial_menu();
     RenderPresent( renderer );
-    SetRenderTarget( renderer, display_buffer );
 }
 
 // only update if the set interval has elapsed
@@ -695,14 +757,237 @@ static void try_sdl_update()
     }
 }
 
-//for resetting the render target after updating texture caches in cata_tiles.cpp
-void set_displaybuffer_rendertarget()
+void get_display_buffer_dims( int *w, int *h )
 {
-    SetRenderTarget( renderer, display_buffer );
+    int buf_w = 0;
+    int buf_h = 0;
+    if( display_buffer ) {
+#if SDL_MAJOR_VERSION >= 3
+        SDL_PropertiesID props = SDL_GetTextureProperties( display_buffer.get() );
+        if( props ) {
+            buf_w = static_cast<int>( SDL_GetNumberProperty( props,
+                                      SDL_PROP_TEXTURE_WIDTH_NUMBER, 0 ) );
+            buf_h = static_cast<int>( SDL_GetNumberProperty( props,
+                                      SDL_PROP_TEXTURE_HEIGHT_NUMBER, 0 ) );
+        }
+#else
+        SDL_QueryTexture( display_buffer.get(), nullptr, nullptr, &buf_w, &buf_h );
+#endif
+    }
+    if( w ) {
+        *w = buf_w;
+    }
+    if( h ) {
+        *h = buf_h;
+    }
+}
+
+SDL_Point window_to_display_buffer_coords( SDL_Point window_pt )
+{
+    if( !window ) {
+        return window_pt;
+    }
+    int buf_w = 0;
+    int buf_h = 0;
+    get_display_buffer_dims( &buf_w, &buf_h );
+    if( buf_w <= 0 || buf_h <= 0 ) {
+        return window_pt;
+    }
+#if defined(__ANDROID__)
+    // Invert get_android_render_rect's letterbox: translate to letterbox-local,
+    // then scale to buffer dims. Outside-letterbox values are left unclamped so
+    // callers can detect touches outside the playfield.
+    const SDL_Rect dstrect = get_android_render_rect( TERMINAL_WIDTH * fontwidth,
+                             TERMINAL_HEIGHT * fontheight );
+    if( dstrect.w <= 0 || dstrect.h <= 0 ) {
+        return window_pt;
+    }
+    return SDL_Point{
+        static_cast<int>( static_cast<int64_t>( window_pt.x - dstrect.x ) * buf_w / dstrect.w ),
+        static_cast<int>( static_cast<int64_t>( window_pt.y - dstrect.y ) * buf_h / dstrect.h )
+    };
+#else
+    int win_w = 0;
+    int win_h = 0;
+    GetWindowSize( window.get(), &win_w, &win_h );
+    if( win_w <= 0 || win_h <= 0 ) {
+        return window_pt;
+    }
+    return SDL_Point{
+        static_cast<int>( static_cast<int64_t>( window_pt.x ) * buf_w / win_w ),
+        static_cast<int>( static_cast<int64_t>( window_pt.y ) * buf_h / win_h )
+    };
+#endif
+}
+
+void convert_event_to_display_buffer_coords( SDL_Event *event )
+{
+    if( !event ) {
+        return;
+    }
+    switch( event->type ) {
+        case CATA_MOUSEMOTION: {
+#if SDL_MAJOR_VERSION >= 3
+            SDL_Point pt { static_cast<int>( event->motion.x ), static_cast<int>( event->motion.y ) };
+            const SDL_Point conv = window_to_display_buffer_coords( pt );
+            event->motion.x = static_cast<float>( conv.x );
+            event->motion.y = static_cast<float>( conv.y );
+#else
+            SDL_Point pt { event->motion.x, event->motion.y };
+            const SDL_Point conv = window_to_display_buffer_coords( pt );
+            event->motion.x = conv.x;
+            event->motion.y = conv.y;
+#endif
+            break;
+        }
+        case CATA_MOUSEBUTTONDOWN:
+        case CATA_MOUSEBUTTONUP: {
+#if SDL_MAJOR_VERSION >= 3
+            SDL_Point pt { static_cast<int>( event->button.x ), static_cast<int>( event->button.y ) };
+            const SDL_Point conv = window_to_display_buffer_coords( pt );
+            event->button.x = static_cast<float>( conv.x );
+            event->button.y = static_cast<float>( conv.y );
+#else
+            SDL_Point pt { event->button.x, event->button.y };
+            const SDL_Point conv = window_to_display_buffer_coords( pt );
+            event->button.x = conv.x;
+            event->button.y = conv.y;
+#endif
+            break;
+        }
+        case CATA_MOUSEWHEEL: {
+#if SDL_MAJOR_VERSION >= 3
+            SDL_Point pt { static_cast<int>( event->wheel.mouse_x ), static_cast<int>( event->wheel.mouse_y ) };
+            const SDL_Point conv = window_to_display_buffer_coords( pt );
+            event->wheel.mouse_x = static_cast<float>( conv.x );
+            event->wheel.mouse_y = static_cast<float>( conv.y );
+#endif
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+namespace
+{
+// Draw-scope state. depth counts nested scopes. aborted lets an inner
+// abort_unbind() inhibit the outermost dtor's detach (honoring the shader bind
+// boundary). invalid is set when the outermost bind fails; per-scope.
+// recovery_required is the sticky boundary latch: a failed target switch left
+// SDL state undefined, held until the coordinator clears it on rebuild.
+int display_buffer_scope_depth = 0;
+bool display_buffer_scope_aborted = false;
+bool display_buffer_scope_invalid = false;
+bool display_buffer_scope_recovery_required = false;
+} // namespace
+
+bool display_buffer_scope_is_invalid()
+{
+    return display_buffer_scope_invalid;
+}
+
+bool display_buffer_scope_recovery_pending()
+{
+    return display_buffer_scope_recovery_required;
+}
+
+void display_buffer_scope_signal_recovery_required()
+{
+    display_buffer_scope_recovery_required = true;
+    display_buffer_scope_invalid = true;
+}
+
+// sdl_wrappers cannot include sdltiles.h, so it raises and reads the same latch
+// through these renderer_boundary_* names; they forward to the canonical
+// display_buffer_scope_* accessors rather than duplicating the body.
+bool renderer_boundary_recovery_pending()
+{
+    return display_buffer_scope_recovery_pending();
+}
+
+void renderer_boundary_signal_recovery_required()
+{
+    display_buffer_scope_signal_recovery_required();
+}
+
+void display_buffer_scope_clear_recovery_required()
+{
+    display_buffer_scope_recovery_required = false;
+}
+
+display_buffer_draw_scope::display_buffer_draw_scope()
+{
+    if( display_buffer_scope_depth++ != 0 ) {
+        // Inner scopes inherit the outer scope's validity. No bind work.
+        return;
+    }
+    outermost_ = true;
+    display_buffer_scope_aborted = false;
+    // Carry recovery_required across scopes -- it is sticky until the
+    // coordinator clears it. invalid is per-scope; reset here.
+    display_buffer_scope_invalid = display_buffer_scope_recovery_required;
+    if( !renderer || !display_buffer ) {
+        display_buffer_scope_invalid = true;
+        return;
+    }
+    if( display_buffer_scope_recovery_required ) {
+        // Boundary previously lost; refuse the bind until coordinator
+        // rebuilds the renderer.
+        return;
+    }
+    const bind_result r = permanent_render_target_bind( renderer, display_buffer.get() );
+    if( r == bind_result::failed_in_switch ) {
+        // Boundary undefined: latch recovery so this and later scopes refuse.
+        display_buffer_scope_recovery_required = true;
+        display_buffer_scope_invalid = true;
+        return;
+    }
+    if( r != bind_result::ok ) {
+        // Refused, boundary intact: skip the draw but do not latch recovery.
+        display_buffer_scope_invalid = true;
+        return;
+    }
+    active_ = true;
+}
+
+void display_buffer_draw_scope::abort_unbind()
+{
+    display_buffer_scope_aborted = true;
+}
+
+display_buffer_draw_scope::~display_buffer_draw_scope()
+{
+    --display_buffer_scope_depth;
+    if( !outermost_ ) {
+        return;
+    }
+    // Outermost: clear the per-scope invalid flag on exit so the next
+    // scope starts fresh. recovery_required is sticky and must NOT be
+    // cleared here; the coordinator clears it on a successful rebuild.
+    const bool was_active = active_;
+    const bool was_aborted = display_buffer_scope_aborted;
+    display_buffer_scope_invalid = display_buffer_scope_recovery_required;
+    if( !was_active || was_aborted || !renderer
+        || display_buffer_scope_recovery_required ) {
+        // Skip detach when the bind never succeeded, an inner scope aborted
+        // (shader bind boundary), the renderer is null, or recovery is latched
+        // -- another switch on the undefined renderer would deepen corruption.
+        return;
+    }
+    if( permanent_render_target_bind( renderer, nullptr )
+        == bind_result::failed_in_switch ) {
+        // Boundary undefined: latch so later scopes refuse until rebuild.
+        display_buffer_scope_recovery_required = true;
+    }
 }
 
 void clear_window_area( const catacurses::window &win_ )
 {
+    display_buffer_draw_scope draw_scope;
+    if( display_buffer_scope_is_invalid() ) {
+        return;
+    }
     cata_cursesport::WINDOW *const win = win_.get<cata_cursesport::WINDOW>();
     geometry->rect( renderer, point( win->pos.x * fontwidth, win->pos.y * fontheight ),
                     win->width * fontwidth, win->height * fontheight, color_as_sdl( catacurses::black ) );
@@ -873,7 +1158,8 @@ static point draw_string( Font &font,
 
 void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_omt, bool blink )
 {
-    if( !g ) {
+    display_buffer_draw_scope draw_scope;
+    if( display_buffer_scope_is_invalid() || !g ) {
         return;
     }
 
@@ -1370,10 +1656,14 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 
     RenderSetClipRect( renderer, nullptr );
 #if SDL_MAJOR_VERSION >= 3
-    // Flush so GPU shader state from sprite draws is not left bound across a
-    // following ImGui pass or target switch.
-    if( m_variant_pass ) {
-        m_variant_pass->flush();
+    // Flush failure means the shader bind boundary forbids a target switch:
+    // abort the scope's unbind, latch recovery, and throw to unwind
+    // curses_drawwindow instead of drawing terrain overlays on a dead renderer.
+    if( m_variant_pass && !m_variant_pass->flush() ) {
+        draw_scope.abort_unbind();
+        display_buffer_scope_signal_recovery_required();
+        throw std::runtime_error(
+            "cata_tiles::draw_om: variant_pass flush failed at end of frame; renderer in undefined state" );
     }
 #endif
 }
@@ -1505,6 +1795,10 @@ static bool draw_window( Font_Ptr &font, const catacurses::window &w )
 
 void cata_cursesport::curses_drawwindow( const catacurses::window &w )
 {
+    display_buffer_draw_scope draw_scope;
+    if( display_buffer_scope_is_invalid() ) {
+        return;
+    }
     if( scaling_factor > 1 ) {
         RenderSetLogicalSize( renderer, WindowWidth / scaling_factor,
                               WindowHeight / scaling_factor );
@@ -3260,11 +3554,16 @@ static void CheckMessages()
     bool render_target_reset = false;
     using cata::options::mouse;
 
+    int imgui_buf_w = 0;
+    int imgui_buf_h = 0;
+    get_display_buffer_dims( &imgui_buf_w, &imgui_buf_h );
     while( SDL_PollEvent( &ev ) ) {
-        // SDL3: converts event coordinates from window space to render-logical space.
-        // SDL2: no-op (logical size auto-scales events).
-        ConvertEventCoordinates( renderer, &ev );
-        imclient->process_input( &ev );
+        // Build a display_buffer-coord copy for ImGui and gameplay
+        // consumers. The raw `ev` stays in window coordinates so android
+        // shortcut and joystick hit-tests see the same domain SDL emitted.
+        SDL_Event ev_display = ev;
+        convert_event_to_display_buffer_coords( &ev_display );
+        imclient->process_input( &ev_display, imgui_buf_w, imgui_buf_h );
 
         // Window events: SDL3 flattens the SDL_WINDOWEVENT+subtype to top-level events.
         // IsWindowEvent/GetWindowEventID normalize across versions.
@@ -4274,7 +4573,16 @@ input_event input_manager::get_input_event( const keyboard_mode preferred_keyboa
         CheckMessages();
     }
 
-    GetMouseState( &last_input.mouse_pos.x, &last_input.mouse_pos.y );
+    // Sample the raw mouse position (window coords) and convert into
+    // display_buffer coords so canonical gameplay picking matches the
+    // domain ImGui and tile draws use.
+    {
+        point raw;
+        GetMouseState( &raw.x, &raw.y );
+        const SDL_Point buf_pt = window_to_display_buffer_coords( SDL_Point{ raw.x, raw.y } );
+        last_input.mouse_pos.x = buf_pt.x;
+        last_input.mouse_pos.y = buf_pt.y;
+    }
     if( last_input.type == input_event_t::keyboard_char ) {
         previously_pressed_key = last_input.get_first_input();
 #if defined(__ANDROID__)
@@ -4554,6 +4862,12 @@ bool catacurses::supports_256_colors()
 */
 bool save_screenshot( const std::string &file_path )
 {
+    // Capture from the terminal-sized buffer so the screenshot matches the
+    // in-game presentation rather than the raw window output.
+    display_buffer_draw_scope draw_scope;
+    if( display_buffer_scope_is_invalid() ) {
+        return false;
+    }
     // Note: the viewport is returned by SDL and we don't have to manage its lifetime.
     SDL_Rect viewport;
 

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -69,6 +69,61 @@ void clear_sdl_window();
 // Returns the main game window. Needed by text input wrappers and other
 // SDL3 APIs that require an explicit window parameter.
 SDL_Window *get_sdl_window();
+// Dimensions of the terminal-sized display_buffer (logical game pixels),
+// queried from the SDL texture. Differs from window output under SCALING_FACTOR
+// or android letterboxing. Zero before the buffer exists.
+void get_display_buffer_dims( int *w, int *h );
+
+// Map window coordinates to display_buffer (terminal) pixel coordinates.
+// Returns the input unchanged when either dimension source is unavailable.
+SDL_Point window_to_display_buffer_coords( SDL_Point window_pt );
+
+// Convert a coord-bearing mouse event (motion/button/wheel) in place to
+// display_buffer coordinates. Touch events are left in window coordinates: the
+// android shortcut overlay and virtual joystick hit-test against the window.
+void convert_event_to_display_buffer_coords( SDL_Event *event );
+
+// True while the active scope failed to bind the buffer target. Per-scope;
+// consult before drawing so nothing paints onto an unknown SDL target.
+bool display_buffer_scope_is_invalid();
+
+// Sticky renderer-boundary recovery latch (failure sources: see bind_result in
+// sdl_wrappers.h). Once set, scope ctors refuse the bind until the coordinator
+// clears it. Sticky across scopes, unlike display_buffer_scope_is_invalid.
+bool display_buffer_scope_recovery_pending();
+
+// Raise the recovery latch from outside a draw scope (e.g. the present-time
+// bind in refresh_display); most helper failures already latch internally.
+void display_buffer_scope_signal_recovery_required();
+
+// Clear the latch once the poisoned renderer is gone and a fresh one is wired.
+void display_buffer_scope_clear_recovery_required();
+
+// Nestable RAII guard: binds display_buffer on entry, restores the idle null
+// target on exit. Only the outermost switches; nested scopes are no-ops. On a
+// failed bind the scope is inactive and display_buffer_scope_is_invalid() is
+// true so draw entry points skip. A caller hitting a mid-scope shader failure
+// must call abort_unbind() so the destructor does not switch target with shader
+// state still bound.
+class display_buffer_draw_scope
+{
+    public:
+        display_buffer_draw_scope();
+        ~display_buffer_draw_scope();
+        display_buffer_draw_scope( const display_buffer_draw_scope & ) = delete;
+        display_buffer_draw_scope &operator=( const display_buffer_draw_scope & ) = delete;
+        display_buffer_draw_scope( display_buffer_draw_scope && ) = delete;
+        display_buffer_draw_scope &operator=( display_buffer_draw_scope && ) = delete;
+
+        // Skip the outermost destructor's switch back to the null target.
+        // Used after a variant_pass::flush failure to honor the shader
+        // bind boundary.
+        void abort_unbind();
+
+    private:
+        bool outermost_ = false;
+        bool active_ = false;
+};
 
 #endif // TILES
 

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -366,11 +366,36 @@ void ui_adaptor::redraw_invalidated( )
     if( test_mode || ui_stack.empty() ) {
         return;
     }
+#if defined(TILES)
+    display_buffer_draw_scope draw_scope;
+    if( display_buffer_scope_is_invalid() ) {
+        // Bind failed; skip the redraw. Invalidation is preserved for retry.
+        return;
+    }
+    int buf_w = 0;
+    int buf_h = 0;
+    get_display_buffer_dims( &buf_w, &buf_h );
+#endif
     // This boolean is needed when a debug error is thrown inside redraw_invalidated
     if( !imgui_frame_started ) {
+#if defined(TILES)
+        imclient->new_frame( buf_w, buf_h );
+#else
         imclient->new_frame();
+#endif
     }
     imgui_frame_started = true;
+
+    // On abnormal exit (exception unwinding a draw callback) close the frame
+    // without rendering so the next NewFrame() does not assert. No-op on the
+    // normal path: end_frame()/abort_frame() clear imgui_frame_started first.
+    on_out_of_scope imgui_frame_balance( [] {
+        if( imgui_frame_started )
+        {
+            imclient->abort_frame();
+            imgui_frame_started = false;
+        }
+    } );
 
     restore_on_out_of_scope prev_redraw_in_progress( redraw_in_progress );
     restore_on_out_of_scope prev_restart_redrawing( restart_redrawing );
@@ -476,6 +501,18 @@ void ui_adaptor::redraw_invalidated( )
     emscripten_sleep( 1 );
 #endif
 
+#if defined(TILES)
+    if( display_buffer_scope_recovery_pending() ) {
+        // An inner draw latched recovery mid-frame: abort the frame instead of
+        // painting the drawlist onto the undefined target. The coordinator
+        // rebuilds before the next ui pass.
+        if( imgui_frame_started ) {
+            imclient->abort_frame();
+        }
+        imgui_frame_started = false;
+        return;
+    }
+#endif
     imclient->end_frame();
     imgui_frame_started = false;
 


### PR DESCRIPTION
#### Summary
Infrastructure "Keep the renderer's idle target at null, bind display_buffer per draw through an RAII scope"

#### Purpose of change
More SDL3 render-pipeline hardening, stacked on #87418. The renderer used to leave display_buffer bound as the render target the whole time. That is fragile across a device reset: the bound target can go stale and nothing along the pipeline knows the renderer is in a bad state. So leave the renderer pointed at the window (null target) when idle and have each draw path bind display_buffer through a scoped guard instead.

#### Describe the solution
display_buffer_draw_scope is a nestable RAII guard: the outermost binds on entry and restores the null target on exit, nested scopes are no-ops. Every draw entry point (tiles, overmap, minimap, curses windows, screenshots, the language picker) wraps itself in one and bails if the bind failed.

A sticky recovery latch covers target-switch or shader-flush failures mid-pipeline. SDL can leave the renderer undefined after a failed SetRenderTarget, so once that happens draw and present skip until the renderer is rebuilt (that part lands later). scoped_render_target grows boundary_intact() and restore(), and permanent_render_target_bind returns a bind_result so callers can tell "refused, still fine" from "failed, renderer poisoned".

The renderer no longer holds a logical presentation between frames, so input events are converted from window to display_buffer coordinates explicitly in the event pump and ImGui gets the buffer dims for DisplaySize. Touch events stay in window coordinates on purpose, since the android shortcut overlay and joystick hit-test against the window.

Textures that cannot be safely destroyed because the renderer might still reference them (shader probe textures, a staged buffer) go into a gpu_handle_graveyard that holds them until a renderer teardown reclaims them.

No intended behavior change on desktop.

#### Describe alternatives you've considered
Keep display_buffer permanently bound and just rebind it after a reset. That is the status quo, and it is exactly what makes reset recovery awkward: there is no clear point where "the target is currently nonsense" is observable. The scope plus latch gives every draw path a cheap "is the renderer ok" check.

#### Testing
Game builds and runs, no changes.

#### Additional context
The recovery latch is wired but nothing raises-and-rebuilds yet; the coordinator that clears it comes later in the series.