### PR TITLE
Add the renderer-resource recovery coordinator and its drain planner

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -70,6 +70,7 @@
 #include "overmap.h"
 #include "pixel_minimap.h"
 #include "scent_map.h"
+#include "sdl_renderer_recovery.h"
 #include "sdl_utils.h"
 #include "sdl_wrappers.h"
 #include "sdltiles.h"
@@ -405,7 +406,13 @@ tile_type &tileset::create_tile_type( const std::string &id, tile_type &&new_til
 void cata_tiles::load_tileset( const std::string &tileset_id, const bool precheck,
                                const bool force, const bool pump_events, const bool terrain )
 {
-    if( tileset_ptr && tileset_ptr->get_tileset_id() == tileset_id && !force ) {
+    const renderer_texture_generations gens = renderer_coordinator.texture_generations();
+    // Skip the reload only when the same tileset is already bound against the
+    // current renderer and texture generations; a generation bump from a
+    // device reset or loss invalidates the bundle and must reload.
+    if( tileset_ptr && tileset_ptr->get_tileset_id() == tileset_id && !force
+        && tileset_ptr->get_renderer_instance_generation_at_upload() == gens.instance
+        && tileset_ptr->get_gpu_textures_generation_at_upload() == gens.textures ) {
         return;
     }
     // TODO: move into clear or somewhere else.
@@ -413,7 +420,7 @@ void cata_tiles::load_tileset( const std::string &tileset_id, const bool prechec
     tileset_mutation_overlay_ordering.clear();
 
     tileset_ptr = cache.load_tileset( tileset_id, renderer, precheck, force, pump_events, terrain,
-                                      memory_map_mode, 0, 0 );
+                                      memory_map_mode, gens.instance, gens.textures );
 
     set_draw_scale( 16 );
 
@@ -4068,6 +4075,47 @@ std::shared_ptr<const tileset> tileset_cache::load_tileset( const std::string &t
         ts->set_upload_generations( current_renderer_instance_gen, current_gpu_textures_gen );
     }
     return ts;
+}
+
+void tileset_cache::release_live_atlases()
+{
+    for( auto it = tilesets_.begin(); it != tilesets_.end(); ) {
+        std::shared_ptr<tileset> ts = it->second.lock();
+        if( !ts ) {
+            it = tilesets_.erase( it );
+            continue;
+        }
+        ts->release_gpu_atlases();
+        ++it;
+    }
+}
+
+atlas_upload_interrupt tileset_cache::replay_live_atlases( const SDL_Renderer_Ptr &renderer,
+        const uint64_t renderer_instance_gen, const uint64_t gpu_textures_gen,
+        const atlas_upload_poll &poll, atlas_replay_quarantine &quarantine )
+{
+    for( auto it = tilesets_.begin(); it != tilesets_.end(); ) {
+        if( poll ) {
+            const atlas_upload_interrupt interrupt = poll();
+            if( interrupt != atlas_upload_interrupt::none ) {
+                return interrupt;
+            }
+        }
+        std::shared_ptr<tileset> ts = it->second.lock();
+        if( !ts ) {
+            it = tilesets_.erase( it );
+            continue;
+        }
+        const atlas_upload_interrupt interrupt =
+            loader::upload_atlases( *ts, renderer, ts->get_memory_map_mode_at_upload(),
+                                    ts->get_atlas_descriptors(), renderer_instance_gen,
+                                    gpu_textures_gen, false, poll, &quarantine );
+        if( interrupt != atlas_upload_interrupt::none ) {
+            return interrupt;
+        }
+        ++it;
+    }
+    return atlas_upload_interrupt::none;
 }
 
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -3,10 +3,12 @@
 #define CATA_SRC_CATA_TILES_H
 
 #include <array>
+#include <atomic>
 #include <bitset>
 #include <chrono>
 #include <cstddef>
 #include <deque>
+#include <functional>
 #include <map>
 #include <memory>
 #include <optional>
@@ -183,6 +185,50 @@ class texture
         }
 };
 
