### PR TITLE
feat(sort armor): add toggle favorite action

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -723,6 +723,17 @@
   },
   {
     "type": "keybinding",
+    "id": "TOGGLE_FAVORITE",
+    "category": "SORT_ARMOR",
+    "name": "Toggle item as favorite",
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+    ]
+  },
+  {
+    "type": "keybinding",
     "id": "HELP_KEYBINDINGS",
     "name": "Display keybindings menu",
     "bindings": [ { "input_method": "keyboard_char", "key": "?" }, { "input_method": "keyboard_code", "key": "/", "mod": [ "shift" ] } ]

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -684,6 +684,7 @@ void outfit::sort_armor( Character &guy )
     ctxt.register_action( "EQUIP_ARMOR" );
     ctxt.register_action( "EQUIP_ARMOR_HERE" );
     ctxt.register_action( "REMOVE_ARMOR" );
+    ctxt.register_action( "TOGGLE_FAVORITE" );
     ctxt.register_action( "USAGE_HELP" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "SCROLL_ITEM_INFO_UP" );
@@ -1138,6 +1139,11 @@ void outfit::sort_armor( Character &guy )
                     return;
                 }
             }
+        } else if( action == "TOGGLE_FAVORITE" ) {
+            if( leftListIndex < leftListSize ) {
+                item &item_to_toggle = *tmp_worn[leftListIndex];
+                item_to_toggle.set_favorite( !item_to_toggle.is_favorite );
+            }
         } else if( action == "ASSIGN_INVLETS" ) {
             // prompt first before doing this (yes, yes, more popups...)
             if( query_yn( _( "Reassign inventory letters for armor?" ) ) ) {
@@ -1193,6 +1199,8 @@ void outfit::sort_armor( Character &guy )
                                ctxt.get_desc( "EQUIP_ARMOR_HERE" ) ),
                 string_format( _( "[<color_yellow>%s</color>] to remove selected item.\n" ),
                                ctxt.get_desc( "REMOVE_ARMOR" ) ),
+                string_format( _( "[<color_yellow>%s</color>] to toggle item as favorite.\n" ),
+                               ctxt.get_desc( "TOGGLE_FAVORITE" ) ),
                 "\n",
                 _( "Encumbrance explanation:\n" ),
                 _( "<color_light_gray>The first number is the summed encumbrance from all clothing on that bodypart."


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Allow favoriting on sort armor screen"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Closes #87491 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Add TOGGLE_FAVORITE action to sort armor screen.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
NA
#### Testing

Tested by favorating and unfavorating on sort armor screen. Also tested on follower NPC's sort armor screen. Works as expected (same as favorating their item in the trade menu).
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
NA
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
