### PR TITLE
Fix "Semi frequent crash when using the safehouse teleporter"

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json
@@ -4,6 +4,14 @@
     "id": "EOC_LS_Teleport_to_labyrinth",
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
+      {
+        "if": { "compare_string": [ "yes", { "u_val": "traveled_to_labyrinth_safehouse" } ] },
+        "then": { "u_message": "Zwoink.", "popup": true },
+        "else": {
+          "u_message": "The world around you folds in on itself - zwoink.  Then, you hear three soft chimes, and find yourself standing in a metal ring.  A tall, bulbous computer screen looms before you, slightly too tall to comfortably look at without craning your neck.  Text starts to populate the screen.",
+          "popup": true
+        }
+      },
       { "u_location_variable": { "u_val": "player_location_home_before_labyrinth" } },
       { "u_add_var": "traveled_home_to_labyrinth", "value": "yes" },
       {
@@ -23,16 +31,8 @@
       },
       { "u_teleport": { "u_val": "safehouse_floor_portal_enclosure" } },
       {
-        "if": { "compare_string": [ "yes", { "u_val": "traveled_to_labyrinth_safehouse" } ] },
-        "then": { "u_message": "Zwoink.", "popup": true },
-        "else": [
-          {
-            "u_message": "The world around you folds in on itself - zwoink.  Then, you hear three soft chimes, and find yourself standing in a metal ring.  A tall, bulbous computer screen looms before you, slightly too tall to comfortably look at without craning your neck.  Text starts to populate the screen.",
-            "popup": true
-          },
-          { "u_add_var": "traveled_to_labyrinth_safehouse", "value": "yes" },
-          { "open_dialogue": { "topic": "COMP_labyrinthine_safehouse_computer_meeting" } }
-        ]
+        "if": { "not": { "compare_string": [ "yes", { "u_val": "traveled_to_labyrinth_safehouse" } ] } },
+        "then": { "open_dialogue": { "topic": "COMP_labyrinthine_safehouse_computer_meeting" } }
       }
     ],
     "false_effect": [ { "u_message": "You feel a prickle at the edge of your senses." } ]
@@ -42,6 +42,14 @@
     "id": "EOC_LS_SD_Teleport_to_labyrinth",
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
+      {
+        "if": { "compare_string": [ "yes", { "u_val": "traveled_to_labyrinth_safehouse" } ] },
+        "then": { "u_message": "Zwoink.", "popup": true },
+        "else": {
+          "u_message": "The world around you folds in on itself - zwoink.  Then, you hear three soft chimes, and find yourself standing in a metal ring.  A tall, bulbous computer screen looms before you, slightly too tall to comfortably look at without craning your neck.  Text starts to populate the screen.",
+          "popup": true
+        }
+      },
       { "u_location_variable": { "u_val": "player_location_string_dimension_before_labyrinth" } },
       { "u_add_var": "traveled_string_dimension_to_labyrinth", "value": "yes" },
       {
@@ -62,16 +70,8 @@
       { "u_teleport": { "u_val": "safehouse_floor_portal_enclosure" } },
       { "alter_timed_events": "string_dimension_lights_on" },
       {
-        "if": { "compare_string": [ "yes", { "u_val": "traveled_to_labyrinth_safehouse" } ] },
-        "then": { "u_message": "Zwoink.", "popup": true },
-        "else": [
-          {
-            "u_message": "The world around you folds in on itself - zwoink.  Then, you hear three soft chimes, and find yourself standing in a metal ring.  A tall, bulbous computer screen looms before you, slightly too tall to comfortably look at without craning your neck.  Text starts to populate the screen.",
-            "popup": true
-          },
-          { "u_add_var": "traveled_to_labyrinth_safehouse", "value": "yes" },
-          { "open_dialogue": { "topic": "COMP_labyrinthine_safehouse_computer_meeting" } }
-        ]
+        "if": { "not": { "compare_string": [ "yes", { "u_val": "traveled_to_labyrinth_safehouse" } ] } },
+        "then": { "open_dialogue": { "topic": "COMP_labyrinthine_safehouse_computer_meeting" } }
       }
     ],
     "false_effect": [ { "u_message": "You feel a prickle at the edge of your senses." } ]
