### PR TITLE
Add reset and rebind primitives for renderer-owned GPU resources

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -118,7 +118,10 @@ cataimgui::client::~client()
 {
     ImTui_ImplNcurses_Shutdown();
     ImTui_ImplText_Shutdown();
-    ImGui::Shutdown();
+    // DestroyContext runs the internal Shutdown and frees the context;
+    // calling ImGui::Shutdown alone leaks the context created in the
+    // constructor.
+    ImGui::DestroyContext();
 }
 
 void cataimgui::client::new_frame( int display_buffer_w, int display_buffer_h )
@@ -307,12 +310,71 @@ cataimgui::client::client( const SDL_Renderer_Ptr &sdl_renderer, const SDL_Windo
     // Default cellPadding is {4, 2}. We reduce this to {3, 2}.
     ImGui::PushStyleVar( ImGuiStyleVar_CellPadding, ImVec2( 3, style.CellPadding.y ) );
 
+    init_platform_backend();
+    init_renderer_backend();
+}
+
+void cataimgui::client::init_platform_backend()
+{
+    if( platform_backend_active_ ) {
+        return;
+    }
 #if SDL_MAJOR_VERSION >= 3
     ImGui_ImplSDL3_InitForSDLRenderer( sdl_window.get(), sdl_renderer.get() );
-    ImGui_ImplSDLRenderer3_Init( sdl_renderer.get() );
 #else
     ImGui_ImplSDL2_InitForSDLRenderer( sdl_window.get(), sdl_renderer.get() );
+#endif
+    platform_backend_active_ = true;
+}
+
+void cataimgui::client::init_renderer_backend()
+{
+    if( renderer_backend_active_ ) {
+        return;
+    }
+#if SDL_MAJOR_VERSION >= 3
+    ImGui_ImplSDLRenderer3_Init( sdl_renderer.get() );
+#else
     ImGui_ImplSDLRenderer2_Init( sdl_renderer.get() );
+#endif
+    renderer_backend_active_ = true;
+}
+
+void cataimgui::client::shutdown_renderer_backend()
+{
+    if( !renderer_backend_active_ ) {
+        return;
+    }
+#if SDL_MAJOR_VERSION >= 3
+    ImGui_ImplSDLRenderer3_Shutdown();
+#else
+    ImGui_ImplSDLRenderer2_Shutdown();
+#endif
+    renderer_backend_active_ = false;
+}
+
+void cataimgui::client::shutdown_platform_backend()
+{
+    if( !platform_backend_active_ ) {
+        return;
+    }
+#if SDL_MAJOR_VERSION >= 3
+    ImGui_ImplSDL3_Shutdown();
+#else
+    ImGui_ImplSDL2_Shutdown();
+#endif
+    platform_backend_active_ = false;
+}
+
+void cataimgui::client::destroy_backend_device_objects() const
+{
+    if( !renderer_backend_active_ ) {
+        return;
+    }
+#if SDL_MAJOR_VERSION >= 3
+    ImGui_ImplSDLRenderer3_DestroyDeviceObjects();
+#else
+    ImGui_ImplSDLRenderer2_DestroyDeviceObjects();
 #endif
 }
 
