### PR TITLE
[XedraWood] Override insect age_grow and remove higher-growth insects from monstergroups

### DIFF
--- a/data/mods/XedraWood/monstergroups/default_additions.json
+++ b/data/mods/XedraWood/monstergroups/default_additions.json
@@ -177,16 +177,5 @@
       { "monster": "mon_mi_go_juggernaut", "weight": 200, "cost_multiplier": 5 },
       { "monster": "mon_mi_go_juggernaut", "weight": 50, "cost_multiplier": 20, "pack_size": [ 2, 3 ] }
     ]
-  },
-  {
-    "id": "GROUP_WASP_PUPA",
-    "type": "monstergroup",
-    "default": "mon_wasp_small",
-    "override": true,
-    "monsters": [
-      { "monster": "mon_dermatik", "weight": 50 },
-      { "monster": "mon_wasp_small_guard", "weight": 500 },
-      { "monster": "mon_wasp_small", "weight": 450 }
-    ]
   }
 ]

--- a/data/mods/XedraWood/monstergroups/default_additions.json
+++ b/data/mods/XedraWood/monstergroups/default_additions.json
@@ -177,5 +177,16 @@
       { "monster": "mon_mi_go_juggernaut", "weight": 200, "cost_multiplier": 5 },
       { "monster": "mon_mi_go_juggernaut", "weight": 50, "cost_multiplier": 20, "pack_size": [ 2, 3 ] }
     ]
+  },
+  {
+    "id": "GROUP_WASP_PUPA",
+    "type": "monstergroup",
+    "default": "mon_wasp_small",
+    "override": true,
+    "monsters": [
+      { "monster": "mon_dermatik", "weight": 50 },
+      { "monster": "mon_wasp_small_guard", "weight": 500 },
+      { "monster": "mon_wasp_small", "weight": 450 }
+    ]
   }
 ]