@@ -81,6 +81,30 @@
     "id": "EOC_LS_scarlet_Teleport_to_labyrinth",
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
+      {
+        "if": { "compare_string": [ "yes", { "u_val": "traveled_to_labyrinth_safehouse" } ] },
+        "then": { "u_message": "Zwoink.", "popup": true },
+        "else": [
+          {
+            "if": { "compare_string": [ "yes", { "u_val": "scenario_trapped_in_labyrinth" } ] },
+            "then": [
+              {
+                "u_message": "As you place your hand in the depression the scarlet light fades in a dizzying pinch of your senses.  Then the world itself folds inward - pop - your senses go black, as if you've entered a deep sleep.\n\nYou awake to three soft chimes and a stiff neck.  You find yourself standing in a metal ring.  The air around you is clean, and where the obelisk once stood is now a tall, bulbous computer screen, slightly too tall to comfortably look at without craning your neck.  It's certainly more home-like than the place you just came from, but alien in its own right.  Text starts to populate the screen.",
+                "popup": true
+              },
+              { "u_add_bionic": "bio_nl_collar" },
+              { "u_add_trait": "NL_CBM_Interface" },
+              { "finish_mission": "MISSION_FIND_LABYRINTH_SPIRE", "success": true }
+            ],
+            "else": [
+              {
+                "u_message": "As you place your hand in the depression the scarlet light fades in a dizzying pinch of your senses.  Then the world itself folds inward - pop.\n\nYou hear three soft chimes, and find yourself standing in a metal ring.  The air around you is clean, and where the obelisk once stood is now a tall, bulbous computer screen, slightly too tall to comfortably look at without craning your neck.  It's certainly more home-like than the place you just came from, but alien in its own right.  Text starts to populate the screen.",
+                "popup": true
+              }
+            ]
+          }
+        ]
+      },
       { "u_location_variable": { "u_val": "player_location_scarlet_before_labyrinth" } },
       { "u_add_var": "traveled_scarlet_to_labyrinth", "value": "yes" },
       {
@@ -100,32 +124,12 @@
       },
       { "u_teleport": { "u_val": "safehouse_floor_portal_enclosure" } },
       {
-        "if": { "compare_string": [ "yes", { "u_val": "traveled_to_labyrinth_safehouse" } ] },
-        "then": { "u_message": "Zwoink.", "popup": true },
-        "else": [
+        "if": { "not": { "compare_string": [ "yes", { "u_val": "traveled_to_labyrinth_safehouse" } ] } },
+        "then": [
           {
             "if": { "compare_string": [ "yes", { "u_val": "scenario_trapped_in_labyrinth" } ] },
-            "then": [
-              {
-                "u_message": "As you place your hand in the depression,the scarlet light fades in a dizzying pinch of your senses.  Then the world itself folds inward - pop - your senses go black, as if you've entered a deep sleep.\n\nYou awake to three soft chimes and a stiff neck.  You find yourself standing in a metal ring.  The air around you is clean, and where the obelisk once stood is now a tall, bulbous computer screen, slightly too tall to comfortably look at without craning your neck.  It's certainly more home-like than the place you just came from, but alien in its own right.  Text starts to populate the screen.",
-                "popup": true
-              },
-              { "u_add_var": "traveled_to_labyrinth_safehouse", "value": "yes" },
-              { "u_add_bionic": "bio_nl_collar" },
-              { "u_add_trait": "NL_CBM_Interface" },
-              { "finish_mission": "MISSION_FIND_LABYRINTH_SPIRE", "success": true },
-              {
-                "open_dialogue": { "topic": "COMP_labyrinthine_safehouse_computer_meeting_scenario_trapped_in_labyrinth" }
-              }
-            ],
-            "else": [
-              {
-                "u_message": "As you place your hand in the depression the scarlet light fades in a dizzying pinch of your senses.  Then the world itself folds inward - pop.\n\nYou hear three soft chimes, and find yourself standing in a metal ring.  The air around you is clean, and where the obelisk once stood is now a tall, bulbous computer screen, slightly too tall to comfortably look at without craning your neck.  It's certainly more home-like than the place you just came from, but alien in its own right.  Text starts to populate the screen.",
-                "popup": true
-              },
-              { "u_add_var": "traveled_to_labyrinth_safehouse", "value": "yes" },
-              { "open_dialogue": { "topic": "COMP_labyrinthine_safehouse_computer_meeting" } }
-            ]
+            "then": { "open_dialogue": { "topic": "COMP_labyrinthine_safehouse_computer_meeting_scenario_trapped_in_labyrinth" } },
+            "else": { "open_dialogue": { "topic": "COMP_labyrinthine_safehouse_computer_meeting" } }
           }
         ]
       }
@@ -137,6 +141,7 @@
     "id": "EOC_LS_SAFEHOUSE_Teleport_to_labyrinth",
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
+      { "u_message": "Zwoink.", "popup": true },
       { "u_location_variable": { "u_val": "player_location_safehouse_before_labyrinth" } },
       { "u_add_var": "traveled_safehouse_to_labyrinth", "value": "yes" },
       {
@@ -155,8 +160,7 @@
         "x_adjust": 1
       },
       { "u_teleport": { "global_val": "original_labyrinth_portal_loc" }, "fail_message": "Nope!", "force": true },
-      { "run_eocs": [ "EOC_LS_ROLL_FOR_STRING_DIMENSION_ENCOUNTER" ] },
-      { "u_message": "Zwoink.", "popup": true }
+      { "run_eocs": [ "EOC_LS_ROLL_FOR_STRING_DIMENSION_ENCOUNTER" ] }
     ],
     "false_effect": [ { "u_message": "You feel a prickle at the edge of your senses." } ]
   },
