### PR TITLE
Fix Rubik/exodii is way too peaceful #87450

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/exodii_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/exodii_npc_eocs.json
@@ -5,7 +5,8 @@
     "effect": [
       { "math": [ "faction_like('exodii') = -100" ] },
       { "math": [ "faction_respect('exodii') = -100" ] },
-      { "math": [ "faction_trust('exodii') = -100" ] }
+      { "math": [ "faction_trust('exodii') = -100" ] },
+      { "u_add_trait": "EXODII_WRATH" }
     ]
   },
   {

--- a/data/json/mutations/cybernetic_traits.json
+++ b/data/json/mutations/cybernetic_traits.json
@@ -9,16 +9,15 @@
   },
   {
     "type": "mutation",
+    "//~": "NO_I18N",
     "id": "EXODII_WRATH",
     "player_display": false,
-    "name": { "str": "XEDRA Neurobionic Interface" },
+    "name": { "str": "Exodii Wrath" },
     "points": 0,
-    "description": "The compact bionic command and control interface interwoven with your nervous system had a previous life inside of a cybernetic tribesperson.  Best case scenario, none of them are on this Earth.",
+    "description": "Makes sure all the exodii mobs shoot you on sight.",
     "valid": false,
     "purifiable": false,
-    "types": [ "Cybernetic" ],
-    "anger_relations": [ [ "CYBORG", 95 ] ],
-    "cancels": [ "NO_CBM_INSTALLATION" ]
+    "anger_relations": [ [ "CYBORG", 95 ] ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/cybernetic_traits.json
+++ b/data/json/mutations/cybernetic_traits.json
@@ -9,6 +9,19 @@
   },
   {
     "type": "mutation",
+    "id": "EXODII_WRATH",
+    "//": "When Hub01 is able to develop their own bionic installations they might receive this trait.",
+    "name": { "str": "XEDRA Neurobionic Interface" },
+    "points": 0,
+    "description": "The compact bionic command and control interface interwoven with your nervous system had a previous life inside of a cybernetic tribesperson.  Best case scenario, none of them are on this Earth.",
+    "valid": false,
+    "purifiable": false,
+    "types": [ "Cybernetic" ],
+    "anger_relations": [ [ "CYBORG", 95 ] ],
+    "cancels": [ "NO_CBM_INSTALLATION" ]
+  },
+  {
+    "type": "mutation",
     "id": "CBM_Interface",
     "name": { "str": "Standard Neurobionic Interface" },
     "points": 0,

--- a/data/json/mutations/cybernetic_traits.json
+++ b/data/json/mutations/cybernetic_traits.json
@@ -9,12 +9,11 @@
   },
   {
     "type": "mutation",
-    "//~": "NO_I18N",
     "id": "EXODII_WRATH",
     "player_display": false,
-    "name": { "str": "Exodii Wrath" },
+    "name": { "//~": "NO_I18N", "str": "Exodii Wrath" },
     "points": 0,
-    "description": "Makes sure all the exodii mobs shoot you on sight.",
+    "description": { "//~": "NO_I18N", "str": "Makes sure all the exodii mobs shoot you on sight." },
     "valid": false,
     "purifiable": false,
     "anger_relations": [ [ "CYBORG", 95 ] ]

--- a/data/json/mutations/cybernetic_traits.json
+++ b/data/json/mutations/cybernetic_traits.json
@@ -10,7 +10,7 @@
   {
     "type": "mutation",
     "id": "EXODII_WRATH",
-    "//": "When Hub01 is able to develop their own bionic installations they might receive this trait.",
+    "player_display": false,
     "name": { "str": "XEDRA Neurobionic Interface" },
     "points": 0,
     "description": "The compact bionic command and control interface interwoven with your nervous system had a previous life inside of a cybernetic tribesperson.  Best case scenario, none of them are on this Earth.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #87450 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds the same kind of effect that Xedra Cyborgs get in XE
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Worked in XE
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
