### PR TITLE
Bundle the SDL3 stack into release artifacts

### DIFF
--- a/.github/vcpkg_triplets/x64-windows-static.cmake
+++ b/.github/vcpkg_triplets/x64-windows-static.cmake
@@ -3,3 +3,10 @@ set(VCPKG_CRT_LINKAGE static)
 set(VCPKG_LIBRARY_LINKAGE static)
 
 set(VCPKG_BUILD_TYPE release)
+
+# mpg123 is LGPL-2.1: static-linking into a closed binary triggers full
+# LGPL obligations. Force dynamic so the DLL stays swappable; SDL_mixer
+# links it via the import lib (IAT), shipped beside cataclysm-tiles.exe.
+if(PORT MATCHES "^mpg123$")
+    set(VCPKG_LIBRARY_LINKAGE dynamic)
+endif()

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -90,7 +90,7 @@ jobs:
       id: runvcpkg
       with:
         vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-        vcpkgGitCommitId: 'c3867e714dd3a51c272826eea77267876517ed99'
+        vcpkgGitCommitId: 'f6672d8e480ccdecddfad3fd1b838ba369ffe6cd'
 
     - name: Integrate vcpkg
       run: |
@@ -102,7 +102,7 @@ jobs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: msvc-full-features/vcpkg_installed
-        key: vcpkg-installed-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-c3867e714dd3a51c272826eea77267876517ed99
+        key: vcpkg-installed-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-f6672d8e480ccdecddfad3fd1b838ba369ffe6cd
 
     - name: Download ccache
       uses: robinraju/release-downloader@368754b9c6f47c345fcfbf42bcb577c2f0f5f395 # v1.9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,7 +239,7 @@ jobs:
           - name: macOS Tiles Universal Binary (SDL3)
             os: macos-15
             tiles: 1
-            sound: 0
+            sound: 1
             sdl3: 1
             artifact: osx-with-graphics-sdl3-universal
             ext: dmg
@@ -472,34 +472,47 @@ jobs:
       - name: install macports packages (mac, SDL3)
         if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 == 1
         run: |
-          sudo port install freetype +universal pkgconfig +universal
+          # SDL_mixer VENDORED=OFF pulls every mixer codec from a system lib.
+          # The macOS artifact is universal, so each (plus libiconv, a
+          # transitive dep of flac/wavpack) must be +universal.
+          sudo port install freetype +universal pkgconfig +universal \
+              libiconv +universal libogg +universal flac +universal \
+              libvorbis +universal wavpack +universal mpg123 +universal
       - name: Cache SDL3 stack source build (mac, SDL3)
         if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 == 1
         id: cache-sdl3-release-macos
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ runner.workspace }}/sdl3_prefix
-          key: sdl3-stack-universal-sdl-3.4.4-image-3.4.2-ttf-3.2.2-mixer-3.2.0-${{ runner.os }}-v1
+          key: sdl3-stack-universal-sdl-3.4.10-image-3.4.4-ttf-3.2.2-mixer-3.2.4-${{ runner.os }}-v5
       - name: Build SDL3 stack from source (mac, SDL3, universal)
         if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 == 1 && steps.cache-sdl3-release-macos.outputs.cache-hit != 'true'
         run: |
           PREFIX=${{ runner.workspace }}/sdl3_prefix
           export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig:/opt/local/lib/pkgconfig
-          export CMAKE_PREFIX_PATH=$PREFIX
+          # wavpack's Findwavpack.cmake uses plain find_library (no pkg-config),
+          # so /opt/local must be on CMAKE_PREFIX_PATH.
+          export CMAKE_PREFIX_PATH=$PREFIX:/opt/local
           ARCH_ARG='-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64'
-          git clone --depth 1 --branch release-3.4.4 https://github.com/libsdl-org/SDL.git sdl3_src
+          git clone --depth 1 --branch release-3.4.10 https://github.com/libsdl-org/SDL.git sdl3_src
           cmake -S sdl3_src -B sdl3_build "$ARCH_ARG" \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX=$PREFIX \
               -DBUILD_SHARED_LIBS=ON
           cmake --build sdl3_build -j$(sysctl -n hw.ncpu)
           cmake --install sdl3_build
-          git clone --depth 1 --branch release-3.4.2 --recurse-submodules --shallow-submodules https://github.com/libsdl-org/SDL_image.git sdl3_image_src
+          git clone --depth 1 --branch release-3.4.4 --recurse-submodules --shallow-submodules https://github.com/libsdl-org/SDL_image.git sdl3_image_src
           cmake -S sdl3_image_src -B sdl3_image_build "$ARCH_ARG" \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX=$PREFIX \
               -DSDLIMAGE_VENDORED=ON \
-              -DSDLIMAGE_AVIF=OFF -DSDLIMAGE_JXL=OFF -DSDLIMAGE_WEBP=OFF \
+              -DSDLIMAGE_DEPS_SHARED=OFF \
+              -DSDLIMAGE_STRICT=ON \
+              -DSDLIMAGE_BACKEND_IMAGEIO=OFF \
+              -DSDLIMAGE_PNG=ON -DSDLIMAGE_PNG_LIBPNG=ON \
+              -DSDLIMAGE_JPG=ON \
+              -DSDLIMAGE_AVIF=OFF -DSDLIMAGE_JXL=OFF \
+              -DSDLIMAGE_TIF=OFF -DSDLIMAGE_WEBP=OFF \
               -DPNG_ARM_NEON=off \
               -DBUILD_SHARED_LIBS=ON
           cmake --build sdl3_image_build -j$(sysctl -n hw.ncpu)
@@ -509,26 +522,102 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX=$PREFIX \
               -DSDLTTF_VENDORED=ON \
+              -DSDLTTF_STRICT=ON \
+              -DSDLTTF_PLUTOSVG=OFF \
               -DBUILD_SHARED_LIBS=ON
           cmake --build sdl3_ttf_build -j$(sysctl -n hw.ncpu)
           cmake --install sdl3_ttf_build
-          git clone --depth 1 --branch release-3.2.0 --recurse-submodules --shallow-submodules https://github.com/libsdl-org/SDL_mixer.git sdl3_mixer_src
+          git clone --depth 1 --branch release-3.2.4 --recurse-submodules --shallow-submodules https://github.com/libsdl-org/SDL_mixer.git sdl3_mixer_src
+          # VENDORED=OFF links the MacPorts codecs (LC_LOAD_DYLIB), not static-
+          # embed; mpg123 (LGPL) ships as a separate dylib. DEPS_SHARED=OFF keeps
+          # real link edges, not dlopen-by-name (no LC_LOAD_DYLIB, breaks bundler).
           cmake -S sdl3_mixer_src -B sdl3_mixer_build "$ARCH_ARG" \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX=$PREFIX \