@@ -396,11 +458,11 @@ void cataimgui::client::load_fonts( UNUSED const Font_Ptr &gui_font,
 
 cataimgui::client::~client()
 {
-#if SDL_MAJOR_VERSION >= 3
-    ImGui_ImplSDL3_Shutdown();
-#else
-    ImGui_ImplSDL2_Shutdown();
-#endif
+    // Reverse-order teardown: renderer backend, platform backend, context.
+    // Skipping any one leaks that resource.
+    shutdown_renderer_backend();
+    shutdown_platform_backend();
+    ImGui::DestroyContext();
 }
 
 #if 0 and not TUI

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -71,6 +71,13 @@ constexpr int min_screen_res_y = 384;
 class client
 {
         std::vector<int> cata_input_trail;
+#ifndef TUI
+        // Backend-active latches for the platform (SDL2/SDL3) and
+        // renderer (SDLRenderer2/3) ImGui backends. Guard the wrappers
+        // so partial teardown + retry is idempotent.
+        bool platform_backend_active_ = false;
+        bool renderer_backend_active_ = false;
+#endif
     public:
 #ifdef TUI
         client();
@@ -83,9 +90,9 @@ class client
 #endif
         ~client();
 
-        // display_buffer_w/h drive ImGui layout (DisplaySize) and SDL2 mouse
-        // scaling. Pass 0 to fall back to the bound target's output size (only
-        // valid while a draw scope has display_buffer bound).
+        // display_buffer_w/h drive ImGui layout (DisplaySize). Pass 0 to fall
+        // back to the bound target's output size (only valid while a draw scope
+        // has display_buffer bound).
         void new_frame( int display_buffer_w = 0, int display_buffer_h = 0 );
         void end_frame();
         // Close the active ImGui frame without any backend draw commands, for
@@ -101,6 +108,18 @@ class client
         const SDL_Renderer_Ptr &sdl_renderer;
         const SDL_Window_Ptr &sdl_window;
         const GeometryRenderer_Ptr &sdl_geometry;
+
+        // ImGui backend lifecycle wrappers. Each tracks backend-active state so
+        // the vendored Shutdown (which asserts when inactive) is never doubled.
+        // Pair: init platform then renderer; shutdown reverse.
+        void init_platform_backend();
+        void init_renderer_backend();
+        void shutdown_renderer_backend();
+        void shutdown_platform_backend();
+        // Drop the renderer backend's GPU device objects (font atlas,
+        // buffers) without tearing down the backend; they recreate
+        // lazily on the next RenderDrawData.
+        void destroy_backend_device_objects() const;
 #endif
         bool auto_size_frame_active();
         bool any_window_shown();

--- a/src/cata_shader.cpp
+++ b/src/cata_shader.cpp
@@ -350,7 +350,10 @@ variant_pass::variant_pass( SDL_Renderer *renderer )
 
 variant_pass::~variant_pass()
 {
-    flush();
+    const bool flushed = flush();
+    // On flush failure the handles may still be referenced; abandon rather
+    // than have RAII teardown call SDL on a still-bound resource.
+    clear_state_arrays( !flushed );
 }
 
 namespace
@@ -524,19 +527,40 @@ load_outcome load_and_probe( SDL_GPUDevice *device, SDL_Renderer *renderer,
 
 void variant_pass::reset()
 {
-    flush();
-    for( size_t i = 0; i < shaders_.size(); ++i ) {
-        states_[i] = render_state{};
-        shaders_[i] = shader{};
-    }
-    for( size_t i = 0; i < memory_shaders_.size(); ++i ) {
-        memory_states_[i] = render_state{};
-        memory_shaders_[i] = shader{};
-    }
+    const bool flushed = flush();
+    clear_state_arrays( !flushed );
     probe_attempted_ = false;
     probed_ok_ = false;
-    session_disabled_ = false;
-    unbind_required_ = false;
+    // On flush failure leave session_disabled_ set so callers refuse the
+    // boundary; the rebuild driving reset() decides when to clear it.
+    if( flushed ) {
+        session_disabled_ = false;
+        unbind_required_ = false;
+    }
+}
+
+void variant_pass::clear_state_arrays( bool abandon_handles )
+{
+    if( abandon_handles ) {
+        for( shader &s : shaders_ ) {
+            s.abandon();
+        }
+        for( render_state &s : states_ ) {
+            s.abandon();
+        }
+        for( shader &s : memory_shaders_ ) {
+            s.abandon();
+        }
+        for( render_state &s : memory_states_ ) {
+            s.abandon();
+        }
+    }
+    // Render states reference their fragment shader; clear states before
+    // shaders so SDL does not see a dangling reference on the clean path.
+    states_ = {};
+    memory_states_ = {};
+    shaders_ = {};
+    memory_shaders_ = {};
 }
 
 void variant_pass::probe()
@@ -600,30 +624,42 @@ SDL_GPURenderState *variant_pass::state_for( variant_kind v ) const
     return states_[static_cast<size_t>( v )].get();
 }
 
-bool variant_pass::try_begin( variant_kind v )
+variant_pass::begin_result variant_pass::try_begin( variant_kind v )
 {
+    if( abandoned_pending_rebind_ ) {
+        // Embargo raised: refuse without calling SDL until rebind.
+        return begin_result::abort_frame;
+    }
     if( reprobe_requested() ) {
         reset();
         clear_reprobe();
     }
     if( session_disabled_ ) {
         // Drop any held bind so the disabled session does not leave shader
-        // state on subsequent draws.
-        flush();
-        return false;
+        // state on subsequent draws. If flush fails the renderer is undefined
+        // -- signal abort.
+        if( !flush() ) {
+            return begin_result::abort_frame;
+        }
+        return begin_result::use_atlas;
     }
     if( !probe_attempted_ ) {
         probe();
+        if( unbind_required_ ) {
+            // probe() observed a boundary-loss probe failure and latched
+            // unbind_required_. Renderer state is undefined.
+            return begin_result::abort_frame;
+        }
     }
     if( !probed_ok_ ) {
-        return false;
+        return begin_result::use_atlas;
     }
     SDL_GPURenderState *target = state_for( v );
     SDL_GPURenderState *current = currently_bound_
                                   ? state_for( *currently_bound_ )
                                   : nullptr;
     if( target == current ) {
-        return target != nullptr;
+        return target != nullptr ? begin_result::bound : begin_result::use_atlas;
     }
     if( !SDL_SetGPURenderState( renderer_, target ) ) {
         DebugLog( D_ERROR, DC_ALL )
@@ -634,7 +670,7 @@ bool variant_pass::try_begin( variant_kind v )
         // currently_bound_ so operator== rejects the boundary, and force the
         // next flush() to call null-state even if currently_bound_ was empty.
         unbind_required_ = true;
-        return false;
+        return begin_result::abort_frame;
     }
     if( target ) {
         currently_bound_ = v;
@@ -642,7 +678,7 @@ bool variant_pass::try_begin( variant_kind v )
         currently_bound_.reset();
     }
     unbind_required_ = false;
-    return target != nullptr;
+    return target != nullptr ? begin_result::bound : begin_result::use_atlas;
 }
 
 bool variant_pass::end()
@@ -652,6 +688,10 @@ bool variant_pass::end()
 
 bool variant_pass::flush()
 {
+    if( abandoned_pending_rebind_ ) {
+        // Embargo raised: refuse without SDL. false signals the boundary loss.
+        return false;
+    }
     if( !currently_bound_ && !unbind_required_ ) {
         return true;
     }
@@ -672,57 +712,56 @@ void variant_pass::select_memory_preset( std::optional<memory_preset> preset )
     active_memory_preset_ = preset;
 }
 
-render_target_scope::render_target_scope( SDL_Renderer *renderer, SDL_Texture *target,
-        variant_pass *vp )
-    : renderer_( renderer )
+void variant_pass::release_gpu_resources()
 {
-    if( !renderer_ ) {
+    if( abandoned_pending_rebind_ ) {
+        // Embargo already raised; nothing to do until rebind.
         return;
     }
-    prior_target_ = SDL_GetRenderTarget( renderer_ );
-    if( vp && !vp->flush() ) {
-        return;
+    // flush() returns false on an undefined bind; abandon the handles in that
+    // case rather than let their destructors touch a still-referenced resource.
+    bool flushed = true;
+    if( currently_bound_ || unbind_required_ ) {
+        flushed = flush();
     }
-    if( !SDL_SetRenderTarget( renderer_, target ) ) {
-        DebugLog( D_ERROR, DC_ALL )
-                << "cata_shader::render_target_scope: SDL_SetRenderTarget failed: "
-                << SDL_GetError();
-        return;
+    clear_state_arrays( !flushed );
+    currently_bound_.reset();
+    probe_attempted_ = false;
+    probed_ok_ = false;
+    // active_memory_preset_ is logical config, not a GPU handle; keep it.
+    if( flushed ) {
+        unbind_required_ = false;
+        session_disabled_ = false;
+    } else {
+        // Abandoned: raise the embargo so later calls refuse SDL (see header).
+        abandoned_pending_rebind_ = true;
     }
-    valid_ = true;
 }
 
-bool render_target_scope::restore()
+void variant_pass::force_abandon_gpu_resources()
 {
-    if( restored_ ) {
-        return true;
-    }
-    if( !renderer_ || !valid_ ) {
-        return false;
-    }
-    if( !SDL_SetRenderTarget( renderer_, prior_target_ ) ) {
-        DebugLog( D_ERROR, DC_ALL )
-                << "cata_shader::render_target_scope::restore: SDL_SetRenderTarget failed: "
-                << SDL_GetError();
-        return false;
-    }
-    restored_ = true;
-    return true;
+    clear_state_arrays( true );
+    currently_bound_.reset();
+    probe_attempted_ = false;
+    probed_ok_ = false;
+    session_disabled_ = true;
+    unbind_required_ = false;
+    abandoned_pending_rebind_ = true;
 }
 
-render_target_scope::~render_target_scope()
+void variant_pass::rebind_renderer( SDL_Renderer *renderer )
 {
-    if( restored_ || !valid_ ) {
-        return;
-    }
-    // Fallback for early exit. Mark restored regardless to avoid
-    // retry loops; double failure means the invariant is lost.
-    restored_ = true;
-    if( !SDL_SetRenderTarget( renderer_, prior_target_ ) ) {
-        DebugLog( D_ERROR, DC_ALL )
-                << "cata_shader::~render_target_scope: SDL_SetRenderTarget failed: "
-                << SDL_GetError();
-    }
+    // Do NOT call release_gpu_resources() here: its flush() would touch
+    // renderer_, already destroyed on a LOST recovery. Callers release against
+    // the OLD renderer first, so the arrays are already empty by now.
+    clear_state_arrays( true );
+    currently_bound_.reset();
+    unbind_required_ = false;
+    probe_attempted_ = false;
+    probed_ok_ = false;
+    session_disabled_ = false;
+    abandoned_pending_rebind_ = false;
+    renderer_ = renderer;
 }
 
 } // namespace cata_shader

--- a/src/cata_shader.h
+++ b/src/cata_shader.h
@@ -170,9 +170,8 @@ class render_state
 //   - select_memory_preset(p) picks which memory shader try_begin(MEMORY)
 //     binds. Nullopt disables the MEMORY shader path so callers fall back
 //     to the memory atlas (used for the custom MEMORY_MAP_MODE preset).
-//   - try_begin(v) returns true iff v has an active shader path AND the
-//     state is bound. NORMAL or unsupported MEMORY preset returns false and
-//     ensures no shader stays bound from a previous draw.
+//   - try_begin(v) binds the shader for v and returns a begin_result (see
+//     the enum doc). Atlas-fallback paths clear any prior bind first.
 //   - end() is a no-op; bind persists for the next sprite.
 //   - flush() unbinds any held state. Call once per frame after the last
 //     sprite draw so ImGui or the next-frame draws see no leaked bind.
@@ -194,7 +193,19 @@ class variant_pass
             return probed_ok_ && !session_disabled_;
         }
 
-        bool try_begin( variant_kind v );
+        // try_begin outcome. bound: shader path active, draw with it.
+        // use_atlas: safe fallback (NORMAL, unsupported MEMORY preset, clean
+        // session_disabled) -- renderer valid, fall through to the pre-baked
+        // atlas. abort_frame: a failed SDL_SetGPURenderState left the renderer
+        // undefined -- caller MUST stop rendering; the frame aborts and the
+        // coordinator rebuilds.
+        enum class begin_result {
+            bound,
+            use_atlas,
+            abort_frame,
+        };
+
+        begin_result try_begin( variant_kind v );
         bool end();
 
         // Returns false on SDL_SetGPURenderState(NULL) failure; pass
@@ -204,9 +215,28 @@ class variant_pass
 
         void select_memory_preset( std::optional<memory_preset> preset );
 
+        // Drop all GPU resources, flushing held state first; idempotent. On
+        // flush failure the handles are abandoned and the embargo raised (see
+        // abandoned_pending_rebind_). Run before the owning renderer dies.
+        void release_gpu_resources();
+
+        // Abandon every handle without calling SDL: intentional leak for when
+        // even flush() is unsafe (dangling renderer), reclaimed at process
+        // exit. Raises the embargo. Prefer release_gpu_resources() otherwise.
+        void force_abandon_gpu_resources();
+
+        // Adopt a freshly created renderer after LOST/DEVICE_RESET, reset local
+        // boundary state, and clear the embargo so the next try_begin re-probes.
+        // Never skips on pointer equality: DEVICE_RESET keeps the pointer.
+        void rebind_renderer( SDL_Renderer *renderer );
+
     private:
         void probe();
         void reset();
+        // Drop shader + render-state slots. abandon_handles=true skips SDL
+        // destroy on each (renderer undefined or about to die); false runs the
+        // destructors normally to release the SDL handles.
+        void clear_state_arrays( bool abandon_handles );
         SDL_GPURenderState *state_for( variant_kind v ) const;
 
         SDL_Renderer *renderer_ = nullptr;
@@ -221,42 +251,15 @@ class variant_pass
         // a probe boundary loss): next flush() must call null-state regardless
         // of currently_bound_ to clear whatever the renderer holds.
         bool unbind_required_ = false;
+        // The "embargo": while true, every SDL-touching method (flush,
+        // try_begin, release_gpu_resources, dtor) refuses without calling SDL,
+        // the renderer being presumed dangling/unsafe. Raised by
+        // force_abandon_gpu_resources() and by release_gpu_resources() on flush
+        // failure; cleared by rebind_renderer().
+        bool abandoned_pending_rebind_ = false;
         bool probe_attempted_ = false;
         bool probed_ok_ = false;
         bool session_disabled_ = false;
-};
-
-// RAII guard for SDL_SetRenderTarget. Flushes variant_pass before
-// switching targets - SDL3 has been observed to crash inside
-// SDL_SetRenderTarget when variant GPU state is bound across the
-// transition. Pass nullptr if no variant_pass is involved.
-// Caller checks is_valid() before drawing and restore() before
-// continuing on the prior target.
-class render_target_scope
-{
-    public:
-        render_target_scope( SDL_Renderer *renderer, SDL_Texture *target,
-                             variant_pass *vp );
-        ~render_target_scope();
-
-        render_target_scope( const render_target_scope & ) = delete;
-        render_target_scope &operator=( const render_target_scope & ) = delete;
-        render_target_scope( render_target_scope && ) = delete;
-        render_target_scope &operator=( render_target_scope && ) = delete;
-
-        bool is_valid() const {
-            return valid_;
-        }
-
-        // Returns false if the scope is invalid or SDL_SetRenderTarget
-        // fails; failure leaves restored_ unset so the destructor retries.
-        bool restore();
-
-    private:
-        SDL_Renderer *renderer_ = nullptr;
-        SDL_Texture *prior_target_ = nullptr;
-        bool valid_ = false;
-        bool restored_ = false;
 };
 
 } // namespace cata_shader

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1482,6 +1482,11 @@ bool cata_tiles::has_blinking_minimap() const
     return minimap->has_blinking_beacons();
 }
 
