### PR TITLE
Stop rebuilding crafting cost context every tick

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6473,7 +6473,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
         }
     }
     // Charge shortfall rewinds the turn before any skill gain.
-    if( !crafter.craft_consume_step_tools( craft ) ) {
+    if( !crafter.craft_consume_step_tools( craft, &cached_cost_ctx ) ) {
         rewind_turn();
         return;
     }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6387,12 +6387,18 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
         return;
     }
 
+    // Book bonuses and tool speeds come from the nearby inventory, not the
+    // crafter's proficiency, so they survive the per-5% proficiency invalidation.
+    // batch_time still applies the live proficiency malus on top of this context,
+    // so the move totals stay current without rebuilding it each step.
+    if( !cost_ctx_ready ) {
+        cached_cost_ctx = { crafter.book_bonuses_nearby(), compute_tool_speeds( rec, crafter ) };
+        cost_ctx_ready = true;
+    }
+
     if( cached_crafting_speed != crafting_speed || cached_assistants != assistants ) {
         cached_crafting_speed = crafting_speed;
         cached_assistants = assistants;
-        // Recompute cost context: tool speeds + book proficiency bonuses
-        cached_cost_ctx = { crafter.book_bonuses_nearby(), compute_tool_speeds( rec, crafter ) };
-
         // Base moves for batch size with no speed modifier or assistants
         // Must ensure >= 1 so we don't divide by 0;
         cached_base_total_moves = std::max( static_cast<int64_t>( 1 ),

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1972,6 +1972,7 @@ class craft_activity_actor : public activity_actor
         float cached_crafting_speed; // NOLINT(cata-serialize)
         int cached_assistants; // NOLINT(cata-serialize)
         crafting_cost_context cached_cost_ctx; // NOLINT(cata-serialize)
+        bool cost_ctx_ready = false; // NOLINT(cata-serialize)
         double cached_base_total_moves; // NOLINT(cata-serialize)
         double cached_cur_total_moves; // NOLINT(cata-serialize)
         float cached_workbench_multiplier; // NOLINT(cata-serialize)

--- a/src/character.h
+++ b/src/character.h
@@ -102,6 +102,7 @@ enum npc_attitude : int;
 struct attention_plan;
 struct bionic;
 struct construction;
+struct crafting_cost_context;
 struct dealt_projectile_attack;
 /// @brief Item slot used to apply modifications from food and meds
 struct islot_comestible;
@@ -3845,8 +3846,10 @@ class Character : public Creature, public visitable
         /** Consume tools for the next multiplier * 5% progress of the craft */
         bool craft_consume_tools( item &craft, int multiplier, bool start_craft );
         /** Advance per-step tool consumption so each step's allocations match its
-         *  current progress.  Returns false (consuming nothing) if charges are short. */
-        bool craft_consume_step_tools( item &craft );
+         *  current progress.  Returns false (consuming nothing) if charges are short.
+         *  When cost_ctx is supplied, it is reused for step budgets instead of
+         *  recomputing crafting_cost_context::for_recipe. */
+        bool craft_consume_step_tools( item &craft, const crafting_cost_context *cost_ctx = nullptr );
         /** Advance the active unattended step's tool consumption to match its
          *  wall-clock progress.  Returns false (consuming nothing) if charges are short. */
         bool craft_consume_passive_step_tools( item &craft, time_point now, const item_location &loc );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -3782,7 +3782,7 @@ bool Character::verify_step_tools( item &craft, int step_idx,
     return true;
 }
 
-bool Character::craft_consume_step_tools( item &craft )
+bool Character::craft_consume_step_tools( item &craft, const crafting_cost_context *cost_ctx )
 {
     if( has_trait( trait_DEBUG_HS ) ) {
         return true;
@@ -3795,7 +3795,13 @@ bool Character::craft_consume_step_tools( item &craft )
     const int cur_step = craft.get_current_step();
     const double cur_progress = craft.get_step_progress();
     const bool craft_done = craft.item_counter >= 10000000;
-    const crafting_cost_context ctx = crafting_cost_context::for_recipe( *this, rec );
+    // for_recipe rebuilds the nearby inventory and rescans qualities, too costly
+    // to run every turn in a dense base; lean on the caller's cache when given.
+    std::optional<crafting_cost_context> ctx_owned;
+    if( cost_ctx == nullptr ) {
+        ctx_owned = crafting_cost_context::for_recipe( *this, rec );
+    }
+    const crafting_cost_context &ctx = cost_ctx != nullptr ? *cost_ctx : *ctx_owned;
 
     std::vector<int> targets( n_steps, 0 );
     for( int s = 0; s < n_steps; ++s ) {


### PR DESCRIPTION
#### Summary
Performance "Stop rebuilding crafting cost context every tick"

#### Purpose of change
Fixes #87414. #87343 missed stepped recipes. Crafting a steel mace in a hoarder base, every tick burned ~250ms rebuilding the nearby inventory and rescanning every step's qualities, so it just crawled.

#### Describe the solution
craft_consume_step_tools was recomputing crafting_cost_context::for_recipe every tick when do_turn already has it cached. Now it just takes the cached one.

do_turn was also rebuilding that context on every 5% proficiency tick for no reason: book bonuses and tool speeds come from the nearby stuff, not proficiency. So build it once. Move totals still recompute and batch_time still applies the live proficiency malus, so speed keeps up with proficiency.

#### Describe alternatives you've considered
N/A

#### Testing
Verified with the save provided in the original issue.