-              -DSDLMIXER_VENDORED=ON \
-              -DSDLMIXER_OPUS=OFF -DSDLMIXER_MOD=OFF -DSDLMIXER_MIDI=OFF \
+              -DSDLMIXER_VENDORED=OFF \
+              -DSDLMIXER_DEPS_SHARED=OFF \
+              -DSDLMIXER_STRICT=ON \
+              -DSDLMIXER_FLAC=ON -DSDLMIXER_FLAC_LIBFLAC=ON -DSDLMIXER_FLAC_DRFLAC=OFF \
+              -DSDLMIXER_MP3=ON -DSDLMIXER_MP3_MPG123=ON -DSDLMIXER_MP3_MPG123_SHARED=OFF -DSDLMIXER_MP3_DRMP3=OFF \
+              -DSDLMIXER_VORBIS_VORBISFILE=ON -DSDLMIXER_VORBIS_STB=OFF -DSDLMIXER_VORBIS_TREMOR=OFF \
+              -DSDLMIXER_WAVPACK=ON \
+              -DSDLMIXER_OPUS=OFF -DSDLMIXER_MOD=OFF -DSDLMIXER_MIDI=OFF -DSDLMIXER_GME=OFF \
               -DBUILD_SHARED_LIBS=ON
           cmake --build sdl3_mixer_build -j$(sysctl -n hw.ncpu)
           cmake --install sdl3_mixer_build
+          # Confirm a real link edge, not dlopen-by-name: otherwise
+          # dylibbundler ships no mpg123 dylib and LGPL swappability is lost.
+          if ! otool -L "$PREFIX"/lib/libSDL3_mixer*.dylib | grep -q mpg123; then
+              echo "ERROR: SDL3_mixer.dylib has no mpg123 LC_LOAD_DYLIB edge" >&2
+              exit 1
+          fi
           mkdir -p $PREFIX/share
           cp sdl3_src/LICENSE.txt $PREFIX/share/LICENSE-SDL.txt
+          cp sdl3_image_src/LICENSE.txt $PREFIX/share/LICENSE-SDL3_image.txt
+          cp sdl3_ttf_src/LICENSE.txt $PREFIX/share/LICENSE-SDL3_ttf.txt
           cp sdl3_mixer_src/LICENSE.txt $PREFIX/share/LICENSE-SDL3_mixer.txt
+          # SDL_image/SDL_ttf use VENDORED=ON (codecs static in the companion
+          # dylib), so harvest each codec's LICENSE/COPYING from external/.
+          for dep in \
+              sdl3_image_src/external/libpng \
+              sdl3_image_src/external/jpeg \
+              sdl3_ttf_src/external/freetype \
+              sdl3_ttf_src/external/harfbuzz; do
+              if [ -d "$dep" ]; then
+                  name=$(basename "$dep")
+                  for cand in "$dep"/LICENSE "$dep"/LICENSE.txt "$dep"/LICENSE.md \
+                              "$dep"/COPYING "$dep"/COPYING.txt "$dep"/COPYING.LIB \
+                              "$dep"/copyright; do
+                      if [ -f "$cand" ]; then
+                          cp "$cand" "$PREFIX/share/LICENSE-vendored-$name.txt"
+                          break
+                      fi
+                  done
+              fi
+          done
+          # SDL_mixer VENDORED=OFF ships flac/ogg/vorbis/mpg123/wavpack as
+          # separate MacPorts dylibs (no license installed); glob COPYING*/
+          # LICENSE* from each SDL_mixer submodule (FLAC uses COPYING.Xiph), fail if empty.
+          for dep in flac ogg vorbis mpg123 wavpack; do
+              src="sdl3_mixer_src/external/$dep"
+              out="$PREFIX/share/LICENSE-vendored-$dep.txt"
+              : > "$out"
+              for lic in "$src"/COPYING* "$src"/COPYRIGHT* "$src"/LICENSE* "$src"/License* "$src"/license*; do
+                  if [ -f "$lic" ]; then
+                      echo "=== $(basename "$lic") ===" >> "$out"
+                      cat "$lic" >> "$out"
+                      echo >> "$out"
+                  fi
+              done
+              if [ ! -s "$out" ]; then
+                  echo "ERROR: no license for bundled codec $dep in SDL_mixer source" >&2
+                  exit 1
+              fi
+          done
       - name: Stage SDL3 license files (mac, SDL3)
         if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 == 1
         run: |
           cp ${{ runner.workspace }}/sdl3_prefix/share/LICENSE-SDL.txt ${{ github.workspace }}/LICENSE-SDL.txt
+          cp ${{ runner.workspace }}/sdl3_prefix/share/LICENSE-SDL3_image.txt ${{ github.workspace }}/LICENSE-SDL3_image.txt
+          cp ${{ runner.workspace }}/sdl3_prefix/share/LICENSE-SDL3_ttf.txt ${{ github.workspace }}/LICENSE-SDL3_ttf.txt
           cp ${{ runner.workspace }}/sdl3_prefix/share/LICENSE-SDL3_mixer.txt ${{ github.workspace }}/LICENSE-SDL3_mixer.txt
+          for f in ${{ runner.workspace }}/sdl3_prefix/share/LICENSE-vendored-*.txt; do
+              if [ -f "$f" ]; then
+                  cp "$f" "${{ github.workspace }}/$(basename "$f")"
+              fi
+          done
+          # libiconv (LGPL) is bundled transitively via flac/wavpack but has no
+          # license on the MacPorts install or in any source tree, so ship the
+          # vendored copy committed in the repo.
+          cp ${{ github.workspace }}/build-data/osx/LICENSE-libiconv.txt ${{ github.workspace }}/LICENSE-vendored-libiconv.txt
+          # Every bundled codec plus libiconv must carry a non-empty license,
+          # independent of cache state (a stale prefix could skip the harvest).
+          for required in libiconv flac ogg vorbis mpg123 wavpack; do
+              if [ ! -s "${{ github.workspace }}/LICENSE-vendored-$required.txt" ]; then
+                  echo "ERROR: LICENSE-vendored-$required.txt missing or empty" >&2
+                  exit 1
+              fi
+          done
       - name: Create VERSION.TXT
         shell: bash
         run: |
@@ -594,15 +683,24 @@ jobs:
       - name: Build CDDA (osx, SDL2)
         if: runner.os == 'macOS' && matrix.sdl3 != 1
         run: |
-          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 FRAMEWORK=1 UNIVERSAL_BINARY=1 WARN_STALE_DATA=1 dmgdist
+          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.sound }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 FRAMEWORK=1 UNIVERSAL_BINARY=1 WARN_STALE_DATA=1 dmgdist
           mv Cataclysm.dmg cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
       - name: Build CDDA (osx, SDL3)
         if: runner.os == 'macOS' && matrix.sdl3 == 1
         env:
           PKG_CONFIG_PATH: ${{ runner.workspace }}/sdl3_prefix/lib/pkgconfig:/opt/local/lib/pkgconfig
-          DYLIBBUNDLER_SEARCH_PATHS: ${{ runner.workspace }}/sdl3_prefix/lib
+          # The MacPorts codecs live in /opt/local/lib; dylibbundler needs it
+          # so the mpg123 (and friends) dylibs get pulled into the bundle.
+          DYLIBBUNDLER_SEARCH_PATHS: ${{ runner.workspace }}/sdl3_prefix/lib /opt/local/lib
         run: |