+// Reason an atlas upload was interrupted. A separate enum from the recovery
+// coordinator's severity so the tileset loader needs no coordinator header;
+// the coordinator maps these to severities. paused stops the upload so it
+// retries on foreground; the *_invalidated reasons mean a reset or device
+// loss was observed mid upload.
+enum class atlas_upload_interrupt {
+    none,
+    paused,
+    texture_resources_invalidated,
+    renderer_invalidated,
+};
+// Polled between atlas chunks. Returns the reason to stop, or none.
+using atlas_upload_poll = std::function<atlas_upload_interrupt()>;
+
+// Candidate atlas textures captured when an upload is interrupted, kept
+// alive past the pause so their destructors never run against a suspended or
+// destroyed renderer. Each batch shares one gate captured by every texture's
+// deleter: setting it suppresses SDL_DestroyTexture when the originating
+// renderer is torn down before the quarantine is drained.
+class atlas_replay_quarantine
+{
+    public:
+        using gate = gpu_handle_graveyard::gate;
+
+        struct batch {
+            gpu_handle_graveyard handles;
+            uint64_t renderer_instance_generation = 0;
+        };
+
+        void add( batch &&b );
+        bool empty() const {
+            return batches_.empty();
+        }
+        // Destroy the quarantined textures against the still-live renderer.
+        void drain_live_renderer();
+        // Release C++ ownership without SDL_DestroyTexture because the
+        // originating renderer is being destroyed; its device reclaims the
+        // GPU memory on teardown.
+        void abandon_pre_lost_renderer();
+
+    private:
+        std::vector<batch> batches_;
+};
+
 /**
  * Bundles per-tile rendering state so the draw path carries all lighting
  * decisions in one place. Future fields (light color tint, per-tile
@@ -267,6 +313,9 @@ class tileset
         // is stale and must be reuploaded before use.
         uint64_t renderer_instance_generation_at_upload = 0;
         uint64_t gpu_textures_generation_at_upload = 0;
+        // Memory-map mode the atlases were uploaded with, retained so a
+        // device-reset replay regenerates the memory tiles identically.
+        std::string memory_map_mode_at_upload;
 
         std::unordered_set<std::string> duplicate_ids;
 
@@ -363,6 +412,22 @@ class tileset
             renderer_instance_generation_at_upload = renderer_instance_gen;
             gpu_textures_generation_at_upload = gpu_textures_gen;
         }
+        const std::string &get_memory_map_mode_at_upload() const {
+            return memory_map_mode_at_upload;
+        }
+        void set_memory_map_mode_at_upload( const std::string &mode ) {
+            memory_map_mode_at_upload = mode;
+        }
+        // Drop the per-variant atlas textures. Safe to call repeatedly; the
+        // descriptors and metadata are retained for a later replay.
+        void release_gpu_atlases() {
+            tile_values.clear();
+            shadow_tile_values.clear();
+            night_tile_values.clear();
+            overexposed_tile_values.clear();
+            memory_tile_values.clear();
+            silhouette_tile_values.clear();
+        }
 
         tile_type &create_tile_type( const std::string &id, tile_type &&new_tile_type );
         const tile_type *find_tile_type( const std::string &id ) const;
@@ -429,6 +494,19 @@ class tileset_cache
                 const std::string &memory_map_mode,
                 uint64_t current_renderer_instance_gen,
                 uint64_t current_gpu_textures_gen );
+
+        // Drop the atlas textures on every live cached tileset. Called before
+        // renderer destruction so the handles are freed against the live
+        // renderer. Expired entries are pruned. Idempotent.
+        void release_live_atlases();
+
+        // Re-upload atlases over every live cached tileset against `renderer`
+        // and the given generations, replaying each bundle's descriptors and
+        // memory-map mode. poll is consulted between entries and chunks; on
+        // interrupt the upload stops, candidates quarantine, and the reason returns.
+        atlas_upload_interrupt replay_live_atlases( const SDL_Renderer_Ptr &renderer,
+                uint64_t renderer_instance_gen, uint64_t gpu_textures_gen,
+                const atlas_upload_poll &poll, atlas_replay_quarantine &quarantine );
     private:
         class loader;
 

--- a/src/cursesport.cpp
+++ b/src/cursesport.cpp
@@ -35,6 +35,12 @@
 
 catacurses::window catacurses::stdscr;
 std::array<cata_cursesport::pairs, 100> cata_cursesport::colorpairs;   //storage for pair'ed colored
+unsigned cata_cursesport::curses_render_epoch = 0;
+
+void cata_cursesport::bump_curses_render_epoch()
+{
+    ++curses_render_epoch;
+}
 
 static bool wmove_internal( const catacurses::window &win_, const point &p )
 {
@@ -174,7 +180,10 @@ void catacurses::wnoutrefresh( const window &win_ )
 {
     cata_cursesport::WINDOW *const win = win_.get<cata_cursesport::WINDOW>();
     // TODO: log win == nullptr
-    if( win != nullptr && win->draw ) {
+    // Force a redraw when the window is stale against the render epoch even if
+    // its text was not touched, so a renderer rebuild re-emits every window.
+    if( win != nullptr && ( win->draw
+                            || win->last_render_epoch != cata_cursesport::curses_render_epoch ) ) {
         cata_cursesport::curses_drawwindow( win_ );
     }
 }

--- a/src/cursesport.h
+++ b/src/cursesport.h
@@ -69,11 +69,20 @@ struct WINDOW {
     bool inuse;
     // Tracks if the window text has been changed
     bool draw;
+    // Render epoch this window was last fully drawn against. When it differs
+    // from curses_render_epoch the window is forced to redraw in full,
+    // bypassing the per-line touched skip, so a renderer rebuild re-emits
+    // every window even if its text is unchanged.
+    unsigned last_render_epoch = 0;
     point cursor;
     std::vector<curseline> line;
 };
 
 extern std::array<pairs, 100> colorpairs;
+// Bumped once after a renderer-resource recovery to force every curses
+// window to re-emit on its next refresh.
+extern unsigned curses_render_epoch;
+void bump_curses_render_epoch();
 void curses_drawwindow( const catacurses::window &win );
 
 } // namespace cata_cursesport

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -395,6 +395,11 @@ BitmapFont::BitmapFont(
     const std::string &typeface_path )
     : Font( w, h, palette ), typeface_path( typeface_path ), source_pixel_format( pixel_format )
 {
+    build_textures( renderer, pixel_format );
+}
+
+void BitmapFont::build_textures( const SDL_Renderer_Ptr &renderer, const Uint32 pixel_format )
+{
     dbg( D_INFO ) << "Loading bitmap font [" + typeface_path + "].";
     SDL_Surface_Ptr asciiload = load_image( typeface_path.c_str() );
     cata_assert( asciiload );
@@ -638,11 +643,25 @@ void BitmapFont::release_gpu_resources()
     }
 }
 
+void BitmapFont::rebuild_for_renderer( const SDL_Renderer_Ptr &renderer )
+{
+    build_textures( renderer, source_pixel_format );
+}
+
 void FontFallbackList::release_gpu_resources()
 {
     for( std::unique_ptr<Font> &child : fonts ) {
         if( child ) {
             child->release_gpu_resources();
+        }
+    }
+}
+
+void FontFallbackList::rebuild_for_renderer( const SDL_Renderer_Ptr &renderer )
+{
+    for( std::unique_ptr<Font> &child : fonts ) {
+        if( child ) {
+            child->rebuild_for_renderer( renderer );
         }
     }
 }

--- a/src/sdl_font.h
+++ b/src/sdl_font.h
@@ -57,6 +57,13 @@ class Font
         /// kept so the font can be rebuilt against a fresh renderer.
         virtual void release_gpu_resources() {}
 
+        /// Recreate GPU-side glyph textures against `renderer` after a device
+        /// reset. Default is a no-op for fonts whose glyphs repopulate lazily
+        /// on the next OutputChar (the TTF glyph cache).
+        virtual void rebuild_for_renderer( const SDL_Renderer_Ptr &renderer ) {
+            ( void )renderer;
+        }
+
         /// Try to load a font by typeface (Bitmap or Truetype).
         static std::unique_ptr<Font> load_font(
             SDL_Renderer_Ptr &renderer, Uint32 pixel_format,
@@ -150,7 +157,12 @@ class BitmapFont : public Font
         void draw_ascii_lines( const SDL_Renderer_Ptr &renderer, const GeometryRenderer_Ptr &geometry,
                                unsigned char line_id, const point &p, unsigned char color ) const override;
         void release_gpu_resources() override;
+        void rebuild_for_renderer( const SDL_Renderer_Ptr &renderer ) override;
     protected:
+        // Build the per-color glyph atlases from typeface_path against
+        // `renderer`, leaving ascii[] ready for OutputChar.
+        void build_textures( const SDL_Renderer_Ptr &renderer, Uint32 pixel_format );
+
         std::array<SDL_Texture_Ptr, color_loader<SDL_Color>::COLOR_NAMES_COUNT> ascii;
         int tilewidth;
         // Retained for atlas rebuild after a GPU device-texture reset.
@@ -177,6 +189,7 @@ class FontFallbackList : public Font
                          const point &p,
                          unsigned char color, float opacity = 1.0f ) override;
         void release_gpu_resources() override;
+        void rebuild_for_renderer( const SDL_Renderer_Ptr &renderer ) override;
     protected:
         std::vector<std::unique_ptr<Font>> fonts;
         std::map<std::string, std::vector<std::unique_ptr<Font>>::iterator> glyph_font;

--- a/src/sdl_renderer_recovery.h
+++ b/src/sdl_renderer_recovery.h
@@ -1,0 +1,199 @@
+#pragma once
+#ifndef CATA_SRC_SDL_RENDERER_RECOVERY_H
+#define CATA_SRC_SDL_RENDERER_RECOVERY_H
+
+#if defined(TILES)
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+
+#include "cata_tiles.h"
+
+// Severity of a renderer-resource recovery, ordered so the inbox can keep
+// the maximum pending level via a monotonic-max. Android foreground maps to
+// device_reset through the lifecycle epoch rather than a distinct severity.
+enum class renderer_recovery_severity : int {
+    none = 0,
+    targets_reset = 1,
+    device_reset = 2,
+    device_lost = 3,
+};
+
+enum class renderer_recovery_state {
+    bootstrapping,
+    ready,
+    recovering,
+    retry_needed,
+};
+
+// Packed into the lifecycle epoch alongside a sequence number so a
+// background-foreground-background ordering cannot be lost between the two
+// separate stores a watcher makes.
+enum class lifecycle_state : uint64_t {
+    active = 0,
+    paused = 1,
+    resumed_pending_rebuild = 2,
+};
+
+// The two generations sampled together at tileset fetch time so the cache
+// can reject a bundle uploaded against a since-invalidated renderer or
+// device-texture epoch.
+struct renderer_texture_generations {
+    uint64_t instance;
+    uint64_t textures;
+};
+
+// Outcome of a recovery recipe. restart_required means the recipe bailed
+// before any destructive teardown (e.g. an unsafe unbind) and the drain
+// should re-claim work at restart_severity without bumping generations.
+enum class recipe_outcome {
+    success,
+    failure,
+    restart_required,
+};
+struct recipe_result {
+    recipe_outcome outcome;
+    renderer_recovery_severity restart_severity = renderer_recovery_severity::none;
+};
+
+// SDL-free state machine that owns the drain transition policy: lifecycle epoch
+// pack/unpack, severity coalesce, the resize-after-recovery ordering, the
+// post-success seq-CAS decision, and retry persistence. The coordinator owns the
+// atomic inbox, the SDL recipes, and the generations; drain_pending() is a thin
+// driver that asks the planner for the next action, performs that one side
+// effect (recipe, resize, inbox read, seq-CAS), and feeds the result back. The
+// policy lives here so the coalesce / seq-CAS / restart / resize branches are
+// unit-testable with plain values and no renderer.
+class recovery_drain_planner
+{
+    public:
+        // Lifecycle epoch packs a sequence number with the state so a
+        // background-foreground-background ordering survives the two separate
+        // stores a watcher makes: [63..2] seq, [1..0] state.
+        static constexpr uint64_t make_lifecycle_epoch( uint64_t seq, lifecycle_state s ) {
+            return ( seq << 2 ) | static_cast<uint64_t>( s );
+        }
+        static constexpr uint64_t lifecycle_seq_of( uint64_t epoch ) {
+            return epoch >> 2;
+        }
+        static constexpr lifecycle_state lifecycle_state_of( uint64_t epoch ) {
+            return static_cast<lifecycle_state>( epoch & 0x3 );
+        }
+        static constexpr renderer_recovery_severity severity_max(
+            renderer_recovery_severity a, renderer_recovery_severity b ) {
+            return static_cast<int>( a ) >= static_cast<int>( b ) ? a : b;
+        }
+
+        // The next side effect drain_pending must perform. For the read /
+        // exchange / recipe / resize kinds the driver performs it and feeds the
+        // result back through the matching advance_*; finish_ready and
+        // finish_retry are terminal.
+        enum class action_kind {
+            load_entry_epoch,     // load lifecycle epoch -> advance_entry_epoch
+            claim_initial_inbox,  // exchange severity, load resize, read latch -> advance_initial_inbox
+            run_recipe,           // run_recipe_for(action.severity) -> advance_recipe
+            attempt_seq_cas,      // clear the serviced foreground epoch -> advance_seq_cas_done
+            claim_after_success,  // exchange severity, load lifecycle -> advance_after_success
+            claim_after_restart,  // load lifecycle, exchange severity -> advance_after_restart
+            load_post_resize,     // load resize epoch -> advance_post_resize
+            apply_resize,         // apply_resize_only(action.resize_epoch) -> advance_resize
+            finish_ready,
+            finish_retry,
+        };
+        struct action {
+            action_kind kind;
+            renderer_recovery_severity severity = renderer_recovery_severity::none;
+            uint32_t resize_epoch = 0;
+            uint64_t serviced_seq = 0;
+        };
+
+        // Pure state the coordinator predicates and recipes consult.
+        renderer_recovery_state state() const {
+            return state_;
+        }
+        bool abort_latch() const {
+            return abort_latch_;
+        }
+        uint32_t observed_resize_epoch() const {
+            return observed_resize_epoch_;
+        }
+        uint64_t serviced_lifecycle_seq() const {
+            return serviced_lifecycle_seq_;
+        }
+        renderer_recovery_severity current_claimed() const {
+            return current_claimed_;
+        }
+
+        // Bootstrapping -> ready, once the base UI is up.
+        void finish_bootstrap() {
+            state_ = renderer_recovery_state::ready;
+        }
+        // Back to the initial bootstrapping state for a fresh test fixture.
+        void reset() {
+            *this = recovery_drain_planner{};
+        }
+
+        // Driver protocol. begin() opens a drain (recovering + abort latch) and
+        // returns the first action. Each advance_* consumes the result of the
+        // side effect the previous action named and returns the next action.
+        action begin();
+        action advance_entry_epoch( uint64_t entry_epoch );
+        action advance_initial_inbox( renderer_recovery_severity pulled, uint32_t resize_epoch,
+                                      bool boundary_recovery_pending );
+        action advance_recipe( recipe_result r );
+        action advance_seq_cas_done();
+        action advance_after_success( renderer_recovery_severity pulled, uint64_t live_epoch );
+        action advance_after_restart( uint64_t live_epoch, renderer_recovery_severity pulled );
+        action advance_post_resize( uint32_t resize_epoch );
+        action advance_resize( bool applied );
+
+        // Called from inside an SDL recipe (or apply_resize_only) when a pause is
+        // observed: persists the in-flight severity as the retry and arms the
+        // mid-recipe abort so the next advance_recipe finishes as retry_needed.
+        void note_pause_abort();
+        // Called from inside apply_resize_only at the point the serviced resize
+        // epoch is committed, before the post-success blank, so the blank
+        // predicate sees no phantom pending resize.
+        void acknowledge_resize( uint32_t serviced_resize_epoch ) {
+            observed_resize_epoch_ = serviced_resize_epoch;
+        }
+
+    private:
+        // Merge a freshly exchanged inbox severity with any persisted retry, then
+        // clear the retry slot. The exchange itself is the coordinator's atomic
+        // side effect; only the merge half is pure policy.
+        renderer_recovery_severity merge_retry( renderer_recovery_severity pulled );
+        action emit_run_recipe( renderer_recovery_severity sev );
+        action emit_apply_resize( uint32_t resize_epoch, bool fast_path );
+        action finish_ready_action();
+        action finish_retry_action();
+
+        renderer_recovery_state state_ = renderer_recovery_state::bootstrapping;
+        renderer_recovery_severity retry_severity_ = renderer_recovery_severity::none;
+        // Severity of the recipe currently in flight, so a mid-recipe pause abort
+        // can persist it as the retry severity.
+        renderer_recovery_severity current_claimed_ = renderer_recovery_severity::none;
+        bool abort_latch_ = false;
+        uint32_t observed_resize_epoch_ = 0;
+        // Lifecycle sequence the current drain is servicing. A resumed epoch with
+        // this sequence is the foreground rebuild in progress and does not
+        // self-interrupt; a different sequence is a newer foreground.
+        uint64_t serviced_lifecycle_seq_ = 0;
+        // epoch_implied severity derived from the entry lifecycle state, carried
+        // from advance_entry_epoch to advance_initial_inbox.
+        renderer_recovery_severity entry_epoch_implied_ = renderer_recovery_severity::none;
+        // restart_severity from the recipe result, carried from advance_recipe to
+        // advance_after_restart.
+        renderer_recovery_severity restart_severity_pending_ = renderer_recovery_severity::none;
+        // Set by note_pause_abort so the following advance_recipe finishes the
+        // drain as retry_needed regardless of the recipe's own outcome.
+        bool recipe_pause_aborted_ = false;
+        // Whether the apply_resize in flight is the entry fast path (clears retry
+        // on failure) rather than the post-recovery step (leaves it).
+        bool resize_fast_path_ = false;
+};
+
+#endif // TILES
+
+#endif // CATA_SRC_SDL_RENDERER_RECOVERY_H

--- a/src/sdl_renderer_recovery.h
+++ b/src/sdl_renderer_recovery.h
@@ -194,6 +194,134 @@ class recovery_drain_planner
         bool resize_fast_path_ = false;
 };
 
+// Main-thread executor that recovers every renderer-owned GPU resource
+// across SDL render-target reset, device reset, device loss, and android
+// background/foreground. The event watch writes only the atomic inbox;
+// drain_pending() runs the ordered recovery recipes at the named outer
+// boundaries.
+class renderer_resource_coordinator
+{
+    public:
+        // Inbox writers. Safe to call from the SDL event-watch thread: they
+        // touch only the atomic inbox.
+        void request_recovery( renderer_recovery_severity sev );
+        void notify_resize();
+        void notify_lifecycle( lifecycle_state ev );
+
+        // Seed the renderer creation policy from the live renderer (backend
+        // name plus actual software/accelerated mode). Stays in
+        // bootstrapping; rendering is not yet allowed.
+        void seed_renderer_policy( const std::string &renderer_name );
+        // Move bootstrapping -> ready once the cold-start tileset upload has
+        // succeeded. Rendering is allowed from here.
+        void finish_bootstrap();
+
+        // Main-thread surface.
+        void drain_pending();
+        bool is_render_allowed() const;
+        bool should_abort_frame() const;
+
+        renderer_recovery_state state() const {
+            return planner_.state();
+        }
+        renderer_recovery_severity pending() const {
+            return pending_severity_.load();
+        }
+        uint64_t resource_generation() const {
+            return renderer_resource_generation_;
+        }
+        uint64_t instance_generation() const {
+            return renderer_instance_generation_;
+        }
+        uint64_t textures_generation() const {
+            return gpu_textures_generation_;
+        }
+        // Sampled together by the tileset fetch path for the cache staleness
+        // check.
+        renderer_texture_generations texture_generations() const {
+            return { renderer_instance_generation_, gpu_textures_generation_ };
+        }
+
+    private:
+        // should_abort_frame without the recovery-owned abort latch: true when
+        // the external inbox (lifecycle, severity, resize, boundary latch)
+        // forbids rendering.
+        bool external_inbox_blocks_render() const;
+        // Like external_inbox_blocks_render but permits the foreground epoch
+        // this drain is servicing (resumed with serviced_lifecycle_seq_), so
+        // the recovery-owned post-success blank may run for it; a pause, a
+        // newer resumed sequence, or other inbox work still blocks.
+        bool recovery_blank_blocked() const;
+        // Clear the foreground epoch the drain serviced so the next coalesce
+        // iteration re-derives epoch_implied from the current lifecycle state.
+        void attempt_serviced_seq_cas( uint64_t serviced_seq );
+        recipe_result run_recipe_for( renderer_recovery_severity sev );
+        // Debug-only invariant check run after each recipe success: usable
+        // renderer + display buffer, boundary latch cleared, generations not
+        // rolled backward from the pre-dispatch snapshot.
+        void assert_recipe_postcondition( uint64_t resource_gen_before,
+                                          renderer_texture_generations gens_before ) const;
+        // serviced_resize_epoch is the pending_resize_epoch value sampled by
+        // the drain; it is acknowledged into observed_resize_epoch_ on success
+        // so the post-success blank predicate sees no phantom pending resize.
+        bool apply_resize_only( uint32_t serviced_resize_epoch );
+        void run_post_success_full_invalidation();
+        bool install_renderer_with_fallback();
+        bool safe_pre_teardown_unbind( recipe_result &out );
+        bool check_pause_abort();
+        // Drop every live cached tileset's atlas textures against the still-
+        // live renderer, before any renderer destruction. Idempotent.
+        void release_live_atlases() const;
+        // Re-upload atlases over every live tileset, polling for pause/loss
+        // between chunks and routing interrupted candidates into the replay
+        // quarantine. Returns the interrupt reason, or none on full success.
+        atlas_upload_interrupt replay_live_atlases();
+        // Map an atlas-replay interrupt to a recipe outcome: paused persists
+        // retry and yields retry_needed; the *_invalidated reasons restart at
+        // the matching severity.
+        recipe_result map_replay_interrupt( atlas_upload_interrupt reason );
+        // Poll consulted during atlas replay: reports pause or a higher
+        // pending severity so the upload stops and quarantines.
+        atlas_upload_interrupt replay_poll() const;
+        // Rebuild display_buffer, recording its dims on success. A failure
+        // with the sticky boundary latch raised escalates to device-loss in
+        // the same drain rather than a plain retry.
+        recipe_result setup_target_phase();
+        recipe_result recipe_targets_reset();
+        recipe_result recipe_device_reset();
+        recipe_result recipe_device_lost();
+        void record_display_buffer_dims();
+
+        // Pure drain transition policy. drain_pending() drives it; the
+        // coordinator supplies the atomic inbox reads and the SDL side effects.
+        recovery_drain_planner planner_;
+        uint64_t renderer_resource_generation_ = 0;
+        uint64_t renderer_instance_generation_ = 0;
+        uint64_t gpu_textures_generation_ = 0;
+        // Display-buffer dims the coordinator last built, so a resize can
+        // skip the rebuild when only DPI or letterboxing changed.
+        int display_buffer_w_ = 0;
+        int display_buffer_h_ = 0;
+        // Renderer creation policy, retained so a device-loss rebuild can
+        // recreate with the same backend choice and track the actual
+        // installed backend after any accelerated-to-software fallback.
+        std::string renderer_name_;
+        bool software_renderer_ = false;
+
+        std::atomic<renderer_recovery_severity> pending_severity_{ renderer_recovery_severity::none };
+        std::atomic<uint32_t> pending_resize_epoch_{ 0 };
+        std::atomic<uint64_t> lifecycle_epoch_{ 0 };
+
+        // Candidate atlas textures captured when a replay is interrupted by a
+        // pause or loss; drained on the live renderer before retry or
+        // abandoned before a renderer is destroyed.
+        atlas_replay_quarantine replay_quarantine_;
+};
+
+// Process-lifetime coordinator; the event-watch userdata must outlive
+// every callback.
+extern renderer_resource_coordinator renderer_coordinator;
+
 #endif // TILES
 
 #endif // CATA_SRC_SDL_RENDERER_RECOVERY_H

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <climits>
 #include <cmath>
 #include <cstdint>
@@ -658,6 +659,8 @@ static void WinCreate()
 #endif
 
     imclient = std::make_unique<cataimgui::client>( renderer, window, geometry );
+
+    renderer_coordinator.seed_renderer_policy( renderer_name );
 }
 
 static void WinDestroy()
@@ -1099,6 +1102,799 @@ void clear_window_area( const catacurses::window &win_ )
     cata_cursesport::WINDOW *const win = win_.get<cata_cursesport::WINDOW>();
     geometry->rect( renderer, point( win->pos.x * fontwidth, win->pos.y * fontheight ),
                     win->width * fontwidth, win->height * fontheight, color_as_sdl( catacurses::black ) );
+}
+
+// Shared variant_pass pointer for the pass-aware target binds, or null on
+// SDL2 where there is no shader pass.
+static cata_shader::variant_pass *shared_variant_pass_or_null()
+{
+#if SDL_MAJOR_VERSION >= 3
+    return get_shared_variant_pass();
+#else
+    return nullptr;
+#endif
+}
+
+// Renderer-resource coordinator: recovery recipes and the drain state
+// machine that run on the main thread. The header declares the public
+// lifecycle surface and the atomic inbox.
+
+// Thin forwards to the planner's canonical pack/unpack so the coordinator's
+// inbox writers and predicates read the epoch the same way the planner does.
+static constexpr uint64_t make_lifecycle_epoch( uint64_t seq, lifecycle_state s )
+{
+    return recovery_drain_planner::make_lifecycle_epoch( seq, s );
+}
+static constexpr uint64_t lifecycle_seq_of( uint64_t epoch )
+{
+    return recovery_drain_planner::lifecycle_seq_of( epoch );
+}
+static constexpr lifecycle_state lifecycle_state_of( uint64_t epoch )
+{
+    return recovery_drain_planner::lifecycle_state_of( epoch );
+}
+
+static_assert( std::atomic<uint64_t>::is_always_lock_free );
+static_assert( std::atomic<uint32_t>::is_always_lock_free );
+static_assert( std::atomic<renderer_recovery_severity>::is_always_lock_free );
+
+// Process-lifetime storage: the event-watch userdata must outlive every
+// callback, so the coordinator is never destroyed before SDL teardown.
+renderer_resource_coordinator renderer_coordinator;
+
+void renderer_resource_coordinator::request_recovery( renderer_recovery_severity sev )
+{
+    renderer_recovery_severity cur = pending_severity_.load();
+    while( static_cast<int>( sev ) > static_cast<int>( cur ) ) {
+        if( pending_severity_.compare_exchange_weak( cur, sev ) ) {
+            break;
+        }
+    }
+}
+
+void renderer_resource_coordinator::notify_resize()
+{
+    pending_resize_epoch_.fetch_add( 1 );
+}
+
+void renderer_resource_coordinator::notify_lifecycle( lifecycle_state ev )
+{
+    uint64_t cur = lifecycle_epoch_.load();
+    uint64_t desired = 0;
+    do {
+        desired = make_lifecycle_epoch( lifecycle_seq_of( cur ) + 1, ev );
+    } while( !lifecycle_epoch_.compare_exchange_weak( cur, desired ) );
+}
+
+bool renderer_resource_coordinator::is_render_allowed() const
+{
+    return planner_.state() == renderer_recovery_state::ready
+           && pending_severity_.load() == renderer_recovery_severity::none
+           && pending_resize_epoch_.load() == planner_.observed_resize_epoch()
+           && lifecycle_state_of( lifecycle_epoch_.load() ) == lifecycle_state::active
+           && !display_buffer_scope_recovery_pending();
+}
+
+bool renderer_resource_coordinator::external_inbox_blocks_render() const
+{
+    return pending_severity_.load() != renderer_recovery_severity::none
+           || lifecycle_state_of( lifecycle_epoch_.load() ) != lifecycle_state::active
+           || pending_resize_epoch_.load() != planner_.observed_resize_epoch()
+           || display_buffer_scope_recovery_pending();
+}
+
+bool renderer_resource_coordinator::recovery_blank_blocked() const
+{
+    const uint64_t epoch = lifecycle_epoch_.load();
+    const lifecycle_state ls = lifecycle_state_of( epoch );
+    if( ls == lifecycle_state::paused ) {
+        return true;
+    }
+    // The foreground epoch this drain services may blank; a newer one cannot.
+    if( ls == lifecycle_state::resumed_pending_rebuild
+        && lifecycle_seq_of( epoch ) != planner_.serviced_lifecycle_seq() ) {
+        return true;
+    }
+    return pending_severity_.load() != renderer_recovery_severity::none
+           || pending_resize_epoch_.load() != planner_.observed_resize_epoch()
+           || display_buffer_scope_recovery_pending();
+}
+
+bool renderer_resource_coordinator::should_abort_frame() const
+{
+    return planner_.abort_latch() || external_inbox_blocks_render();
+}
+
+// Apply fn to each live tile context once, deduplicating the aliased global
+// slots (tilecontext usually aliases closetilecontext).
+static void for_each_unique_tile_context( const std::function<void( cata_tiles & )> &fn )
+{
+    cata_tiles *ctxs[] = { tilecontext.get(), closetilecontext.get(),
+                           fartilecontext.get(), overmap_tilecontext.get()
+                         };
+    cata_tiles *seen[4] = {};
+    size_t n = 0;
+    for( cata_tiles *c : ctxs ) {
+        if( !c ) {
+            continue;
+        }
+        bool dup = false;
+        for( size_t i = 0; i < n; ++i ) {
+            if( seen[i] == c ) {
+                dup = true;
+                break;
+            }
+        }
+        if( dup ) {
+            continue;
+        }
+        seen[n++] = c;
+        fn( *c );
+    }
+}
+
+static void reset_context_minimaps()
+{
+    for_each_unique_tile_context( []( cata_tiles & c ) {
+        c.reset_minimap();
+    } );
+}
+
+// The silhouette mask target only goes stale on a device reset or loss, not a
+// target reset.
+static void reset_context_tint_masks()
+{
+    for_each_unique_tile_context( []( cata_tiles & c ) {
+        c.reset_tint_mask();
+    } );
+}
+
+// Drop the glyph atlases on every font root. The TTF glyph cache repopulates
+// lazily on the next OutputChar; bitmap atlases need an explicit rebuild.
+static void release_font_roots()
+{
+    for( Font_Ptr *f : {
+             &font, &gui_font, &map_font, &overmap_font
+         } ) {
+        if( *f ) {
+            ( *f )->release_gpu_resources();
+        }
+    }
+}
+
+// Rebuild bitmap glyph atlases on every font root against the live renderer.
+// TTF fonts are a no-op here and recreate their glyphs lazily.
+static void rebuild_font_roots()
+{
+    for( Font_Ptr *f : {
+             &font, &gui_font, &map_font, &overmap_font
+         } ) {
+        if( *f ) {
+            ( *f )->rebuild_for_renderer( renderer );
+        }
+    }
+}
+
+recipe_result renderer_resource_coordinator::run_recipe_for( renderer_recovery_severity sev )
+{
+    const uint64_t resource_gen_before = renderer_resource_generation_;
+    const renderer_texture_generations gens_before{
+        renderer_instance_generation_, gpu_textures_generation_ };
+    recipe_result r{ recipe_outcome::success };
+    switch( sev ) {
+        case renderer_recovery_severity::targets_reset:
+            r = recipe_targets_reset();
+            break;
+        case renderer_recovery_severity::device_reset:
+            r = recipe_device_reset();
+            break;
+        case renderer_recovery_severity::device_lost:
+            r = recipe_device_lost();
+            break;
+        case renderer_recovery_severity::none:
+            return r;
+    }
+    if( r.outcome == recipe_outcome::success ) {
+        assert_recipe_postcondition( resource_gen_before, gens_before );
+    }
+    return r;
+}
+
+void renderer_resource_coordinator::assert_recipe_postcondition(
+    [[maybe_unused]] const uint64_t resource_gen_before,
+    [[maybe_unused]] const renderer_texture_generations gens_before ) const
+{
+    // See header. Catches a recipe that reports success without restoring the
+    // invariant, instead of a silent failure on the next frame.
+    cata_assert( renderer );
+    cata_assert( display_buffer );
+    cata_assert( !display_buffer_scope_recovery_pending() );
+    cata_assert( renderer_resource_generation_ >= resource_gen_before );
+    cata_assert( renderer_instance_generation_ >= gens_before.instance );
+    cata_assert( gpu_textures_generation_ >= gens_before.textures );
+}
+
+bool renderer_resource_coordinator::check_pause_abort()
+{
+    if( lifecycle_state_of( lifecycle_epoch_.load() ) == lifecycle_state::paused ) {
+        planner_.note_pause_abort();
+        return true;
+    }
+    return false;
+}
+
+// Unbind the render target before destructive teardown. A failed_in_switch
+// means SDL left the renderer undefined, so escalate to a full device-loss
+// rebuild rather than tear down against an unusable renderer. Device-loss
+// recovery is best-effort and does not call this.
+bool renderer_resource_coordinator::safe_pre_teardown_unbind( recipe_result &out )
+{
+    const bind_result r = permanent_render_target_bind( renderer, nullptr,
+                          shared_variant_pass_or_null() );
+    if( r == bind_result::failed_in_switch ) {
+        out = { recipe_outcome::restart_required, renderer_recovery_severity::device_lost };
+        return false;
+    }
+    return true;
+}
+
+void renderer_resource_coordinator::run_post_success_full_invalidation()
+{
+    // Blank the rebuilt buffer, skipping the draw if a pause, newer recovery, or
+    // resize landed mid-drain. Either way mark every UI adaptor for a full
+    // redraw so the next frame re-emits from scratch, not onto stale contents.
+    if( !recovery_blank_blocked() ) {
+        display_buffer_draw_scope draw_scope;
+        if( !display_buffer_scope_is_invalid() ) {
+            ClearScreen();
+        }
+    }
+    ui_manager::invalidate_all_ui_adaptors();
+}
+
+recipe_result renderer_resource_coordinator::recipe_targets_reset()
+{
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+#if SDL_MAJOR_VERSION >= 3
+    if( cata_shader::variant_pass *vp = get_shared_variant_pass() ) {
+        if( !vp->flush() ) {
+            // An undefined shader boundary must escalate before any further
+            // SDL call lands on this renderer.
+            return { recipe_outcome::restart_required, renderer_recovery_severity::device_lost };
+        }
+    }
+#endif
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    recipe_result restart { recipe_outcome::failure };
+    if( !safe_pre_teardown_unbind( restart ) ) {
+        return restart;
+    }
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    reset_context_minimaps();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    display_buffer.reset();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    const recipe_result setup = setup_target_phase();
+    if( setup.outcome != recipe_outcome::success ) {
+        return setup;
+    }
+    ++renderer_resource_generation_;
+    display_buffer_scope_clear_recovery_required();
+    run_post_success_full_invalidation();
+    return { recipe_outcome::success };
+}
+
+recipe_result renderer_resource_coordinator::recipe_device_reset()
+{
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+#if SDL_MAJOR_VERSION >= 3
+    if( cata_shader::variant_pass *vp = get_shared_variant_pass() ) {
+        if( !vp->flush() ) {
+            return { recipe_outcome::restart_required, renderer_recovery_severity::device_lost };
+        }
+    }
+#endif
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    recipe_result restart { recipe_outcome::failure };
+    if( !safe_pre_teardown_unbind( restart ) ) {
+        return restart;
+    }
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    reset_context_minimaps();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    reset_context_tint_masks();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    // Drop atlas textures against the live renderer before the rest of the
+    // teardown so no atlas handle outlives the renderer that owns it.
+    release_live_atlases();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    // Destroy any partial candidates from a previously interrupted replay on
+    // the same live renderer before re-uploading.
+    replay_quarantine_.drain_live_renderer();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    release_font_roots();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    if( geometry ) {
+        geometry->release_gpu_resources();
+    }
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+#if defined(__ANDROID__)
+    touch_joystick.reset();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+#endif
+    display_buffer.reset();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+#if SDL_MAJOR_VERSION >= 3
+    if( cata_shader::variant_pass *vp = get_shared_variant_pass() ) {
+        vp->release_gpu_resources();
+    }
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+#endif
+    if( imclient ) {
+        imclient->destroy_backend_device_objects();
+    }
+    // SDL3 documents a device reset as invalidating every texture, so cached
+    // atlas bundles are rejected by the texture-generation bump and replayed
+    // explicitly below over every live tileset.
+    ++gpu_textures_generation_;
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+#if SDL_MAJOR_VERSION >= 3
+    if( cata_shader::variant_pass *vp = get_shared_variant_pass() ) {
+        vp->rebind_renderer( renderer.get() );
+    }
+#endif
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    const recipe_result setup = setup_target_phase();
+    if( setup.outcome != recipe_outcome::success ) {
+        return setup;
+    }
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    if( geometry ) {
+        geometry->rebuild_for_renderer( renderer );
+    }
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    rebuild_font_roots();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+#if defined(__ANDROID__)
+    touch_joystick = CreateTextureFromSurface( renderer, load_image( "android/joystick.png" ) );
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+#endif
+    const atlas_upload_interrupt replay = replay_live_atlases();
+    if( replay != atlas_upload_interrupt::none ) {
+        return map_replay_interrupt( replay );
+    }
+    ++renderer_resource_generation_;
+    display_buffer_scope_clear_recovery_required();
+    run_post_success_full_invalidation();
+    return { recipe_outcome::success };
+}
+
+// Install a renderer and its display target, falling back to software if the
+// requested backend fails. ImGui and variant_pass re-attach to whichever
+// renderer wins; on success the installed backend is recorded and the instance
+// and texture generations bump. False only if even software fails.
+bool renderer_resource_coordinator::install_renderer_with_fallback()
+{
+    for( const bool software : {
+             software_renderer_, true
+         } ) {
+        if( check_pause_abort() ) {
+            return false;
+        }
+        if( imclient ) {
+            imclient->shutdown_renderer_backend();
+            if( check_pause_abort() ) {
+                return false;
+            }
+            imclient->shutdown_platform_backend();
+        }
+        if( check_pause_abort() ) {
+            return false;
+        }
+        renderer.reset();
+        if( check_pause_abort() ) {
+            return false;
+        }
+        renderer = create_game_renderer( renderer_name_, software );
+        if( !renderer ) {
+            continue;
+        }
+        if( check_pause_abort() ) {
+            return false;
+        }
+        detect_renderer_backend();
+        if( check_pause_abort() ) {
+            return false;
+        }
+        if( imclient ) {
+            imclient->init_platform_backend();
+            if( check_pause_abort() ) {
+                return false;
+            }
+            imclient->init_renderer_backend();
+        }
+        if( check_pause_abort() ) {
+            return false;
+        }
+#if SDL_MAJOR_VERSION >= 3
+        if( cata_shader::variant_pass *vp = get_shared_variant_pass() ) {
+            vp->rebind_renderer( renderer.get() );
+        }
+#endif
+        if( check_pause_abort() ) {
+            return false;
+        }
+        // The new renderer is valid: clear the sticky boundary latch left by
+        // the lost renderer so the target setup's pass-aware bind is not
+        // pre-refused.
+        display_buffer_scope_clear_recovery_required();
+        if( !SetupRenderTarget() ) {
+            continue;
+        }
+        if( check_pause_abort() ) {
+            return false;
+        }
+        record_display_buffer_dims();
+        software_renderer_ = IsRendererSoftware( renderer );
+        ++renderer_instance_generation_;
+        ++gpu_textures_generation_;
+        return true;
+    }
+    return false;
+}
+
+recipe_result renderer_resource_coordinator::recipe_device_lost()
+{
+    // Teardown before install_renderer_with_fallback is best-effort: the
+    // renderer is dying, so a failed flush force-abandons local shader state
+    // instead of calling SDL again, and the unbind ignores its result.
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+#if SDL_MAJOR_VERSION >= 3
+    if( cata_shader::variant_pass *vp = get_shared_variant_pass() ) {
+        if( !vp->flush() ) {
+            vp->force_abandon_gpu_resources();
+        }
+    }
+#endif
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    permanent_render_target_bind( renderer, nullptr, shared_variant_pass_or_null() );
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    reset_context_minimaps();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    reset_context_tint_masks();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    // Drop atlas textures against the dying-but-still-live renderer before it
+    // is destroyed in the fallback install below.
+    release_live_atlases();
+    // The renderer is about to be destroyed: abandon any quarantined replay
+    // candidates so their deleters skip SDL_DestroyTexture on the dead
+    // renderer.
+    replay_quarantine_.abandon_pre_lost_renderer();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    release_font_roots();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    if( geometry ) {
+        geometry->release_gpu_resources();
+    }
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+#if defined(__ANDROID__)
+    touch_joystick.reset();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+#endif
+    display_buffer.reset();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+#if SDL_MAJOR_VERSION >= 3
+    if( cata_shader::variant_pass *vp = get_shared_variant_pass() ) {
+        vp->release_gpu_resources();
+    }
+#endif
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    if( !install_renderer_with_fallback() ) {
+        return { recipe_outcome::failure };
+    }
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    // Reselect geometry strategy now the final installed backend is known --
+    // a software fallback may not support color-modulated textures.
+    rebuild_geometry_strategy( software_renderer_ );
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+    rebuild_font_roots();
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+#if defined(__ANDROID__)
+    touch_joystick = CreateTextureFromSurface( renderer, load_image( "android/joystick.png" ) );
+    if( check_pause_abort() ) {
+        return { recipe_outcome::failure };
+    }
+#endif
+    const atlas_upload_interrupt replay = replay_live_atlases();
+    if( replay != atlas_upload_interrupt::none ) {
+        return map_replay_interrupt( replay );
+    }
+    ++renderer_resource_generation_;
+    display_buffer_scope_clear_recovery_required();
+    run_post_success_full_invalidation();
+    return { recipe_outcome::success };
+}
+
+void renderer_resource_coordinator::record_display_buffer_dims()
+{
+    const point d = compute_display_buffer_dims();
+    display_buffer_w_ = d.x;
+    display_buffer_h_ = d.y;
+}
+
+void renderer_resource_coordinator::release_live_atlases() const
+{
+    ts_cache.release_live_atlases();
+}
+
+atlas_upload_interrupt renderer_resource_coordinator::replay_poll() const
+{
+    const uint64_t epoch = lifecycle_epoch_.load();
+    const lifecycle_state ls = lifecycle_state_of( epoch );
+    if( ls == lifecycle_state::paused ) {
+        return atlas_upload_interrupt::paused;
+    }
+    if( ls == lifecycle_state::resumed_pending_rebuild
+        && lifecycle_seq_of( epoch ) != planner_.serviced_lifecycle_seq() ) {
+        // A newer foreground epoch arrived mid-replay; restart so the
+        // just-uploaded textures are not published against a since-reset
+        // device. The epoch this drain services does not self-interrupt.
+        return atlas_upload_interrupt::texture_resources_invalidated;
+    }
+    const renderer_recovery_severity sev = pending_severity_.load();
+    if( sev == renderer_recovery_severity::device_lost
+        || display_buffer_scope_recovery_pending() ) {
+        return atlas_upload_interrupt::renderer_invalidated;
+    }
+    if( sev == renderer_recovery_severity::device_reset ) {
+        return atlas_upload_interrupt::texture_resources_invalidated;
+    }
+    // A queued targets_reset is left for the drain loop, not the upload.
+    return atlas_upload_interrupt::none;
+}
+
+atlas_upload_interrupt renderer_resource_coordinator::replay_live_atlases()
+{
+    return ts_cache.replay_live_atlases( renderer, renderer_instance_generation_,
+                                         gpu_textures_generation_,
+    [this]() {
+        return replay_poll();
+    },
+    replay_quarantine_ );
+}
+
+recipe_result renderer_resource_coordinator::map_replay_interrupt(
+    const atlas_upload_interrupt reason )
+{
+    switch( reason ) {
+        case atlas_upload_interrupt::paused:
+            planner_.note_pause_abort();
+            return { recipe_outcome::failure };
+        case atlas_upload_interrupt::texture_resources_invalidated:
+            return { recipe_outcome::restart_required, renderer_recovery_severity::device_reset };
+        case atlas_upload_interrupt::renderer_invalidated:
+            return { recipe_outcome::restart_required, renderer_recovery_severity::device_lost };
+        case atlas_upload_interrupt::none:
+            break;
+    }
+    return { recipe_outcome::success };
+}
+
+recipe_result renderer_resource_coordinator::setup_target_phase()
+{
+    if( SetupRenderTarget() ) {
+        record_display_buffer_dims();
+        return { recipe_outcome::success };
+    }
+    if( display_buffer_scope_recovery_pending() ) {
+        return { recipe_outcome::restart_required, renderer_recovery_severity::device_lost };
+    }
+    return { recipe_outcome::failure };
+}
+
+void renderer_resource_coordinator::seed_renderer_policy( const std::string &renderer_name )
+{
+    renderer_name_ = renderer_name;
+    software_renderer_ = IsRendererSoftware( renderer );
+    record_display_buffer_dims();
+}
+
+void renderer_resource_coordinator::finish_bootstrap()
+{
+    planner_.finish_bootstrap();
+}
+
+bool renderer_resource_coordinator::apply_resize_only( const uint32_t serviced_resize_epoch )
+{
+    // The planner cleared current_claimed_ when it issued this resize, so a
+    // pause here persists no stale recipe severity as the retry.
+    if( check_pause_abort() ) {
+        return false;
+    }
+    const point want = compute_display_buffer_dims();
+    if( display_buffer && want.x == display_buffer_w_ && want.y == display_buffer_h_ ) {
+        // DPI-only or letterbox-only change: the display buffer keeps its
+        // size, so no target recreate and no generation bump.
+        planner_.acknowledge_resize( serviced_resize_epoch );
+        return true;
+    }
+    const bind_result r = permanent_render_target_bind( renderer, nullptr,
+                          shared_variant_pass_or_null() );
+    if( r == bind_result::failed_in_switch ) {
+        // Undefined renderer state -- escalate to a full device-loss rebuild
+        // at the next drain rather than recreating against it.
+        request_recovery( renderer_recovery_severity::device_lost );
+        return false;
+    }
+    if( check_pause_abort() ) {
+        return false;
+    }
+    display_buffer.reset();
+    if( check_pause_abort() ) {
+        return false;
+    }
+    if( !SetupRenderTarget() ) {
+        if( display_buffer_scope_recovery_pending() ) {
+            request_recovery( renderer_recovery_severity::device_lost );
+        }
+        return false;
+    }
+    record_display_buffer_dims();
+    ++renderer_resource_generation_;
+    display_buffer_scope_clear_recovery_required();
+    // Acknowledge the serviced epoch before the blank so the post-success
+    // predicate sees no phantom pending resize. A newer resize arriving during
+    // setup keeps a higher pending epoch and is serviced on the next drain.
+    planner_.acknowledge_resize( serviced_resize_epoch );
+    run_post_success_full_invalidation();
+    return true;
+}
+
+void renderer_resource_coordinator::attempt_serviced_seq_cas( const uint64_t serviced_seq )
+{
+    // Clear only the exact foreground epoch this drain serviced, so the next
+    // coalesce derives epoch_implied fresh instead of re-deriving device_reset
+    // from a stale resumed epoch. A newer sequence fails the match, left to re-service.
+    uint64_t latest = lifecycle_epoch_.load();
+    if( lifecycle_seq_of( latest ) == serviced_seq
+        && lifecycle_state_of( latest ) == lifecycle_state::resumed_pending_rebuild ) {
+        const uint64_t desired = make_lifecycle_epoch( serviced_seq, lifecycle_state::active );
+        lifecycle_epoch_.compare_exchange_strong( latest, desired );
+    }
+}
+
+void renderer_resource_coordinator::drain_pending()
+{
+    // Refuse drains until the cold-start upload finishes (finish_bootstrap),
+    // and guard against re-entry while a drain is already running.
+    if( planner_.state() == renderer_recovery_state::bootstrapping
+        || planner_.state() == renderer_recovery_state::recovering ) {
+        return;
+    }
+    // Thin driver: the planner names the next side effect, the coordinator runs
+    // that one atomic read / SDL recipe / resize, and the result feeds straight
+    // back. The branch policy lives in the planner.
+    using action_kind = recovery_drain_planner::action_kind;
+    recovery_drain_planner::action a = planner_.begin();
+    for( ;; ) {
+        switch( a.kind ) {
+            case action_kind::load_entry_epoch:
+                a = planner_.advance_entry_epoch( lifecycle_epoch_.load() );
+                break;
+            case action_kind::claim_initial_inbox: {
+                const renderer_recovery_severity pulled =
+                    pending_severity_.exchange( renderer_recovery_severity::none );
+                const bool boundary = display_buffer_scope_recovery_pending();
+                const uint32_t resize_epoch = pending_resize_epoch_.load();
+                a = planner_.advance_initial_inbox( pulled, resize_epoch, boundary );
+                break;
+            }
+            case action_kind::run_recipe:
+                a = planner_.advance_recipe( run_recipe_for( a.severity ) );
+                break;
+            case action_kind::attempt_seq_cas:
+                attempt_serviced_seq_cas( a.serviced_seq );
+                a = planner_.advance_seq_cas_done();
+                break;
+            case action_kind::claim_after_success: {
+                const renderer_recovery_severity pulled =
+                    pending_severity_.exchange( renderer_recovery_severity::none );
+                const uint64_t live = lifecycle_epoch_.load();
+                a = planner_.advance_after_success( pulled, live );
+                break;
+            }
+            case action_kind::claim_after_restart: {
+                const uint64_t live = lifecycle_epoch_.load();
+                const renderer_recovery_severity pulled =
+                    pending_severity_.exchange( renderer_recovery_severity::none );
+                a = planner_.advance_after_restart( live, pulled );
+                break;
+            }
+            case action_kind::load_post_resize:
+                a = planner_.advance_post_resize( pending_resize_epoch_.load() );
+                break;
+            case action_kind::apply_resize:
+                a = planner_.advance_resize( apply_resize_only( a.resize_epoch ) );
+                break;
+            case action_kind::finish_ready:
+            case action_kind::finish_retry:
+                return;
+        }
+    }
 }
 
 recovery_drain_planner::action recovery_drain_planner::begin()
@@ -4737,6 +5533,8 @@ void catacurses::init_interface()
 void load_tileset()
 {
     if( !tilecontext || !use_tiles ) {
+        // No atlas upload to gate; the coordinator may allow drains.
+        renderer_coordinator.finish_bootstrap();
         return;
     }
     closetilecontext->load_tileset( get_option<std::string>( "TILES" ),
@@ -4756,6 +5554,9 @@ void load_tileset()
                                            /*pump_events=*/true, /*terrain=*/true );
         overmap_tilecontext->do_tile_loading_report();
     }
