### PR TITLE
Increase `EOC_ROBOFAC_HQ_UPDATE_EVENT` condition's maximum range to 180 OMT

### DIFF
--- a/data/json/mapgen/robofaq_locs/EOC_robofac_hq_updater.json
+++ b/data/json/mapgen/robofaq_locs/EOC_robofac_hq_updater.json
@@ -12,7 +12,7 @@
     "global": true,
     "condition": {
       "and": [
-        { "u_near_om_location": "robofachq_surface_road1", "range": 30 },
+        { "u_near_om_location": "robofachq_surface_road1", "range": 180 },
         { "not": { "u_near_om_location": "robofachq_surface_road1", "range": 4 } },
         { "math": [ "robofac_destroyed != 1" ] }
       ]


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
I recall candlebury saying in the devcord that the maximum radius of the `EOC_ROBOFAC_HQ_UPDATE_EVENT` eoc condition could be changed to 180 OMT, so i changed it to that.

#### Describe the solution

30 -> 180

#### Describe alternatives you've considered

Not doing so? Higher or lower number than 180?

#### Testing

Made a new char starting at winter year 1, debug reveal to find where the hub is, Found one at the distance of ~160 OMT from where i am. I waited for 12 hours and then jump there to check. The sandbags are infact placed down.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
