### PR TITLE
Iron Safari, Circuit Safari, and the Hub 01 Bionic Garage no longer require you to physically lift massive robots to finish missions

### DIFF
--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NC_ROBOFAC_SCIENTIST_GARAGE.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NC_ROBOFAC_SCIENTIST_GARAGE.json
@@ -94,95 +94,46 @@
     "responses": [
       {
         "text": "[1 HGC] I've brought you one of those workers.",
-        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
-        "condition": { "u_has_items": { "item": "broken_exodii_worker", "count": 1 } },
+        "topic": "TALK_DONE",
+        "condition": { "u_has_items_sum": [ { "item": "broken_exodii_worker", "amount": 1 } ] },
         "effect": [
-          { "u_consume_item": "broken_exodii_worker", "count": 1, "popup": true },
+          { "u_consume_item_sum": [ { "item": "broken_exodii_worker", "amount": 1 } ] },
           { "u_spawn_item": "RobofacCoin", "count": 1 },
           { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
         ]
       },
       {
         "text": "[2 HGC] I've brought you one of those quadrupeds.",
-        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
-        "condition": { "u_has_items": { "item": "broken_exodii_quad", "count": 1 } },
+        "topic": "TALK_DONE",
+        "condition": { "u_has_items_sum": [ { "item": "broken_exodii_quad", "amount": 1 } ] },
         "effect": [
-          { "u_consume_item": "broken_exodii_quad", "count": 1, "popup": true },
+          { "u_consume_item_sum": [ { "item": "broken_exodii_quad", "amount": 1 } ] },
           { "u_spawn_item": "RobofacCoin", "count": 2 },
           { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
         ]
       },
       {
         "text": "[2 HGC] I've brought you one of those turrets.",
-        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
-        "condition": { "u_has_items": { "item": "broken_exodii_turret", "count": 1 } },
+        "topic": "TALK_DONE",
+        "condition": { "u_has_items_sum": [ { "item": "broken_exodii_turret", "amount": 1 } ] },
         "effect": [
-          { "u_consume_item": "broken_exodii_turret", "count": 1, "popup": true },
+          { "u_consume_item_sum": [ { "item": "broken_exodii_turret", "amount": 1 } ] },
           { "u_spawn_item": "RobofacCoin", "count": 2 },
           { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
         ]
       },
       {
         "text": "[4 HGC] I found this strange balloon robot.",
-        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
-        "condition": { "u_has_items": { "item": "broken_exodii_sniper_drone", "count": 1 } },
+        "topic": "TALK_DONE",
+        "condition": { "u_has_items_sum": [ { "item": "broken_exodii_sniper_drone", "amount": 1 } ] },
         "effect": [
-          { "u_consume_item": "broken_exodii_sniper_drone", "count": 1, "popup": true },
+          { "u_consume_item_sum": [ { "item": "broken_exodii_sniper_drone", "amount": 1 } ] },
           { "u_spawn_item": "RobofacCoin", "count": 4 },
           { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
         ]
       },
       { "text": "Nevermind.  Let's talk about something else.", "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE" },
       { "text": "Actually, I'd better be going.", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
-    "dynamic_line": "Thanks, man.  Enjoy that.",
-    "responses": [
-      {
-        "text": "[1 HGC] I've also got one of those workers.",
-        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
-        "condition": { "u_has_items": { "item": "broken_exodii_worker", "count": 1 } },
-        "effect": [
-          { "u_consume_item": "broken_exodii_worker", "count": 1, "popup": true },
-          { "u_spawn_item": "RobofacCoin", "count": 1 },
-          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
-        ]
-      },
-      {
-        "text": "[2 HGC] I've also got one of those quadrupeds.",
-        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
-        "condition": { "u_has_items": { "item": "broken_exodii_quad", "count": 1 } },
-        "effect": [
-          { "u_consume_item": "broken_exodii_quad", "count": 1, "popup": true },
-          { "u_spawn_item": "RobofacCoin", "count": 2 },
-          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
-        ]
-      },
-      {
-        "text": "[2 HGC] I've also got one of those turrets.",
-        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
-        "condition": { "u_has_items": { "item": "broken_exodii_turret", "count": 1 } },
-        "effect": [
-          { "u_consume_item": "broken_exodii_turret", "count": 1, "popup": true },
-          { "u_spawn_item": "RobofacCoin", "count": 2 },
-          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
-        ]
-      },
-      {
-        "text": "[4 HGC] I also found this strange balloon robot.",
-        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
-        "condition": { "u_has_items": { "item": "broken_exodii_sniper_drone", "count": 1 } },
-        "effect": [
-          { "u_consume_item": "broken_exodii_sniper_drone", "count": 1, "popup": true },
-          { "u_spawn_item": "RobofacCoin", "count": 4 },
-          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
-        ]
-      },
-      { "text": "Let's talk about something else.", "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE" },
-      { "text": "I'd better be going.", "topic": "TALK_DONE" }
     ]
   },
   {

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -52,8 +52,14 @@
       },
       {
         "text": "The weapon worked!  [Hand over the inactive trifacet.]",
-        "condition": { "and": [ { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_ROBOT_SM_1" }, { "u_has_item": "bot_yrax_trifacet" } ] },
+        "condition": {
+          "and": [
+            { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_ROBOT_SM_1" },
+            { "u_has_items_sum": [ { "item": "bot_yrax_trifacet", "amount": 1 } ] }
+          ]
+        },
         "effect": [
+          { "u_consume_item_sum": [ { "item": "bot_yrax_trifacet", "amount": 1 } ] },
           { "u_consume_item": "bot_yrax_trifacet", "count": 1, "popup": true },
           { "u_spawn_item": "RobofacCoin", "count": 2 },
           { "finish_mission": "MISSION_ROBOFAC_INTERCOM_ROBOT_SM_1", "success": true }
@@ -136,9 +142,14 @@
       },
       {
         "text": "I've returned with a disabled Exodii worker.  [Hand over the broken Exodii worker]",
-        "condition": { "and": [ { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI" }, { "u_has_item": "broken_exodii_worker" } ] },
+        "condition": {
+          "and": [
+            { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI" },
+            { "u_has_items_sum": [ { "item": "broken_exodii_worker", "amount": 1 } ] }
+          ]
+        },
         "effect": [
-          { "u_consume_item": "broken_exodii_worker", "count": 1, "popup": true },
+          { "u_consume_item_sum": [ { "item": "broken_exodii_worker", "amount": 1 } ] },
           { "finish_mission": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI", "success": true },
           { "math": [ "u_timer_hub_waiting_on_autodoc = time('now')" ] },
           { "math": [ "robofac_exodii_cbm_knowledge += 1" ] },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Iron Safari, Circuit Safari, and the Hub 01 Bionic Garage no longer require you to physically lift massive robots to finish missions"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

These missions/dialogue used `u_has_item`, but the items in question are too big to hold (at least comfortable).  Players often just drag them along (sensibly)

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

`u_has_item` which checks inventory -> `u_has_items_sum` which checks surrounding tiles.  Also `u_consume_item` -> `u_consume_item_sum`

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Did dialogue

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Removed chunk of dialogue from Garage NPC that didn't play nice with the change (maybe need to open an issue: it didn't resolve that the items had been consumed until dialogue was closed)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
