### PR TITLE
set duct_tape length

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -1071,8 +1071,10 @@
     "description": "A roll of semi-opaque medical tape, intended to hold bandages in place.  Not as versatile as duct tape.",
     "material": [ "plastic" ],
     "//": "25 x 200 x 0.2 mm per unit, 5 meters roll is 25 units",
+    "display_type": "BY_LENGTH",
     "volume": "1 ml",
-    "weight": "1 g"
+    "weight": "1 g",
+    "longest_side": "20 cm"
   },
   {
     "type": "ITEM",

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -421,6 +421,7 @@
     "material": [ "plastic" ],
     "volume": "2 ml",
     "weight": "2 g",
+    "longest_side": "125 mm",
     "ammo_type": "tape",
     "count": 1,
     "//1": "50 x 125 x 0.3 mm per unit, rounded up. 200 units = 25 m",

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -5043,6 +5043,7 @@
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "1 L",
+        "max_item_length": "30 cm",
         "max_contains_weight": "1 kg",
         "item_restriction": [ "duct_tape", "medical_tape" ],
         "volume_multiplier": 0.75


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
duct_tape uses `"display_type": "BY_LENGTH"`, but it's length (from comment, 125 mm) do not match the default calculated (1 cm)
#### Describe the solution
Update the length of duct_tape
Update the length of medical_tape, make it `"display_type": "BY_LENGTH"` as well