+
+    // The real cold-start atlas upload is complete; allow drains and rendering.
+    renderer_coordinator.finish_bootstrap();
 }
 
 //Ends the terminal, destroy everything

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -72,6 +72,7 @@
 #include "overmapbuffer.h"
 #include "path_info.h"
 #include "sdl_geometry.h"
+#include "sdl_renderer_recovery.h"
 #include "sdl_wrappers.h"
 #include "sdl_font.h"
 #include "sdl_gamepad.h"
@@ -1098,6 +1099,182 @@ void clear_window_area( const catacurses::window &win_ )
     cata_cursesport::WINDOW *const win = win_.get<cata_cursesport::WINDOW>();
     geometry->rect( renderer, point( win->pos.x * fontwidth, win->pos.y * fontheight ),
                     win->width * fontwidth, win->height * fontheight, color_as_sdl( catacurses::black ) );
+}
+
+recovery_drain_planner::action recovery_drain_planner::begin()
+{
+    state_ = renderer_recovery_state::recovering;
+    abort_latch_ = true;
+    current_claimed_ = renderer_recovery_severity::none;
+    entry_epoch_implied_ = renderer_recovery_severity::none;
+    restart_severity_pending_ = renderer_recovery_severity::none;
+    recipe_pause_aborted_ = false;
+    resize_fast_path_ = false;
+    return { action_kind::load_entry_epoch };
+}
+
+recovery_drain_planner::action recovery_drain_planner::advance_entry_epoch(
+    const uint64_t entry_epoch )
+{
+    const lifecycle_state entry_state = lifecycle_state_of( entry_epoch );
+    if( entry_state == lifecycle_state::paused ) {
+        // Suspended: no rendering. Severity stays queued (never exchanged) for
+        // the next foreground.
+        return finish_ready_action();
+    }
+    // resumed_pending_rebuild implies an effective severity of at least
+    // device_reset until the post-success seq-CAS clears it.
+    entry_epoch_implied_ = ( entry_state == lifecycle_state::resumed_pending_rebuild )
+                           ? renderer_recovery_severity::device_reset
+                           : renderer_recovery_severity::none;
+    serviced_lifecycle_seq_ = lifecycle_seq_of( entry_epoch );
+    return { action_kind::claim_initial_inbox };
+}
+
+recovery_drain_planner::action recovery_drain_planner::advance_initial_inbox(
+    const renderer_recovery_severity pulled, const uint32_t resize_epoch,
+    const bool boundary_recovery_pending )
+{
+    renderer_recovery_severity claimed = severity_max( merge_retry( pulled ), entry_epoch_implied_ );
+    if( boundary_recovery_pending ) {
+        // A draw-path boundary loss raised the sticky latch without queuing
+        // inbox work. Escalate to a full device-loss rebuild.
+        claimed = severity_max( claimed, renderer_recovery_severity::device_lost );
+    }
+    if( claimed == renderer_recovery_severity::none ) {
+        // Resize-only fast path; otherwise nothing to recover, but still re-read
+        // the resize epoch after the empty recipe loop.
+        if( resize_epoch != observed_resize_epoch_ ) {
+            return emit_apply_resize( resize_epoch, true );
+        }
+        return { action_kind::load_post_resize };
+    }
+    return emit_run_recipe( claimed );
+}
+
+recovery_drain_planner::action recovery_drain_planner::advance_recipe( const recipe_result r )
+{
+    if( recipe_pause_aborted_ ) {
+        // A mid-recipe pause already set retry_needed and persisted the severity.
+        return finish_retry_action();
+    }
+    if( r.outcome == recipe_outcome::failure ) {
+        retry_severity_ = current_claimed_;
+        return finish_retry_action();
+    }
+    if( r.outcome == recipe_outcome::restart_required ) {
+        restart_severity_pending_ = r.restart_severity;
+        return { action_kind::claim_after_restart };
+    }
+    return { action_kind::attempt_seq_cas, renderer_recovery_severity::none, 0,
+             serviced_lifecycle_seq_ };
+}
+
+recovery_drain_planner::action recovery_drain_planner::advance_seq_cas_done()
+{
+    return { action_kind::claim_after_success };
+}
+
+recovery_drain_planner::action recovery_drain_planner::advance_after_success(
+    const renderer_recovery_severity pulled, const uint64_t live_epoch )
+{
+    const renderer_recovery_severity new_work = merge_retry( pulled );
+    renderer_recovery_severity next_epoch_implied = renderer_recovery_severity::none;
+    if( lifecycle_state_of( live_epoch ) == lifecycle_state::resumed_pending_rebuild
+        && lifecycle_seq_of( live_epoch ) != serviced_lifecycle_seq_ ) {
+        // A newer foreground raced the seq-CAS: re-service it as a device reset.
+        next_epoch_implied = renderer_recovery_severity::device_reset;
+        serviced_lifecycle_seq_ = lifecycle_seq_of( live_epoch );
+    }
+    const renderer_recovery_severity claimed = severity_max( new_work, next_epoch_implied );
+    if( claimed == renderer_recovery_severity::none ) {
+        return { action_kind::load_post_resize };
+    }
+    return emit_run_recipe( claimed );
+}
+
+recovery_drain_planner::action recovery_drain_planner::advance_after_restart(
+    const uint64_t live_epoch, const renderer_recovery_severity pulled )
+{
+    if( lifecycle_state_of( live_epoch ) == lifecycle_state::resumed_pending_rebuild ) {
+        // A newer foreground triggered the restart (e.g. a replay interrupt);
+        // adopt its sequence so the next replay does not interrupt on the same
+        // epoch forever.
+        serviced_lifecycle_seq_ = lifecycle_seq_of( live_epoch );
+    }
+    const renderer_recovery_severity claimed =
+        severity_max( merge_retry( pulled ), restart_severity_pending_ );
+    if( claimed == renderer_recovery_severity::none ) {
+        return { action_kind::load_post_resize };
+    }
+    return emit_run_recipe( claimed );
+}
+
+recovery_drain_planner::action recovery_drain_planner::advance_post_resize(
+    const uint32_t resize_epoch )
+{
+    if( resize_epoch != observed_resize_epoch_ ) {
+        return emit_apply_resize( resize_epoch, false );
+    }
+    return finish_ready_action();
+}
+
+recovery_drain_planner::action recovery_drain_planner::advance_resize( const bool applied )
+{
+    if( applied ) {
+        return finish_ready_action();
+    }
+    if( resize_fast_path_ ) {
+        // The entry resize fast path carries no recipe severity, so a failure
+        // must not persist a stale one as the retry.
+        retry_severity_ = renderer_recovery_severity::none;
+    }
+    return finish_retry_action();
+}
+
+void recovery_drain_planner::note_pause_abort()
+{
+    retry_severity_ = severity_max( retry_severity_, current_claimed_ );
+    state_ = renderer_recovery_state::retry_needed;
+    recipe_pause_aborted_ = true;
+}
+
+renderer_recovery_severity recovery_drain_planner::merge_retry( const renderer_recovery_severity
+        pulled )
+{
+    const renderer_recovery_severity claimed = severity_max( pulled, retry_severity_ );
+    retry_severity_ = renderer_recovery_severity::none;
+    return claimed;
+}
+
+recovery_drain_planner::action recovery_drain_planner::emit_run_recipe(
+    const renderer_recovery_severity sev )
+{
+    current_claimed_ = sev;
+    return { action_kind::run_recipe, sev };
+}
+
+recovery_drain_planner::action recovery_drain_planner::emit_apply_resize(
+    const uint32_t resize_epoch, const bool fast_path )
+{
+    // Resize carries no recipe severity; clear current_claimed_ so a pause inside
+    // apply_resize_only persists nothing.
+    current_claimed_ = renderer_recovery_severity::none;
+    resize_fast_path_ = fast_path;
+    return { action_kind::apply_resize, renderer_recovery_severity::none, resize_epoch };
+}
+
+recovery_drain_planner::action recovery_drain_planner::finish_ready_action()
+{
+    state_ = renderer_recovery_state::ready;
+    abort_latch_ = false;
+    return { action_kind::finish_ready };
+}
+
+recovery_drain_planner::action recovery_drain_planner::finish_retry_action()
+{
+    state_ = renderer_recovery_state::retry_needed;
+    return { action_kind::finish_retry };
 }
 
 static std::optional<std::pair<tripoint_abs_omt, std::string>> get_mission_arrow(

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1350,6 +1350,10 @@ void renderer_resource_coordinator::run_post_success_full_invalidation()
         }
     }
     ui_manager::invalidate_all_ui_adaptors();
