### PR TITLE
Look around: show memorised terrain and furniture

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -1034,9 +1034,9 @@ class game
         void print_fields_info( const tripoint_bub_ms &lp, const catacurses::window &w_look, int column,
                                 int &line );
         void print_terrain_info( const tripoint_bub_ms &lp, const catacurses::window &w_look,
-                                 std::string_view area_name, int column, int &line );
+                                 std::string_view area_name, int column, int &line, bool visible );
         void print_furniture_info( const tripoint_bub_ms &lp, const catacurses::window &w_look, int column,
-                                   int &line );
+                                   int &line, bool visible );
         void print_trap_info( const tripoint_bub_ms &lp, const catacurses::window &w_look, int column,
                               int &line );
         void print_part_con_info( const tripoint_bub_ms &lp, const catacurses::window &w_look, int column,

--- a/src/game_ui_tile_info.cpp
+++ b/src/game_ui_tile_info.cpp
@@ -174,7 +174,7 @@ void game::print_visibility_info( const catacurses::window &w_look, int column, 
             break;
     }
 
-    mvwprintz( w_look, point( line, column ), c_light_gray, visibility_message );
+    mvwprintz( w_look, point( column, line ), c_light_gray, visibility_message );
     line += 2;
 }
 

--- a/src/game_ui_tile_info.cpp
+++ b/src/game_ui_tile_info.cpp
@@ -34,6 +34,7 @@
 #include "lightmap.h"
 #include "magic_enchantment.h"
 #include "map.h"
+#include "map_memory.h"
 #include "map_scale_constants.h"
 #include "mapdata.h"
 #include "npc.h"