@@ -165,6 +169,7 @@
     "id": "EOC_LS_SAFEHOUSE_Teleport_to_labyrinth_reenter",
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
+      { "u_message": "Zwoink.", "popup": true },
       { "u_location_variable": { "u_val": "player_location_safehouse_before_labyrinth" } },
       { "u_add_var": "traveled_safehouse_to_labyrinth", "value": "yes" },
       {
@@ -193,8 +198,7 @@
         "u_teleport": { "u_val": "player_location_temp_labyrinth_return_loc" },
         "fail_message": "Nope!",
         "force": true
-      },
-      { "u_message": "Zwoink.", "popup": true }
+      }
     ],
     "false_effect": [ { "u_message": "You feel a prickle at the edge of your senses." } ]
   },
@@ -203,6 +207,7 @@
     "id": "EOC_LS_Exit_labyrinth",
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
+      { "u_message": "Zworunk.", "popup": true },
       {
         "u_travel_to_dimension": "",
         "npc_travel_radius": 0,
@@ -211,7 +216,6 @@
         "success_message": "Your surroundings warp and fold into the recesses of the world you know."
       },
       { "u_teleport": { "u_val": "player_location_home_before_labyrinth" }, "force": true },
-      { "u_message": "Zworunk", "popup": true },
       { "clear_dimension": "netherum_labyrinth" }
     ],
     "false_effect": [ { "u_message": "You feel a prickle at the edge of your senses." } ]
@@ -221,6 +225,7 @@
     "id": "EOC_LS_SD_Exit_labyrinth",
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
+      { "u_message": "Zworunk.", "popup": true },
       {
         "u_travel_to_dimension": "string_dimension",
         "npc_travel_radius": 0,
@@ -230,7 +235,6 @@
         "success_message": "Your surroundings warp and fold into the recesses of another world."
       },
       { "u_teleport": { "u_val": "player_location_string_dimension_before_labyrinth" }, "force": true },
-      { "u_message": "Zworunk", "popup": true },
       { "custom_light_level": 125, "length": "9999 days", "key": "string_dimension_lights_on" },
       { "clear_dimension": "netherum_labyrinth" }
     ],
