### PR TITLE
Let dmgbuild size macOS disk images

### DIFF
--- a/build-data/osx/dmgsettings.py
+++ b/build-data/osx/dmgsettings.py
@@ -37,9 +37,6 @@ def icon_from_app(app_path):
 # Volume format (see hdiutil create -help)
 format = defines.get('format', 'UDBZ')
 
-# Volume size (must be large enough for your files)
-size = defines.get('size', '500M')
-
 # Files to include
 #
 # SDL3 builds stage LICENSE-SDL*.txt / LICENSE-vendored-*.txt at the repo


### PR DESCRIPTION
#### Summary
Build "Let dmgbuild size macOS disk images"

#### Purpose of change

The macOS SDL3 release bundle outgrows the fixed 500 MB image capacity before the final compressed DMG is produced: https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/27055462931/job/79859627918

#### Describe the solution

Remove the explicit DMG size from the dmgbuild settings. dmgbuild will calculate the writable image size from the files it packages.

#### Describe alternatives you've considered

Bumping the fixed size would work, but this is one less manual size knob to maintain.

#### Testing

N/A, just read the docs.

#### Additional context

N/A