-          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} SDL3=1 RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 UNIVERSAL_BINARY=1 WARN_STALE_DATA=1 dmgdist
+          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.sound }} SDL3=1 RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 UNIVERSAL_BINARY=1 WARN_STALE_DATA=1 dmgdist
+          # LGPL gate: mpg123 must ship as a standalone dylib in the bundle so
+          # it stays user-replaceable. Empty match means dylibbundler did not
+          # bundle it and the build must fail rather than ship a violation.
+          if ! ls Cataclysm.app/Contents/Resources/libmpg123*.dylib >/dev/null 2>&1; then
+              echo "ERROR: libmpg123 dylib missing from app bundle Resources" >&2
+              exit 1
+          fi
           mv Cataclysm.dmg cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
       - name: Set up JDK (android)
         if: runner.os == 'Linux' && matrix.android != 'none'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,7 +204,7 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: Linux Tiles Sounds x64 (SDL3)
-            os: ubuntu-24.04
+            os: ubuntu-22.04
             android: none
             libbacktrace: 1
             tiles: 1
@@ -362,9 +362,12 @@ jobs:
         if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm && matrix.sdl3 == 1
         run: |
           sudo apt-get update
+          wget -O /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+          chmod +x /tmp/llvm.sh
+          sudo /tmp/llvm.sh 18
           sudo apt-get install libflac-dev libogg-dev libvorbis-dev libmpg123-dev libwavpack-dev \
               libfreetype-dev libharfbuzz-dev libjpeg-dev libpng-dev libwebp-dev libtiff-dev \
-              libpulse-dev libncursesw5-dev ccache gettext parallel pkg-config cmake \
+              libpulse-dev libncursesw5-dev ccache gettext parallel pkg-config cmake patchelf \
               libx11-dev libxext-dev libxcursor-dev libxi-dev libxfixes-dev libxrandr-dev \
               libxrender-dev libxss-dev libxtst-dev libxkbcommon-dev libwayland-dev \
               libdecor-0-dev libdrm-dev libgbm-dev libudev-dev libpipewire-0.3-dev \
@@ -375,25 +378,31 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ runner.workspace }}/sdl3_prefix
-          key: sdl3-stack-sdl-3.4.4-image-3.4.2-ttf-3.2.2-mixer-3.2.0-${{ runner.os }}-v2
+          key: sdl3-stack-sdl-3.4.10-image-3.4.4-ttf-3.2.2-mixer-3.2.4-ubuntu-22.04-v4
       - name: Build SDL3 stack from source (Linux, SDL3)
         if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm && matrix.sdl3 == 1 && steps.cache-sdl3-release.outputs.cache-hit != 'true'
         run: |
           PREFIX=${{ runner.workspace }}/sdl3_prefix
           export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig:$PREFIX/lib/x86_64-linux-gnu/pkgconfig
           export CMAKE_PREFIX_PATH=$PREFIX
-          git clone --depth 1 --branch release-3.4.4 https://github.com/libsdl-org/SDL.git sdl3_src
+          git clone --depth 1 --branch release-3.4.10 https://github.com/libsdl-org/SDL.git sdl3_src
           cmake -S sdl3_src -B sdl3_build \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX=$PREFIX \
               -DBUILD_SHARED_LIBS=ON
           cmake --build sdl3_build -j$(nproc)
           cmake --install sdl3_build
-          git clone --depth 1 --branch release-3.4.2 https://github.com/libsdl-org/SDL_image.git sdl3_image_src
+          git clone --depth 1 --branch release-3.4.4 https://github.com/libsdl-org/SDL_image.git sdl3_image_src
           cmake -S sdl3_image_src -B sdl3_image_build \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX=$PREFIX \
               -DSDLIMAGE_VENDORED=OFF \
+              -DSDLIMAGE_DEPS_SHARED=OFF \
+              -DSDLIMAGE_STRICT=ON \
+              -DSDLIMAGE_PNG=ON -DSDLIMAGE_PNG_LIBPNG=ON \
+              -DSDLIMAGE_JPG=ON \
+              -DSDLIMAGE_AVIF=OFF -DSDLIMAGE_JXL=OFF \
+              -DSDLIMAGE_TIF=OFF -DSDLIMAGE_WEBP=OFF \
               -DBUILD_SHARED_LIBS=ON
           cmake --build sdl3_image_build -j$(nproc)
           cmake --install sdl3_image_build
@@ -402,29 +411,37 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX=$PREFIX \
               -DSDLTTF_VENDORED=OFF \
+              -DSDLTTF_STRICT=ON \
+              -DSDLTTF_PLUTOSVG=OFF \
               -DBUILD_SHARED_LIBS=ON
           cmake --build sdl3_ttf_build -j$(nproc)
           cmake --install sdl3_ttf_build
-          git clone --depth 1 --branch release-3.2.0 https://github.com/libsdl-org/SDL_mixer.git sdl3_mixer_src
+          git clone --depth 1 --branch release-3.2.4 https://github.com/libsdl-org/SDL_mixer.git sdl3_mixer_src
           cmake -S sdl3_mixer_src -B sdl3_mixer_build \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX=$PREFIX \
               -DSDLMIXER_VENDORED=OFF \
-              -DSDLMIXER_FLAC=ON -DSDLMIXER_FLAC_LIBFLAC=ON \
-              -DSDLMIXER_MP3=ON -DSDLMIXER_MP3_MPG123=ON \
-              -DSDLMIXER_VORBIS=VORBISFILE \
+              -DSDLMIXER_DEPS_SHARED=OFF \
+              -DSDLMIXER_STRICT=ON \
+              -DSDLMIXER_FLAC=ON -DSDLMIXER_FLAC_LIBFLAC=ON -DSDLMIXER_FLAC_DRFLAC=OFF \
+              -DSDLMIXER_MP3=ON -DSDLMIXER_MP3_MPG123=ON -DSDLMIXER_MP3_DRMP3=OFF \
+              -DSDLMIXER_VORBIS_VORBISFILE=ON -DSDLMIXER_VORBIS_STB=OFF -DSDLMIXER_VORBIS_TREMOR=OFF \
               -DSDLMIXER_WAVPACK=ON \
-              -DSDLMIXER_OPUS=OFF -DSDLMIXER_MOD=OFF -DSDLMIXER_MIDI=OFF \
+              -DSDLMIXER_OPUS=OFF -DSDLMIXER_MOD=OFF -DSDLMIXER_MIDI=OFF -DSDLMIXER_GME=OFF \
               -DBUILD_SHARED_LIBS=ON
           cmake --build sdl3_mixer_build -j$(nproc)
           cmake --install sdl3_mixer_build
           mkdir -p $PREFIX/share
           cp sdl3_src/LICENSE.txt $PREFIX/share/LICENSE-SDL.txt
