### PR TITLE
Fix SDL3 colored light tint accumulation and dimming

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -467,8 +467,10 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
         SDL_Rect clipRect = {dest.x, dest.y, width, height};
         RenderSetClipRect( renderer, &clipRect );
 
-        //fill render area with black to prevent artifacts where no new pixels are drawn
-        geometry->rect( renderer, clipRect, SDL_Color() );
+        //fill render area with opaque black to prevent artifacts where no new pixels are drawn.
+        //alpha must be 255: the color-modulated geometry backend composites via a BLEND texture,
+        //so an alpha-0 fill would be a no-op and leave the persistent display_buffer uncleared.
+        geometry->rect( renderer, clipRect, SDL_Color{ 0, 0, 0, 255 } );
     }
 
     const point s = get_window_base_tile_counts( point( width, height ) );
@@ -1180,7 +1182,23 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                             const SDL_Color tc = { tp->com.tint_color.r, tp->com.tint_color.g,
                                                    tp->com.tint_color.b, tp->com.tint_color.a
                                                  };
+#if SDL_MAJOR_VERSION >= 3
+                            // SDL3's straight-alpha draw-color modulation renders the fill
+                            // dimmer than SDL2 for the same alpha. Composite as a premultiplied
+                            // source to keep the additive look: out = tint*a + dst*(1-a).
+                            // SDL_BLENDMODE_BLEND_PREMULTIPLIED is SDL3-only; the SDL2 geometry
+                            // helper already produces the expected intensity.
+                            const Uint8 a = tc.a;
+                            SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_BLEND_PREMULTIPLIED );
+                            SetRenderDrawColor( renderer,
+                                                static_cast<Uint8>( tc.r * a / 255 ),
+                                                static_cast<Uint8>( tc.g * a / 255 ),
+                                                static_cast<Uint8>( tc.b * a / 255 ),
+                                                a );
+                            RenderFillRect( renderer, &tile_rect );
+#else
                             geometry->rect( renderer, tile_rect, tc );
+#endif
                             continue;
                         }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3735,7 +3735,8 @@ std::string options_manager::show( bool ingame, const bool world_options_only, b
                 case ItemType::GroupHeader:
                     return true;
                 case ItemType::Option:
-                    return groups_state[curr_item.group];
+                    return groups_state[curr_item.group]
+                    && !get_options().get_option( curr_item.data ).is_hidden();
                 default:
                     cata_fatal( "invalid ItemType" );
             }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2745,9 +2745,19 @@ void options_manager::add_options_graphics()
         get_option( "FRAMEBUFFER_ACCEL" ).setPrerequisite( "RENDERER", "software" );
 #endif
 
+        // Color-modulated textures are an SDL2-era speed-up that replaces
+        // RenderFillRect with a stretched 1x1 texture. Under SDL3 the renderer
+        // batches fills efficiently and the texture path blends differently, so
+        // the saved value is ignored at startup and the option is hidden; the ID
+        // is retained so existing configs still parse.
+#if defined(USE_SDL3)
+        const options_manager::copt_hide_t color_modulated_hide = COPT_ALWAYS_HIDE;
+#else
+        const options_manager::copt_hide_t color_modulated_hide = COPT_CURSES_HIDE;
+#endif
         add( "USE_COLOR_MODULATED_TEXTURES", page_id, to_translation( "Use color modulated textures" ),
              to_translation( "If true, tries to use color modulated textures to speed-up ASCII drawing.  Requires restart." ),
-             false, COPT_CURSES_HIDE
+             false, color_modulated_hide
            );
 
         add( "SCALING_MODE", page_id, to_translation( "Scaling mode" ),

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -542,11 +542,18 @@ static void WinCreate()
     DebugLog( D_INFO, DC_ALL ) << "USE_COLOR_MODULATED_TEXTURES is set to " <<
                                get_option<bool>( "USE_COLOR_MODULATED_TEXTURES" );
     //initialize the alternate rectangle texture for replacing SDL_RenderFillRect
+#if SDL_MAJOR_VERSION >= 3
+    // SDL3 batches RenderFillRect efficiently and the modulated texture path
+    // blends differently from a plain fill (it breaks the per-frame clear), so
+    // the saved option value is ignored and the default renderer is always used.
+    geometry = std::make_unique<DefaultGeometryRenderer>();
+#else
     if( get_option<bool>( "USE_COLOR_MODULATED_TEXTURES" ) && !software_renderer ) {
         geometry = std::make_unique<ColorModulatedGeometryRenderer>( renderer );
     } else {
         geometry = std::make_unique<DefaultGeometryRenderer>();
     }
+#endif
 
     imclient = std::make_unique<cataimgui::client>( renderer, window, geometry );
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix SDL3 colored light tint rendering"

#### Purpose of change

Fixes #87338. Colored light tint renders wrong on SDL3: it piles up every frame into a trippy mess with color modulated textures on, and reads dimmer than SDL2 otherwise.

#### Describe the solution

The per-frame map clear used a zero-alpha fill, which is a no-op under the color-modulated backend (BLEND texture copy), so the persistent display buffer never cleared and tint stacked. So USE_COLOR_MODULATED_TEXTURES was basically the root cause. Clear with opaque black, and retire that option on SDL3 anyway (SDL2-era hack, blends wrong, now forced off and hidden).

For the dimness, SDL3 renders the same alpha fill dimmer than SDL2. Simple tint now composites premultiplied under SDL_BLENDMODE_BLEND_PREMULTIPLIED, which keeps SDL2's look. That mode is SDL3-only so it's guarded; SDL2 was fine already.

While in there, fixed a known bug the SDL3 renderer-option deprecation exposed: the options menu let keyboard nav land on hidden rows, so you had to press down twice past them. is_selectable skips hidden options now.

#### Describe alternatives you've considered

MUL blend matches both builds but looks washed out, no thanks. Left the silhouette tint path (tall sprites) alone, it uses a different blend path that isn't affected.

#### Testing

Verified in-game on SDL2 and SDL3 with the reported save.

#### Additional context

N/A