@@ -241,6 +245,7 @@
     "id": "EOC_LS_scarlet_Exit_labyrinth",
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
+      { "u_message": "Pop.", "popup": true },
       {
         "u_travel_to_dimension": "scarlet",
         "npc_travel_radius": 0,
@@ -250,7 +255,6 @@
         "success_message": "Your surroundings warp and fold into the recesses of another world."
       },
       { "u_teleport": { "u_val": "player_location_scarlet_before_labyrinth" }, "force": true },
-      { "u_message": "Pop", "popup": true },
       { "clear_dimension": "netherum_labyrinth" }
     ],
     "false_effect": [ { "u_message": "You feel a prickle at the edge of your senses." } ]
@@ -260,6 +264,7 @@
     "id": "EOC_LS_SAFEHOUSE_Exit_labyrinth",
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
+      { "u_message": "Zworunk.", "popup": true },
       {
         "u_travel_to_dimension": "netherum_labyrinth_safehouse",
         "npc_travel_radius": 0,
@@ -269,7 +274,6 @@
         "success_message": "Your surroundings warp and fold into a familiar place."
       },
       { "u_teleport": { "u_val": "player_location_safehouse_before_labyrinth" }, "force": true },
-      { "u_message": "Zworunk", "popup": true },
       { "clear_dimension": "netherum_labyrinth" }
     ],
     "false_effect": [ { "u_message": "You feel a prickle at the edge of your senses." } ]
@@ -280,6 +284,7 @@
     "//": "For going to the safehouse when too deep in the labyrinth to escape.",
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
+      { "u_message": "Zworunk.", "popup": true },
       { "u_location_variable": { "u_val": "player_location_temp_labyrinth_return_loc" } },
       {
         "u_travel_to_dimension": "netherum_labyrinth_safehouse",
@@ -289,8 +294,7 @@
         "fail_message": "You feel a prickle at the edge of your senses.",
         "success_message": "Your surroundings warp and fold into a familiar place."
       },
-      { "u_teleport": { "u_val": "player_location_safehouse_before_labyrinth" }, "force": true },
-      { "u_message": "Zworunk", "popup": true }
+      { "u_teleport": { "u_val": "player_location_safehouse_before_labyrinth" }, "force": true }
     ],
     "false_effect": [ { "u_message": "You feel a prickle at the edge of your senses." } ]
   },
@@ -298,6 +302,10 @@
     "type": "effect_on_condition",
     "id": "EOC_LS_Exit_labyrinth_sparkling_chasm",
     "effect": [
+      {
+        "u_message": "As you fall into the chasm, you see a multitude of stars, spots, and other shapes.  It's like you're sinking ever further into quicksand, yet falling through the air at the same time.  Your head throbs with pain as the pressure increases, and you black out.  When you come to, you're back in your home away from home: disoriented but unharmed.",
+        "popup": true
+      },
       {
         "u_travel_to_dimension": "netherum_labyrinth_safehouse",
         "npc_travel_radius": 0,
@@ -307,11 +315,7 @@
         "success_message": "Your surroundings warp and fold into a familiar place."
       },
       { "u_teleport": { "u_val": "player_location_safehouse_before_labyrinth" }, "force": true },
-      { "clear_dimension": "netherum_labyrinth" },
-      {
-        "u_message": "As you fall into the chasm, you see a multitude of stars, spots, and other shapes.  It's like you're sinking ever further into quicksand, yet falling through the air at the same time.  Your head throbs with pain as the pressure increases, and you black out.  When you come to, you're back in your home away from home: disoriented but unharmed.",
-        "popup": true
-      }
+      { "clear_dimension": "netherum_labyrinth" }
     ]
   },
   {
@@ -425,6 +429,7 @@
     "id": "EOC_TEST_PORTAL_TO_LABYRINTH_SAFEHOUSE",
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
+      { "u_message": "Kuhhh-wunk.", "popup": true },
       {
         "u_travel_to_dimension": "netherum_labyrinth_safehouse",
         "npc_travel_radius": 0,
@@ -437,8 +442,7 @@
         "furniture": "f_exodii_floor_portal_enclosure",
         "target_max_radius": 100
       },
-      { "u_teleport": { "context_val": "safehouse_floor_portal_enclosure" } },
-      { "u_message": "Kuhhh-wunk.", "popup": true }
+      { "u_teleport": { "context_val": "safehouse_floor_portal_enclosure" } }
     ],
     "false_effect": { "u_message": "Something tickles at the edge of your senses.", "popup": false }
   },