+    // Force every curses window to re-emit in full on its next refresh, then
+    // request a present so the rebuilt buffer reaches the screen.
+    cata_cursesport::bump_curses_render_epoch();
+    needupdate = true;
 }
 
 recipe_result renderer_resource_coordinator::recipe_targets_reset()
@@ -2750,7 +2754,8 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 #endif
 }
 
-static bool draw_window( Font_Ptr &font, const catacurses::window &w, const point &offset )
+static bool draw_window( Font_Ptr &font, const catacurses::window &w, const point &offset,
+                         const bool force_full = false )
 {
     if( scaling_factor > 1 ) {
         const point buffer_dims = compute_display_buffer_dims();
@@ -2765,7 +2770,9 @@ static bool draw_window( Font_Ptr &font, const catacurses::window &w, const poin
     const bool option_use_draw_ascii_lines_routine = get_option<bool>( "USE_DRAW_ASCII_LINES_ROUTINE" );
     bool update = false;
     for( int j = 0; j < win->height; j++ ) {
-        if( !win->line[j].touched ) {
+        // force_full redraws every line after a renderer rebuild, ignoring the
+        // per-line touched skip.
+        if( !force_full && !win->line[j].touched ) {
             continue;
         }
 
@@ -2867,12 +2874,14 @@ static bool draw_window( Font_Ptr &font, const catacurses::window &w, const poin
     return update;
 }
 
-static bool draw_window( Font_Ptr &font, const catacurses::window &w )
+static bool draw_window( Font_Ptr &font, const catacurses::window &w,
+                         const bool force_full = false )
 {
     cata_cursesport::WINDOW *const win = w.get<cata_cursesport::WINDOW>();
     // Use global font sizes here to make this independent of the
     // font used for this window.
-    return draw_window( font, w, point( win->pos.x * ::fontwidth, win->pos.y * ::fontheight ) );
+    return draw_window( font, w, point( win->pos.x * ::fontwidth, win->pos.y * ::fontheight ),
+                        force_full );
 }
 
 void cata_cursesport::curses_drawwindow( const catacurses::window &w )
@@ -2886,6 +2895,8 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
         RenderSetLogicalSize( renderer, buffer_dims.x, buffer_dims.y );
     }
     WINDOW *const win = w.get<WINDOW>();
+    // Stale against the render epoch after a renderer rebuild: redraw in full.
+    const bool force_full = win->last_render_epoch != curses_render_epoch;
     bool update = false;
     if( g && w == g->w_terrain && use_tiles ) {
         // color blocks overlay; drawn on top of tiles and on top of overlay strings (if any).
@@ -2991,19 +3002,19 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
                             color_as_sdl( catacurses::black ) );
         }
         // Special font for the terrain window
-        update = draw_window( map_font, w );
+        update = draw_window( map_font, w, force_full );
     } else if( g && w == g->w_overmap && use_tiles && use_tiles_overmap ) {
         overmap_tilecontext->draw_om( win->pos, overmap_ui::redraw_info.center,
                                       overmap_ui::redraw_info.blink );
         update = true;
     } else if( g && w == g->w_overmap && overmap_font ) {
         // Special font for the terrain window
-        update = draw_window( overmap_font, w );
+        update = draw_window( overmap_font, w, force_full );
     } else if( g && w == g->w_pixel_minimap && pixel_minimap_option ) {
         // ensure the space the minimap covers is "dirtied".
         // this is necessary when it's the only part of the sidebar being drawn
         // TODO: Figure out how to properly make the minimap code do whatever it is this does
-        draw_window( font, w );
+        draw_window( font, w, force_full );
 
         // Make sure the entire minimap window is black before drawing.
         clear_window_area( w );
@@ -3015,11 +3026,18 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
 
     } else {
         // Either not using tiles (tilecontext) or not the w_terrain window.
-        update = draw_window( font, w );
+        update = draw_window( font, w, force_full );
     }
     if( update ) {
         needupdate = true;
     }
+    // Single ack point at the common exit covers every draw branch. Leave the
+    // window stale if the inbox embargoed the frame mid-draw so the next
+    // foreground draw replays it in full instead of acking a partial paint.
+    if( renderer_coordinator.should_abort_frame() ) {
+        return;
+    }
+    win->last_render_epoch = curses_render_epoch;
 }
 
 static int alt_buffer = 0;

--- a/src/tileset_loader.cpp
+++ b/src/tileset_loader.cpp
@@ -23,6 +23,7 @@
 
 #include "cata_assert.h"
 #include "cata_path.h"
+#include "cata_scope_helpers.h"
 #include "cata_utility.h"
 #include "cuboid_rectangle.h"
 #include "cursesdef.h"
@@ -182,16 +183,45 @@ static bool is_contained( const SDL_Rect &smaller, const SDL_Rect &larger )
            smaller.y + smaller.h <= larger.y + larger.h;
 }
 