--- a/data/mods/XedraWood/monstergroups/insect_overrides.json
+++ b/data/mods/XedraWood/monstergroups/insect_overrides.json
@@ -1,0 +1,260 @@
+[
+  {
+    "type": "monstergroup",
+    "id": "GROUP_ANT_SURFACE",
+    "is_animal": true,
+    "override": true,
+    "monsters": [
+      { "monster": "mon_ant_soldier", "weight": 90, "cost_multiplier": 5 },
+      { "group": "GROUP_APHID", "weight": 40, "pack_size": [ 3, 10 ], "cost_multiplier": 0 },
+      { "group": "GROUP_LADY_BUG", "weight": 15, "pack_size": [ 1, 3 ], "cost_multiplier": 10 },
+      { "monster": "mon_antlion_larva", "weight": 5, "cost_multiplier": 10 },
+      { "monster": "mon_ant_small", "weight": 852, "cost_multiplier": 0 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_ACID_ANT_SURFACE",
+    "is_animal": true,
+    "override": true,
+    "monsters": [
+      { "monster": "mon_ant_acid_soldier", "weight": 90, "cost_multiplier": 5 },
+      { "group": "GROUP_APHID", "weight": 40, "pack_size": [ 3, 10 ], "cost_multiplier": 0 },
+      { "group": "GROUP_LADY_BUG", "weight": 15, "pack_size": [ 1, 3 ], "cost_multiplier": 10 },
+      { "monster": "mon_antlion_larva", "weight": 5, "cost_multiplier": 10 },
+      { "monster": "mon_ant_acid_small", "weight": 852, "cost_multiplier": 0 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_BEEHIVE",
+    "override": true,
+    "monsters": [ { "monster": "mon_bee_small", "cost_multiplier": 0 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_BEE",
+    "monsters": [ { "monster": "mon_bee_small", "cost_multiplier": 0 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_SPIDER",
+    "override": true,
+    "monsters": [ { "monster": "mon_spider_web_small", "weight": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_SPIDER_BASEMENT",
+    "override": true,
+    "default": "mon_spider_cellar_small",
+    "monsters": [ { "monster": "mon_spider_cellar_small", "weight": 30 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_SPIDER_CELLAR_GIANT",
+    "override": true,
+    "monsters": [ { "monster": "mon_null", "weight": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_SPIDER_TRAPDOOR",
+    "override": true,
+    "monsters": [ { "monster": "mon_spider_trapdoor_small", "weight": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_SPIDER_WIDOW",
+    "override": true,
+    "monsters": [ { "monster": "mon_spider_widow_small", "weight": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_SPIDER_WOLF",
+    "override": true,
+    "monsters": [ { "monster": "mon_spider_wolf_small", "weight": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_SPIDER_JUMPING",
+    "override": true,
+    "monsters": [ { "monster": "mon_spider_jumping_small", "weight": 5 } ]
+  },
+  {
+    "id": "GROUP_WASP_NEST",
+    "type": "monstergroup",
+    "override": true,
+    "monsters": [
+      { "monster": "mon_wasp_small", "weight": 500, "ends": "30 days", "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
+      {
+        "monster": "mon_wasp_small",
+        "weight": 500,
+        "starts": "30 days",
+        "pack_size": [ 2, 4 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      { "monster": "mon_wasp_small_guard", "weight": 500, "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
+      {
+        "monster": "mon_wasp_small_guard",
+        "weight": 500,
+        "starts": "30 days",
+        "pack_size": [ 2, 4 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      }
+    ]
+  },
+  {
+    "id": "GROUP_WASP_FORAGER",
+    "type": "monstergroup",
+    "override": true,
+    "monsters": [
+      { "monster": "mon_wasp_small", "weight": 1000, "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
+      {
+        "monster": "mon_wasp_small",
+        "weight": 500,
+        "starts": "30 days",
+        "pack_size": [ 2, 4 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      }
+    ]
+  },
+  {
+    "id": "GROUP_WASP_GUARD",
+    "type": "monstergroup",
+    "override": true,
+    "monsters": [
+      { "monster": "mon_wasp_small_guard", "weight": 1000, "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
+      {
+        "monster": "mon_wasp_small_guard",
+        "weight": 500,
+        "starts": "30 days",
+        "pack_size": [ 2, 4 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      }
+    ]
+  },
+  {
+    "id": "GROUP_WASP_QUEEN",
+    "type": "monstergroup",
+    "override": true,
+    "monsters": [ { "monster": "mon_wasp_queen", "weight": 1000, "cost_multiplier": 50 } ]
+  },
+  {
+    "id": "GROUP_WASP_PUPA",
+    "type": "monstergroup",
+    "default": "mon_wasp_small",
+    "override": true,
+    "monsters": [
+      { "monster": "mon_dermatik", "weight": 50 },
+      { "monster": "mon_wasp_small_guard", "weight": 500 },
+      { "monster": "mon_wasp_small", "weight": 450 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_FLY",
+    "override": true,
+    "monsters": [ { "monster": "mon_fly_small", "weight": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_MOSQUITO",
+    "override": true,
+    "monsters": [ { "monster": "mon_mosquito_small", "weight": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_GRASSHOPPER",
+    "override": true,
+    "monsters": [ { "monster": "mon_grasshopper_small" } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_LOCUST",
+    "override": true,
+    "monsters": [ { "monster": "mon_locust_small", "weight": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_WATER_STRIDER",
+    "override": true,
+    "monsters": [ { "monster": "mon_strider_small" } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_PRAYING_MANTIS",
+    "override": true,
+    "monsters": [ { "monster": "mon_mantis_small", "weight": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_APHID",
+    "override": true,
+    "monsters": [ { "monster": "mon_aphid_small" } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_LADY_BUG",
+    "override": true,
+    "monsters": [ { "monster": "mon_lady_bug" } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_CENTIPEDE",
+    "override": true,
+    "monsters": [ { "monster": "mon_centipede_small", "weight": 30 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_STAG_BEETLE",
+    "override": true,
+    "monsters": [ { "monster": "mon_stag_beetle_small", "weight": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_BUTTERFLY",
+    "override": true,
+    "monsters": [ { "monster": "mon_butterfly", "weight": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_MOTH",
+    "override": true,
+    "monsters": [ { "monster": "mon_moth", "weight": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_SNAIL",
+    "override": true,
+    "monsters": [ { "monster": "mon_snail_forest", "weight": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_SLUG",
+    "override": true,
+    "monsters": [ { "monster": "mon_slug_forest", "weight": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_MOTH_FLY",
+    "override": true,
+    "monsters": [ { "monster": "mon_moth_fly_small" } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_SILVERFISH",
+    "override": true,
+    "monsters": [ { "monster": "mon_silverfish_small" } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_CENTIPEDE_HOUSE",
+    "override": true,
+    "monsters": [ { "monster": "mon_centipede_house_small" } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_CENTIPEDE",
+    "override": true,
+    "monsters": [ { "monster": "mon_centipede_small", "weight": 30 } ]
+  }
+]

--- a/data/mods/XedraWood/monsters/vanilla_overrides.json
+++ b/data/mods/XedraWood/monsters/vanilla_overrides.json
@@ -1,0 +1,284 @@
+[
+  {
+    "id": "mon_large_cockroach",
+    "copy-from": "mon_large_cockroach",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_worm_small",
+    "copy-from": "mon_worm_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_silverfish_small",
+    "copy-from": "mon_silverfish_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_bee",
+    "copy-from": "mon_bee",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_centipede_small",
+    "copy-from": "mon_centipede_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_centipede_house_small",
+    "copy-from": "mon_centipede_house_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_dragonfly_giant",
+    "copy-from": "mon_dragonfly_giant",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_fly",
+    "copy-from": "mon_fly",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_mosquito_small",
+    "copy-from": "mon_mosquito_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_mosquito_larva",
+    "copy-from": "mon_mosquito_larva",
+    "type": "MONSTER",
+    "upgrades": { "age_grow": 30, "into": "mon_mosquito_small" }
+  },
+  {
+    "id": "mon_spider_cellar_small",
+    "copy-from": "mon_spider_cellar_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_spider_cellar_giant_s",
+    "copy-from": "mon_spider_cellar_giant_s",
+    "type": "MONSTER",
+    "upgrades": { "age_grow": 30, "into": "mon_spider_cellar_small" }
+  },
+  {
+    "id": "mon_spider_jumping_small",
+    "copy-from": "mon_spider_jumping_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_spider_jumping_giant_s",
+    "copy-from": "mon_spider_jumping_giant_s",
+    "type": "MONSTER",
+    "upgrades": { "age_grow": 30, "into": "mon_spider_jumping_small" }
+  },
+  {
+    "id": "mon_spider_trapdoor_small",
+    "copy-from": "mon_spider_trapdoor_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_spider_trapdoor_s",
+    "copy-from": "mon_spider_jumping_giant_s",
+    "type": "MONSTER",
+    "upgrades": { "age_grow": 30, "into": "mon_spider_trapdoor_small" }
+  },
+  {
+    "id": "mon_spider_web_small",
+    "copy-from": "mon_spider_web_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_spider_web_s",
+    "copy-from": "mon_spider_jumping_giant_s",
+    "type": "MONSTER",
+    "upgrades": { "age_grow": 30, "into": "mon_spider_web_small" }
+  },
+  {
+    "id": "mon_spider_widow_small",
+    "copy-from": "mon_spider_widow_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_spider_widow_giant_s",
+    "copy-from": "mon_spider_widow_giant_s",
+    "type": "MONSTER",
+    "upgrades": { "age_grow": 30, "into": "mon_spider_widow_small" }
+  },
+  {
+    "id": "mon_spider_wolf_small",
+    "copy-from": "mon_spider_wolf_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_spider_wolf_giant_s",
+    "copy-from": "mon_spider_wolf_giant_s",
+    "type": "MONSTER",
+    "upgrades": { "age_grow": 30, "into": "mon_spider_wolf_small" }
+  },
+  {
+    "id": "mon_wasp_small",
+    "copy-from": "mon_wasp_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_wasp_small_guard",
+    "copy-from": "mon_wasp_small_guard",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_ant_small",
+    "copy-from": "mon_ant_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_ant_larva",
+    "copy-from": "mon_ant_larva",
+    "type": "MONSTER",
+    "upgrades": { "age_grow": 30, "into": "mon_ant_small" }
+  },
+  {
+    "id": "mon_ant_soldier",
+    "copy-from": "mon_ant_soldier",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_ant_acid_small",
+    "copy-from": "mon_ant_acid_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_ant_acid_larva",
+    "copy-from": "mon_ant_acid_larva",
+    "type": "MONSTER",
+    "upgrades": { "age_grow": 30, "into": "mon_ant_acid_small" }
+  },
+  {
+    "id": "mon_ant_acid_soldier",
+    "copy-from": "mon_ant_acid_soldier",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_locust_small",
+    "copy-from": "mon_locust_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_locust_nymph",
+    "copy-from": "mon_locust_nymph",
+    "type": "MONSTER",
+    "upgrades": { "age_grow": 30, "into": "mon_locust_small" }
+  },
+  {
+    "id": "mon_aphid_small",
+    "copy-from": "mon_aphid_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_mantis_small",
+    "copy-from": "mon_mantis_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_mantis_nymph",
+    "copy-from": "mon_mantis_nymph",
+    "type": "MONSTER",
+    "upgrades": { "age_grow": 30, "into": "mon_mantis_small" }
+  },
+  {
+    "id": "mon_lady_bug",
+    "copy-from": "mon_lady_bug",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_lady_bug_larva",
+    "copy-from": "mon_lady_bug_larva",
+    "type": "MONSTER",
+    "upgrades": { "age_grow": 30, "into": "mon_lady_bug" }
+  },
+  {
+    "id": "mon_grasshopper_small",
+    "copy-from": "mon_grasshopper_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_grasshopper_nymph",
+    "copy-from": "mon_grasshopper_nymph",
+    "type": "MONSTER",
+    "upgrades": { "age_grow": 30, "into": "mon_grasshopper_small" }
+  },
+  {
+    "id": "mon_stag_beetle_small",
+    "copy-from": "mon_stag_beetle_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_antlion_giant",
+    "copy-from": "mon_antlion_giant",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_strider_small",
+    "copy-from": "mon_strider_small",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_strider_nymph",
+    "copy-from": "mon_strider_nymph",
+    "type": "MONSTER",
+    "upgrades": { "age_grow": 30, "into": "mon_strider_small" }
+  },
+  {
+    "id": "mon_butterfly",
+    "copy-from": "mon_butterfly",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_moth",
+    "copy-from": "mon_moth",
+    "type": "MONSTER",
+    "upgrades": false
+  },
+  {
+    "id": "mon_butterfly_cocoon",
+    "copy-from": "mon_butterfly_cocoon",
+    "type": "MONSTER",
+    "upgrades": { "age_grow": 30, "into": "mon_butterfly" }
+  },
+  {
+    "id": "mon_moth_cocoon",
+    "copy-from": "mon_moth_cocoon",
+    "type": "MONSTER",
+    "upgrades": { "age_grow": 30, "into": "mon_moth" }
+  }
+]

--- a/data/mods/XedraWood/monsters/vanilla_overrides.json
+++ b/data/mods/XedraWood/monsters/vanilla_overrides.json
@@ -40,6 +40,7 @@
     "copy-from": "mon_dragonfly_giant",
     "type": "MONSTER",
     "aggression": 0,
+    "aggro_character": false,
     "upgrades": false
   },
   {

--- a/data/mods/XedraWood/monsters/vanilla_overrides.json
+++ b/data/mods/XedraWood/monsters/vanilla_overrides.json
@@ -39,6 +39,7 @@
     "id": "mon_dragonfly_giant",
     "copy-from": "mon_dragonfly_giant",
     "type": "MONSTER",
+    "aggression": 0,
     "upgrades": false
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[XedraWood] Override insect age_grow and remove higher-growth insects from monstergroups"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

We're going to hand-place them, not turn every single swamp into a Deathworld.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove all automatic `age_grow` limits. from insects. Nymphs now grow into small versions, which do not upgrade. Override monstergroups to remove giant and mega versions of insects. 

Also reduce giant dragonfly aggression.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Teleported around to swamps, observed a lack of horrific 200 kg insects. 

Still some death rumbles between a few zombies, giant insects, a claw hunter pack, a pair of renfields, and a changeling war party but it's up to you to avoid all of that. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
