### PR TITLE
graphite spawn and stats adjustments

### DIFF
--- a/data/json/itemgroups/netherum/labyrinth_SUS_itemgroups.json
+++ b/data/json/itemgroups/netherum/labyrinth_SUS_itemgroups.json
@@ -29,7 +29,7 @@
       [ "multitool", 10 ],
       [ "recharge_station", 10 ],
       [ "hand_crank_charger", 25 ],
-      { "item": "graphite", "prob": 10, "count": [ 1, 250 ] },
+      { "group": "graphite_small_bottle_part", "prob": 10 },
       [ "metal_file", 10 ],
       [ "clamp", 10 ],
       [ "sandpaper", 80 ],

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -54,6 +54,19 @@
     ]
   },
   {
+    "id": "graphite_small_bottle",
+    "type": "item_group",
+    "container-item": "bottle_plastic_355ml",
+    "//": "8 oz",
+    "items": [ { "item": "graphite", "count": 118 } ]
+  },
+  {
+    "id": "graphite_small_bottle_part",
+    "type": "item_group",
+    "container-item": "bottle_plastic_355ml",
+    "items": [ { "item": "graphite", "count": [ 2, 118 ] } ]
+  },
+  {
     "id": "sandbag",
     "type": "item_group",
     "container-item": "bag_durasack",

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -10,7 +10,7 @@
       [ "crucible", 30 ],
       [ "swage", 60 ],
       [ "drift", 70 ],
-      { "item": "graphite", "prob": 70, "count": [ 1, 250 ] },
+      { "group": "graphite_small_bottle_part", "prob": 70 },
       { "group": "borax_box_part", "prob": 90 },
       [ "metal_file", 90 ],
       [ "hotcut", 90 ],
@@ -67,7 +67,7 @@
       { "item": "cordless_impact_wrench", "prob": 20, "charges": [ 0, 500 ] },
       [ "metal_smoother", 90 ],
       { "item": "jackhammer", "prob": 40, "charges": [ 0, 1200 ] },
-      { "item": "graphite", "prob": 10, "count": [ 1, 250 ] },
+      { "group": "graphite_small_bottle_part", "prob": 10 },
       { "group": "tools_toolbox", "prob": 20 },
       { "group": "tools_workshop", "prob": 5 },
       [ "recharge_station", 10 ],
@@ -127,7 +127,7 @@
       [ "multitool", 10 ],
       [ "recharge_station", 10 ],
       [ "hand_crank_charger", 25 ],
-      { "item": "graphite", "prob": 10, "count": [ 1, 250 ] },
+      { "group": "graphite_small_bottle_part", "prob": 10 },
       [ "metal_file", 10 ],
       [ "clamp", 10 ],
       [ "sandpaper", 80 ],
@@ -152,7 +152,7 @@
       [ "hand_pump", 1 ],
       [ "funnel", 50 ],
       [ "metal_file", 40 ],
-      { "item": "graphite", "prob": 50, "count": [ 1, 250 ] },
+      { "group": "graphite_small_bottle_part", "prob": 50 },
       { "item": "tape_measure", "prob": 70 },
       [ "sandpaper", 65 ]
     ]
@@ -179,7 +179,7 @@
       [ "hacksaw", 30 ],
       [ "saw", 65 ],
       { "item": "bow_saw", "prob": 40 },
-      { "item": "graphite", "prob": 30, "count": [ 1, 250 ] },
+      { "group": "graphite_small_bottle_part", "prob": 30 },
       [ "pin_reamer", 18 ],
       [ "clamp", 30 ],
       [ "boxcutter", 20 ],
@@ -340,7 +340,7 @@
       { "item": "reciprocating_saw", "prob": 50, "charges": [ 0, 500 ] },
       { "item": "cordless_drill", "prob": 100, "charges": [ 0, 500 ] },
       [ "pin_reamer", 30 ],
-      { "item": "graphite", "prob": 30, "count": [ 1, 250 ] },
+      { "group": "graphite_small_bottle_part", "prob": 30 },
       [ "clamp", 10 ],
       [ "sandpaper", 90 ],
       [ "bench_vise", 15 ]
@@ -450,7 +450,7 @@
       [ "welding_papr_helmet", 40 ],
       { "group": "papr_kit", "prob": 20 },
       [ "thread_cutting_set", 40 ],
-      { "item": "graphite", "prob": 40, "count": [ 1, 250 ] }
+      { "group": "graphite_small_bottle_part", "prob": 40 }
     ]
   },
   {
@@ -462,7 +462,7 @@
       { "item": "jack", "prob": 100 },
       { "item": "lug_wrench", "prob": 80 },
       { "item": "jack_small", "prob": 80 },
-      { "item": "graphite", "prob": 50, "count": [ 1, 250 ] },
+      { "group": "graphite_small_bottle_part", "prob": 50 },
       { "item": "compressor", "prob": 40 },
       { "group": "tools_toolbox", "prob": 80 },
       { "group": "tools_workshop", "prob": 70 },
@@ -865,7 +865,7 @@
       { "item": "plut_cell", "prob": 4, "charges": [ 1, 5 ] },
       { "group": "glue_weak_domestic", "prob": 15 },
       { "group": "glue_strong_domestic", "prob": 15 },
-      { "item": "graphite", "prob": 30, "count": [ 1, 250 ] },
+      { "group": "graphite_small_bottle_part", "prob": 30 },
       [ "pliers", 10 ],
       [ "tin_snips", 10 ],
       { "item": "matches", "prob": 10, "charges": [ 1, 20 ] },

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -77,13 +77,13 @@
     "name": { "str_sp": "graphite" },
     "symbol": "!",
     "description": "Graphite, aka elemental carbon, mixed with a little clay or oil.  Produces gray or black marks that are easily erased, but otherwise resistant to moisture, most chemicals, ultraviolet radiation, and natural aging.  Useful as a lubricant in metalworking.",
-    "material": [ "powder" ],
+    "material": [ "dense_powder_nonflam" ],
+    "display_type": "BY_WEIGHT",
     "volume": "1 ml",
-    "weight": "40 mg",
+    "weight": "2 g",
     "color": "dark_gray",
     "looks_like": "charcoal",
-    "flags": [ "TRADER_AVOID" ],
-    "container": "bottle_plastic_small"
+    "flags": [ "TRADER_AVOID" ]
   },
   {
     "type": "ITEM",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #87409
#### Describe the solution
Make an itemgroup for graphite in bottle, replace all spawns of graphite with this bottle
Also make graphite 2 g, in line with #87000 that increased it's volume 50 times as part of decharging, but missed to increase the item weight
also make graphite `"display_type": "BY_WEIGHT"`
#### Testing
<img width="438" height="158" alt="image" src="https://github.com/user-attachments/assets/d1ec2a86-fef7-4a5b-8ce4-0e82c75e04a9" />
