### PR TITLE
vitrified farmstead, LIXA, lost levels, and portal storm dungeon are all viable exits from the Labyrinth Bound challenge

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json
@@ -1406,10 +1406,10 @@
             { "current_dimension": "" },
             { "not": { "u_has_effect": "VITRIFYING" } },
             { "not": { "u_has_effect": "LIXA_unfolded_eff" } },
-            { "not":  { "u_is_on_terrain": "t_floor_warped" } },
-            { "not":  { "u_at_om_location": "nether_glass" } },
-            { "not":  { "u_at_om_location": "nether_glass_deep" } },
-            { "not":  { "u_at_om_location": "microlab_portal_elevator_nether_glass" } }       
+            { "not": { "u_is_on_terrain": "t_floor_warped" } },
+            { "not": { "u_at_om_location": "nether_glass" } },
+            { "not": { "u_at_om_location": "nether_glass_deep" } },
+            { "not": { "u_at_om_location": "microlab_portal_elevator_nether_glass" } }
           ]
         },
         "then": [

--- a/data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json
@@ -1401,7 +1401,17 @@
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" } ] },
     "effect": [
       {
-        "if": { "current_dimension": "" },
+        "if": {
+          "and": [
+            { "current_dimension": "" },
+            { "not": { "u_has_effect": "VITRIFYING" } },
+            { "not": { "u_has_effect": "LIXA_unfolded_eff" } },
+            { "not":  { "u_is_on_terrain": "t_floor_warped" } },
+            { "not":  { "u_at_om_location": "nether_glass" } },
+            { "not":  { "u_at_om_location": "nether_glass_deep" } },
+            { "not":  { "u_at_om_location": "microlab_portal_elevator_nether_glass" } }       
+          ]
+        },
         "then": [
           {
             "u_travel_to_dimension": "netherum_labyrinth_safehouse",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The Labyrinth Bound scenario can be "escaped" if you enter another dimension and stay there until your jaunt extraction time.  Several viable options didn't count because the check only looked for `current_dimension`

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The following conditions now count:
- Being stuck in the vitrified farmstead
- Being in the endless hallway in LIXA
- Being in the portal dungeon
- Being anywhere in the lost levels

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Most/all these places should be made their own dimension, anyway?

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Ran EOC in these locations.  Freed from AltarOS.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
