### PR TITLE
Abort and quarantine tileset atlas uploads interrupted by a renderer reset

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -403,10 +403,38 @@ tile_type &tileset::create_tile_type( const std::string &id, tile_type &&new_til
     return inserted_tile;
 }
 
+bool service_mode2_upload_interrupt( const atlas_upload_interrupt interrupt,
+                                     atlas_replay_quarantine &quarantine,
+                                     const uint64_t instance_before )
+{
+    if( interrupt == atlas_upload_interrupt::renderer_invalidated ) {
+        // The drain is about to destroy the renderer; release the quarantined
+        // handles without SDL_DestroyTexture.
+        quarantine.abandon_pre_lost_renderer();
+    } else if( interrupt == atlas_upload_interrupt::paused ) {
+        // Wait out the background; the foreground event queues the rebuild.
+        pump_until_renderer_foreground();
+    }
+    drain_renderer_recovery();
+    const bool recovered = renderer_coordinator.state() == renderer_recovery_state::ready;
+    if( !quarantine.empty() ) {
+        // Destroy on the live renderer only when the drain left it healthy and the
+        // instance is unchanged (a reset the renderer survived). A bumped instance
+        // or unfinished recovery means the origin renderer is gone -- abandon,
+        // since a loss teardown can destroy it before the instance bumps.
+        if( recovered && renderer_coordinator.instance_generation() == instance_before ) {
+            quarantine.drain_live_renderer();
+        } else {
+            quarantine.abandon_pre_lost_renderer();
+        }
+    }
+    return recovered;
+}
+
 void cata_tiles::load_tileset( const std::string &tileset_id, const bool precheck,
                                const bool force, const bool pump_events, const bool terrain )
 {
-    const renderer_texture_generations gens = renderer_coordinator.texture_generations();
+    renderer_texture_generations gens = renderer_coordinator.texture_generations();
     // Skip the reload only when the same tileset is already bound against the
     // current renderer and texture generations; a generation bump from a
     // device reset or loss invalidates the bundle and must reload.
@@ -415,29 +443,66 @@ void cata_tiles::load_tileset( const std::string &tileset_id, const bool prechec
         && tileset_ptr->get_gpu_textures_generation_at_upload() == gens.textures ) {
         return;
     }
+    // Snapshot the global mutation-overlay ordering before the candidate parse
+    // rewrites it: the ordering must match the bound tileset, so restore it if
+    // the load aborts without publishing a new one.
+    const std::map<std::string, int> overlay_ordering_snapshot = tileset_mutation_overlay_ordering;
     // TODO: move into clear or somewhere else.
     // reset the overlay ordering from the previous loaded tileset
     tileset_mutation_overlay_ordering.clear();
 
-    {
-        // Gate drains across parse + upload + finalize so recovery cannot rebuild
-        // under an unpublished candidate (see atlas_upload_scope). A precheck does
-        // no GPU upload, so it is not gated.
-        atlas_upload_scope upload_guard( !precheck );
-        tileset_ptr = cache.load_tileset( tileset_id, renderer, precheck, force, pump_events, terrain,
-                                          memory_map_mode, gens.instance, gens.textures );
-
-        set_draw_scale( 16 );
-
-        // Precalculate fog transparency
-        // On isometric tilesets, fog intensity scales with zlevel_height in tile_config.json
-        fog_alpha = is_isometric() ? std::min( std::max( int( 255.0f - 255.0f * pow( 155.0f / 255.0f,
-                                               zlevel_height / 100.0f ) ), 40 ), 150 ) : 100;
+    // A reset/loss/pause mid-upload aborts the load and quarantines the partial
+    // candidate; the live tileset stays bound. Drain outside the upload scope
+    // (drains are refused while it owns candidate textures), dispose the
+    // quarantine against the resulting renderer, and retry until the upload lands.
+    atlas_replay_quarantine quarantine;
+    const atlas_upload_poll poll = []() {
+        return renderer_coordinator.mode2_upload_poll();
+    };
+    bool published = false;
+    while( true ) {
+        atlas_upload_interrupt interrupt = atlas_upload_interrupt::none;
+        std::shared_ptr<const tileset> loaded;
+        const uint64_t instance_before = gens.instance;
+        {
+            // Gate drains across the upload (see atlas_upload_scope). A precheck
+            // does no GPU upload, so it is neither gated nor polled.
+            atlas_upload_scope upload_guard( !precheck );
+            loaded = cache.load_tileset( tileset_id, renderer, precheck, force, pump_events, terrain,
+                                         memory_map_mode, gens.instance, gens.textures,
+                                         precheck ? atlas_upload_poll{} : poll,
+                                         precheck ? nullptr : &quarantine, &interrupt );
+        }
+        if( interrupt == atlas_upload_interrupt::none ) {
+            tileset_ptr = loaded;
+            published = true;
+            break;
+        }
+        // Recover the renderer and dispose the quarantined candidate; stop when
+        // the drain could not ready it rather than spinning on a failed recovery.
+        if( !service_mode2_upload_interrupt( interrupt, quarantine, instance_before ) ) {
+            break;
+        }
+        gens = renderer_coordinator.texture_generations();
     }
-    if( !precheck ) {
-        // Service recovery queued during the upload, now that the candidate is
-        // published. An exception unwind skips this, leaving recovery for the next
-        // outer boundary.
+
+    if( !published ) {
+        // The load aborted with the previous tileset still bound; restore the
+        // overlay ordering that matched it.
+        tileset_mutation_overlay_ordering = overlay_ordering_snapshot;
+    }
+
+    set_draw_scale( 16 );
+
+    // Precalculate fog transparency
+    // On isometric tilesets, fog intensity scales with zlevel_height in tile_config.json
+    fog_alpha = is_isometric() ? std::min( std::max( int( 255.0f - 255.0f * pow( 155.0f / 255.0f,
+                                           zlevel_height / 100.0f ) ), 40 ), 150 ) : 100;
+
+    if( !precheck && published ) {
+        // Service any recovery queued during the now-published upload. An
+        // aborted load already drained inside service_mode2_upload_interrupt and
+        // left recovery for the next outer boundary, so do not redrain here.
         drain_renderer_recovery();
     }
 }
@@ -4076,35 +4141,50 @@ std::shared_ptr<tileset> tileset_cache::find_fresh_cached( const tileset_cache_k
 std::shared_ptr<const tileset> tileset_cache::load_tileset( const std::string &tileset_id,
         const SDL_Renderer_Ptr &renderer, const bool precheck, const bool force, const bool pump_events,
         const bool terrain, const std::string &memory_map_mode,
-        const uint64_t current_renderer_instance_gen, const uint64_t current_gpu_textures_gen )
+        const uint64_t current_renderer_instance_gen, const uint64_t current_gpu_textures_gen,
+        const atlas_upload_poll &poll, atlas_replay_quarantine *const quarantine,
+        atlas_upload_interrupt *const out_interrupt )
 {
+    if( out_interrupt ) {
+        *out_interrupt = atlas_upload_interrupt::none;
+    }
     const tileset_cache_key key {
         tileset_id, memory_map_mode, compute_tileset_filter_fingerprint( memory_map_mode )
     };
 
-    const auto get_or_create_tileset = [&]() {
+    // Reuse a bundle uploaded against the current generations unless a reload
+    // is forced. A metadata-only precheck bundle (empty id) is rebuilt when a
+    // real load arrives.
+    if( !force ) {
         if( std::shared_ptr<tileset> fresh = find_fresh_cached( key, current_renderer_instance_gen,
                                              current_gpu_textures_gen ) ) {
-            return fresh;
+            if( precheck || !fresh->get_tileset_id().empty() ) {
+                return fresh;
+            }
         }
-        std::shared_ptr<tileset> new_ts = std::make_shared<tileset>();
-        loader loader( *new_ts, renderer, memory_map_mode );
-        loader.load( tileset_id, precheck, pump_events, terrain );
-        new_ts->set_upload_generations( current_renderer_instance_gen, current_gpu_textures_gen );
-        // insert_or_assign so an expired weak_ptr at this key is replaced
-        // instead of being kept alongside a duplicate emplace attempt.
-        tilesets_.insert_or_assign( key, new_ts );
-        return new_ts;
-    };
-
-    std::shared_ptr<tileset> ts = get_or_create_tileset();
-
-    if( force || ( ts->get_tileset_id().empty() && !precheck ) ) {
-        loader loader( *ts, renderer, memory_map_mode );
-        loader.load( tileset_id, precheck, pump_events, terrain );
-        ts->set_upload_generations( current_renderer_instance_gen, current_gpu_textures_gen );
     }
-    return ts;
+
+    // Build the candidate in isolation and publish only on a fully successful
+    // upload, so an interrupted load never replaces the live bundle in the
+    // cache or in any consumer.
+    std::shared_ptr<tileset> candidate = std::make_shared<tileset>();
+    loader loader( *candidate, renderer, memory_map_mode );
+    const atlas_upload_interrupt interrupt =
+        loader.load( tileset_id, precheck, pump_events, terrain,
+                     current_renderer_instance_gen, current_gpu_textures_gen, poll, quarantine );
+    if( interrupt != atlas_upload_interrupt::none ) {
+        if( out_interrupt ) {
+            *out_interrupt = interrupt;
+        }
+        // Candidate dropped; its textures are already in the quarantine. The
+        // cache entry and every live tileset_ptr stay on the previous bundle.
+        return nullptr;
+    }
+    // load() recorded the generations on the bundle during upload.
+    // insert_or_assign so an expired weak_ptr at this key is replaced instead
+    // of being kept alongside a duplicate emplace attempt.
+    tilesets_.insert_or_assign( key, candidate );
+    return candidate;
 }
 
 void tileset_cache::release_live_atlases()

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -218,6 +218,13 @@ class atlas_replay_quarantine
         bool empty() const {
             return batches_.empty();
         }
+        // Abandon gate shared by the most recently added batch's handles, or
+        // null when empty, so a caller can tell an abandoned batch (gate set)
+        // from a drained one.
+        gate last_batch_gate() const {
+            return batches_.empty() ? gate{} :
+                   batches_.back().handles.current_gate();
+        }
         // Destroy the quarantined textures against the still-live renderer.
         void drain_live_renderer();
         // Release C++ ownership without SDL_DestroyTexture because the
@@ -491,13 +498,18 @@ class tileset_cache
         // Look up or load a tileset bundle. current_renderer_instance_gen and
         // current_gpu_textures_gen are compared against the bundle's recorded
         // generations; a mismatch on either treats the cached entry as stale
-        // and reloads.
+        // and reloads. A fresh upload builds an isolated candidate, published only
+        // on full success; on interrupt the candidate moves into *quarantine, the
+        // live entry stays, and *out_interrupt reports the reason with a null return.
         std::shared_ptr<const tileset> load_tileset( const std::string &tileset_id,
                 const SDL_Renderer_Ptr &renderer, bool precheck,
                 bool force, bool pump_events, bool terrain,
                 const std::string &memory_map_mode,
                 uint64_t current_renderer_instance_gen,
-                uint64_t current_gpu_textures_gen );
+                uint64_t current_gpu_textures_gen,
+                const atlas_upload_poll &poll = {},
+                atlas_replay_quarantine *quarantine = nullptr,
+                atlas_upload_interrupt *out_interrupt = nullptr );
 
         // Drop the atlas textures on every live cached tileset. Called before
         // renderer destruction so the handles are freed against the live

--- a/src/output.h
+++ b/src/output.h
@@ -1236,6 +1236,28 @@ void refresh_display();
 void drain_renderer_recovery();
 
 /**
+ * Pump SDL events on the main thread until the renderer leaves the paused
+ * lifecycle state (a foreground event has landed). Used by the tileset-load
+ * retry loop after a background interrupt; android-only in practice. No-op in
+ * curses or when not paused.
+ */
+void pump_until_renderer_foreground();
+
+enum class atlas_upload_interrupt;
+class atlas_replay_quarantine;
+/**
+ * Service renderer recovery for an interrupted standalone tileset-load upload and
+ * dispose the quarantined candidate against the resulting renderer: destroy on a
+ * healthy same-instance renderer, otherwise abandon without SDL_DestroyTexture.
+ * instance_before is the instance generation sampled when the candidate textures
+ * were created. Returns true if the renderer came back healthy so the caller may
+ * retry, false to stop and keep the previous tileset bound.
+ */
+bool service_mode2_upload_interrupt( atlas_upload_interrupt interrupt,
+                                     atlas_replay_quarantine &quarantine,
+                                     uint64_t instance_before );
+
+/**
  * Sync OS cursor and ImGui cursor-handling flags with the current
  * ENABLE_MOUSE and HIDE_CURSOR option values. No-op in curses builds.
  */

--- a/src/sdl_renderer_recovery.h
+++ b/src/sdl_renderer_recovery.h
@@ -232,6 +232,10 @@ class renderer_resource_coordinator
         void drain_pending();
         bool is_render_allowed() const;
         bool should_abort_frame() const;
+        // True while the mobile lifecycle epoch is in the paused state, so a
+        // caller can wait out a background event before draining and retrying an
+        // interrupted upload.
+        bool lifecycle_paused() const;
 
         renderer_recovery_state state() const {
             return planner_.state();
@@ -253,6 +257,12 @@ class renderer_resource_coordinator
         renderer_texture_generations texture_generations() const {
             return { renderer_instance_generation_, gpu_textures_generation_ };
         }
+        // Poll the inbox for the standalone tileset-load upload (not a recovery
+        // replay): paused -> paused; resumed-foreground or pending device_reset ->
+        // texture_resources_invalidated; device_lost or the boundary latch ->
+        // renderer_invalidated; a queued targets_reset is left to the drain loop.
+        // Carries no drain state, so it is safe to call outside drain_pending().
+        atlas_upload_interrupt mode2_upload_poll();
 
     private:
         // should_abort_frame without the recovery-owned abort latch: true when
@@ -344,6 +354,11 @@ class renderer_resource_coordinator
         int test_phase_countdown_ = 0;
         bool test_phase_fault_fired_ = false;
         int test_replay_pause_countdown_ = 0;
+        // Mode-2 upload poll seam: after the countdown reaches zero,
+        // mode2_upload_poll() reports test_mode2_interrupt_ once, then resumes
+        // reading the real inbox.
+        int test_mode2_interrupt_countdown_ = 0;
+        atlas_upload_interrupt test_mode2_interrupt_ = atlas_upload_interrupt::none;
 };
 
 // Process-lifetime coordinator; the event-watch userdata must outlive
@@ -421,7 +436,15 @@ struct renderer_recovery_test_support {
     static void arm_phase_fail_retry( int phase_countdown );
     static void arm_phase_queue_device_reset( int phase_countdown );
     static void arm_replay_pause( int poll_countdown );
+    // Arm the mode-2 upload poll to report `interrupt` once after
+    // `poll_countdown` polls, simulating a reset/loss/pause landing mid-load.
+    static void arm_mode2_interrupt( int poll_countdown, atlas_upload_interrupt interrupt );
     static bool replay_quarantine_empty();
+    // Run a synthetic atlas upload interrupted after its textures are created,
+    // capturing the real candidate handles into `quarantine` so the mode-2
+    // disposal path can be exercised. Returns the captured batch's abandon gate.
+    static atlas_replay_quarantine::gate populate_mode2_quarantine(
+        atlas_replay_quarantine &quarantine );
     // Whether the most recently armed phase fault has fired since arming.
     static bool phase_fault_fired();
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -502,9 +502,12 @@ static int SDLCALL renderer_event_watch( void *userdata, SDL_Event *event )
     switch( event->type ) {
         case CATA_RENDER_TARGETS_RESET:
 #if SDL_MAJOR_VERSION >= 3
-            if( event->render.windowID == renderer_watch_window_id )
+            if( event->render.windowID == renderer_watch_window_id ) {
 #endif
                 coord->request_recovery( renderer_recovery_severity::targets_reset );
+#if SDL_MAJOR_VERSION >= 3
+            }
+#endif
             break;
         case CATA_RENDER_DEVICE_RESET:
 #if SDL_MAJOR_VERSION >= 3
@@ -1052,6 +1055,13 @@ static void try_sdl_update()
 void drain_renderer_recovery()
 {
     renderer_coordinator.drain_pending();
+}
+
+void pump_until_renderer_foreground()
+{
+    while( renderer_coordinator.lifecycle_paused() ) {
+        inp_mngr.pump_events();
+    }
 }
 
 bool renderer_should_abort_frame()
@@ -1987,6 +1997,50 @@ atlas_upload_interrupt renderer_resource_coordinator::replay_poll()
     return atlas_upload_interrupt::none;
 }
 
+atlas_upload_interrupt renderer_resource_coordinator::mode2_upload_poll()
+{
+    if( test_mode2_interrupt_countdown_ > 0 ) {
+        --test_mode2_interrupt_countdown_;
+        if( test_mode2_interrupt_countdown_ == 0 ) {
+            const atlas_upload_interrupt injected = test_mode2_interrupt_;
+            test_mode2_interrupt_ = atlas_upload_interrupt::none;
+            // Drive the real inbox so the retry loop's drain has matching work,
+            // as a real reset/loss/pause landing mid-upload would.
+            switch( injected ) {
+                case atlas_upload_interrupt::paused:
+                    notify_lifecycle( lifecycle_state::paused );
+                    break;
+                case atlas_upload_interrupt::texture_resources_invalidated:
+                    request_recovery( renderer_recovery_severity::device_reset );
+                    break;
+                case atlas_upload_interrupt::renderer_invalidated:
+                    request_recovery( renderer_recovery_severity::device_lost );
+                    break;
+                case atlas_upload_interrupt::none:
+                    break;
+            }
+            return injected;
+        }
+    }
+    const uint64_t epoch = lifecycle_epoch_.load();
+    const lifecycle_state ls = lifecycle_state_of( epoch );
+    if( ls == lifecycle_state::paused ) {
+        return atlas_upload_interrupt::paused;
+    }
+    if( ls == lifecycle_state::resumed_pending_rebuild ) {
+        return atlas_upload_interrupt::texture_resources_invalidated;
+    }
+    const renderer_recovery_severity sev = pending_severity_.load();
+    if( sev == renderer_recovery_severity::device_lost
+        || display_buffer_scope_recovery_pending() ) {
+        return atlas_upload_interrupt::renderer_invalidated;
+    }
+    if( sev == renderer_recovery_severity::device_reset ) {
+        return atlas_upload_interrupt::texture_resources_invalidated;
+    }
+    return atlas_upload_interrupt::none;
+}
+
 atlas_upload_interrupt renderer_resource_coordinator::replay_live_atlases()
 {
     return ts_cache.replay_live_atlases( renderer, renderer_instance_generation_,
@@ -2036,6 +2090,11 @@ void renderer_resource_coordinator::seed_renderer_policy( const std::string &ren
 void renderer_resource_coordinator::finish_bootstrap()
 {
     planner_.finish_bootstrap();
+}
+
+bool renderer_resource_coordinator::lifecycle_paused() const
+{
+    return lifecycle_state_of( lifecycle_epoch_.load() ) == lifecycle_state::paused;
 }
 
 void renderer_resource_coordinator::begin_atlas_upload()
@@ -2134,6 +2193,8 @@ void renderer_recovery_test_support::reset_coordinator()
     c.test_phase_countdown_ = 0;
     c.test_phase_fault_fired_ = false;
     c.test_replay_pause_countdown_ = 0;
+    c.test_mode2_interrupt_countdown_ = 0;
+    c.test_mode2_interrupt_ = atlas_upload_interrupt::none;
 }
 
 bool renderer_recovery_test_support::setup_software_renderer()
@@ -2270,6 +2331,35 @@ std::shared_ptr<const tileset> renderer_recovery_test_support::install_synthetic
     return ts;
 }
 
+atlas_replay_quarantine::gate renderer_recovery_test_support::populate_mode2_quarantine(
+    atlas_replay_quarantine &quarantine )
+{
+    tileset ts;
+    ts.tileset_id = "synthetic_mode2_ts";
+    atlas_replay_descriptor desc;
+    desc.image_path_u8 = "tests/data/renderer_recovery_atlas.png";
+    desc.sprite_width = 1;
+    desc.sprite_height = 1;
+    desc.atlas_offset = 0;
+    desc.expected_tilecount = 1;
+    ts.append_atlas_descriptor( desc );
+    // Pass the per-descriptor and pre-subrect polls so the atlas textures are
+    // created, then interrupt at the post-loop poll so the populated candidate
+    // is captured into the quarantine with live handles.
+    int polls = 0;
+    const atlas_upload_poll poll = [&polls]() {
+        return ++polls >= 3 ? atlas_upload_interrupt::texture_resources_invalidated
+               : atlas_upload_interrupt::none;
+    };
+    tileset_cache::loader::upload_atlases( ts, renderer, "color_pixel_sepia_light",
+                                           ts.get_atlas_descriptors(),
+                                           renderer_coordinator.instance_generation(),
+                                           renderer_coordinator.textures_generation(),
+                                           false, poll, &quarantine );
+    cata_assert( !quarantine.empty() );
+    return quarantine.last_batch_gate();
+}
+
 std::shared_ptr<const tileset> renderer_recovery_test_support::fetch_cached_bundle(
     const std::string &tileset_id, const std::string &memory_map_mode,
     const uint64_t current_renderer_instance_gen, const uint64_t current_gpu_textures_gen )
@@ -2312,6 +2402,14 @@ void renderer_recovery_test_support::arm_replay_pause( const int poll_countdown 
 {
     cata_assert( poll_countdown > 0 );
     renderer_coordinator.test_replay_pause_countdown_ = poll_countdown;
+}
+
+void renderer_recovery_test_support::arm_mode2_interrupt( const int poll_countdown,
+        const atlas_upload_interrupt interrupt )
+{
+    cata_assert( poll_countdown > 0 );
+    renderer_coordinator.test_mode2_interrupt_countdown_ = poll_countdown;
+    renderer_coordinator.test_mode2_interrupt_ = interrupt;
 }
 
 bool renderer_recovery_test_support::replay_quarantine_empty()

--- a/src/tileset_loader.cpp
+++ b/src/tileset_loader.cpp
@@ -300,12 +300,6 @@ void tileset_cache::loader::create_textures_from_tile_atlas( const SDL_Surface_P
     }
 }
 
-template<typename T>
-static void extend_vector_by( std::vector<T> &vec, const size_t additional_size )
-{
-    vec.resize( vec.size() + additional_size );
-}
-
 void tileset_cache::loader::read_image_dimensions( const cata_path &img_path,
         const int kr, const int kg, const int kb )
 {
@@ -317,12 +311,6 @@ void tileset_cache::loader::read_image_dimensions( const cata_path &img_path,
 
     const int expected_tilecount = ( tile_atlas->w / sprite_width ) *
                                    ( tile_atlas->h / sprite_height );
-    extend_vector_by( ts.tile_values, expected_tilecount );
-    extend_vector_by( ts.shadow_tile_values, expected_tilecount );
-    extend_vector_by( ts.night_tile_values, expected_tilecount );
-    extend_vector_by( ts.overexposed_tile_values, expected_tilecount );
-    extend_vector_by( ts.memory_tile_values, expected_tilecount );
-    extend_vector_by( ts.silhouette_tile_values, expected_tilecount );
 
     atlas_replay_descriptor desc;
     desc.image_path_u8 = img_path.get_unrelative_path().u8string();

--- a/src/tileset_loader.cpp
+++ b/src/tileset_loader.cpp
@@ -326,8 +326,10 @@ void tileset_cache::loader::read_image_dimensions( const cata_path &img_path,
     size = expected_tilecount;
 }
 
-void tileset_cache::loader::load( const std::string &tileset_id, const bool precheck,
-                                  const bool pump_events, const bool terrain )
+atlas_upload_interrupt tileset_cache::loader::load( const std::string &tileset_id,
+        const bool precheck, const bool pump_events, const bool terrain,
+        const uint64_t renderer_instance_generation, const uint64_t gpu_textures_generation,
+        const atlas_upload_poll &poll, atlas_replay_quarantine *const quarantine )
 {
     std::string json_conf;
     std::string layering;
@@ -393,7 +395,10 @@ void tileset_cache::loader::load( const std::string &tileset_id, const bool prec
 
     if( precheck ) {
         config.allow_omitted_members();
-        return;
+        // A precheck loads no textures; still record the generations so the
+        // metadata-only bundle is cache-fresh until the next renderer epoch.
+        ts.set_upload_generations( renderer_instance_generation, gpu_textures_generation );
+        return atlas_upload_interrupt::none;
     }
 
     ts.clear();
@@ -500,8 +505,9 @@ void tileset_cache::loader::load( const std::string &tileset_id, const bool prec
         load_layers( layer_config );
     }
 
-    upload_atlases( ts, renderer, memory_map_mode, ts.get_atlas_descriptors(),
-                    0, 0, pump_events );
+    return upload_atlases( ts, renderer, memory_map_mode, ts.get_atlas_descriptors(),
+                           renderer_instance_generation, gpu_textures_generation,
+                           pump_events, poll, quarantine );
 }
 
 void tileset_cache::loader::parse_atlases( const JsonObject &config,

--- a/src/tileset_loader.h
+++ b/src/tileset_loader.h
@@ -116,9 +116,16 @@ class tileset_cache::loader
         // tileset_id matches the option string. precheck only loads metadata
         // (tile dimensions). pump_events handles window events / refreshes
         // the screen during the upload pass. terrain marks this as an
-        // overmap/terrain tileset.
-        void load( const std::string &tileset_id, bool precheck, bool pump_events = false,
-                   bool terrain = false );
+        // overmap/terrain tileset. poll is consulted between atlas chunks; on
+        // interrupt the candidate textures move into *quarantine and the reason
+        // is returned without committing to ts. The generations are recorded on
+        // the uploaded bundle for the cache staleness check.
+        atlas_upload_interrupt load( const std::string &tileset_id, bool precheck,
+                                     bool pump_events = false, bool terrain = false,
+                                     uint64_t renderer_instance_generation = 0,
+                                     uint64_t gpu_textures_generation = 0,
+                                     const atlas_upload_poll &poll = {},
+                                     atlas_replay_quarantine *quarantine = nullptr );
 
         // Upload every descriptor and regenerate the default highlight when
         // active. Builds candidate vectors and swaps them into ts on full

--- a/tests/renderer_recovery_test.cpp
+++ b/tests/renderer_recovery_test.cpp
@@ -10,6 +10,7 @@
 #include "cata_imgui.h"
 #include "cata_tiles.h"
 #include "options_helpers.h"
+#include "output.h"
 #include "point.h"
 #include "sdl_renderer_recovery.h"
 
@@ -300,6 +301,48 @@ TEST_CASE( "renderer_coordinator_embargoes_render_on_inbox_change", "[tiles][ren
         coord.notify_lifecycle( lifecycle_state::paused );
         CHECK_FALSE( coord.is_render_allowed() );
         CHECK( coord.should_abort_frame() );
+    }
+}
+
+TEST_CASE( "renderer_coordinator_mode2_upload_poll_maps_inbox", "[tiles][renderer_recovery]" )
+{
+    // The standalone tileset-load upload polls the inbox through
+    // mode2_upload_poll; each inbox state must map to the interrupt the retry loop
+    // acts on, so a mid-upload reset/loss/pause aborts and quarantines instead of
+    // creating textures against a dead renderer.
+    renderer_resource_coordinator coord;
+    coord.finish_bootstrap();
+    REQUIRE( coord.mode2_upload_poll() == atlas_upload_interrupt::none );
+
+    SECTION( "paused lifecycle pauses the upload" ) {
+        coord.notify_lifecycle( lifecycle_state::paused );
+        CHECK( coord.mode2_upload_poll() == atlas_upload_interrupt::paused );
+    }
+
+    SECTION( "resumed foreground invalidates textures" ) {
+        coord.notify_lifecycle( lifecycle_state::resumed_pending_rebuild );
+        CHECK( coord.mode2_upload_poll() == atlas_upload_interrupt::texture_resources_invalidated );
+    }
+
+    SECTION( "queued device reset invalidates textures" ) {
+        coord.request_recovery( renderer_recovery_severity::device_reset );
+        CHECK( coord.mode2_upload_poll() == atlas_upload_interrupt::texture_resources_invalidated );
+    }
+
+    SECTION( "queued targets reset is left to the drain loop" ) {
+        coord.request_recovery( renderer_recovery_severity::targets_reset );
+        CHECK( coord.mode2_upload_poll() == atlas_upload_interrupt::none );
+    }
+
+    SECTION( "queued device loss invalidates the renderer" ) {
+        coord.request_recovery( renderer_recovery_severity::device_lost );
+        CHECK( coord.mode2_upload_poll() == atlas_upload_interrupt::renderer_invalidated );
+    }
+
+    SECTION( "paused outranks a queued device loss" ) {
+        coord.request_recovery( renderer_recovery_severity::device_lost );
+        coord.notify_lifecycle( lifecycle_state::paused );
+        CHECK( coord.mode2_upload_poll() == atlas_upload_interrupt::paused );
     }
 }
 
@@ -833,6 +876,79 @@ TEST_CASE( "renderer_coordinator_replay_pause_quarantines_then_retries",
     renderer_coordinator.drain_pending();
     CHECK( renderer_recovery_test_support::replay_quarantine_empty() );
     CHECK( renderer_coordinator.is_render_allowed() );
+}
+
+TEST_CASE( "renderer_coordinator_mode2_interrupt_disposes_quarantine",
+           "[tiles][renderer_recovery]" )
+{
+    // The standalone tileset-load retry path quarantines a candidate on an
+    // interrupted upload, then disposes it against the post-drain renderer:
+    // destroy on the live renderer only when recovery left it healthy and the same
+    // instance survived, otherwise abandon so no SDL_DestroyTexture runs against a
+    // dead or half-rebuilt renderer.
+    software_render_fixture fx;
+    if( !fx.available() ) {
+        WARN( "dummy SDL video backend unavailable; skipping" );
+        return;
+    }
+
+    SECTION( "successful reset drains the candidate on the surviving renderer" ) {
+        atlas_replay_quarantine quarantine;
+        const atlas_replay_quarantine::gate gate =
+            renderer_recovery_test_support::populate_mode2_quarantine( quarantine );
+        REQUIRE_FALSE( quarantine.empty() );
+        REQUIRE( gate );
+        REQUIRE_FALSE( gate->load() );
+        const uint64_t inst = renderer_coordinator.instance_generation();
+
+        renderer_coordinator.request_recovery( renderer_recovery_severity::device_reset );
+        const bool recovered = service_mode2_upload_interrupt(
+                                   atlas_upload_interrupt::texture_resources_invalidated, quarantine, inst );
+
+        CHECK( recovered );
+        CHECK( quarantine.empty() );
+        CHECK_FALSE( gate->load() );
+    }
+
+    SECTION( "a failed reset drain abandons the candidate and stops" ) {
+        atlas_replay_quarantine quarantine;
+        const atlas_replay_quarantine::gate gate =
+            renderer_recovery_test_support::populate_mode2_quarantine( quarantine );
+        REQUIRE_FALSE( quarantine.empty() );
+        REQUIRE( gate );
+        const uint64_t inst = renderer_coordinator.instance_generation();
+
+        // Bail the reset recipe so the drain ends retry_needed: the renderer may
+        // be mid-teardown, so the candidate must be abandoned, not destroyed, and
+        // the caller must stop rather than retry against an unready renderer.
+        renderer_coordinator.request_recovery( renderer_recovery_severity::device_reset );
+        renderer_recovery_test_support::arm_phase_fail_retry( 1 );
+        const bool recovered = service_mode2_upload_interrupt(
+                                   atlas_upload_interrupt::texture_resources_invalidated, quarantine, inst );
+
+        CHECK_FALSE( recovered );
+        CHECK( quarantine.empty() );
+        CHECK( gate->load() );
+    }
+
+    SECTION( "device loss abandons the candidate before the renderer is recreated" ) {
+        atlas_replay_quarantine quarantine;
+        const atlas_replay_quarantine::gate gate =
+            renderer_recovery_test_support::populate_mode2_quarantine( quarantine );
+        REQUIRE_FALSE( quarantine.empty() );
+        REQUIRE( gate );
+        const uint64_t inst = renderer_coordinator.instance_generation();
+
+        renderer_coordinator.request_recovery( renderer_recovery_severity::device_lost );
+        const bool recovered = service_mode2_upload_interrupt(
+                                   atlas_upload_interrupt::renderer_invalidated, quarantine, inst );
+
+        CHECK( recovered );
+        CHECK( quarantine.empty() );
+        // renderer_invalidated abandons up front; the recreated renderer must
+        // never receive SDL_DestroyTexture for the old handles.
+        CHECK( gate->load() );
+    }
 }
 
 TEST_CASE( "renderer_coordinator_retries_from_any_phase", "[tiles][renderer_recovery]" )


### PR DESCRIPTION
#### Summary
Infrastructure "Abort and quarantine tileset atlas uploads interrupted by a renderer reset"

#### Purpose of change
More SDL3 render-pipeline hardening, stacked on #87424, which wires the recovery coordinator into the event loop. That means a device reset, loss, or background can now land in the middle of a tileset atlas upload (backgrounding the app mid-load, say). Before, an interrupted upload kept creating textures against a renderer being torn down, or published a half-built bundle. This makes the standalone tileset load abort cleanly and retry.

#### Describe the solution
The tileset load builds an isolated candidate bundle and publishes it only on a fully successful upload, so an interrupted load never replaces the live bundle in the cache or in any consumer.

During the upload the loader polls the coordinator between atlas chunks. A paused lifecycle, a queued device reset, or a device loss maps to an interrupt; the partial candidate's textures move into a quarantine instead of being committed, and the load returns the reason.

On each interrupt the retry loop drains recovery outside the upload scope (drains are deferred while the scope owns candidate textures), disposes the quarantined candidate, and retries, until the upload lands or recovery cannot ready the renderer. Disposal is the careful part:

- destroy the textures on the live renderer only when the drain left it healthy and the same instance survived,
- otherwise abandon them without SDL_DestroyTexture, so nothing runs against a renderer that was lost or recreated.

A background interrupt waits out the foreground event before retrying.

Also drops a dead parse-time pre-size of the tile_values vectors; the upload path sizes them, so the early resize did nothing.

#### Describe alternatives you've considered
Let the upload finish and rebuild afterwards, but that creates textures against a renderer already gone on a reset or loss, which is the crash. Draining inside the upload scope would let a rebuild land under half-published textures, which is exactly what the scope defers drains to avoid.

#### Testing
Desktop unchanged, Android still works correctly. New tests cover the inbox-to-interrupt mapping and the quarantine disposal across a surviving reset, a failed drain, and a device loss.

#### Additional context
N/A