### PR TITLE
Fix hardcoded FreeType include path for Windows CMake builds 

### DIFF
--- a/src/third-party/CMakeLists.txt
+++ b/src/third-party/CMakeLists.txt
@@ -145,7 +145,7 @@ if (TILES)
                         imgui
                         SYSTEM
                         PRIVATE
-                        /usr/include/freetype2
+                        ${FREETYPE_INCLUDE_DIRS}
                         )
             endif ()
         else ()
@@ -154,7 +154,7 @@ if (TILES)
                     SYSTEM
                     PRIVATE
                     ${SDL2_INCLUDE_DIR}/..
-                    /usr/include/freetype2
+                    ${FREETYPE_INCLUDE_DIRS}
                     )
         endif ()
 


### PR DESCRIPTION
#### Summary
Build "Fix hardcoded FreeType include path breaking CMake builds on Windows/MSYS2"

#### Purpose of change
CMake build fails on Windows/MSYS2 with:
fatal error: ft2build.h: No such file or directory

src/third-party/CMakeLists.txt hardcoded /usr/include/freetype2 in two places 
(lines 148 and 157). This is a Linux-only path. g++.exe on Windows is a native 
binary and cannot resolve Unix-style paths. FreeType is correctly installed by 
MSYS2 at C:/msys64/mingw64/include/freetype2 but the compiler is never pointed there.

Closes #87441

#### Describe the solution
Replace both occurrences of /usr/include/freetype2 with ${FREETYPE_INCLUDE_DIRS}.
CMake sets this variable automatically to the correct platform path when FreeType 
is found. The project already uses PkgConfig::Freetype correctly in the link step 
— the include path now uses the same approach.

#### Describe alternatives you've considered
Hardcoding the MSYS2 Windows path directly would fix it on MSYS2 but break other 
environments. Using ${FREETYPE_INCLUDE_DIRS} is the correct cross-platform solution.

#### Testing
Tested on Windows 11, MSYS2 MinGW64, GCC 16.1.0, CMake 3.27.1 with 
-DTILES=ON -DSOUND=ON. Build proceeds past the FreeType compilation step 
after this fix.

#### Additional context
Related issue: #87441