@@ -447,6 +451,7 @@
     "id": "EOC_LS_mission_boiler_teleport_to_labyrinth",
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
+      { "u_message": "Zwoink.", "popup": true },
       { "u_location_variable": { "u_val": "player_location_safehouse_before_labyrinth" } },
       { "u_add_var": "traveled_safehouse_to_labyrinth", "value": "yes" },
       {
@@ -469,8 +474,7 @@
         "target_max_radius": 500,
         "x_adjust": 1
       },
-      { "u_teleport": { "global_val": "labyrinth_nl_boiler_loc" }, "fail_message": "Nope!", "force": true },
-      { "u_message": "Zwoink.", "popup": true }
+      { "u_teleport": { "global_val": "labyrinth_nl_boiler_loc" }, "fail_message": "Nope!", "force": true }
     ],
     "false_effect": [ { "u_message": "You feel a prickle at the edge of your senses." } ]
   },
@@ -479,6 +483,10 @@
     "id": "EOC_LS_mission_water_coolor_teleport_to_labyrinth",
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
+      {
+        "u_message": "Zwoink.  You find yourself in a standard entry room, but instead of a terminal, this one houses an obelisk.",
+        "popup": true
+      },
       { "u_location_variable": { "u_val": "player_location_safehouse_before_labyrinth" } },
       { "u_add_var": "traveled_safehouse_to_labyrinth", "value": "yes" },
       {
@@ -510,10 +518,6 @@
       {
         "mapgen_update": "labyrinth_nl_flooded_water_cooler_location",
         "target_var": { "global_val": "LS_WATER_COOLER_LOC" }
-      },
-      {
-        "u_message": "Zwoink.  You find yourself in a standard entry room, but instead of a terminal, this one houses an obelisk.",
-        "popup": true
       }
     ],
     "false_effect": [ { "u_message": "You feel a prickle at the edge of your senses." } ]
@@ -523,6 +527,7 @@
     "id": "EOC_LS_mission_boiler_teleport_to_safehouse",
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
+      { "u_message": "Zworunk.  The ground shakes for a moment.", "popup": true },
       {
         "u_travel_to_dimension": "netherum_labyrinth_safehouse",
         "npc_travel_radius": 0,
@@ -532,7 +537,6 @@
         "success_message": "Your surroundings warp and fold into a familiar place."
       },
       { "u_teleport": { "u_val": "player_location_safehouse_before_labyrinth" }, "force": true },
-      { "u_message": "Zworunk.  The ground shakes for a moment.", "popup": true },
       { "clear_dimension": "netherum_labyrinth" },
       { "run_eocs": [ "EOC_LS_SAFEHOUSE_UPDATE_BOILER" ] }
     ],
@@ -544,6 +548,10 @@
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
       {
+        "u_message": "You move to prick your palm upon the device, but everything goes black.  Did you ever prick it?\n\nZworunk.  The ground shakes for a moment.  Then you hear water bubbling.",
+        "popup": true
+      },
+      {
         "u_travel_to_dimension": "netherum_labyrinth_safehouse",
         "npc_travel_radius": 0,
         "region_type": "netherum_labyrinth_safehouse",
@@ -552,10 +560,6 @@
         "success_message": "Your surroundings warp and fold into a familiar place."
       },
       { "u_teleport": { "u_val": "player_location_safehouse_before_labyrinth" }, "force": true },
-      {
-        "u_message": "You move to prick your palm upon the device, but everything goes black.  Did you ever prick it?\n\nZworunk.  The ground shakes for a moment.  Then you hear water bubbling.",
-        "popup": true
-      },
       { "clear_dimension": "netherum_labyrinth" },
       { "finish_mission": "MISSION_nl_water_coolor", "success": true },
       { "run_eocs": [ "EOC_LS_SAFEHOUSE_UPDATE_WATER_COOLER" ] }