+          cp sdl3_image_src/LICENSE.txt $PREFIX/share/LICENSE-SDL3_image.txt
+          cp sdl3_ttf_src/LICENSE.txt $PREFIX/share/LICENSE-SDL3_ttf.txt
           cp sdl3_mixer_src/LICENSE.txt $PREFIX/share/LICENSE-SDL3_mixer.txt
       - name: Stage SDL3 license files (Linux, SDL3)
         if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm && matrix.sdl3 == 1
         run: |
           cp ${{ runner.workspace }}/sdl3_prefix/share/LICENSE-SDL.txt ${{ github.workspace }}/LICENSE-SDL.txt
+          cp ${{ runner.workspace }}/sdl3_prefix/share/LICENSE-SDL3_image.txt ${{ github.workspace }}/LICENSE-SDL3_image.txt
+          cp ${{ runner.workspace }}/sdl3_prefix/share/LICENSE-SDL3_ttf.txt ${{ github.workspace }}/LICENSE-SDL3_ttf.txt
           cp ${{ runner.workspace }}/sdl3_prefix/share/LICENSE-SDL3_mixer.txt ${{ github.workspace }}/LICENSE-SDL3_mixer.txt
       - name: Install Emscripten (WebAssembly)
         if: matrix.wasm
@@ -545,7 +562,7 @@ jobs:
             export PKG_CONFIG_PATH="$RUNNER_WORKSPACE/sdl3_prefix/lib/pkgconfig:$RUNNER_WORKSPACE/sdl3_prefix/lib/x86_64-linux-gnu/pkgconfig"
             export LD_LIBRARY_PATH="$RUNNER_WORKSPACE/sdl3_prefix/lib:$RUNNER_WORKSPACE/sdl3_prefix/lib/x86_64-linux-gnu"
           fi
-          make COMPILER=clang++-18 -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} SDL3=${{ matrix.sdl3 == 1 && '1' || '0' }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 LIBBACKTRACE=${{ matrix.libbacktrace }} WARN_STALE_DATA=1 PCH=0 bindist
+          make COMPILER=clang++-18 -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.sound }} SDL3=${{ matrix.sdl3 == 1 && '1' || '0' }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 LIBBACKTRACE=${{ matrix.libbacktrace }} WARN_STALE_DATA=1 PCH=0 bindist
           mv cataclysmdda-0.J.tar.gz cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.tar.gz
       - name: Build CDDA (WebAssembly)
         if: matrix.wasm && success()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -678,7 +678,7 @@ jobs:
           VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}\.github\vcpkg_triplets
         run: |
           msbuild -m -p:Configuration=Release -p:Platform=${{ matrix.arch }} -p:UseSDL3=true "-target:Cataclysm-vcpkg-static;JsonFormatter-vcpkg-static;zzip" msvc-full-features\Cataclysm-vcpkg-static.sln
-          .\build-scripts\windist.ps1
+          .\build-scripts\windist.ps1 -SDL3
           mv cataclysmdda-0.J.zip cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.zip
       - name: Build CDDA (osx, SDL2)
         if: runner.os == 'macOS' && matrix.sdl3 != 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
       id: sdl
       uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main
       with:
-        version: 3.4.4
+        version: 3.4.10
         cmake-generator: Ninja
         install-linux-dependencies: true
 
@@ -318,7 +318,7 @@ jobs:
         id: runvcpkg
         with:
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-          vcpkgGitCommitId: 'c3867e714dd3a51c272826eea77267876517ed99'
+          vcpkgGitCommitId: 'f6672d8e480ccdecddfad3fd1b838ba369ffe6cd'
       - name: Install dependencies (windows msvc) (3/4)
         if: runner.os == 'Windows'
         run: |
@@ -336,13 +336,13 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: msvc-full-features/vcpkg_installed
-          key: vcpkg-installed-sdl2-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-c3867e714dd3a51c272826eea77267876517ed99
+          key: vcpkg-installed-sdl2-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-f6672d8e480ccdecddfad3fd1b838ba369ffe6cd
       - name: Cache vcpkg packages (Windows, SDL3)
         if: runner.os == 'Windows' && matrix.sdl3 == 1
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: msvc-full-features/vcpkg_installed
-          key: vcpkg-installed-sdl3-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-c3867e714dd3a51c272826eea77267876517ed99
+          key: vcpkg-installed-sdl3-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-f6672d8e480ccdecddfad3fd1b838ba369ffe6cd
       - name: Install dependencies (Linux, SDL2)
         if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm && matrix.sdl3 != 1
         run: |

--- a/.github/workflows/sdl3-matrix.yml
+++ b/.github/workflows/sdl3-matrix.yml
@@ -65,7 +65,7 @@ jobs:
       id: sdl
       uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main
       with:
-        version: 3.4.4
+        version: 3.4.10
         cmake-generator: Ninja
         install-linux-dependencies: true
 
@@ -184,7 +184,7 @@ jobs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ runner.workspace }}/sdl3_prefix
-        key: sdl3-stack-sdl-3.4.4-image-3.4.2-ttf-3.2.2-mixer-3.2.0-${{ runner.os }}-v1
+        key: sdl3-stack-sdl-3.4.10-image-3.4.4-ttf-3.2.2-mixer-3.2.4-${{ runner.os }}-v2
 
     - name: build SDL3 stack from source (Ubuntu)
       if: matrix.platform == 'linux' && steps.cache-sdl3.outputs.cache-hit != 'true'
@@ -192,14 +192,14 @@ jobs:
           PREFIX=${{ runner.workspace }}/sdl3_prefix
           export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig:$PREFIX/lib/x86_64-linux-gnu/pkgconfig
           export CMAKE_PREFIX_PATH=$PREFIX
-          git clone --depth 1 --branch release-3.4.4 https://github.com/libsdl-org/SDL.git sdl3_src
+          git clone --depth 1 --branch release-3.4.10 https://github.com/libsdl-org/SDL.git sdl3_src
           cmake -S sdl3_src -B sdl3_build \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX=$PREFIX \
               -DBUILD_SHARED_LIBS=ON
           cmake --build sdl3_build -j$(nproc)
           cmake --install sdl3_build
-          git clone --depth 1 --branch release-3.4.2 https://github.com/libsdl-org/SDL_image.git sdl3_image_src
+          git clone --depth 1 --branch release-3.4.4 https://github.com/libsdl-org/SDL_image.git sdl3_image_src
           cmake -S sdl3_image_src -B sdl3_image_build \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX=$PREFIX \
@@ -215,14 +215,14 @@ jobs:
               -DBUILD_SHARED_LIBS=ON
           cmake --build sdl3_ttf_build -j$(nproc)
           cmake --install sdl3_ttf_build
-          git clone --depth 1 --branch release-3.2.0 https://github.com/libsdl-org/SDL_mixer.git sdl3_mixer_src
+          git clone --depth 1 --branch release-3.2.4 https://github.com/libsdl-org/SDL_mixer.git sdl3_mixer_src
           cmake -S sdl3_mixer_src -B sdl3_mixer_build \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX=$PREFIX \
               -DSDLMIXER_VENDORED=OFF \
               -DSDLMIXER_FLAC=ON -DSDLMIXER_FLAC_LIBFLAC=ON \
               -DSDLMIXER_MP3=ON -DSDLMIXER_MP3_MPG123=ON \