+void atlas_replay_quarantine::add( batch &&b )
+{
+    batches_.push_back( std::move( b ) );
+}
+
+void atlas_replay_quarantine::drain_live_renderer()
+{
+    for( batch &b : batches_ ) {
+        b.handles.drain_live_renderer();
+    }
+    batches_.clear();
+}
+
+void atlas_replay_quarantine::abandon_pre_lost_renderer()
+{
+    for( batch &b : batches_ ) {
+        b.handles.abandon();
+    }
+    batches_.clear();
+}
+
+std::shared_ptr<SDL_Texture> tileset_cache::loader::make_gated_atlas_texture(
+    SDL_Texture_Ptr tex, atlas_replay_quarantine::gate abandon_gate )
+{
+    return make_gated_texture( tex.release(), std::move( abandon_gate ) );
+}
+
 void tileset_cache::loader::copy_surface_to_texture( const SDL_Surface_Ptr &surf,
         const point &offset, std::vector<texture> &target,
-        const std::vector<SDL_Rect> &opaque_bounds )
+        const std::vector<SDL_Rect> &opaque_bounds,
+        const atlas_replay_quarantine::gate &abandon_gate )
 {
     cata_assert( surf );
     const rect_range<SDL_Rect> input_range( sprite_width, sprite_height,
                                             point( surf->w / sprite_width,
                                                     surf->h / sprite_height ) );
 
-    const std::shared_ptr<SDL_Texture> texture_ptr = CreateTextureFromSurface( renderer, surf );
+    const std::shared_ptr<SDL_Texture> texture_ptr =
+        make_gated_atlas_texture( CreateTextureFromSurface( renderer, surf ), abandon_gate );
     cata_assert( texture_ptr );
 
     for( const SDL_Rect rect : input_range ) {
@@ -212,7 +242,8 @@ void tileset_cache::loader::copy_surface_to_texture( const SDL_Surface_Ptr &surf
 }
 
 void tileset_cache::loader::create_textures_from_tile_atlas( const SDL_Surface_Ptr &tile_atlas,
-        const point &offset, const tile_value_targets &targets )
+        const point &offset, const tile_value_targets &targets,
+        const atlas_replay_quarantine::gate &abandon_gate )
 {
     cata_assert( tile_atlas );
     cata_assert( targets.normal && targets.shadow && targets.night && targets.overexposed
@@ -259,10 +290,10 @@ void tileset_cache::loader::create_textures_from_tile_atlas( const SDL_Surface_P
                 ( entry ) );
         if( !color_pixel_function ) {
             // TODO: Move it inside apply_color_filter.
-            copy_surface_to_texture( tile_atlas, offset, *tile_values, opaque_bounds );
+            copy_surface_to_texture( tile_atlas, offset, *tile_values, opaque_bounds, abandon_gate );
         } else {
             copy_surface_to_texture( apply_color_filter( tile_atlas, color_pixel_function ), offset,
-                                     *tile_values, opaque_bounds );
+                                     *tile_values, opaque_bounds, abandon_gate );
         }
     }
 }