@@ -695,6 +699,7 @@
     "id": "EOC_LS_SD_tunnel_portal",
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
+      { "u_message": "Zworunk.", "popup": true },
       { "u_add_var": "traveled_string_dimension_to_labyrinth", "value": "yes" },
       {
         "u_travel_to_dimension": "string_dimension",
@@ -711,7 +716,6 @@
         "target_max_radius": 100
       },
       { "u_teleport": { "context_val": "string_dimension_floor_portal_enclosure" } },
-      { "u_message": "Zworunk.", "popup": true },
       { "custom_light_level": 125, "length": "9999 days", "key": "string_dimension_lights_on" },
       { "clear_dimension": "netherum_labyrinth" }
     ],
@@ -721,6 +725,10 @@
     "type": "effect_on_condition",
     "id": "EOC_LS_SD_enter_tunnel",
     "effect": [
+      {
+        "u_message": "You smell something acrid, then your mind reels - you suddenly find yourself standing upon a landscape, yourself and it completely flat.  You try to find your footing.",
+        "popup": true
+      },
       {
         "u_travel_to_dimension": "netherum_labyrinth",
         "npc_travel_radius": 0,
@@ -735,11 +743,7 @@
         "furniture": "f_exodii_lamp_string_warped",
         "target_max_radius": 24
       },
-      { "u_teleport": { "context_val": "string_dimension_tunnel" } },
-      {
-        "u_message": "You smell something acrid, then your mind reels - you suddenly find yourself standing upon a landscape, yourself and it completely flat.  You try to find your footing.",
-        "popup": true
-      }
+      { "u_teleport": { "context_val": "string_dimension_tunnel" } }
     ]
   },
   {
@@ -1377,6 +1381,7 @@
     "id": "EOC_LS_earth_jaunt_4hours",
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
+      { "u_message": "Zworunk.", "popup": true },
       {
         "u_travel_to_dimension": "",
         "npc_travel_radius": 0,
@@ -1390,8 +1395,7 @@
       },
       { "u_teleport": { "u_val": "earth_jaunt_loc" }, "force": true },
       { "u_add_trait": "NL_MUTE" },
-      { "run_eocs": "EOC_LS_earth_jaunt_extraction", "time_in_future": "4 hours" },
-      { "u_message": "Zworunk", "popup": true }
+      { "run_eocs": "EOC_LS_earth_jaunt_extraction", "time_in_future": "4 hours" }
     ],
     "false_effect": [ { "u_message": "You feel a prickle at the edge of your senses." } ]
   },
