### PR TITLE
Fix saving of character-specific Safe Mode and Auto-Pickup configurat…

### DIFF
--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -896,7 +896,7 @@ bool player_settings::save( const bool bCharacter )
         const cata_path player_save = PATH_INFO::player_base_save_path() + ".sav";
         const cata_path player_save_zzip = player_save + zzip_suffix;
         //Character not saved yet.
-        if( !file_exist( player_save ) || !file_exist( player_save_zzip ) ) {
+        if( !file_exist( player_save ) && !file_exist( player_save_zzip ) ) {
             return true;
         }
     }

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -779,7 +779,7 @@ bool safemode::save( const bool is_character_in )
 
     if( is_character ) {
         file = PATH_INFO::player_base_save_path() + ".sfm.json";
-        if( !file_exist( PATH_INFO::player_base_save_path() + ".sav" ) ||
+        if( !file_exist( PATH_INFO::player_base_save_path() + ".sav" ) &&
             !file_exist( PATH_INFO::player_base_save_path() + ".sav" + zzip_suffix ) ) {
             return true; //Character not saved yet.
         }


### PR DESCRIPTION
#### Summary
    Bugfixes "Fix character-specific Safe Mode and Auto-Pickup settings failing to save"
  
    #### Purpose of change
    Fixes a logic error that prevented character-specific Safe Mode configurations (`.sfm.json`) and Auto-Pickup configurations (`.apu.json`) from being written to the character's save folder on game save. Because of this, player-specific safe-  
  mode whitelists and auto-pickup rules were completely reset and lost every time a save game was reloaded.
  
    #### Describe the solution
    In both `src/safemode_ui.cpp` and `src/auto_pickup.cpp`, the game checks if the character has been saved yet before writing the configuration files. 
  
    Because modern CDDA builds compress save files, only the compressed `.sav.zzip` file exists in the character save directory, and the uncompressed `.sav` file is missing. 
  
    The original code used a logical OR (`||`):
    ```cpp
    if( !file_exist( player_save ) || !file_exist( player_save_zzip ) ) {
        return true; // Character not saved yet.
    }
  
  This caused the condition to always evaluate to  true  (since the  .sav  file is always missing), skipping the save operation entirely.
  
  I changed the logical OR ( || ) to a logical AND ( && ) in both check locations. This matches the correct implementation already used in  src/auto_note.cpp . Now, the write is only skipped if both file types are missing (meaning the character  
  truly has never been saved yet).
  
  #### Describe alternatives you've considered
  
  None. Correcting the logical operator to check for the absence of both file formats is the most direct and correct fix.
  
  #### Testing
  
  1. Started a new character, added a custom enemy whitelist entry in the Safe Mode rules, and added custom auto-pickup rules.
  2. Saved and quit the game.
  3. Verified that the  #<CharacterBase64>.sfm.json  and  #<CharacterBase64>.apu.json  configuration files were successfully created in the save directory.
  4. Reloaded the save game and confirmed that the whitelist and auto-pickup settings successfully loaded and persisted.
  
  #### Additional context
  
  This logic check has been aligned with the correct implementation found in  src/auto_note.cpp .
