### PR TITLE
[XedraWood] Playable lizardfolk

### DIFF
--- a/data/mods/XedraWood/effect_on_condition/eoc_game_start.json
+++ b/data/mods/XedraWood/effect_on_condition/eoc_game_start.json
@@ -6,11 +6,5 @@
     "required_event": "game_start",
     "condition": { "u_has_trait": "LIZARDFOLK_BUILD" },
     "effect": [ { "u_mutate_towards": "LIZARDFOLK_NO_HAIR", "category": "ANY", "use_vitamins": false } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_XEDRAWOOD_LIZARDFOLK_HAVE_NO_HAIR_ACTIVE",
-    "condition": { "u_has_trait": "LIZARDFOLK_BUILD" },
-    "effect": [  ]
   }
 ]

--- a/data/mods/XedraWood/effect_on_condition/eoc_game_start.json
+++ b/data/mods/XedraWood/effect_on_condition/eoc_game_start.json
@@ -1,0 +1,16 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_XEDRAWOOD_LIZARDFOLK_HAVE_NO_HAIR",
+    "eoc_type": "EVENT",
+    "required_event": "game_start",
+    "condition": { "u_has_trait": "LIZARDFOLK_BUILD" },
+    "effect": [ { "u_mutate_towards": "LIZARDFOLK_NO_HAIR", "category": "ANY", "use_vitamins": false } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_XEDRAWOOD_LIZARDFOLK_HAVE_NO_HAIR_ACTIVE",
+    "condition": { "u_has_trait": "LIZARDFOLK_BUILD" },
+    "effect": [  ]
+  }
+]