+void cata_tiles::reset_minimap()
+{
+    minimap->reset();
+}
+
 point cata_tiles::get_window_base_tile_counts(
     const point &size, const point &tile_size, const bool iso )
 {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1487,6 +1487,13 @@ void cata_tiles::reset_minimap()
     minimap->reset();
 }
 
+void cata_tiles::reset_tint_mask()
+{
+    tint_mask_tex.reset();
+    tint_mask_w = 0;
+    tint_mask_h = 0;
+}
+
 point cata_tiles::get_window_base_tile_counts(
     const point &size, const point &tile_size, const bool iso )
 {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -248,10 +248,6 @@ cata_tiles::cata_tiles( const SDL_Renderer_Ptr &renderer, const GeometryRenderer
 {
     cata_assert( renderer );
 
-#if SDL_MAJOR_VERSION >= 3
-    m_variant_pass = std::make_unique<cata_shader::variant_pass>( renderer.get() );
-#endif
-
     tile_height = 0;
     tile_width = 0;
 
@@ -279,8 +275,8 @@ void cata_tiles::on_options_changed()
     memory_map_mode = get_option <std::string>( "MEMORY_MAP_MODE" );
 
 #if SDL_MAJOR_VERSION >= 3
-    if( m_variant_pass ) {
-        m_variant_pass->select_memory_preset(
+    if( cata_shader::variant_pass *vp = get_shared_variant_pass() ) {
+        vp->select_memory_preset(
             cata_shader::memory_preset_from_option_value( memory_map_mode ) );
     }
 #endif
@@ -1132,7 +1128,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                         {
                             scoped_render_target mask_scope( renderer, tint_mask_tex.get()
 #if SDL_MAJOR_VERSION >= 3
-                                                             , m_variant_pass.get()
+                                                             , get_shared_variant_pass()
 #endif
                                                            );
                             if( !mask_scope.is_valid() ) {
@@ -1458,11 +1454,13 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
     // Unbind any GPU render state held across sprite batches so ImGui or the
     // next-frame draws see clean state. On flush failure the bind boundary
     // forbids a target switch: abort the unbind, latch recovery, and throw.
-    if( m_variant_pass && !m_variant_pass->flush() ) {
-        draw_scope.abort_unbind();
-        display_buffer_scope_signal_recovery_required();
-        throw std::runtime_error(
-            "cata_tiles::draw: variant_pass flush failed at end of frame; renderer in undefined state" );
+    if( cata_shader::variant_pass *vp = get_shared_variant_pass() ) {
+        if( !vp->flush() ) {
+            draw_scope.abort_unbind();
+            display_buffer_scope_signal_recovery_required();
+            throw std::runtime_error(
+                "cata_tiles::draw: variant_pass flush failed at end of frame; renderer in undefined state" );
+        }
     }
 #endif
 }
@@ -2557,15 +2555,18 @@ bool cata_tiles::draw_sprite_at(
     // Try the GPU shader variant first. On success the main atlas drives
     // the render and the variant transform happens per-pixel in the
     // fragment shader. On unsupported variant (NORMAL, custom MEMORY
-    // preset, late session-disable) try_begin returns false and the
-    // fallthrough below picks the matching pre-baked variant atlas.
-    if( m_variant_pass ) {
+    // preset, clean session-disable) try_begin reports use_atlas; abort_frame
+    // means undefined shader state -- latch recovery and throw.
+    if( cata_shader::variant_pass *vp = get_shared_variant_pass() ) {
         const cata_shader::variant_kind v =
             compute_variant_kind( rp.ll, rp.use_night_vision_tiles );
-        // Call try_begin for every variant including NORMAL. State-cached
-        // bind stays put across same-variant runs; NORMAL clears any prior
-        // shader state so it doesn't leak onto the next sprite.
-        shader_bound = m_variant_pass->try_begin( v );
+        const cata_shader::variant_pass::begin_result br = vp->try_begin( v );
+        if( br == cata_shader::variant_pass::begin_result::abort_frame ) {
+            display_buffer_scope_signal_recovery_required();
+            throw std::runtime_error(
+                "cata_tiles::draw_sprite_at: variant_pass left renderer in undefined shader-state bind" );
+        }
+        shader_bound = ( br == cata_shader::variant_pass::begin_result::bound );
     }
 #endif
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -955,6 +955,10 @@ class cata_tiles
         // they rebuild against the live renderer on the next draw.
         void reset_minimap();
 
+        // Drop the scratch silhouette mask target so the next tinted ortho
+        // draw reallocates it against the live renderer.
+        void reset_tint_mask();
+
         // Draw caches persist data between draws and are only recalculated when dirty
         void set_draw_cache_dirty();
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -830,11 +830,8 @@ class cata_tiles
         tileset_cache &cache;
 
 #if SDL_MAJOR_VERSION >= 3
-        // GPU shader variant brackets per-sprite draws under USE_SDL3.
-        // Constructed eagerly in the cata_tiles constructor; the
-        // SDL_GPURenderState pipeline itself is lazy-probed on the first
-        // try_begin call.
-        std::unique_ptr<cata_shader::variant_pass> m_variant_pass;
+        // Variant pass is process-lifetime, owned alongside the renderer.
+        // Consumers reach it via get_shared_variant_pass in sdltiles.h.
 #endif
         std::shared_ptr<const tileset> tileset_ptr;
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -951,6 +951,10 @@ class cata_tiles
         // True if the minimap rendered critters with blinking beacons.
         bool has_blinking_minimap() const;
 
+        // Drop the pixel minimap's renderer-owned resources and cache so
+        // they rebuild against the live renderer on the next draw.
+        void reset_minimap();
+
         // Draw caches persist data between draws and are only recalculated when dirty
         void set_draw_cache_dirty();
 

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -267,7 +267,11 @@ void pixel_minimap::flush_cache_updates()
             continue;
         }
 
-        scoped_render_target chunk_scope( renderer, mcp.second.chunk_tex.get() );
+        scoped_render_target chunk_scope( renderer, mcp.second.chunk_tex.get()
+#if SDL_MAJOR_VERSION >= 3
+                                          , get_shared_variant_pass()
+#endif
+                                        );
         if( !chunk_scope.is_valid() ) {
             if( !chunk_scope.boundary_intact() ) {
                 // Boundary lost: latch so the enclosing dtor skips detach.
@@ -462,7 +466,11 @@ void pixel_minimap::reset()
 
 void pixel_minimap::render( const tripoint_bub_ms &center )
 {
-    scoped_render_target main_scope( renderer, main_tex.get() );
+    scoped_render_target main_scope( renderer, main_tex.get()
+#if SDL_MAJOR_VERSION >= 3
+                                     , get_shared_variant_pass()
+#endif
+                                   );
     if( !main_scope.is_valid() ) {
         if( !main_scope.boundary_intact() ) {
             display_buffer_scope_signal_recovery_required();

--- a/src/pixel_minimap.h
+++ b/src/pixel_minimap.h
@@ -43,6 +43,11 @@ class pixel_minimap
 
         void draw( const SDL_Rect &screen_rect, const tripoint_bub_ms &center );
 
+        // Drop every renderer-owned GPU resource (main texture, texture
+        // pool) along with the projector and submap cache. All of it
+        // rebuilds lazily on the next draw().
+        void reset();
+
         // True if the last draw() rendered any critters with blinking beacons.
         bool has_blinking_beacons() const {
             return has_blinking_beacons_;
@@ -54,7 +59,6 @@ class pixel_minimap
         submap_cache &get_cache_at( const tripoint_abs_sm &abs_sm_pos );
 
         void set_screen_rect( const SDL_Rect &screen_rect );
-        void reset();
 
         void draw_beacon( const SDL_Rect &rect, const SDL_Color &color );
 

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -393,7 +393,7 @@ BitmapFont::BitmapFont(
     const int w, const int h,
     const palette_array &palette,
     const std::string &typeface_path )
-    : Font( w, h, palette )
+    : Font( w, h, palette ), typeface_path( typeface_path ), source_pixel_format( pixel_format )
 {
     dbg( D_INFO ) << "Loading bitmap font [" + typeface_path + "].";
     SDL_Surface_Ptr asciiload = load_image( typeface_path.c_str() );
@@ -624,6 +624,27 @@ void FontFallbackList::OutputChar( const SDL_Renderer_Ptr &renderer,
         }
     }
     ( *cached->second )->OutputChar( renderer, geometry, ch, p, color, opacity );
+}
+
+void CachedTTFFont::release_gpu_resources()
+{
+    glyph_cache_map.clear();
+}
+
+void BitmapFont::release_gpu_resources()
+{
+    for( SDL_Texture_Ptr &tex : ascii ) {
+        tex.reset();
+    }
+}
+
+void FontFallbackList::release_gpu_resources()
+{
+    for( std::unique_ptr<Font> &child : fonts ) {
+        if( child ) {
+            child->release_gpu_resources();
+        }
+    }
 }
 
 #endif // TILES

--- a/src/sdl_font.h
+++ b/src/sdl_font.h
@@ -52,6 +52,11 @@ class Font
                                        const GeometryRenderer_Ptr &geometry,
                                        unsigned char line_id, const point &p, unsigned char color ) const;
 
+        /// Drop any GPU-side glyph textures owned by this font. Subclasses
+        /// override to clear their own atlases or caches. Path and metadata
+        /// kept so the font can be rebuilt against a fresh renderer.
+        virtual void release_gpu_resources() {}
+
         /// Try to load a font by typeface (Bitmap or Truetype).
         static std::unique_ptr<Font> load_font(
             SDL_Renderer_Ptr &renderer, Uint32 pixel_format,
@@ -84,6 +89,7 @@ class CachedTTFFont : public Font
                          const std::string &ch,
                          const point &p,
                          unsigned char color, float opacity = 1.0f ) override;
+        void release_gpu_resources() override;
 
     protected:
         SDL_Texture_Ptr create_glyph( const SDL_Renderer_Ptr &renderer, const std::string &ch,
@@ -143,9 +149,13 @@ class BitmapFont : public Font
                          unsigned char color, float opacity = 1.0f );
         void draw_ascii_lines( const SDL_Renderer_Ptr &renderer, const GeometryRenderer_Ptr &geometry,
                                unsigned char line_id, const point &p, unsigned char color ) const override;
+        void release_gpu_resources() override;
     protected:
         std::array<SDL_Texture_Ptr, color_loader<SDL_Color>::COLOR_NAMES_COUNT> ascii;
         int tilewidth;
+        // Retained for atlas rebuild after a GPU device-texture reset.
+        std::string typeface_path;
+        Uint32 source_pixel_format = 0;
 };
 
 /// Multiple fonts container. Tries to render character using font on the top,
@@ -166,6 +176,7 @@ class FontFallbackList : public Font
                          const std::string &ch,
                          const point &p,
                          unsigned char color, float opacity = 1.0f ) override;
+        void release_gpu_resources() override;
     protected:
         std::vector<std::unique_ptr<Font>> fonts;
         std::map<std::string, std::vector<std::unique_ptr<Font>>::iterator> glyph_font;

--- a/src/sdl_geometry.cpp
+++ b/src/sdl_geometry.cpp
@@ -38,6 +38,13 @@ void DefaultGeometryRenderer::rect( const SDL_Renderer_Ptr &renderer, const SDL_
 
 ColorModulatedGeometryRenderer::ColorModulatedGeometryRenderer( const SDL_Renderer_Ptr &renderer )
 {
+    build_texture( renderer );
+}
+
+void ColorModulatedGeometryRenderer::build_texture( const SDL_Renderer_Ptr &renderer )
+{
+    tex.reset();
+
     SDL_Surface_Ptr alt_surf;
     try {
         alt_surf = create_surface_32( 1, 1 );
@@ -58,8 +65,18 @@ ColorModulatedGeometryRenderer::ColorModulatedGeometryRenderer( const SDL_Render
     if( !tex_enable ) {
         tex.reset();
     }
-    DebugLog( D_INFO, DC_ALL ) << "ColorModulatedGeometryRenderer constructor() = " <<
+    DebugLog( D_INFO, DC_ALL ) << "ColorModulatedGeometryRenderer build_texture() = " <<
                                ( tex_enable ? "SUCCESS" : "FAIL" ) << ". tex_enable = " << tex_enable;
+}
+
+void ColorModulatedGeometryRenderer::release_gpu_resources()
+{
+    tex.reset();
+}
+
+void ColorModulatedGeometryRenderer::rebuild_for_renderer( const SDL_Renderer_Ptr &renderer )
+{
+    build_texture( renderer );
 }
 
 void ColorModulatedGeometryRenderer::rect( const SDL_Renderer_Ptr &renderer, const SDL_Rect &rect,

--- a/src/sdl_geometry.h
+++ b/src/sdl_geometry.h
@@ -19,6 +19,16 @@ class GeometryRenderer
         virtual void rect( const SDL_Renderer_Ptr &renderer, const SDL_Rect &rect,
                            const SDL_Color &color ) const = 0;
 
+        /// Drop any renderer-owned GPU resources. Safe to call repeatedly.
+        /// Default is a no-op for renderers that hold no GPU handles.
+        virtual void release_gpu_resources() {}
+
+        /// Recreate renderer-owned GPU resources against `renderer` after a
+        /// device reset or renderer recreation. Default is a no-op.
+        virtual void rebuild_for_renderer( const SDL_Renderer_Ptr &renderer ) {
+            ( void )renderer;
+        }
+
         /// Renders a point+width+height defined rectangle with given color.
         void rect( const SDL_Renderer_Ptr &renderer, const point &pos, int width, int height,
                    const SDL_Color &color ) const;
@@ -50,7 +60,15 @@ class ColorModulatedGeometryRenderer: public DefaultGeometryRenderer
 
         void rect( const SDL_Renderer_Ptr &renderer, const SDL_Rect &rect,
                    const SDL_Color &color ) const override;
+
+        void release_gpu_resources() override;
+        void rebuild_for_renderer( const SDL_Renderer_Ptr &renderer ) override;
     private:
+        // Build the 1x1 white modulation texture against `renderer` and
+        // verify color modulation is supported; leaves tex null on failure
+        // so rect() falls back to DefaultGeometryRenderer.
+        void build_texture( const SDL_Renderer_Ptr &renderer );
+
         SDL_Texture_Ptr tex;
 };
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1,6 +1,9 @@
 #include "cursesdef.h" // IWYU pragma: associated
 #include "sdltiles.h" // IWYU pragma: associated
 
+#if SDL_MAJOR_VERSION >= 3
+#include "cata_shader.h"
+#endif
 #include "cuboid_rectangle.h"
 #include "point.h"
 
@@ -140,6 +143,9 @@ static SDL_Renderer_Ptr renderer;
 static Uint32 pixel_format = SDL_PIXELFORMAT_UNKNOWN;
 static SDL_Texture_Ptr display_buffer;
 static GeometryRenderer_Ptr geometry;
+#if SDL_MAJOR_VERSION >= 3
+static std::unique_ptr<cata_shader::variant_pass> shared_variant_pass;
+#endif
 #if defined(__ANDROID__)
 static SDL_Texture_Ptr touch_joystick;
 #endif
@@ -280,8 +286,13 @@ static bool SetupRenderTarget()
     if( printErrorIf( !staged, "Failed to create window buffer" ) ) {
         return false;
     }
+#if SDL_MAJOR_VERSION >= 3
+    cata_shader::variant_pass *vp = get_shared_variant_pass();
+#else
+    cata_shader::variant_pass *vp = nullptr;
+#endif
     {
-        const bind_result r = permanent_render_target_bind( renderer, staged.get() );
+        const bind_result r = permanent_render_target_bind( renderer, staged.get(), vp );
         if( r == bind_result::failed_in_switch ) {
             // Boundary undefined: quarantine staged so its dtor cannot race the
             // active target. The previous display_buffer is untouched.
@@ -289,13 +300,13 @@ static bool SetupRenderTarget()
             return false;
         }
         if( r != bind_result::ok ) {
-            // Refused before binding; staged was never bound, drop it.
+            // variant_pass refused before binding; staged never bound, drop it.
             return false;
         }
     }
     ClearScreen();
     {
-        const bind_result r = permanent_render_target_bind( renderer, nullptr );
+        const bind_result r = permanent_render_target_bind( renderer, nullptr, vp );
         if( r == bind_result::failed_in_switch ) {
             // Detach failed: staged is still the active target, so quarantine
             // rather than destroy.
@@ -600,6 +611,10 @@ static void WinCreate()
     }
 #endif
 
+#if SDL_MAJOR_VERSION >= 3
+    shared_variant_pass = std::make_unique<cata_shader::variant_pass>( renderer.get() );
+#endif
+
     imclient = std::make_unique<cataimgui::client>( renderer, window, geometry );
 }
 
@@ -613,6 +628,9 @@ static void WinDestroy()
     tilecontext.reset();
     gamepad::quit();
     geometry.reset();
+#if SDL_MAJOR_VERSION >= 3
+    shared_variant_pass.reset();
+#endif
     display_buffer.reset();
     renderer.reset();
     ::window.reset();
@@ -740,15 +758,20 @@ void refresh_display()
     // Present from the window target. The buffer stays unbound; draw paths
     // re-bind it next frame. Go through the pass-aware helper so variant_pass
     // can flush before the switch.
+#if SDL_MAJOR_VERSION >= 3
+    cata_shader::variant_pass *present_vp = get_shared_variant_pass();
+#else
+    cata_shader::variant_pass *present_vp = nullptr;
+#endif
     {
-        const bind_result r = permanent_render_target_bind( renderer, nullptr );
+        const bind_result r = permanent_render_target_bind( renderer, nullptr, present_vp );
         if( r == bind_result::failed_in_switch ) {
             // Helper already latched; signal again defensively and skip present.
             display_buffer_scope_signal_recovery_required();
             return;
         }
         if( r != bind_result::ok ) {
-            // Refused; skip this frame.
+            // variant_pass refused; skip this frame.
             return;
         }
     }
@@ -895,6 +918,13 @@ void convert_event_to_display_buffer_coords( SDL_Event *event )
     }
 }
 
+#if SDL_MAJOR_VERSION >= 3
+cata_shader::variant_pass *get_shared_variant_pass()
+{
+    return shared_variant_pass.get();
+}
+#endif
+
 namespace
 {
 // Draw-scope state. depth counts nested scopes. aborted lets an inner
@@ -962,7 +992,12 @@ display_buffer_draw_scope::display_buffer_draw_scope()
         // rebuilds the renderer.
         return;
     }
-    const bind_result r = permanent_render_target_bind( renderer, display_buffer.get() );
+#if SDL_MAJOR_VERSION >= 3
+    cata_shader::variant_pass *vp = get_shared_variant_pass();
+#else
+    cata_shader::variant_pass *vp = nullptr;
+#endif
+    const bind_result r = permanent_render_target_bind( renderer, display_buffer.get(), vp );
     if( r == bind_result::failed_in_switch ) {
         // Boundary undefined: latch recovery so this and later scopes refuse.
         display_buffer_scope_recovery_required = true;
@@ -970,7 +1005,7 @@ display_buffer_draw_scope::display_buffer_draw_scope()
         return;
     }
     if( r != bind_result::ok ) {
-        // Refused, boundary intact: skip the draw but do not latch recovery.
+        // variant_pass refused, boundary intact: skip the draw, do not latch.
         display_buffer_scope_invalid = true;
         return;
     }
@@ -1001,7 +1036,12 @@ display_buffer_draw_scope::~display_buffer_draw_scope()
         // -- another switch on the undefined renderer would deepen corruption.
         return;
     }
-    if( permanent_render_target_bind( renderer, nullptr )
+#if SDL_MAJOR_VERSION >= 3
+    cata_shader::variant_pass *vp = get_shared_variant_pass();
+#else
+    cata_shader::variant_pass *vp = nullptr;
+#endif
+    if( permanent_render_target_bind( renderer, nullptr, vp )
         == bind_result::failed_in_switch ) {
         // Boundary undefined: latch so later scopes refuse until rebuild.
         display_buffer_scope_recovery_required = true;
@@ -1685,11 +1725,13 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     // Flush failure means the shader bind boundary forbids a target switch:
     // abort the scope's unbind, latch recovery, and throw to unwind
     // curses_drawwindow instead of drawing terrain overlays on a dead renderer.
-    if( m_variant_pass && !m_variant_pass->flush() ) {
-        draw_scope.abort_unbind();
-        display_buffer_scope_signal_recovery_required();
-        throw std::runtime_error(
-            "cata_tiles::draw_om: variant_pass flush failed at end of frame; renderer in undefined state" );
+    if( cata_shader::variant_pass *vp = get_shared_variant_pass() ) {
+        if( !vp->flush() ) {
+            draw_scope.abort_unbind();
+            display_buffer_scope_signal_recovery_required();
+            throw std::runtime_error(
+                "cata_tiles::draw_om: variant_pass flush failed at end of frame; renderer in undefined state" );
+        }
     }
 #endif
 }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -275,14 +275,32 @@ gpu_handle_graveyard &setup_target_quarantine()
 }
 } // namespace
 
+// Terminal-sized intermediate buffer dimensions: logical window size over
+// scaling_factor, independent of backing-store pixels.
+static point compute_display_buffer_dims()
+{
+    return point{ WindowWidth / scaling_factor, WindowHeight / scaling_factor };
+}
+
+// Backing-store pixel dimensions of the window, tracked independently of the
+// logical size so a DPI-only change leaves the display buffer alone.
+[[maybe_unused]] static point compute_drawable_dims()
+{
+    int pw = 0;
+    int ph = 0;
+    GetWindowSizeInPixels( ::window.get(), &pw, &ph );
+    return point{ pw, ph };
+}
+
 static bool SetupRenderTarget()
 {
     SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
     // Stage into a local so a failed bind leaves the previous display_buffer
     // intact rather than orphaning a still-referenced target.
+    const point buffer_dims = compute_display_buffer_dims();
     SDL_Texture_Ptr staged = CreateTexture( renderer, SDL_PIXELFORMAT_ARGB8888,
-                                            SDL_TEXTUREACCESS_TARGET, WindowWidth / scaling_factor,
-                                            WindowHeight / scaling_factor );
+                                            SDL_TEXTUREACCESS_TARGET, buffer_dims.x,
+                                            buffer_dims.y );
     if( printErrorIf( !staged, "Failed to create window buffer" ) ) {
         return false;
     }
@@ -382,6 +400,57 @@ static bool only_spirv_shader_artifacts_present()
     return any_spv;
 }
 #endif
+
+// Create an SDL renderer for the window with no render target. software picks
+// the software backend (renderer_name ignored), else accelerated. Null on
+// failure. Deferring the target lets recreation rebind variant_pass first.
+static SDL_Renderer_Ptr create_game_renderer( const std::string &renderer_name, bool software )
+{
+    if( software ) {
+        return CreateRenderer( ::window, nullptr, true, false );
+    }
+    return CreateRenderer( ::window, renderer_name.c_str(), false, true );
+}
+
+// Derive renderer-dependent backend state from the live renderer. Re-run
+// after any renderer (re)creation so a replacement cannot inherit a stale
+// direct3d_mode from the prior renderer choice.
+static void detect_renderer_backend()
+{
+#if SDL_MAJOR_VERSION >= 3
+    direct3d_mode = false;
+    const SDL_PropertiesID props = SDL_GetRendererProperties( renderer.get() );
+    const char *actual_name = props != 0
+                              ? SDL_GetStringProperty( props, SDL_PROP_RENDERER_NAME_STRING, "" )
+                              : "";
+    dbg( D_INFO ) << "SDL renderer in use: " << ( actual_name ? actual_name : "unknown" );
+    if( actual_name && std::string( actual_name ).find( "direct3d" ) != std::string::npos ) {
+        direct3d_mode = true;
+    }
+#endif
+}
+
+// Pick the geometry renderer matching the live renderer's capabilities:
+// color-modulated textures need an accelerated renderer, software falls
+// back to plain RenderFillRect.
+static void rebuild_geometry_strategy( bool software_renderer )
+{
+    DebugLog( D_INFO, DC_ALL ) << "USE_COLOR_MODULATED_TEXTURES is set to " <<
+                               get_option<bool>( "USE_COLOR_MODULATED_TEXTURES" );
+#if SDL_MAJOR_VERSION >= 3
+    ( void )software_renderer;
+    // SDL3 batches RenderFillRect efficiently and the modulated texture path
+    // blends differently from a plain fill (it breaks the per-frame clear), so
+    // the saved option value is ignored and the default renderer is always used.
+    geometry = std::make_unique<DefaultGeometryRenderer>();
+#else
+    if( get_option<bool>( "USE_COLOR_MODULATED_TEXTURES" ) && !software_renderer ) {
+        geometry = std::make_unique<ColorModulatedGeometryRenderer>( renderer );
+    } else {
+        geometry = std::make_unique<DefaultGeometryRenderer>();
+    }
+#endif
+}
 
 //Registers, creates, and shows the Window!!
 static void WinCreate()
@@ -526,7 +595,7 @@ static void WinCreate()
     if( !software_renderer ) {
         dbg( D_INFO ) << "Attempting to initialize accelerated SDL renderer.";
 
-        renderer = CreateRenderer( ::window, renderer_name.c_str(), false, true );
+        renderer = create_game_renderer( renderer_name, false );
         if( printErrorIf( !renderer,
                           "Failed to initialize accelerated renderer, falling back to software rendering" ) ) {
             software_renderer = true;
@@ -550,27 +619,13 @@ static void WinCreate()
             SDL_SetHint( SDL_HINT_FRAMEBUFFER_ACCELERATION, "1" );
         }
 #endif
-        renderer = CreateRenderer( ::window, nullptr, true, false );
+        renderer = create_game_renderer( {}, true );
         throwErrorIf( !renderer, "Failed to initialize software renderer" );
         throwErrorIf( !SetupRenderTarget(),
                       "Failed to initialize display buffer under software rendering, unable to continue." );
     }
 
-#if SDL_MAJOR_VERSION >= 3
-    {
-        // Reset before runtime detection so renderer recreation cannot
-        // leave stale direct3d_mode set from a prior renderer choice.
-        direct3d_mode = false;
-        const SDL_PropertiesID props = SDL_GetRendererProperties( renderer.get() );
-        const char *actual_name = props != 0
-                                  ? SDL_GetStringProperty( props, SDL_PROP_RENDERER_NAME_STRING, "" )
-                                  : "";
-        dbg( D_INFO ) << "SDL renderer in use: " << ( actual_name ? actual_name : "unknown" );
-        if( actual_name && std::string( actual_name ).find( "direct3d" ) != std::string::npos ) {
-            direct3d_mode = true;
-        }
-    }
-#endif
+    detect_renderer_backend();
 
     SetWindowMinimumSize( ::window.get(), fontwidth * EVEN_MINIMUM_TERM_WIDTH * scaling_factor,
                           fontheight * EVEN_MINIMUM_TERM_HEIGHT * scaling_factor );
@@ -595,21 +650,7 @@ static void WinCreate()
     // Set up audio mixer.
     init_sound();
 
-    DebugLog( D_INFO, DC_ALL ) << "USE_COLOR_MODULATED_TEXTURES is set to " <<
-                               get_option<bool>( "USE_COLOR_MODULATED_TEXTURES" );
-    //initialize the alternate rectangle texture for replacing SDL_RenderFillRect
-#if SDL_MAJOR_VERSION >= 3
-    // SDL3 batches RenderFillRect efficiently and the modulated texture path
-    // blends differently from a plain fill (it breaks the per-frame clear), so
-    // the saved option value is ignored and the default renderer is always used.
-    geometry = std::make_unique<DefaultGeometryRenderer>();
-#else
-    if( get_option<bool>( "USE_COLOR_MODULATED_TEXTURES" ) && !software_renderer ) {
-        geometry = std::make_unique<ColorModulatedGeometryRenderer>( renderer );
-    } else {
-        geometry = std::make_unique<DefaultGeometryRenderer>();
-    }
-#endif
+    rebuild_geometry_strategy( software_renderer );
 
 #if SDL_MAJOR_VERSION >= 3
     shared_variant_pass = std::make_unique<cata_shader::variant_pass>( renderer.get() );
@@ -1739,8 +1780,8 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 static bool draw_window( Font_Ptr &font, const catacurses::window &w, const point &offset )
 {
     if( scaling_factor > 1 ) {
-        RenderSetLogicalSize( renderer, WindowWidth / scaling_factor,
-                              WindowHeight / scaling_factor );
+        const point buffer_dims = compute_display_buffer_dims();
+        RenderSetLogicalSize( renderer, buffer_dims.x, buffer_dims.y );
     }
 
     cata_cursesport::WINDOW *const win = w.get<cata_cursesport::WINDOW>();
@@ -1868,8 +1909,8 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
         return;
     }
     if( scaling_factor > 1 ) {
-        RenderSetLogicalSize( renderer, WindowWidth / scaling_factor,
-                              WindowHeight / scaling_factor );
+        const point buffer_dims = compute_display_buffer_dims();
+        RenderSetLogicalSize( renderer, buffer_dims.x, buffer_dims.y );
     }
     WINDOW *const win = w.get<WINDOW>();
     bool update = false;

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -83,6 +83,18 @@ SDL_Point window_to_display_buffer_coords( SDL_Point window_pt );
 // android shortcut overlay and virtual joystick hit-test against the window.
 void convert_event_to_display_buffer_coords( SDL_Event *event );
 
+namespace cata_shader
+{
+class variant_pass;
+} // namespace cata_shader
+
+#if SDL_MAJOR_VERSION >= 3
+// Process-lifetime variant_pass owned alongside the renderer (WinCreate to
+// WinDestroy). One shared handle so a renderer recreate updates a single pass,
+// not per-context copies.
+cata_shader::variant_pass *get_shared_variant_pass();
+#endif
+
 // True while the active scope failed to bind the buffer target. Per-scope;
 // consult before drawing so nothing paints onto an unknown SDL target.
 bool display_buffer_scope_is_invalid();


### PR DESCRIPTION
#### Summary
Infrastructure "Reset and rebind primitives for renderer-owned GPU resources"

#### Purpose of change
More SDL3 render-pipeline hardening, stacked on #87419. Rebuilding the renderer after a device reset or LOST event means first letting go of everything that hangs off the old renderer: the shader variant_pass, font glyph atlases, the geometry renderer's modulation texture, the pixel minimap, the tint mask. None of those had a way to drop their GPU handles and rebuild against a fresh renderer. This adds those primitives. Nothing calls them yet.

#### Describe the solution
variant_pass moves from a per-cata_tiles `unique_ptr` to one process-lifetime instance owned next to the renderer, reachable via `get_shared_variant_pass`. The three new primitives:

- `release_gpu_resources`: flush and drop the GPU handles.
- `force_abandon_gpu_resources`: leak them at the SDL level, for when even flush is unsafe (dangling renderer).
- `rebind_renderer`: adopt a new renderer and re-probe.

An embargo flag makes every SDL-touching method refuse once the handles are abandoned, until rebind clears it. `try_begin` now returns a three-way `begin_result` (`bound`, `use_atlas`, `abort_frame`) instead of a bool, so the draw path can tell a clean atlas fallback from an undefined-renderer abort.

Font and GeometryRenderer get release_gpu_resources (and GeometryRenderer a rebuild_for_renderer) so glyph caches and the modulation texture drop and rebuild. cata_tiles gets reset_minimap and reset_tint_mask forwarders. cataimgui's backend init/shutdown split into idempotent wrappers that track active state, so a partial teardown plus retry does not double-Init or assert on a double-Shutdown; the destructor now DestroyContext's instead of leaking the context.

WinCreate's renderer creation and dim math move into small helpers (create_game_renderer, detect_renderer_backend, rebuild_geometry_strategy, compute_display_buffer_dims) so the recovery path can reuse them instead of duplicating WinCreate.

No behavior change.

#### Describe alternatives you've considered
Keep variant_pass per-tiles-context and rebuild a copy per context on reset, but there is one renderer and one GPU pipeline, so a single shared pass is less to keep in sync. release could also just leak everything and skip the flush attempt, but that leaks GPU state on every normal reset instead of only the unsafe ones.

#### Testing
Game builds and runs, no changes.

#### Additional context
The reset and rebind primitives are dead code until the coordinator that drives them lands later in the series.