-              -DSDLMIXER_VORBIS=VORBISFILE \
+              -DSDLMIXER_VORBIS_VORBISFILE=ON -DSDLMIXER_VORBIS_STB=OFF -DSDLMIXER_VORBIS_TREMOR=OFF \
               -DSDLMIXER_WAVPACK=ON \
               -DSDLMIXER_OPUS=OFF -DSDLMIXER_MOD=OFF -DSDLMIXER_MIDI=OFF \
               -DBUILD_SHARED_LIBS=ON
@@ -245,7 +245,7 @@ jobs:
       uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
       with:
         vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-        vcpkgGitCommitId: 'c3867e714dd3a51c272826eea77267876517ed99'
+        vcpkgGitCommitId: 'f6672d8e480ccdecddfad3fd1b838ba369ffe6cd'
 
     - name: integrate vcpkg (Windows)
       if: matrix.platform == 'windows'
@@ -259,7 +259,7 @@ jobs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: msvc-full-features/vcpkg_installed
-        key: vcpkg-installed-sdl3-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-c3867e714dd3a51c272826eea77267876517ed99
+        key: vcpkg-installed-sdl3-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-f6672d8e480ccdecddfad3fd1b838ba369ffe6cd
 
     - name: build (Ubuntu)
       if: matrix.platform == 'linux'

--- a/Makefile
+++ b/Makefile
@@ -1026,15 +1026,25 @@ ifeq ($(TARGETSYSTEM),LINUX)
   CFLAGS += -mcx16
   CXXFLAGS += -mcx16
   BINDIST_EXTRAS += cataclysm-launcher
+  ifeq ($(SDL3),1)
+    # bundle-sdl3-linux.sh fills bindist/lib/; RUNPATH=$$ORIGIN/lib lets
+    # the binary resolve bundled libs without the launcher.
+    LDFLAGS += -Wl,-rpath,'$$ORIGIN/lib'
+    BUNDLE_SDL3_LINUX = 1
+  endif
   ifneq ("$(wildcard LICENSE-SDL.txt)","")
-    ifeq ($(SDL3),1)
-      SDL_solibs = $(shell ldd $(TARGET) | awk '/libSDL3/ {print $$3}')
-    else
+    ifneq ($(SDL3),1)
       SDL_solibs = $(shell ldd $(TARGET) | grep libSDL2-2\.0 | cut -d ' ' -f 3)
+      INSTALL_EXTRAS += $(SDL_solibs)
     endif
-    INSTALL_EXTRAS += $(SDL_solibs)
     BINDIST_EXTRAS += LICENSE-SDL.txt
     ifeq ($(SDL3),1)
+      ifneq ("$(wildcard LICENSE-SDL3_image.txt)","")
+        BINDIST_EXTRAS += LICENSE-SDL3_image.txt
+      endif
+      ifneq ("$(wildcard LICENSE-SDL3_ttf.txt)","")
+        BINDIST_EXTRAS += LICENSE-SDL3_ttf.txt
+      endif
       ifneq ("$(wildcard LICENSE-SDL3_mixer.txt)","")
         BINDIST_EXTRAS += LICENSE-SDL3_mixer.txt
       endif
