### PR TITLE
Add documentation for talker_zone_const::pos_abs() function

### DIFF
--- a/src/talker_zone.cpp
+++ b/src/talker_zone.cpp
@@ -2,6 +2,11 @@
 #include "talker_zone.h"
 #include "clzones.h"
 
+/**
+ * @brief Gets the absolute position of the zone.
+ * 
+ * @return tripoint_abs_ms The absolute position of the zone's start point.
+ */
 tripoint_abs_ms talker_zone_const::pos_abs() const
 {
     return me_zone_const->get_start_point();


### PR DESCRIPTION
## Background
The public function `talker_zone_const::pos_abs()` lacked a documentation comment. This reduces code readability and makes it harder for other contributors to understand the function's purpose and return value without examining the implementation.

## Changes
- Added a detailed Doxygen-style documentation comment for the `talker_zone_const::pos_abs()` method in `src/talker_zone.cpp`.
- The comment includes a `@brief` tag explaining the function's purpose and a `@return` tag describing the returned value.

## Verification
- Ensure the project still compiles successfully after the change.
- Verify that the new comment accurately reflects the function's behavior as seen in the implementation (`me_zone_const->get_start_point()`).