### PR TITLE
Fix SDL3 shader fallback tiles going black

### DIFF
--- a/src/tileset_loader.cpp
+++ b/src/tileset_loader.cpp
@@ -251,7 +251,10 @@ void tileset_cache::loader::create_textures_from_tile_atlas( const SDL_Surface_P
 
     // Compute per-sprite opaque bounds once from the unfiltered atlas.
     // Color filter variants preserve the alpha channel, so rescanning is unnecessary.
-    // Blit into a 32-bit surface for format-safe pixel access.
+    // Blit into a 32-bit surface for format-safe pixel access. The normal atlas
+    // texture is uploaded from the same 32-bit surface so shader variants sample
+    // the same concrete RGBA pixels as the pre-baked variants; paletted fallback
+    // atlases are not reliable shader sources on every SDL3 GPU backend.
     SDL_Surface_Ptr scan_surf = create_surface_32( tile_atlas->w, tile_atlas->h );
     throwErrorIf( BlitSurface( tile_atlas, nullptr, scan_surf, nullptr ) != 0,
                   "SDL_BlitSurface failed" );
@@ -289,8 +292,7 @@ void tileset_cache::loader::create_textures_from_tile_atlas( const SDL_Surface_P
         color_pixel_function_pointer color_pixel_function = get_color_pixel_function( std::get<1>
                 ( entry ) );
         if( !color_pixel_function ) {
-            // TODO: Move it inside apply_color_filter.
-            copy_surface_to_texture( tile_atlas, offset, *tile_values, opaque_bounds, abandon_gate );
+            copy_surface_to_texture( scan_surf, offset, *tile_values, opaque_bounds, abandon_gate );
         } else {
             copy_surface_to_texture( apply_color_filter( tile_atlas, color_pixel_function ), offset,
                                      *tile_values, opaque_bounds, abandon_gate );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix SDL3 shader fallback tiles going black"

#### Purpose of change

Fixes #87486. Missing tile representations can render as black tiles on SDL3 when the GPU shader variant path is active.

This is easiest to see with fallback glyphs for missing furniture or items in low light. Without shaders, the pre-baked variant atlas path still shows the expected fallback representation.

#### Describe the solution

Upload the normal atlas from the same RGBA32 surface already used for opaque bounds.

The shader path samples the normal atlas and applies the variant in the fragment shader. The non-shader path samples pre-baked variant atlases, and those are already generated from RGBA32 surfaces. Paletted fallback atlases could therefore feed different concrete pixel data into the SDL3 shader path than the pre-baked path saw.

Using the converted surface for the normal atlas keeps both paths sampling the same pixels.

#### Describe alternatives you've considered

Could special-case missing-tile fallback draws and skip shaders there. That dodges the visible bug but leaves paletted atlas sampling different for any other fallback sprite, so no thanks.

#### Testing

Verified in-game with missing tiles and low-light

#### Additional context

N/A