--- a/data/mods/XedraWood/mutations/nonhuman_species.json
+++ b/data/mods/XedraWood/mutations/nonhuman_species.json
@@ -1,0 +1,205 @@
+[
+  {
+    "type": "mutation",
+    "id": "LIZARDFOLK_BUILD",
+    "name": { "str": "Lizardfolk" },
+    "types": [ "HERITAGE" ],
+    "purifiable": false,
+    "mixed_effect": true,
+    "points": 1,
+    "visibility": 3,
+    "ugliness": 0,
+    "description": "Lizardfolk are taller, stronger, and more resilient than humans but not much thicker and are surprisingly fast for their size (+1 STR, +1 DEX).  Also, they are carnivorous.",
+    "enchantments": [
+      {
+        "values": [
+          { "value": "MOVECOST_SWIM_MOD", "multiply": -0.1 },
+          { "value": "STRENGTH", "add": 1 },
+          { "value": "DEXTERITY", "add": 1 },
+          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 0.25 },
+          { "value": "CARRY_WEIGHT", "multiply": 0.05 },
+          { "value": "MAX_HP", "multiply": 0.2 }
+        ]
+      }
+    ],
+    "vitamin_rates": [ [ "vitC", -1200 ] ],
+    "flags": [ "HERITAGE", "CARNIVORE_DIET", "LARGE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "LIZARDFOLK_NO_HAIR",
+    "name": { "str": "Lizardfolk No Hair Or Beard", "//~": "NO_I18N" },
+    "description": { "str": "Removes all hair and beard if you're a lizardfolk.  You shouldn't see this.", "//~": "NO_I18N" },
+    "points": 0,
+    "purifiable": false,
+    "player_display": false,
+    "mixed_effect": true,
+    "cancels": [
+      "hair_beaded",
+      "hair_body_length",
+      "hair_braid",
+      "hair_bun",
+      "hair_buzzcut",
+      "hair_crewcut",
+      "hair_curls",
+      "hair_detective",
+      "hair_extremely_long",
+      "hair_fro",
+      "hair_long",
+      "hair_long_mohawk",
+      "hair_long_over_eye",
+      "hair_medium",
+      "hair_messy",
+      "hair_modern",
+      "hair_mohawk",
+      "hair_mullet",
+      "hair_ponytail",
+      "hair_puff",
+      "hair_punk_long",
+      "hair_short",
+      "hair_short_no_fringe",
+      "hair_short_over_eye",
+      "hair_super_princess",
+      "hair_twintails",
+      "hair_very_long",
+      "natural_hair_growth",
+      "FACIAL_HAIR_GOATEE",
+      "FACIAL_HAIR_CIRCLE",
+      "FACIAL_HAIR_ROYALE",
+      "FACIAL_HAIR_ANCHOR",
+      "FACIAL_HAIR_SHORTBOXED",
+      "FACIAL_HAIR_CHEVRON",
+      "FACIAL_HAIR_3DAYSTUBBLE",
+      "FACIAL_HAIR_HORSESHOE",
+      "FACIAL_HAIR_MUSTACHE",
+      "FACIAL_HAIR_MUTTONCHOPS",
+      "FACIAL_HAIR_GUNSLINGER",
+      "FACIAL_HAIR_CHIN_STRIP",
+      "FACIAL_HAIR_CHIN_CURTAIN",
+      "FACIAL_HAIR_CHIN_STRAP",
+      "FACIAL_HAIR_BEARD",
+      "FACIAL_HAIR_BEARD_LONG",
+      "FACIAL_HAIR_BEARD_VERY_LONG",
+      "FACIAL_HAIR_HANDLEBAR",
+      "FACIAL_HAIR_NECKBEARD",
+      "FACIAL_HAIR_PENCIL",
+      "FACIAL_HAIR_SHENANDOAH",
+      "FACIAL_HAIR_SIDEBURNS",
+      "FACIAL_HAIR_SOUL_PATCH",
+      "FACIAL_HAIR_TOOTHBRUSH",
+      "FACIAL_HAIR_VANDYKE",
+      "FACIAL_HAIR_WALRUS",
+      "FACIAL_HAIR_ZAPPA"
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "WEBBED_LIZ_FEET",
+    "name": { "str": "Lizardfolk Feet" },
+    "//": "Alternate so webbed hands are not a prerequisite",
+    "points": 1,
+    "types": [ "FEET" ],
+    "description": "Your feet are heavily webbed, with three large scaled toes and a dewclaw in the back, allowing you to swim faster.  However, your feet are not designed for human footwear.",
+    "restricts_gear": [ "foot_l", "foot_r" ],
+    "flags": [ "WEBBED_FEET", "TOUGH_FEET" ],
+    "wet_protection": [ { "part": "foot_l", "good": 6 }, { "part": "foot_r", "good": 6 } ]
+  },
+  {
+    "type": "mutation",
+    "id": "WEBBED_LIZ_HANDS",
+    "name": { "str": "Lizardfolk Hands" },
+    "description": "Your hands are heavily webbed, causing problems with gloves.  However, you can swim much faster.  Slightly decreases wet penalties.",
+    "types": [ "HANDS" ],
+    "points": 0,
+    "mixed_effect": true,
+    "vitamin_cost": 60,
+    "visibility": 3,
+    "ugliness": 2,
+    "flags": [ "WEBBED_HANDS" ],
+    "encumbrance_covered": [ [ "hand_l", 50 ], [ "hand_r", 50 ] ],
+    "wet_protection": [ { "part": "hand_l", "good": 3 }, { "part": "hand_r", "good": 3 } ]
+  },
+  {
+    "type": "mutation",
+    "id": "STRONGER_RESISTWARM_LIZ",
+    "name": { "str": "High Heat Tolerance" },
+    "description": "Used to the warmth of the swamps as you are, you are little bothered by heat.",
+    "types": [ "ACCLIMATIZATION" ],
+    "points": 3,
+    "valid": true,
+    "vitamin_cost": 160,
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "CLIMATE_CONTROL_CHILL", "add": 25 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "COLDBLOOD4_LIZ",
+    "flags": [ "ECTOTHERM" ],
+    "name": { "str": "Ectothermia" },
+    "points": -3,
+    "description": "Your body is permanently cold-blooded.  Your speed lowers or raises 1% for every 2 (1.1) degrees below or above 65 F (18.3 C).  All this and you need even more food to maintain your energy.",
+    "purifiable": false,
+    "types": [ "METABOLISM" ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "METABOLISM", "multiply": 0.5 },
+          { "value": "SPEED", "add": { "math": [ "temperature_speed_mod(65, 0.5)" ] } }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "INFRARED_LIZ",
+    "name": { "str": "Heatsight" },
+    "description": "Your eyes are capable of sensing the heat of your prey.  Any anyone else, if necessary.",
+    "points": 5,
+    "vitamin_cost": 210,
+    "enchantments": [ "THERMAL_VISION_GOOD_PASSIVE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "PRED_LIZ",
+    "name": { "str": "Scalefolk Mindset" },
+    "description": "While not completely predatory, the lizardfolk are generally not particularly invested in the welfare of warmbloods.  Their death does not affect you greatly, and your ability to maintain combat skills is enhanced.",
+    "points": 2,
+    "purifiable": false,
+    "types": [ "PREDATION" ],
+    "flags": [ "PRED2" ],
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "COMBAT_CATCHUP", "multiply": 1.5 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "MUZZLE_LONG_LIZ",
+    "name": { "str": "Lizardfolk Muzzle" },
+    "points": 0,
+    "visibility": 8,
+    "ugliness": 8,
+    "mixed_effect": true,
+    "description": "Your face and jaws are those of a predatory lizard, with a set of sharp teeth to go with them.  They look NASTY--as do the bite wounds they can inflict--but prevent wearing mouthgear.",
+    "types": [ "MUZZLE" ],
+    "restricts_gear": [ "mouth" ],
+    "social_modifiers": { "intimidate": 10 },
+    "enchantments": [ { "condition": "ALWAYS", "modified_bodyparts": [ { "lose": "mouth" }, { "gain": "muzzle_long" } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "REGEN_LIZARDFOLK",
+    "name": { "str": "Reptilian Healing" },
+    "description": "Your broken limbs mend themselves without significant difficulty in addition to your already-quick healing.  You do not require splints for broken limbs.",
+    "cancels": [ "ROT1", "ROT2", "ROT3" ],
+    "points": 5,
+    "purifiable": false,
+    "vitamin_cost": 210,
+    "flags": [ "MEND_ALL" ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "MENDING_MODIFIER", "multiply": 19 },
+          { "value": "REGEN_HP", "multiply": 0.5 },
+          { "value": "REGEN_HP_AWAKE", "multiply": 0.2 }
+        ]
+      }
+    ]
+  }
+]

--- a/data/mods/XedraWood/player/nonhuman_species.json
+++ b/data/mods/XedraWood/player/nonhuman_species.json
@@ -1,0 +1,32 @@
+[
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "hobby_species_lizardfolk",
+    "name": "Lizardfolk (Species)",
+    "description": "You are one of the Scaled Ones, called \"lizardfolk\" by the warmbloods.  You keep mostly to yourselves in the swamps, hunting and fishing as you've always done, but something is happening in the world now and you've left your tribe to find out just what it is.",
+    "points": 4,
+    "skills": [ { "level": 2, "name": "swimming" } ],
+    "traits": [
+      "LIZARDFOLK_BUILD",
+      "SCALES",
+      "MEMBRANE",
+      "COLDBLOOD4_LIZ",
+      "STRONGER_RESISTWARM_LIZ",
+      "FORKED_TONGUE",
+      "HISS",
+      "ANTIJUNK",
+      "TAIL_THICK",
+      "LIZ_EYE",
+      "INFRARED_LIZ",
+      "REGEN_LIZARDFOLK",
+      "MUZZLE_LONG_LIZ",
+      "WEBBED_LIZ_FEET",
+      "WEBBED_LIZ_HANDS",
+      "TALONS",
+      "FANGS",
+      "SLIT_NOSTRILS",
+      "PRED_LIZ"
+    ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[XedraWood] Playable lizardfolk"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Non-humans in sword and sorcery are either aliens from beyond the stars, animal people, or degenerate descendants (or ancestors) of humanity. 

We'll go with the middle one for now. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add playable lizardfolk! They have scales, fangs, claws, they're larger, stronger, and tougher than humans, they can see heat, they have a tail, they're better at swimming...

...and to counteract all of this they're cold-blooded and carnivorous, so don't think survival is a cakewalk. 

Lizardfolk, for probably obvious reasons, can't have hair or beards. This is done using EoC on game start because adding them directly to the `cancels` field means your randomly-assigned hair during character generation prevents you from picking lizardfolk.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Started as a lizardfolk. Had appropriate traits.  Did not have hair. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Lizardfolk in the swamps are coming. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