@@ -1521,6 +1531,9 @@ $(BINDIST): distclean version $(TARGET) $(ZZIP_BIN) $(L10N) $(BINDIST_EXTRAS) $(
 	$(foreach lib,$(INSTALL_EXTRAS),install --strip $(lib) $(BINDIST_DIR);)
 ifdef LANGUAGES
 	cp -R --parents lang/mo $(BINDIST_DIR)
+endif
+ifeq ($(BUNDLE_SDL3_LINUX),1)
+	bash build-scripts/bundle-sdl3-linux.sh $(BINDIST_DIR) $(BINDIST_DIR)/$(notdir $(TARGET))
 endif
 	$(BINDIST_CMD)
 

--- a/Makefile
+++ b/Makefile
@@ -1520,6 +1520,11 @@ ifdef OSXCROSS
 	rm Cataclysm-uncompressed.dmg
 else
 	plutil -convert binary1 Cataclysm.app/Contents/Info.plist
+ifeq ($(SDL3), 1)
+	# Sign AFTER plutil rewrites Info.plist; signing earlier would be
+	# invalidated by the plist edit. dmgbuild does not modify the bundle.
+	bash build-scripts/codesign-macos.sh $(APPTARGETDIR)
+endif  # ifeq ($(SDL3), 1)
 	dmgbuild -s build-data/osx/dmgsettings.py "Cataclysm DDA" Cataclysm.dmg
 endif
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -138,14 +138,14 @@ def assetsDir = 'src/main/assets'
 def assetsDirWindows = 'src/main/assetsWinHost'
 
 def sdl3Aars = [
-    [name: 'SDL3',        version: '3.4.8', repo: 'SDL',
-     zipSha256: 'c4c23cec585cb99ea626625dc06b421933dd78733b3841628d86be1c13ab16c6'],
+    [name: 'SDL3',        version: '3.4.10', repo: 'SDL',
+     zipSha256: 'f676e29b1b4eb990e24862b6af5f327379dc496c9f5f3e3f48ab75837f95844e'],
     [name: 'SDL3_image',  version: '3.4.4', repo: 'SDL_image',
      zipSha256: 'a0d1e27d4529c2bbc3e4ac72d2e6c0dd474b32cfe2586d22c4228a34224d1f57'],
     [name: 'SDL3_ttf',    version: '3.2.2', repo: 'SDL_ttf',
      zipSha256: '48e534daf88eec5c7f0c95fa6ca0e8a5f38f5fc7276824573131cebc403ee14c'],
-    [name: 'SDL3_mixer',  version: '3.2.2', repo: 'SDL_mixer',
-     zipSha256: 'bc9684da3d36eb6df7c5f645493dcdaa847822b8613aefadc889e1f8614427f3'],
+    [name: 'SDL3_mixer',  version: '3.2.4', repo: 'SDL_mixer',
+     zipSha256: 'b7f9f1ee5162a0492e71941f2cbdc50ec256ef15c0e995ca72c7e519eebd810d'],
 ]
 
 task fetchSdl3Aars {
@@ -480,8 +480,8 @@ sourceSets {
 dependencies {
     api fileTree(include: ['*.jar'], dir: 'libs')
     implementation files(
-        'libs/SDL3-3.4.8.aar',
+        'libs/SDL3-3.4.10.aar',
         'libs/SDL3_image-3.4.4.aar',
         'libs/SDL3_ttf-3.2.2.aar',
-        'libs/SDL3_mixer-3.2.2.aar')
+        'libs/SDL3_mixer-3.2.4.aar')
 }

--- a/build-data/osx/LICENSE-libiconv.txt
+++ b/build-data/osx/LICENSE-libiconv.txt
@@ -1,0 +1,501 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1990
+  Moe Ghoul, President of Vice
+
+That's all there is to it!

--- a/build-data/osx/dmgsettings.py
+++ b/build-data/osx/dmgsettings.py
@@ -2,6 +2,7 @@
 
 
 import biplist
+import glob
 import os.path
 
 # defines is provided by dmgbuild, but pretend to define it here for the
@@ -40,7 +41,13 @@ format = defines.get('format', 'UDBZ')
 size = defines.get('size', '500M')
 
 # Files to include
-files = [application]
+#
+# SDL3 builds stage LICENSE-SDL*.txt / LICENSE-vendored-*.txt at the repo
+# root (dmgbuild CWD); ship them in the DMG. Empty glob on SDL2/local.
+license_files = sorted(
+    glob.glob('LICENSE-SDL*.txt') + glob.glob('LICENSE-vendored-*.txt')
+)
+files = [application] + license_files
 
 # Symlinks to create
 symlinks = {'Applications': '/Applications'}

--- a/build-scripts/bundle-sdl3-linux.sh
+++ b/build-scripts/bundle-sdl3-linux.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# Bundle the SDL3 ldd closure into a Linux bindist's lib/.
+# Usage: bundle-sdl3-linux.sh <bindist_dir> <main_binary>
+# Copies non-platform deps (with SONAME symlinks), RUNPATH=$ORIGIN each.
+
+set -euo pipefail
+
+BINDIST_DIR="${1:?bindist dir required}"
+MAIN_BIN="${2:?main binary required}"
+LIB_DIR="$BINDIST_DIR/lib"
+
+mkdir -p "$LIB_DIR"
+
+# Platform library name patterns. ldd entries matching any of these are
+# treated as host-owned: not copied, walking stops.
+PLATFORM_PATTERNS=(
+    # libc base
+    'libc\.so'
+    'libc\.so\.6'
+    'libdl\.so'
+    'libm\.so'
+    'libpthread\.so'
+    'libstdc\+\+\.so'
+    'libgcc_s\.so'
+    'librt\.so'
+    'libresolv\.so'
+    'ld-linux-.*\.so'
+    'linux-vdso\.so'
+    # X11
+    'libX11\.so'
+    'libxcb.*\.so'
+    'libXext\.so'
+    'libXcursor\.so'
+    'libXi\.so'
+    'libXfixes\.so'
+    'libXrandr\.so'
+    'libXrender\.so'
+    'libXss\.so'
+    'libXtst\.so'
+    'libXau\.so'
+    'libXdmcp\.so'
+    'libICE\.so'
+    'libSM\.so'
+    # Wayland / input
+    'libwayland-.*\.so'
+    'libxkbcommon.*\.so'
+    'libdecor.*\.so'
+    'libdbus-1\.so'
+    'libibus-1\.0\.so'
+    # Display / DRM
+    'libdrm\.so'
+    'libgbm\.so'
+    'libudev\.so'
+    'libglapi\.so'
+    # GL / Vulkan
+    'libGL\.so'
+    'libGLX\.so'
+    'libGLdispatch\.so'
+    'libOpenGL\.so'
+    'libEGL\.so'
+    'libvulkan\.so'
+    # Audio
+    'libasound\.so'
+    'libpulse\.so'
+    'libpulsecommon-.*\.so'
+    'libpipewire-.*\.so'
+    'libspa-.*\.so'
+    'libsystemd\.so'
+    'libasyncns\.so'
+    'libsndfile\.so'
+    # Misc base
+    'libffi\.so'
+    'libbsd\.so'
+    'libmd\.so'
+)
+
+is_platform() {
+    local soname="$1"
+    for pat in "${PLATFORM_PATTERNS[@]}"; do
+        if [[ "$soname" =~ ^${pat} ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Read ldd output on stdin, emit "soname<TAB>realpath" per non-platform
+# entry. Pathless entries (linux-vdso) are skipped.
+collect_libs() {
+    awk '
+        /=> not found/ { next }
+        / => / {
+            soname = $1
+            path = $3
+            if (path == "" || path ~ /^\(/) next
+            print soname "\t" path
+        }
+    '
+}
+
+declare -A COPIED
+declare -A SEEN
+declare -A ALIAS
+# Map of copied real lib basename -> original resolved system path. Used for
+# license attribution via dpkg -S after the walk completes.
+declare -A REAL_TO_ORIGIN
+
+ensure_alias() {
+    local alias_name="$1" real_base="$2"
+    if [[ -z "$alias_name" || "$alias_name" == "$real_base" ]]; then return; fi
+    local key="$alias_name->$real_base"
+    if [[ -n "${ALIAS[$key]:-}" ]]; then return; fi
+    ALIAS[$key]=1
+    ln -sf "$real_base" "$LIB_DIR/$alias_name"
+}
+
+walk_closure() {
+    local target="$1"
+    if [[ -n "${SEEN[$target]:-}" ]]; then return; fi
+    SEEN[$target]=1
+
+    local soname realpath_resolved real base_real base_path
+    while IFS=$'\t' read -r soname realpath_resolved; do
+        [[ -z "$soname" || -z "$realpath_resolved" ]] && continue
+        if is_platform "$soname"; then
+            continue
+        fi
+        # Resolve symlinks to the real file.
+        real="$(readlink -f "$realpath_resolved")"
+        base_real="$(basename "$real")"
+        base_path="$(basename "$realpath_resolved")"
+
+        # Always create the soname + resolved-path aliases (independent of
+        # whether the real file was copied already on a prior alias).
+        ensure_alias "$soname" "$base_real"
+        ensure_alias "$base_path" "$base_real"
+
+        if [[ -z "${COPIED[$real]:-}" ]]; then
+            COPIED[$real]=1
+            REAL_TO_ORIGIN[$base_real]="$real"
+            cp -L "$real" "$LIB_DIR/$base_real"
+            # Walk this library's own ldd closure.
+            walk_closure "$real"
+        fi
+    done < <(ldd "$target" 2>/dev/null | collect_libs)
+}
+
+walk_closure "$MAIN_BIN"
+
+# RUNPATH=$ORIGIN on each bundled lib: DT_RUNPATH does not inherit to
+# grandchild loads, so each .so needs its own to find sibling peers.
+if ! command -v patchelf >/dev/null 2>&1; then
+    echo "patchelf not available; bundled libs will not resolve transitive deps" >&2
+    exit 1
+fi
+for so in "$LIB_DIR"/*.so*; do
+    if [[ -f "$so" && ! -L "$so" ]]; then
+        # $ORIGIN is a literal dynamic-loader token, not a shell variable.
+        # shellcheck disable=SC2016
+        patchelf --set-rpath '$ORIGIN' "$so"
+    fi
+done
+
+# The main binary is linked with an absolute RUNPATH to the build-time SDL3
+# prefix as well as $ORIGIN/lib; pin it to the bundle alone so the shipped
+# libs win and the build prefix never leaks into resolution.
+# shellcheck disable=SC2016
+patchelf --set-rpath '$ORIGIN/lib' "$MAIN_BIN"
+
+# Gate: every bundled lib resolves with LD_LIBRARY_PATH unset, and the main
+# binary resolves its SDL3 deps from bindist/lib/ not the host.
+echo "Verifying main binary closure with LD_LIBRARY_PATH unset"
+if env -u LD_LIBRARY_PATH ldd "$MAIN_BIN" 2>&1 | grep -E 'not found|=>\s*$' >&2; then
+    echo "ERROR: main binary has unresolved libraries" >&2
+    exit 2
+fi
+echo "Verifying each bundled lib closure"
+for so in "$LIB_DIR"/*.so*; do
+    if [[ -f "$so" && ! -L "$so" ]]; then
+        if env -u LD_LIBRARY_PATH ldd "$so" 2>&1 | grep -E 'not found' >&2; then
+            echo "ERROR: $so has unresolved libraries" >&2
+            exit 3
+        fi
+    fi
+done
+
+# Assert each SDL3-family dep resolves under $LIB_DIR: catch a host SDL3
+# winning rpath order over the bundle.
+LIB_DIR_REAL="$(readlink -f "$LIB_DIR")"
+while IFS= read -r line; do
+    soname="$(awk '{print $1}' <<<"$line")"
+    target="$(awk '{print $3}' <<<"$line")"
+    [[ -z "$target" || "$target" == "(" ]] && continue
+    case "$soname" in
+        libSDL3*|libfreetype*|libharfbuzz*|libpng*|libjpeg*|libFLAC*|libmpg123*|libvorbis*|libogg*|libwavpack*)
+            target_real="$(readlink -f "$target")"
+            case "$target_real" in
+                "$LIB_DIR_REAL"/*) ;;
+                *)
+                    echo "ERROR: $soname resolved to $target_real (outside $LIB_DIR_REAL)" >&2
+                    exit 4
+                    ;;
+            esac
+            ;;
+    esac
+done < <(env -u LD_LIBRARY_PATH ldd "$MAIN_BIN" 2>/dev/null | grep ' => ')
+
+echo "SDL3 closure bundle complete in $LIB_DIR"
+
+# Per-lib license: dpkg -S the ORIGINAL resolved path (the lib/ copy is not
+# in any apt db). Source-built SDL3 libs use the staged LICENSE-SDL*.txt.
+LICENSE_DIR="$BINDIST_DIR/licenses"
+mkdir -p "$LICENSE_DIR"
+declare -A LICENSED_PKGS
+{
+    echo "Bundled third-party libraries (bindist/lib/):"
+    echo
+} > "$LICENSE_DIR/README.txt"
+for base_real in "${!REAL_TO_ORIGIN[@]}"; do
+    origin="${REAL_TO_ORIGIN[$base_real]}"
+    # Source-built SDL3 libs are not registered in apt; skip and rely on the
+    # staged LICENSE-SDL*.txt at the bindist root.
+    case "$base_real" in
+        libSDL3*)
+            echo "$base_real: covered by LICENSE-SDL.txt (libSDL3*_mixer also LICENSE-SDL3_mixer.txt)" >> "$LICENSE_DIR/README.txt"
+            continue
+            ;;
+    esac
+    # dpkg registers some base libs under the pre-usrmerge /lib path while
+    # readlink -f yields /usr/lib (or vice versa). Try both before giving up.
+    # dpkg -S exits non-zero on no match, so swallow it under set -e.
+    pkg="$(dpkg -S "$origin" 2>/dev/null | head -n1 | cut -d: -f1)" || pkg=""
+    if [[ -z "$pkg" ]]; then
+        case "$origin" in
+            /usr/lib/*) alt="${origin#/usr}" ;;
+            /lib/*)     alt="/usr$origin" ;;
+            *)          alt="" ;;
+        esac
+        if [[ -n "$alt" ]]; then
+            pkg="$(dpkg -S "$alt" 2>/dev/null | head -n1 | cut -d: -f1)" || pkg=""
+        fi
+    fi
+    if [[ -z "$pkg" ]]; then
+        echo "$base_real: dpkg -S returned no owner; manual attribution required" >> "$LICENSE_DIR/README.txt"
+        continue
+    fi
+    if [[ -n "${LICENSED_PKGS[$pkg]:-}" ]]; then
+        echo "$base_real: covered by licenses/${pkg}.copyright" >> "$LICENSE_DIR/README.txt"
+        continue
+    fi
+    LICENSED_PKGS[$pkg]=1
+    src_copyright="/usr/share/doc/$pkg/copyright"
+    if [[ -f "$src_copyright" ]]; then
+        cp "$src_copyright" "$LICENSE_DIR/${pkg}.copyright"
+        echo "$base_real: licenses/${pkg}.copyright" >> "$LICENSE_DIR/README.txt"
+    else
+        echo "$base_real: $src_copyright not found; manual attribution required" >> "$LICENSE_DIR/README.txt"
+    fi
+done
+
+echo "License staging complete in $LICENSE_DIR"

--- a/build-scripts/codesign-macos.sh
+++ b/build-scripts/codesign-macos.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Ad-hoc codesign every nested Mach-O in a .app, then the bundle itself.
+# CDDA places dylibs under Contents/Resources/ which codesign --deep skips;
+# without per-file signing macOS rejects the bundle on launch.
+#
+# Usage: codesign-macos.sh <path/to/Cataclysm.app>
+
+set -euo pipefail
+
+APP_DIR="${1:?app bundle path required}"
+
+if [[ ! -d "$APP_DIR" ]]; then
+    echo "ERROR: $APP_DIR is not a directory" >&2
+    exit 1
+fi
+
+if ! command -v codesign >/dev/null 2>&1; then
+    echo "ERROR: codesign not available (not running on macOS?)" >&2
+    exit 2
+fi
+
+echo "Signing nested Mach-O files in $APP_DIR"
+# Find every Mach-O file under Contents/MacOS and Contents/Resources.
+# Suffix matching alone misses helper executables; use file(1) probe.
+while IFS= read -r -d '' candidate; do
+    if file "$candidate" | grep -qE 'Mach-O'; then
+        codesign --force --sign - "$candidate"
+    fi
+done < <(find "$APP_DIR/Contents/MacOS" "$APP_DIR/Contents/Resources" -type f \( -perm -u+x -o -name '*.dylib' \) -print0)
+
+echo "Signing app bundle $APP_DIR"
+codesign --force --sign - "$APP_DIR"
+
+echo "Verifying signature integrity"
+codesign --verify --deep --strict --verbose=2 "$APP_DIR"
+
+echo "Codesign sequence complete for $APP_DIR"

--- a/build-scripts/windist.ps1
+++ b/build-scripts/windist.ps1
@@ -1,3 +1,10 @@
+param(
+	# Set by the SDL3 release step. When set, mpg123 dynamic DLLs and their
+	# copyright are mandatory: the build links mpg123 (LGPL), so the zip must
+	# carry a replaceable DLL plus its license. A miss is a hard failure.
+	[switch]$SDL3
+)
+
 if (Test-path bindist) {
   rm -Force -Recurse bindist
 }
@@ -7,6 +14,50 @@ cp cataclysm-tiles.exe bindist/cataclysm-tiles.exe
 cp cataclysm-tiles.stripped.pdb bindist/cataclysm-tiles.pdb
 cp tools/format/json_formatter.exe bindist/json_formatter.exe
 cp zzip.exe bindist/zzip.exe
+
+# SDL3 dynamic-links mpg123 (LGPL). Stage the mpg123 family DLLs
+# (libmpg123/out123/syn123) from wherever vcpkg/msbuild left them.
+# Non-SDL3 builds match nothing.
+$dllSearchRoots = @(
+	'.',
+	'msvc-full-features',
+	'msvc-full-features\vcpkg_installed\x64-windows-static\bin',
+	'msvc-full-features\vcpkg_installed\x86-windows-static\bin'
+)
+$dllPatterns = @('mpg123*.dll', 'libmpg123*.dll', 'out123*.dll', 'libout123*.dll', 'syn123*.dll', 'libsyn123*.dll')
+$staged = @{}
+ForEach ($root in $dllSearchRoots) {
+	if (Test-Path $root) {
+		ForEach ($pattern in $dllPatterns) {
+			$found = Get-ChildItem -Path $root -Filter $pattern -Recurse -ErrorAction SilentlyContinue
+			ForEach ($dll in $found) {
+				if (-not $staged.ContainsKey($dll.Name)) {
+					cp $dll.FullName bindist/
+					$staged[$dll.Name] = $true
+				}
+			}
+		}
+	}
+}
+
+# vcpkg nests the triplet dir (vcpkg_installed\<triplet>\<triplet>\share),
+# so find the mpg123 copyright recursively rather than at a fixed depth.
+if ($staged.Count -gt 0) {
+	$copyright = Get-ChildItem -Path 'msvc-full-features\vcpkg_installed' -Recurse -Filter 'copyright' -ErrorAction SilentlyContinue |
+		Where-Object { $_.FullName -match '[\\/]mpg123[\\/]copyright$' } |
+		Select-Object -First 1
+	if ($copyright) {
+		cp $copyright.FullName bindist/LICENSE-mpg123.txt
+	} else {
+		throw "mpg123 DLL staged without its copyright; refusing to ship LGPL binary."
+	}
+}
+
+# SDL3 links mpg123 dynamically; the DLL must be packaged. Empty staging
+# means msbuild left it elsewhere; fail rather than ship without MP3.
+if ($SDL3 -and $staged.Count -eq 0) {
+	throw "SDL3 build staged no mpg123 DLLs; dynamic mpg123 missing from package."
+}
 
 mkdir bindist/lang
 cp -r lang/mo bindist/lang

--- a/cataclysm-launcher
+++ b/cataclysm-launcher
@@ -45,7 +45,7 @@ fi
 
 if [ "$BIN" ]
 then
-    env LD_LIBRARY_PATH="${DIR}:${LD_LIBRARY_PATH}" ./"${BIN}" "$@"
+    env LD_LIBRARY_PATH="${DIR}/lib:${DIR}:${LD_LIBRARY_PATH}" ./"${BIN}" "$@"
 else
     printerr "Couldn't find cataclysm game binary in '$DIR'/"
     exit 1

--- a/doc/c++/COMPILING-VS-VCPKG.md
+++ b/doc/c++/COMPILING-VS-VCPKG.md
@@ -38,7 +38,7 @@ Steps from current guide were tested on Windows 11 (64 bit), Visual Studio 2022 
 
 2. Install `Git for Windows` (installer can be downloaded from [Git homepage](https://git-scm.com/)).
 
-3. Install and configure `vcpkg`. If you already have `vcpkg` installed, you should update it to at least commit `c3867e714dd3a51c272826eea77267876517ed99` (the most recent tested good revision) and rerun `.\bootstrap-vcpkg.bat` as described:
+3. Install and configure `vcpkg`. If you already have `vcpkg` installed, you should update it to at least commit `f6672d8e480ccdecddfad3fd1b838ba369ffe6cd` (the most recent tested good revision) and rerun `.\bootstrap-vcpkg.bat` as described:
 
 ***WARNING: It is important that, wherever you decide to clone this repo, the path does not include whitespace or special symbols. That is, `C:/dev/vcpkg` is acceptable, but `C:/dev test/vcpkg` and `C:/C++Projects/vcpkg` is not.***
 

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -32,5 +32,5 @@
       ]
     }
   },
-  "builtin-baseline": "c3867e714dd3a51c272826eea77267876517ed99"
+  "builtin-baseline": "f6672d8e480ccdecddfad3fd1b838ba369ffe6cd"
 }


### PR DESCRIPTION
#### Summary
Build "Bundle the SDL3 stack into release artifacts"

#### Purpose of change
Prep for eventually flipping SDL3 to the default.

The SDL3 release jobs build against a source SDL3 stack but don't ship it self-contained, and the macOS SDL3 build static-embeds mpg123 (LGPL), which isn't really shippable.

This gets the SDL3 release artifacts self-contained and LGPL-clean on all three desktop platforms so the eventual default switch is mostly a flag flip.

#### Describe the solution
Pins the SDL3 stack (SDL 3.4.10, image 3.4.4, ttf 3.2.2, mixer 3.2.4) and bumps the vcpkg baseline so Windows matches.

Linux: a new bundle-sdl3-linux.sh walks the ldd closure of the binary, copies every non-platform lib into bindist/lib with RUNPATH=$ORIGIN, and harvests per-lib copyrights via dpkg. The main binary gets RUNPATH=$ORIGIN/lib so it runs off the bundle, not the host or the build prefix.

macOS: dylibbundler already pulls the dylibs in; this adds an ad-hoc codesign pass for the nested Mach-Os (codesign --deep skips Resources/), ships the staged license files in the DMG (they were being dropped), and switches SDL_mixer to VENDORED=OFF so mpg123 links as a separate swappable dylib instead of static-embedded. Codec and libiconv licenses get harvested or vendored alongside.

Windows: forces the mpg123 vcpkg port to dynamic so the DLL ships next to the exe, with its copyright.

Android: bumps the SDL3 AAR pins to match.

#### Describe alternatives you've considered
Could keep mpg123 static-embedded like before, but that's the whole LGPL problem this is avoiding.

The Linux bundler is a hand-rolled ldd walker; lddtree from pax-utils would be tidier but adds a CI dependency for little gain, maybe later.

#### Testing
Built and published a full experimental release off this branch on a fork: https://github.com/dobbry-vechur/Cataclysm-DDA/releases/tag/cdda-experimental-2026-06-05-1604 (run https://github.com/dobbry-vechur/Cataclysm-DDA/actions/runs/27025774412).
Windows, Linux, and macOS SDL3 jobs all green.

Pulled the macOS DMG and Linux tarball back down and inspected them. 

macOS: universal binary, every SDL3/codec dep is @executable_path and the only LC_RPATH is @executable_path, libmpg123 is bundled and SDL3_mixer loads it as a swappable dylib, and all the license files land in the DMG root

Linux: binary RUNPATH is $ORIGIN/lib, the full SDL3 + codec closure is in lib/ (platform libs left out), copyrights in licenses/, and with LD_LIBRARY_PATH unset it resolves everything from the bundle and launches headless.

Android builds need signing secrets forks lack, but verified the AAR bump on my phone; will be compile-checked in CI for this PR as well.

#### Additional context
N/A