### PR TITLE
Fix sewage treatment quicklime drum error

### DIFF
--- a/data/json/itemgroups/Agriculture_Forage_Excavation/agriculture.json
+++ b/data/json/itemgroups/Agriculture_Forage_Excavation/agriculture.json
@@ -81,6 +81,7 @@
       [ "elec_shears", 10 ],
       [ "tree_spile", 40 ],
       { "group": "quicklime_bag", "prob": 30 },
+      { "group": "quicklime_barrel_part", "prob": 30 },
       [ "pitchfork", 40 ],
       [ "steam_triple_small", 1 ],
       [ "steam_triple_medium", 1 ],

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -2088,7 +2088,11 @@
   {
     "id": "farm_supply_quicklime_and_saltpetre",
     "type": "item_group",
-    "items": [ { "group": "quicklime_bag", "prob": 85 }, { "item": "chem_saltpetre", "prob": 15, "count": [ 10, 50 ] } ]
+    "items": [
+      { "group": "quicklime_bag", "prob": 85 },
+      { "group": "quicklime_barrel", "prob": 20 },
+      { "item": "chem_saltpetre", "prob": 15, "count": [ 10, 50 ] }
+    ]
   },
   {
     "id": "farm_supply_animal_feed",

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -126,6 +126,18 @@
     "items": [ { "item": "material_quicklime", "count": [ 400, 1200 ] } ]
   },
   {
+    "id": "quicklime_barrel",
+    "type": "item_group",
+    "container-item": "30gal_barrel",
+    "items": [ { "item": "material_quicklime", "count": 6000 } ]
+  },
+  {
+    "id": "quicklime_barrel_part",
+    "type": "item_group",
+    "container-item": "30gal_barrel",
+    "items": [ { "item": "material_quicklime", "count": [ 600, 6000 ] } ]
+  },
+  {
     "id": "paintcans",
     "type": "item_group",
     "items": [ { "item": "paint_can_steel" }, { "item": "paint_can_plastic" } ]
@@ -305,6 +317,7 @@
       { "group": "fertilizer_commercial_bag_canvas_60", "prob": 100 },
       { "group": "styrofoam_sheet_pack", "prob": 30, "count": [ 1, 4 ] },
       { "group": "quicklime_bag", "prob": 70 },
+      { "group": "quicklime_barrel", "prob": 5 },
       { "group": "concrete_bag", "count": [ 3, 7 ], "prob": 100 },
       { "group": "cement_bag", "count": [ 1, 3 ], "prob": 100 },
       { "item": "nuts_bolts", "prob": 60, "count": [ 250, 400 ], "entry-wrapper": "box_small" },
@@ -750,6 +763,7 @@
       { "group": "fertilizer_commercial_bag_canvas_60", "prob": 100 },
       [ "fertilizer_liquid", 60 ],
       { "group": "quicklime_bag", "prob": 80 },
+      { "group": "quicklime_barrel", "prob": 20 },
       { "item": "chem_saltpetre", "prob": 15, "count": [ 10, 50 ] }
     ]
   },

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -252,6 +252,7 @@
     "price": "1 USD",
     "price_postapoc": "10 cent",
     "name": { "str_sp": "quicklime" },
+    "display_type": "BY_WEIGHT",
     "symbol": "=",
     "color": "dark_gray",
     "description": "The product of burning limestone, this white powder is a crucial ingredient in making cement.  That said, it is also extremely caustic and will cause severe burns to any tissue it comes in contact with.  This property could probably be exploited.",

--- a/data/json/mapgen/sewage_treatment.json
+++ b/data/json/mapgen/sewage_treatment.json
@@ -125,7 +125,10 @@
     "items": [
       { "item": "bleach", "container-item": "55gal_drum", "charges": [ 10, 126 ], "prob": 50 },
       { "item": "chem_sulphuric_acid", "container-item": "55gal_drum", "charges": [ 2, 50 ], "prob": 20 },
-      { "item": "material_quicklime", "container-item": "55gal_drum", "count": [ 2, 50 ], "prob": 20 },
+      {
+        "collection": [ { "group": "quicklime_barrel", "prob": 40, "count": [ 1, 2 ] }, { "group": "quicklime_barrel_part" } ],
+        "prob": 60
+      },
       { "item": "55gal_drum", "prob": 50 }
     ]
   },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #87385
#### Describe the solution
Replace incorrect spawn of sewage treatment quicklime with new itemgroup that include 30 gallon plastic barrel full of quicklime
Add such itemgroup in some more places
Also add `"display_type": "BY_WEIGHT",` to quicklime

#### Testing
<img width="685" height="77" alt="image" src="https://github.com/user-attachments/assets/b1167691-0b14-4c63-b027-a746afd9ebe5" />