@@ -972,12 +1003,15 @@ void tileset_cache::loader::load_tile_spritelists( const JsonObject &entry,
         vs.add( std::vector<int>( {entry.get_int( objname ) + sprite_id_offset} ), 1 );
     }
 }
-void tileset_cache::loader::upload_atlases( tileset &ts, const SDL_Renderer_Ptr &renderer,
+atlas_upload_interrupt tileset_cache::loader::upload_atlases( tileset &ts,
+        const SDL_Renderer_Ptr &renderer,
         const std::string &memory_map_mode,
         const std::vector<atlas_replay_descriptor> &descriptors,
         const uint64_t renderer_instance_generation,
         const uint64_t gpu_textures_generation,
-        const bool pump_events )
+        const bool pump_events,
+        const atlas_upload_poll &poll,
+        atlas_replay_quarantine *const quarantine )
 {
     int total = 0;
     for( const atlas_replay_descriptor &d : descriptors ) {
@@ -996,6 +1030,41 @@ void tileset_cache::loader::upload_atlases( tileset &ts, const SDL_Renderer_Ptr 
     std::vector<texture> cand_memory( total );
     std::vector<texture> cand_silhouette( total );
 
+    // Candidates are built against this gate; on success they commit and destroy
+    // normally, on abnormal exit they are adopted into the graveyard (below).
+    gpu_handle_graveyard candidate_graveyard;
+    const atlas_replay_quarantine::gate abandon_gate = candidate_graveyard.current_gate();
+
+    // Any abnormal exit before commit -- interrupt return or exception -- routes
+    // the candidates into *quarantine so they never destroy against a dead
+    // renderer. Callers without a quarantine just destruct on the live renderer.
+    bool committed = false;
+    auto quarantine_candidates = [&]() {
+        if( !quarantine ) {
+            return;
+        }
+        // Adopt every built candidate into the graveyard so its gated handles
+        // outlive the renderer teardown; the candidate vectors then drop their
+        // refs, leaving the graveyard the last owner.
+        for( const std::vector<texture> *v : {
+                 &cand_normal, &cand_shadow, &cand_night,
+                 &cand_overexposed, &cand_memory, &cand_silhouette
+             } ) {
+            for( const texture &t : *v ) {
+                candidate_graveyard.adopt( t.get_texture_ptr() );
+            }
+        }
+        atlas_replay_quarantine::batch b;
+        b.handles = std::move( candidate_graveyard );
+        b.renderer_instance_generation = renderer_instance_generation;
+        quarantine->add( std::move( b ) );
+    };
+    on_out_of_scope capture_guard( [&]() {
+        if( !committed ) {
+            quarantine_candidates();
+        }
+    } );
+
     loader uploader( ts, renderer, memory_map_mode );
     tile_value_targets targets;
     targets.normal = &cand_normal;
@@ -1006,7 +1075,24 @@ void tileset_cache::loader::upload_atlases( tileset &ts, const SDL_Renderer_Ptr 
     targets.silhouette = &cand_silhouette;
 
     for( const atlas_replay_descriptor &desc : descriptors ) {
-        uploader.upload_one_atlas( desc, targets, pump_events );
+        if( poll ) {
+            const atlas_upload_interrupt interrupt = poll();
+            if( interrupt != atlas_upload_interrupt::none ) {
+                return interrupt;
+            }
+        }
+        const atlas_upload_interrupt interrupt =
+            uploader.upload_one_atlas( desc, targets, pump_events, abandon_gate, poll );
+        if( interrupt != atlas_upload_interrupt::none ) {
+            return interrupt;
+        }
+    }
+
+    if( poll ) {
+        const atlas_upload_interrupt interrupt = poll();
+        if( interrupt != atlas_upload_interrupt::none ) {
+            return interrupt;
+        }
     }
 
     if( highlight_idx ) {
@@ -1017,8 +1103,19 @@ void tileset_cache::loader::upload_atlases( tileset &ts, const SDL_Renderer_Ptr 
                                 highlight_alpha ) ) != 0, "SDL_FillRect failed" );
         const int idx = *highlight_idx;
         cata_assert( idx >= 0 && idx < static_cast<int>( cand_normal.size() ) );
-        cand_normal[idx] = texture( CreateTextureFromSurface( renderer, surface ),
-                                    SDL_Rect{ 0, 0, ts.tile_width, ts.tile_height } );
+        cand_normal[idx] = texture(
+                               make_gated_atlas_texture( CreateTextureFromSurface( renderer, surface ),
+                                       abandon_gate ),
+                               SDL_Rect{ 0, 0, ts.tile_width, ts.tile_height } );
+    }
+
+    // Final poll before publishing: a reset or loss observed after the
+    // highlight upload must not publish the candidates against a stale device.
+    if( poll ) {
+        const atlas_upload_interrupt interrupt = poll();
+        if( interrupt != atlas_upload_interrupt::none ) {
+            return interrupt;
+        }
     }
 
     // Commit candidates atomically so a partial upload is never observable.
@@ -1030,10 +1127,14 @@ void tileset_cache::loader::upload_atlases( tileset &ts, const SDL_Renderer_Ptr 
     ts.silhouette_tile_values = std::move( cand_silhouette );
 
     ts.set_upload_generations( renderer_instance_generation, gpu_textures_generation );
+    ts.set_memory_map_mode_at_upload( memory_map_mode );
+    committed = true;
+    return atlas_upload_interrupt::none;
 }
 
-void tileset_cache::loader::upload_one_atlas( const atlas_replay_descriptor &desc,
-        const tile_value_targets &targets, const bool pump_events )
+atlas_upload_interrupt tileset_cache::loader::upload_one_atlas( const atlas_replay_descriptor &desc,
+        const tile_value_targets &targets, const bool pump_events,
+        const atlas_replay_quarantine::gate &abandon_gate, const atlas_upload_poll &poll )
 {
     cata_assert( desc.sprite_width > 0 );
     cata_assert( desc.sprite_height > 0 );
@@ -1111,6 +1212,12 @@ void tileset_cache::loader::upload_one_atlas( const atlas_replay_descriptor &des
     tile_atlas_width = tile_atlas->w;
 
     for( const SDL_Rect sub_rect : output_range ) {
+        if( poll ) {
+            const atlas_upload_interrupt interrupt = poll();
+            if( interrupt != atlas_upload_interrupt::none ) {
+                return interrupt;
+            }
+        }
         cata_assert( sub_rect.x % desc.sprite_width == 0 );
         cata_assert( sub_rect.y % desc.sprite_height == 0 );
         cata_assert( sub_rect.w % desc.sprite_width == 0 );
@@ -1133,12 +1240,14 @@ void tileset_cache::loader::upload_one_atlas( const atlas_replay_descriptor &des
         const SDL_Surface_Ptr &surf_to_use = smaller_surf ? smaller_surf : tile_atlas;
         cata_assert( surf_to_use );
 
-        create_textures_from_tile_atlas( surf_to_use, point( sub_rect.x, sub_rect.y ), targets );
+        create_textures_from_tile_atlas( surf_to_use, point( sub_rect.x, sub_rect.y ), targets,
+                                         abandon_gate );
 
         if( pump_events ) {
             inp_mngr.pump_events();
         }
     }
+    return atlas_upload_interrupt::none;
 }
 
 #endif // defined(TILES)

--- a/src/tileset_loader.h
+++ b/src/tileset_loader.h
@@ -53,11 +53,18 @@ class tileset_cache::loader
 
         int tile_atlas_width = 0;
 
+        // Wrap a freshly created atlas texture in a shared handle whose
+        // deleter skips SDL_DestroyTexture while abandon_gate is set.
+        static std::shared_ptr<SDL_Texture> make_gated_atlas_texture(
+            SDL_Texture_Ptr tex, atlas_replay_quarantine::gate abandon_gate );
+
         void copy_surface_to_texture( const SDL_Surface_Ptr &surf, const point &offset,
                                       std::vector<texture> &target,
-                                      const std::vector<SDL_Rect> &opaque_bounds );
+                                      const std::vector<SDL_Rect> &opaque_bounds,
+                                      const atlas_replay_quarantine::gate &abandon_gate );
         void create_textures_from_tile_atlas( const SDL_Surface_Ptr &tile_atlas, const point &offset,
-                                              const tile_value_targets &targets );
+                                              const tile_value_targets &targets,
+                                              const atlas_replay_quarantine::gate &abandon_gate );
 
         void process_variations_after_loading( weighted_int_list<std::vector<int>> &v ) const;
 
@@ -92,12 +99,15 @@ class tileset_cache::loader
         // Load layering data from json.
         void load_layers( const JsonObject &config );
 
-        // Upload one atlas: split to renderer-sized chunks, apply color
-        // keying, emit all six filter variants. Mutates loader sprite-state
-        // from the descriptor.
-        void upload_one_atlas( const atlas_replay_descriptor &desc,
-                               const tile_value_targets &targets,
-                               bool pump_events );
+        // Upload one atlas: split into renderer-sized chunks, color-key, emit all
+        // six filter variants, mutating loader sprite-state from the descriptor.
+        // Polls before each chunk; on interrupt returns the reason with targets
+        // partly filled for the caller to quarantine.
+        atlas_upload_interrupt upload_one_atlas( const atlas_replay_descriptor &desc,
+                const tile_value_targets &targets,
+                bool pump_events,
+                const atlas_replay_quarantine::gate &abandon_gate,
+                const atlas_upload_poll &poll );
 
     public:
         loader( tileset &ts, const SDL_Renderer_Ptr &r, std::string memory_map_mode )
@@ -114,12 +124,17 @@ class tileset_cache::loader
         // active. Builds candidate vectors and swaps them into ts on full
         // success; ts is unchanged on failure. Stamps the upload generations
         // onto the bundle so a later cache lookup can spot a stale upload.
-        static void upload_atlases( tileset &ts, const SDL_Renderer_Ptr &renderer,
-                                    const std::string &memory_map_mode,
-                                    const std::vector<atlas_replay_descriptor> &descriptors,
-                                    uint64_t renderer_instance_generation,
-                                    uint64_t gpu_textures_generation,
-                                    bool pump_events );
+        // poll is consulted between chunks; on interrupt the candidate
+        // textures are moved into *quarantine and the reason is returned, ts
+        // untouched. A default (empty) poll never interrupts.
+        static atlas_upload_interrupt upload_atlases( tileset &ts, const SDL_Renderer_Ptr &renderer,
+                const std::string &memory_map_mode,
+                const std::vector<atlas_replay_descriptor> &descriptors,
+                uint64_t renderer_instance_generation,
+                uint64_t gpu_textures_generation,
+                bool pump_events,
+                const atlas_upload_poll &poll = {},
+                atlas_replay_quarantine *quarantine = nullptr );
 };
 
 #endif // CATA_SRC_TILESET_LOADER_H


### PR DESCRIPTION
#### Summary
Infrastructure "Renderer-resource recovery coordinator and its SDL-free drain planner"

#### Purpose of change
More SDL3 render-pipeline hardening, stacked on #87421, which added the per-resource release/rebind primitives. This adds the thing that drives them. On a render-target reset, device reset, device loss, or android background/foreground, something has to tear down every renderer-owned GPU resource and rebuild it in order, while coping with a pause landing mid-rebuild or a newer reset racing in. That is the coordinator. It is built but not yet wired to the SDL event watch.

#### Describe the solution
Two pieces, deliberately split.

recovery_drain_planner is an SDL-free state machine holding the transition policy. It touches no SDL and no renderer, so the fiddly bits are unit-testable with plain values:

- lifecycle epochs: the app's active/paused/resuming state plus a sequence counter packed into one atomic word, and read back out.
- severity coalescing: when several resets pile up, keep only the worst one pending.
- resize-after-recovery ordering: apply a pending window resize only once a recovery has finished.
- post-success sequence-CAS: after a foreground rebuild succeeds, atomically clear exactly the lifecycle event it serviced, so a newer one that raced in is not dropped.
- retry persistence: remember a recovery that aborted (e.g. the app paused mid-rebuild) so it reruns on the next drain.

renderer_resource_coordinator owns the SDL side:

- the atomic inbox: pending severity, resize epoch, lifecycle epoch.
- the recovery recipes: targets-reset, device-reset, device-loss, each tearing down and rebuilding the renderer-owned resources in order.
- drain_pending(): a thin driver that asks the planner for the next side effect, does that one thing (an atomic read, a recipe, a resize), and feeds the result back.
- recipes poll for a pause between steps, so a backgrounding app bails mid-rebuild and retries on foreground; an interrupted atlas upload routes into a quarantine so its textures are never destroyed against a suspended or dead renderer.
- only the inbox writers (request_recovery, notify_resize, notify_lifecycle) are safe to call off the main thread, since they touch only atomics.

Separately, a curses render epoch: a recovery bumps it and every curses window redraws in full on its next refresh instead of trusting its per-line touched flags, so a rebuilt buffer re-emits every window even where the text did not change.

No behavior change.

#### Describe alternatives you've considered
Fold the policy into the coordinator and test it through the SDL path, but the ordering, coalesce, and retry logic is the subtle part and mocking a renderer to exercise it is miserable; a pure state machine makes those branches testable with plain values. Recipes could also tear down unconditionally, but polling for a pause lets a backgrounded app abandon a half-done rebuild instead of fighting SDL on a suspended renderer.

#### Testing
Game builds and runs, no changes.

#### Additional context
Dormant until a later PR wires the SDL event watch to the inbox and calls drain_pending from the main loop; planner unit tests come next.