### PR TITLE
Migrate base unit of volume from milliliter (mL) to microliter (uL)

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2221,14 +2221,14 @@ units::volume item::volume( bool integral, bool ignore_contents, int charges_in_
 
     if( is_craft() ) {
         if( !craft_data_->cached_volume ) {
-            units::volume ret = 0_ml;
+            units::volume ret = 0_ul;
             for( const item_components::type_vector_pair &tvp : components ) {
                 for( const item &it : tvp.second ) {
                     ret += it.volume();
                 }
             }
-            // 1 mL minimum craft volume to avoid 0 volume errors from practices or hammerspace
-            craft_data_->cached_volume = std::max( ret, 1_ml );
+            // 1 uL minimum craft volume to avoid 0 volume errors from practices or hammerspace
+            craft_data_->cached_volume = std::max( ret, 1_ul );
         }
         return *craft_data_->cached_volume;
     }
@@ -2244,7 +2244,7 @@ units::volume item::volume( bool integral, bool ignore_contents, int charges_in_
     }
 
     if( count_by_charges() || made_of( phase_id::LIQUID ) ) {
-        units::quantity<int64_t, units::volume_in_milliliter_tag> num = ret * static_cast<int64_t>
+        units::quantity<int64_t, units::volume_in_microliter_tag> num = ret * static_cast<int64_t>
                 ( charges_in_vol );
         if( type->stack_size <= 0 ) {
             if( type->charges_default() <= 0 ) {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -495,13 +495,13 @@ void Item_factory::finalize_pre( itype &obj )
 
     // Items always should have some volume.
     // TODO: handle possible exception software?
-    if( obj.volume <= 0_ml ) {
+    if( obj.volume <= 0_ul ) {
         if( is_physical( obj ) ) {
             debugmsg( "item %s has zero volume (if zero volume is intentional "
                       "you can suppress this error with the ZERO_WEIGHT "
                       "flag)\n", obj.id.str() );
         }
-        obj.volume = units::from_milliliter( 1 );
+        obj.volume = units::from_microliter( 1 );
     }
 
     // Finalize vitamins in food

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -13,10 +13,12 @@ namespace units
 template<>
 void volume::serialize( JsonOut &jsout ) const
 {
-    if( value_ % 1000 == 0 ) {
-        jsout.write( string_format( "%d L", value_ / 1000 ) );
+    if (value_ % 1000000 == 0) {
+        jsout.write(string_format("%d L", value_ / 1000000));
+    } else if (value_ % 1000 == 0) {
+        jsout.write(string_format("%d mL", value_ / 1000));
     } else {
-        jsout.write( string_format( "%d ml", value_ ) );
+        jsout.write( string_format( "%d uL", value_ ) );
     }
 }
 

--- a/src/units.h
+++ b/src/units.h
@@ -305,27 +305,39 @@ operator%=( quantity<lvt, ut> &lhs, const quantity<rvt, ut> &rhs )
 /**@}*/
 
 template<typename value_type>
-inline constexpr quantity<value_type, volume_in_milliliter_tag> from_milliliter(
+inline constexpr quantity<value_type, volume_in_microliter_tag> from_microliter(
+    const value_type v)
+{
+    return quantity<value_type, volume_in_microliter_tag>(v, volume_in_microliter_tag{});
+}
+
+template<typename value_type>
+inline constexpr quantity<value_type, volume_in_microliter_tag> from_milliliter(
     const value_type v )
 {
-    return quantity<value_type, volume_in_milliliter_tag>( v, volume_in_milliliter_tag{} );
+    return from_microliter<value_type>(v * 1000);
 }
 
 template<typename value_type>
-inline constexpr quantity<value_type, volume_in_milliliter_tag> from_liter( const value_type v )
+inline constexpr quantity<value_type, volume_in_microliter_tag> from_liter( const value_type v )
 {
-    return from_milliliter<value_type>( v * 1000 );
+    return from_microliter<value_type>( v * 1000000 );
 }
 
 template<typename value_type>
-inline constexpr value_type to_milliliter( const quantity<value_type, volume_in_milliliter_tag> &v )
+inline constexpr value_type to_microliter( const quantity<value_type, volume_in_microliter_tag> &v )
 {
-    return v / from_milliliter<value_type>( 1 );
+    return v / from_microliter<value_type>( 1 );
 }
 
-inline constexpr double to_liter( const volume &v )
+inline constexpr double to_milliliter( const volume &v )
 {
     return v.value() / 1000.0;
+}
+
+inline constexpr double to_liter(const volume& v)
+{
+    return v.value() / 1000000.0;
 }
 
 template<typename value_type>
@@ -870,31 +882,43 @@ std::string display( units::power v );
 
 } // namespace units
 
-// Implicitly converted to volume, which has int as value_type!
+// Implicitly converted to volume, which has int64_t as value_type!
+inline constexpr units::volume operator""_ul(const unsigned long long v)
+{
+    return units::from_microliter(v);
+}
+
+inline constexpr units::quantity<double, units::volume_in_microliter_tag> operator""_ul(
+    const long double v)
+{
+    return units::from_microliter(v);
+}
+
+// Implicitly converted to volume, which has int64_t as value_type!
 inline constexpr units::volume operator""_ml( const unsigned long long v )
 {
     return units::from_milliliter( v );
 }
 
-inline constexpr units::quantity<double, units::volume_in_milliliter_tag> operator""_ml(
+inline constexpr units::quantity<double, units::volume_in_microliter_tag> operator""_ml(
     const long double v )
 {
     return units::from_milliliter( v );
 }
 
-// Implicitly converted to volume, which has int as value_type!
+// Implicitly converted to volume, which has int64_t as value_type!
 inline constexpr units::volume operator""_liter( const unsigned long long v )
 {
-    return units::from_milliliter( v * 1000 );
+    return units::from_liter( v );
 }
 
-inline constexpr units::quantity<double, units::volume_in_milliliter_tag> operator""_liter(
+inline constexpr units::quantity<double, units::volume_in_microliter_tag> operator""_liter(
     const long double v )
 {
-    return units::from_milliliter( v * 1000 );
+    return units::from_liter( v );
 }
 
-// Implicitly converted to mass, which has int as value_type!
+// Implicitly converted to mass, which has int64_t as value_type!
 inline constexpr units::mass operator""_milligram( const unsigned long long v )
 {
     return units::from_milligram( v );
@@ -1232,7 +1256,8 @@ constexpr std::array<std::pair<std::string_view, money>, 6> money_units = { {
         { "kUSD", 1_kUSD },
     }
 };
-constexpr std::array<std::pair<std::string_view, volume>, 2> volume_units = { {
+constexpr std::array<std::pair<std::string_view, volume>, 3> volume_units = { {
+        { "ul", 1_ul },
         { "ml", 1_ml },
         { "L", 1_liter }
     }

--- a/src/units_fwd.h
+++ b/src/units_fwd.h
@@ -10,11 +10,15 @@ namespace units
 template<typename V, typename U>
 class quantity;
 
+class volume_in_microliter_tag
+{
+};
+
 class volume_in_milliliter_tag
 {
 };
 
-using volume = quantity<int, volume_in_milliliter_tag>;
+using volume = quantity<std::int64_t, volume_in_microliter_tag>;
 
 class mass_in_microgram_tag
 {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Migrate base unit of volume from milliliter to microliter"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

With the recent leaps in progress taken towards decharging items, we've observed numerous issues related to density mismatches that have been made difficult to resolve by the maximum resolution of item sizes being 1mL, as many decharged items had proper per-charge sizes below that line, often by an order of magnitude.

The high number of decharged items whose single charge volume falls below the floor, and the number of recipes whose input and output amounts require a greater granularity to migrate intact than the current floor would allow, represent numerous individual instances where it was decided that volumes below 1 mL were necessary and appropriate for their role in the game. Refactoring the existing systems to accommodate the collective decision-making behind those items and their associated recipes avoids the pitfall of mass-editing items with an eye towards convenience over fidelity to our existing design goals.

<!-- With a few sentences, describe your reasons for making this change.

If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Microliters (uL) was chosen as the new base unit of volume as it is the next standard SI unit below mL and to match the 1 : 1000000 ratio between the smallest and largest units of mass the game uses. It also provides more than enough precision to accommodate all decharged items and any reasonable future systems for chemistry or medicine that require sub-mL volumes.

Due to the larger values, `volume` was migrated from `int` to `int64_t`. This brings our units of volume in line with units of mass, which were already stored as `int64_t` values. Existing functions were audited for use with the new units.

***DRAFT PR NOTE:*** *I am nowhere near done auditing the functions or making sure the game doesn't explode, that is why this is still a draft.*

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

The default assumption if we do not move to a more precise unit of volume is that all decharged items and recipes are audited and redesigned to match the new, sometimes significantly larger, minimum interactable size. Unfortunately, there is an unavoidable loss of precision, sometimes severe, implicit in this solution, and the workload towards redesigning all affected recipes with due care is conceivably much higher than migrating the base unit of volume.

Another possible solution is that we somehow replicate the existing calculations the game does for charged item volume, where the total combined volume is recalculated every time a charged item is added or removed from a container and then rounded to the nearest mL. This is not a good solution.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Besides being laborious, there are downstream effects ranging from loss of precision (due to the need to round input material counts) to, in some instances, requirements that entire recipes are migrated to substantially larger batch variants if not removed entirely.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