@@ -79,7 +80,7 @@ void game::print_all_tile_info( const tripoint_bub_ms &lp, const catacurses::win
     switch( visibility ) {
         case visibility_type::CLEAR: {
             const optional_vpart_position vp = here.veh_at( lp );
-            print_terrain_info( lp, w_look, area_name, column, line );
+            print_terrain_info( lp, w_look, area_name, column, line, true );
             print_fields_info( lp, w_look, column, line );
             print_trap_info( lp, w_look, column, line );
             print_part_con_info( lp, w_look, column, line );
@@ -95,6 +96,7 @@ void game::print_all_tile_info( const tripoint_bub_ms &lp, const catacurses::win
         case visibility_type::DARK:
         case visibility_type::LIT:
         case visibility_type::HIDDEN:
+            print_terrain_info( lp, w_look, area_name, column, line, false );
             print_visibility_info( w_look, column, line, visibility );
 
             static std::string raw_description;
@@ -179,23 +181,32 @@ void game::print_visibility_info( const catacurses::window &w_look, int column, 
 }
 
 void game::print_terrain_info( const tripoint_bub_ms &lp, const catacurses::window &w_look,
-                               const std::string_view area_name, int column, int &line )
+                               const std::string_view area_name, int column, int &line, bool visible )
 {
     map &here = get_map();
 
+    if( !visible && !get_avatar().has_memory_at( here.get_abs( lp ) ) ) {
+        return;
+    }
+
     const int max_width = getmaxx( w_look ) - column - 1;
 
+    const ter_t &terrain = visible
+                           ? here.ter( lp ).obj()
+                           : ter_str_id( get_avatar().get_memorized_tile( here.get_abs( lp ) ).get_ter_id() ).id().obj();
     // Print OMT type and terrain type on first two lines
     // if can't fit in one line.
-    const std::string tile = uppercase_first_letter( here.tername( lp ) );
+    const std::string tile = uppercase_first_letter( terrain.name() );
     std::string area = uppercase_first_letter( area_name );
-    if( const timed_event *e = get_timed_events().get( timed_event_type::OVERRIDE_PLACE ) ) {
-        area = e->string_id;
+    if( visible ) {
+        if( const timed_event *e = get_timed_events().get( timed_event_type::OVERRIDE_PLACE ) ) {
+            area = e->string_id;
+        }
     }
     mvwprintz( w_look, point( column, line++ ), c_yellow, area );
     mvwprintz( w_look, point( column, line++ ), c_light_blue, _( "-----TERRAIN-----" ) );
     mvwprintz( w_look, point( column, line++ ), c_white, tile );
-    std::string desc = string_format( here.ter( lp ).obj().description.translated() );
+    std::string desc = string_format( terrain.description.translated() );
     std::vector<std::string> lines = foldstring( desc, max_width );
     int numlines = lines.size();
     wattron( w_look, c_light_gray );
@@ -205,7 +216,12 @@ void game::print_terrain_info( const tripoint_bub_ms &lp, const catacurses::wind
     wattroff( w_look, c_light_gray );
 
     // Furniture, if any
-    print_furniture_info( lp, w_look, column, line );
+    print_furniture_info( lp, w_look, column, line, visible );
+    if( !visible ) {
+        // separate visibility_message
+        ++line;
+        return;
+    }
 
     // Cover percentage from terrain and furniture next.
     fold_and_print( w_look, point( column, ++line ), max_width, c_light_gray, _( "Concealment: %d%%" ),
@@ -273,12 +289,14 @@ void game::print_terrain_info( const tripoint_bub_ms &lp, const catacurses::wind
 
 void game::print_furniture_info( const tripoint_bub_ms &lp, const catacurses::window &w_look,
                                  int column,
-                                 int &line )
+                                 int &line, bool visible )
 {
     map &here = get_map();
 
+    const furn_str_id &f_memory = furn_str_id( get_avatar().get_memorized_tile( here.get_abs( lp ) )
+                                  .get_dec_id() );
     // Do nothing if there is no furniture here
-    if( !here.has_furn( lp ) ) {
+    if( ( visible && !here.has_furn( lp ) ) || ( !visible && !f_memory.is_valid() ) ) {
         return;
     }
     const int max_width = getmaxx( w_look ) - column - 1;
@@ -288,12 +306,12 @@ void game::print_furniture_info( const tripoint_bub_ms &lp, const catacurses::wi
 
     mvwprintz( w_look, point( column, line++ ), c_light_blue, _( "-----FURNITURE-----" ) );
 
+    const furn_id &f = visible ? here.furn( lp ) : f_memory.id();
     // Print furniture name in white
-    std::string desc = uppercase_first_letter( here.furnname( lp ) );
+    std::string desc = uppercase_first_letter( visible ? here.furnname( lp ) : f.obj().name() );
     mvwprintz( w_look, point( column, line++ ), c_white, desc );
 
     // Print each line of furniture description in gray
-    const furn_id &f = here.furn( lp );
     desc = string_format( f.obj().description.translated() );
     std::vector<std::string> lines = foldstring( desc, max_width );
     int numlines = lines.size();

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4487,6 +4487,14 @@ void mm_submap::serialize( JsonOut &jsout ) const
     jsout.end_array();
 }
 
+static std::string migrate_memorized_terrain( const std::string &ter_id )
+{
+    if( auto it = ter_migrations.find( ter_str_id( ter_id ) ); it != ter_migrations.end() ) {
+        return it->second.first.str();
+    }
+    return ter_id;
+}
+
 void mm_submap::deserialize( int version, const JsonArray &ja )
 {
     size_t submap_array_idx = 0;
@@ -4504,7 +4512,7 @@ void mm_submap::deserialize( int version, const JsonArray &ja )
                 if( version < 1 ) { // legacy, remove after 0.H comes out
                     std::string id = ja_tile.get_string( 0 );
                     if( string_starts_with( id, "t_" ) ) {
-                        tile.set_ter_id( std::move( id ) );
+                        tile.set_ter_id( migrate_memorized_terrain( id ) );
                         tile.set_ter_subtile( ja_tile.get_int( 1 ) );
                         tile.set_ter_rotation( ja_tile.get_int( 2 ) );
                         tile.set_dec_id( "" );
@@ -4533,7 +4541,7 @@ void mm_submap::deserialize( int version, const JsonArray &ja )
                 } else {
                     remaining = ja_tile.get_int( 0 ) - 1;
                     tile.symbol = ja_tile.get_int( 1 );
-                    tile.set_ter_id( ja_tile.get_string( 2 ) );
+                    tile.set_ter_id( migrate_memorized_terrain( ja_tile.get_string( 2 ) ) );
                     tile.ter_subtile = ja_tile.get_int( 3 );
                     tile.ter_rotation = ja_tile.get_int( 4 );
                     if( ja_tile.size() > 5 ) {


### PR DESCRIPTION
#### Summary
Interface "Look around: show memorised terrain and furniture"

#### Purpose of change

Resolve #87467

#### Describe the solution

There are 3 commits:
1. Fix "Unseen."
   - fix point(y, x) -> point(x, y)
3. Migrate memorised tiles.
   - It threw a debug message on memorised tile `t_underbrush_harvested_spring` which was migrated to `t_underbrush_harvested` in 0.J.
   - Therefore, migration was added.
5. Show remembered terrain.
   - Load terrain & furniture from the avatar's memory.

#### Describe alternatives you've considered

Rather than migrating, solve old terrain on the fly.

Show more info:
 - Move cost. Move cost is computed from vehicles, which the avatar doesn't (fully) remember. I would like it, though.
 - Impassable (it's move cost).
 - "Tree can be cut down with the right tools" - It's possible, but a bit hacky.
 - Vehicle part. I didn't bother. Can be added later. (Only the vehicle parts needed for images would be shown.)

Do it elsewhere too:
 - When you look around on a memorised tile, then `e`xamine that tile, it will tell you you can't see there.
   - We could show the memorised terain & furniture there.
   - <img width="640" height="384" alt="image" src="https://github.com/user-attachments/assets/36e76f65-8593-4d35-99e8-387e24ed9fa2" />


#### Testing

Migration:
1. Loaded old save with `t_underbrush_harvested_spring` out of the vision field.
3. Look around and look at the tile.
4. It correctly displays `t_underbrush_harvested` info & breakpoint shows that the migration is used.

Show remembered terrain:
 - Looked around a bunch,

visible `rose bush` on a `field`
<img width="640" height="367" alt="image" src="https://github.com/user-attachments/assets/3ae15337-47a2-43fc-86e2-7957bd112846" />

memorised `rose bush` on a `field` (note the `Unseen.`)
<img width="640" height="365" alt="image" src="https://github.com/user-attachments/assets/6b34d8d6-e98a-42a5-8cf7-d8ecdf3861f2" />

Works for BOOMER text as well:
<img width="641" height="365" alt="image" src="https://github.com/user-attachments/assets/c7d16f78-7513-4225-b52c-f39230e66896" />


#### Additional context