@@ -1413,6 +1417,7 @@
           ]
         },
         "then": [
+          { "u_message": "There is a tightening in your throat as the world folds in around you.", "popup": true },
           {
             "u_travel_to_dimension": "netherum_labyrinth_safehouse",
             "npc_travel_radius": 0,
@@ -1421,8 +1426,7 @@
           },
           { "u_teleport": { "u_val": "safehouse_floor_portal_enclosure" } },
           { "u_lose_trait": "NL_MUTE" },
-          { "math": [ "scenario_trapped_in_labyrinth_anchor_counter = 0" ] },
-          { "u_message": "There is a tightening in your throat as the world folds in around you.", "popup": true }
+          { "math": [ "scenario_trapped_in_labyrinth_anchor_counter = 0" ] }
         ],
         "else": [
           { "u_lose_trait": "NL_MUTE" },

--- a/data/json/npcs/exodii/netherum/labyrinth_safehouse_computers.json
+++ b/data/json/npcs/exodii/netherum/labyrinth_safehouse_computers.json
@@ -4,8 +4,16 @@
     "id": "COMP_labyrinthine_safehouse_computer_meeting",
     "dynamic_line": "& █████╗ ██╗  ████████╗ █████╗ ██████╗      ██████╗ ███████╗\n██╔══██╗██║  ╚══██╔══╝██╔══██╗██╔══██╗    ██╔═══██╗██╔════╝\n███████║██║     ██║   ███████║██████╔╝    ██║   ██║███████╗\n██╔══██║██║     ██║   ██╔══██║██╔══██╗    ██║   ██║╚════██║\n██║  ██║███████╗██║   ██║  ██║██║  ██║    ╚██████╔╝███████║\n╚═╝  ╚═╝╚══════╝╚═╝   ╚═╝  ╚═╝╚═╝  ╚═╝     ╚═════╝ ╚══════╝\n\nWelcome ᴴᵁᴹᴬᴺ, to your home ᵃʷᵃʸ ᶠʳᵒᵐ ʰᵒᵐᵉ.\n\nThis is a ˡᵒᵃᵈᴵⁿᵍ ᵖʳᴼᵍʳᵃᵐ.\n\nThis is the ᵐᵉᵈᴵᵘᵐ ᵖˡᵃᶜᵉ.\n\nᵖˡᵉᵃˢᵉ make yourself at home.\n\n @AltarOS > skill -ELEVATE -@User\n\n @User > _",
     "responses": [
-      { "text": "[Step closer to the terminal and touch the keyboard]", "topic": "COMP_labyrinthine_safehouse_computer" },
-      { "text": "[Step away from the terminal]", "topic": "TALK_DONE" }
+      {
+        "text": "[Step closer to the terminal and touch the keyboard]",
+        "topic": "COMP_labyrinthine_safehouse_computer",
+        "effect": { "u_add_var": "traveled_to_labyrinth_safehouse", "value": "yes" }
+      },
+      {
+        "text": "[Step away from the terminal]",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "traveled_to_labyrinth_safehouse", "value": "yes" }
+      }
     ]
   },
   {
@@ -13,8 +21,16 @@
     "id": "COMP_labyrinthine_safehouse_computer_meeting_scenario_trapped_in_labyrinth",
     "dynamic_line": "& █████╗ ██╗  ████████╗ █████╗ ██████╗      ██████╗ ███████╗\n██╔══██╗██║  ╚══██╔══╝██╔══██╗██╔══██╗    ██╔═══██╗██╔════╝\n███████║██║     ██║   ███████║██████╔╝    ██║   ██║███████╗\n██╔══██║██║     ██║   ██╔══██║██╔══██╗    ██║   ██║╚════██║\n██║  ██║███████╗██║   ██║  ██║██║  ██║    ╚██████╔╝███████║\n╚═╝  ╚═╝╚══════╝╚═╝   ╚═╝  ╚═╝╚═╝  ╚═╝     ╚═════╝ ╚══════╝\n\nWelcome ᴴᵁᴹᴬᴺ, to your home ᵃʷᵃʸ ᶠʳᵒᵐ ʰᵒᵐᵉ.\n\nThis is a ˡᵒᵃᵈᴵⁿᵍ ᵖʳᴼᵍʳᵃᵐ.\n\nThis is the ᵐᵉᵈᴵᵘᵐ ᵖˡᵃᶜᵉ.\n\nYou were saved from your peril.\n\nYour new implants were necessary to stabilize your reality.\n\nᵖˡᵉᵃˢᵉ make yourself at home.\n\n @AltarOS > skill -ELEVATE -@User\n\n @User > _",
     "responses": [
-      { "text": "[Step closer to the terminal and touch the keyboard]", "topic": "COMP_labyrinthine_safehouse_computer" },
-      { "text": "[Step away from the terminal]", "topic": "TALK_DONE" }
+      {
+        "text": "[Step closer to the terminal and touch the keyboard]",
+        "topic": "COMP_labyrinthine_safehouse_computer",
+        "effect": { "u_add_var": "traveled_to_labyrinth_safehouse", "value": "yes" }
+      },
+      {
+        "text": "[Step away from the terminal]",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "traveled_to_labyrinth_safehouse", "value": "yes" }
+      }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix semi frequent crash when using safehouse teleporter"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #87485

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<img width="1077" height="252" alt="image" src="https://github.com/user-attachments/assets/871cd98e-cce7-4bcc-800a-f62ea601962e" />

Moves all `u_message` etc. calls to before dimension transport, for all Labyrinth EOCs.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Did the various teleports.  Everything seems to be working properly.

Jumped back and forth to labyrinth and safehouse many, many times.  No crash.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

There may be other dimension-hopping EOCs that have the same issue.  Will need to follow up.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
