### PR TITLE
Make Android system bars configurable

### DIFF
--- a/android/app/src/experimental/res/values/styles.xml
+++ b/android/app/src/experimental/res/values/styles.xml
@@ -1,10 +1,11 @@
 <resources>
 
-    <style name="AppTheme" parent="@android:style/Theme.Material.NoActionBar.Fullscreen">
+    <style name="AppTheme" parent="@android:style/Theme.Material.NoActionBar">
         <item name="android:windowBackground">@drawable/background_splash</item>
         <item name="android:colorAccent">@color/accent_material_dark</item>
         <item name="android:colorPrimary">@color/primary_material_dark</item>
         <item name="android:colorBackground">@color/background_material_dark</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
     </style>
 
 </resources>

--- a/android/app/src/main/java/com/cleverraven/cataclysmdda/CataclysmDDA.java
+++ b/android/app/src/main/java/com/cleverraven/cataclysmdda/CataclysmDDA.java
@@ -3,13 +3,17 @@ package com.cleverraven.cataclysmdda;
 import org.libsdl.app.SDLActivity;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.res.Configuration;
+import android.graphics.Insets;
+import android.graphics.Rect;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Vibrator;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.View;
+import android.view.ViewTreeObserver;
 import android.view.WindowInsets;
 import android.view.WindowInsetsController;
 import android.view.WindowManager;
@@ -17,8 +21,18 @@ import android.widget.Toast;
 
 public class CataclysmDDA extends SDLActivity {
     private static final String TAG = "CDDA";
+    public static final String PREF_SYSTEM_UI_MODE = "Android system UI mode";
+    public static final String PREF_FORCE_FULLSCREEN = "Force fullscreen";
+    public static final String SYSTEM_UI_MODE_SYSTEM_BARS = "system_bars";
+    public static final String SYSTEM_UI_MODE_FULLSCREEN = "fullscreen";
+    public static final String SYSTEM_UI_MODE_EDGE_TO_EDGE = "edge_to_edge";
 
     private NativeUI nativeUI = new NativeUI(CataclysmDDA.this);
+    private int lastImeLeft = -1;
+    private int lastImeTop = -1;
+    private int lastImeRight = -1;
+    private int lastImeBottom = -1;
+    private boolean lastImeVisible = false;
 
     // libmain.so must load first so cata_allocator binds before SDL's malloc.
     // SDL3 dlsym's SDL_main from getMainSharedObject(), which we point at libmain.so.
@@ -44,46 +58,163 @@ public class CataclysmDDA extends SDLActivity {
         if (mLayout != null) {
             mLayout.setVisibility(View.INVISIBLE);
         }
-        applyImmersive();
+        setImeInsetListener();
+        applySystemUiMode();
     }
 
     @Override
     protected void onResume() {
         super.onResume();
-        applyImmersive();
+        applySystemUiMode();
     }
 
     @Override
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
         if (hasFocus) {
-            applyImmersive();
+            applySystemUiMode();
         }
     }
 
-    private void applyImmersive() {
+    private String normalizeSystemUiMode(String mode) {
+        if (SYSTEM_UI_MODE_FULLSCREEN.equals(mode) || SYSTEM_UI_MODE_EDGE_TO_EDGE.equals(mode)) {
+            return mode;
+        }
+        return SYSTEM_UI_MODE_SYSTEM_BARS;
+    }
+
+    private String getStoredSystemUiMode() {
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+        String mode;
+        if (preferences.contains(PREF_SYSTEM_UI_MODE)) {
+            mode = normalizeSystemUiMode(preferences.getString(PREF_SYSTEM_UI_MODE, SYSTEM_UI_MODE_SYSTEM_BARS));
+        } else {
+            mode = preferences.getBoolean(PREF_FORCE_FULLSCREEN, false)
+                ? SYSTEM_UI_MODE_EDGE_TO_EDGE
+                : SYSTEM_UI_MODE_SYSTEM_BARS;
+        }
+        preferences.edit().putString(PREF_SYSTEM_UI_MODE, mode).apply();
+        return mode;
+    }
+
+    private void applySystemUiMode() {
+        applySystemUiMode(getStoredSystemUiMode());
+    }
+
+    private void applySystemUiMode(String rawMode) {
+        String mode = normalizeSystemUiMode(rawMode);
+        boolean hideSystemBars = !SYSTEM_UI_MODE_SYSTEM_BARS.equals(mode);
+        boolean edgeToEdge = SYSTEM_UI_MODE_EDGE_TO_EDGE.equals(mode);
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            // Lay the surface out edge to edge. Hiding the bars does not put the
-            // surface under them, so on pre-15 Android the splash window background
-            // shows as an empty strip in the status bar area.
-            getWindow().setDecorFitsSystemWindows(false);
+            getWindow().setDecorFitsSystemWindows(!edgeToEdge);
             WindowInsetsController controller = getWindow().getInsetsController();
             if (controller != null) {
-                controller.hide(WindowInsets.Type.systemBars());
-                controller.setSystemBarsBehavior(
-                    WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+                if (hideSystemBars) {
+                    controller.hide(WindowInsets.Type.systemBars());
+                    controller.setSystemBarsBehavior(
+                        WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+                } else {
+                    controller.show(WindowInsets.Type.systemBars());
+                }
             }
         } else {
             View decor = getWindow().getDecorView();
-            decor.setSystemUiVisibility(
-                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                | View.SYSTEM_UI_FLAG_FULLSCREEN);
+            if (hideSystemBars) {
+                decor.setSystemUiVisibility(
+                    View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                    | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                    | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                    | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                    | View.SYSTEM_UI_FLAG_FULLSCREEN);
+            } else {
+                decor.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+            }
+        }
+
+        if (hideSystemBars) {
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+        } else {
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
         }
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+    }
+
+    private void setImeInsetListener() {
+        final View decor = getWindow().getDecorView();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            decor.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
+                @Override
+                public WindowInsets onApplyWindowInsets(View view, WindowInsets insets) {
+                    boolean imeVisible = insets.isVisible(WindowInsets.Type.ime());
+                    Insets imeInsets = insets.getInsets(WindowInsets.Type.ime());
+                    notifyImeInsetsChanged(
+                        imeInsets.left,
+                        imeInsets.top,
+                        Math.max(0, view.getWidth() - imeInsets.right),
+                        Math.max(0, view.getHeight() - imeInsets.bottom),
+                        imeVisible);
+                    return insets;
+                }
+            });
+            decor.requestApplyInsets();
+        } else {
+            decor.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+                @Override
+                public void onGlobalLayout() {
+                    Rect visibleFrame = new Rect();
+                    decor.getWindowVisibleDisplayFrame(visibleFrame);
+                    int rootHeight = decor.getRootView().getHeight();
+                    boolean imeVisible = rootHeight - visibleFrame.bottom > rootHeight / 5;
+                    notifyImeInsetsChanged(
+                        visibleFrame.left,
+                        visibleFrame.top,
+                        visibleFrame.right,
+                        visibleFrame.bottom,
+                        imeVisible);
+                }
+            });
+        }
+    }
+
+    private void notifyImeInsetsChanged(int left, int top, int right, int bottom, boolean visible) {
+        if (lastImeLeft == left && lastImeTop == top && lastImeRight == right &&
+                lastImeBottom == bottom && lastImeVisible == visible) {
+            return;
+        }
+        lastImeLeft = left;
+        lastImeTop = top;
+        lastImeRight = right;
+        lastImeBottom = bottom;
+        lastImeVisible = visible;
+        try {
+            onNativeImeInsetsChanged(left, top, right, bottom, visible);
+        } catch(UnsatisfiedLinkError e) {
+            // The Activity can receive early inset callbacks before native startup.
+        }
+    }
+
+    private static native void onNativeImeInsetsChanged(
+        int left, int top, int right, int bottom, boolean visible);
+
+    public void setSystemUiMode(final String mode) {
+        final String normalizedMode = normalizeSystemUiMode(mode);
+        PreferenceManager.getDefaultSharedPreferences(getApplicationContext())
+            .edit()
+            .putString(PREF_SYSTEM_UI_MODE, normalizedMode)
+            .apply();
+        try {
+            runOnUiThread(new Runnable() {
+                public void run() {
+                    applySystemUiMode(normalizedMode);
+                }
+            });
+        } catch(Exception e) {
+            System.err.println(e.getMessage());
+        }
     }
 
     public void vibrate(int duration) {
@@ -131,6 +262,15 @@ public class CataclysmDDA extends SDLActivity {
 
     public boolean getDefaultSetting(final String settingsName, boolean defaultValue) {
         return PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getBoolean(settingsName, defaultValue);
+    }
+
+    public String getDefaultStringSetting(final String settingsName, String defaultValue) {
+        if (PREF_SYSTEM_UI_MODE.equals(settingsName)) {
+            return getStoredSystemUiMode();
+        }
+        String setting = PreferenceManager.getDefaultSharedPreferences(getApplicationContext())
+            .getString(settingsName, defaultValue);
+        return setting != null ? setting : defaultValue;
     }
 
     public String getSystemLang() {

--- a/android/app/src/main/java/com/cleverraven/cataclysmdda/SplashScreen.java
+++ b/android/app/src/main/java/com/cleverraven/cataclysmdda/SplashScreen.java
@@ -21,12 +21,20 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnShowListener;
+import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.res.AssetManager;
 import android.net.Uri;
 import android.os.*;
 import android.preference.PreferenceManager;
 import android.util.Log;
+import android.view.ViewGroup;
+import android.widget.CheckBox;
+import android.widget.LinearLayout;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
+import android.widget.ScrollView;
+import android.widget.TextView;
 
 import com.cleverraven.cataclysmdda.CataclysmDDA_Helpers;
 
@@ -37,8 +45,8 @@ public class SplashScreen extends Activity {
 
     private AlertDialog accessibilityServicesAlert;
 
-    public CharSequence[] mSettingsNames;
-    public boolean[] mSettingsValues = { false, false, true, true };
+    public boolean[] mSettingsValues = { false, true, true };
+    private int mSystemUiModeIndex = 0;
 
     private String getVersionName() {
         try {
@@ -261,27 +269,18 @@ public class SplashScreen extends Activity {
                     }
                 }).create();
 
-            mSettingsNames = new CharSequence[] {
-                getString(R.string.softwareRendering),
-                getString(R.string.forceFullscreen),
-                getString(R.string.trapBackButton),
-                getString(R.string.nativeAndroidUI)
-            };
+            loadSettingsDefaults();
 
             settingsAlert = new AlertDialog.Builder(SplashScreen.this)
                 .setTitle(getString(R.string.settings))
-                .setMultiChoiceItems(SplashScreen.this.mSettingsNames, SplashScreen.this.mSettingsValues, new DialogInterface.OnMultiChoiceClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which, boolean isChecked) {
-                        SplashScreen.this.mSettingsValues[which] = isChecked;
-                    }})
+                .setView(createSettingsView())
                 .setCancelable(false)
                 .setPositiveButton(getString(R.string.startGame), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).edit().putBoolean("Software rendering", SplashScreen.this.mSettingsValues[0]).commit();
-                        PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).edit().putBoolean("Force fullscreen", SplashScreen.this.mSettingsValues[1]).commit();
-                        PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).edit().putBoolean("Trap Back button", SplashScreen.this.mSettingsValues[2]).commit();
-                        PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).edit().putBoolean("Native Android UI", SplashScreen.this.mSettingsValues[3]).commit();
+                        PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).edit().putString(CataclysmDDA.PREF_SYSTEM_UI_MODE, getSelectedSystemUiMode()).commit();
+                        PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).edit().putBoolean("Trap Back button", SplashScreen.this.mSettingsValues[1]).commit();
+                        PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).edit().putBoolean("Native Android UI", SplashScreen.this.mSettingsValues[2]).commit();
                         SplashScreen.this.startGameActivity(false);
                         return;
                     }
@@ -292,6 +291,106 @@ public class SplashScreen extends Activity {
                         return;
                     }
                 }).create();
+        }
+
+        private void loadSettingsDefaults() {
+            SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+            SplashScreen.this.mSettingsValues[0] = preferences.getBoolean("Software rendering", false);
+            SplashScreen.this.mSettingsValues[1] = preferences.getBoolean("Trap Back button", true);
+            SplashScreen.this.mSettingsValues[2] = preferences.getBoolean("Native Android UI", true);
+
+            String mode;
+            if (preferences.contains(CataclysmDDA.PREF_SYSTEM_UI_MODE)) {
+                mode = preferences.getString(
+                    CataclysmDDA.PREF_SYSTEM_UI_MODE,
+                    CataclysmDDA.SYSTEM_UI_MODE_SYSTEM_BARS);
+            } else {
+                mode = preferences.getBoolean(CataclysmDDA.PREF_FORCE_FULLSCREEN, false)
+                    ? CataclysmDDA.SYSTEM_UI_MODE_EDGE_TO_EDGE
+                    : CataclysmDDA.SYSTEM_UI_MODE_SYSTEM_BARS;
+            }
+            SplashScreen.this.mSystemUiModeIndex = systemUiModeIndex(mode);
+        }
+
+        private ScrollView createSettingsView() {
+            ScrollView scrollView = new ScrollView(SplashScreen.this);
+            LinearLayout layout = new LinearLayout(SplashScreen.this);
+            layout.setOrientation(LinearLayout.VERTICAL);
+            int padding = (int)(24 * getResources().getDisplayMetrics().density);
+            layout.setPadding(padding, 0, padding, 0);
+
+            TextView displayModeLabel = new TextView(SplashScreen.this);
+            displayModeLabel.setText(getString(R.string.androidSystemUiMode));
+            layout.addView(displayModeLabel);
+
+            RadioGroup displayModeGroup = new RadioGroup(SplashScreen.this);
+            displayModeGroup.setOrientation(RadioGroup.VERTICAL);
+            addSystemUiModeButton(displayModeGroup, 0, getString(R.string.androidSystemUiModeSystemBars));
+            addSystemUiModeButton(displayModeGroup, 1, getString(R.string.androidSystemUiModeFullscreen));
+            addSystemUiModeButton(displayModeGroup, 2, getString(R.string.androidSystemUiModeEdgeToEdge));
+            displayModeGroup.check(systemUiModeButtonId(mSystemUiModeIndex));
+            displayModeGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(RadioGroup group, int checkedId) {
+                    SplashScreen.this.mSystemUiModeIndex = systemUiModeIndexFromButtonId(checkedId);
+                }
+            });
+            layout.addView(displayModeGroup);
+
+            addBooleanSetting(layout, 0, getString(R.string.softwareRendering));
+            addBooleanSetting(layout, 1, getString(R.string.trapBackButton));
+            addBooleanSetting(layout, 2, getString(R.string.nativeAndroidUI));
+            scrollView.addView(layout, new ScrollView.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT));
+            return scrollView;
+        }
+
+        private void addSystemUiModeButton(RadioGroup group, int id, String label) {
+            RadioButton button = new RadioButton(SplashScreen.this);
+            button.setId(systemUiModeButtonId(id));
+            button.setText(label);
+            group.addView(button, new RadioGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT));
+        }
+
+        private int systemUiModeButtonId(int index) {
+            return 1000 + index;
+        }
+
+        private int systemUiModeIndexFromButtonId(int buttonId) {
+            return buttonId - 1000;
+        }
+
+        private void addBooleanSetting(LinearLayout layout, final int index, String label) {
+            CheckBox checkBox = new CheckBox(SplashScreen.this);
+            checkBox.setText(label);
+            checkBox.setChecked(SplashScreen.this.mSettingsValues[index]);
+            checkBox.setOnClickListener(v -> SplashScreen.this.mSettingsValues[index] = checkBox.isChecked());
+            layout.addView(checkBox, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT));
+        }
+
+        private String getSelectedSystemUiMode() {
+            switch (mSystemUiModeIndex) {
+                case 1:
+                    return CataclysmDDA.SYSTEM_UI_MODE_FULLSCREEN;
+                case 2:
+                    return CataclysmDDA.SYSTEM_UI_MODE_EDGE_TO_EDGE;
+                default:
+                    return CataclysmDDA.SYSTEM_UI_MODE_SYSTEM_BARS;
+            }
+        }
+
+        private int systemUiModeIndex(String mode) {
+            if (CataclysmDDA.SYSTEM_UI_MODE_FULLSCREEN.equals(mode)) {
+                return 1;
+            } else if (CataclysmDDA.SYSTEM_UI_MODE_EDGE_TO_EDGE.equals(mode)) {
+                return 2;
+            }
+            return 0;
         }
 
         @Override

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -9,6 +9,10 @@
     <string name="ignoreFalsePostives">Mark as false positive(s)</string>
     <string name="softwareRendering">Software rendering</string>
     <string name="forceFullscreen">Force fullscreen</string>
+    <string name="androidSystemUiMode">Android system bars</string>
+    <string name="androidSystemUiModeSystemBars">Show system bars</string>
+    <string name="androidSystemUiModeFullscreen">Fullscreen</string>
+    <string name="androidSystemUiModeEdgeToEdge">Edge-to-edge fullscreen</string>
     <string name="trapBackButton">Trap Back button</string>
     <string name="nativeAndroidUI">Native Android UI menus</string>
     <string name="settings">Settings</string>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,10 +1,11 @@
 <resources>
 
-    <style name="AppTheme" parent="@android:style/Theme.Material.NoActionBar.Fullscreen">
+    <style name="AppTheme" parent="@android:style/Theme.Material.NoActionBar">
         <item name="android:windowBackground">@drawable/background_splash</item>
         <item name="android:colorAccent">@color/accent_material_dark</item>
         <item name="android:colorPrimary">@color/primary_material_dark</item>
         <item name="android:colorBackground">@color/background_material_dark</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
     </style>
 
     <style name="AlertDialogTheme" parent="@android:style/Theme.Material.Dialog.Alert" >

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1410,11 +1410,54 @@ bool android_get_default_setting( const char *settings_name, bool default_value 
     jobject activity = ( jobject )GetAndroidActivity();
     jclass clazz( env->GetObjectClass( activity ) );
     jmethodID method_id = env->GetMethodID( clazz, "getDefaultSetting", "(Ljava/lang/String;Z)Z" );
-    jboolean ans = env->CallBooleanMethod( activity, method_id, env->NewStringUTF( settings_name ),
-                                           default_value );
+    jstring settings_name_arg = env->NewStringUTF( settings_name );
+    jboolean ans = env->CallBooleanMethod( activity, method_id, settings_name_arg, default_value );
+    env->DeleteLocalRef( settings_name_arg );
     env->DeleteLocalRef( activity );
     env->DeleteLocalRef( clazz );
     return ans;
+}
+
+std::string android_get_default_string_setting( const char *settings_name,
+        const char *default_value )
+{
+    JNIEnv *env = ( JNIEnv * )GetAndroidJNIEnv();
+    jobject activity = ( jobject )GetAndroidActivity();
+    jclass clazz( env->GetObjectClass( activity ) );
+    jmethodID method_id = env->GetMethodID( clazz, "getDefaultStringSetting",
+                                            "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;" );
+    jstring settings_name_arg = env->NewStringUTF( settings_name );
+    jstring default_value_arg = env->NewStringUTF( default_value );
+    jstring result = static_cast<jstring>( env->CallObjectMethod(
+            activity, method_id, settings_name_arg, default_value_arg ) );
+    const char *result_chars = result != nullptr ? env->GetStringUTFChars( result, nullptr ) : nullptr;
+    std::string ans = result_chars != nullptr ? result_chars : default_value;
+    if( result_chars != nullptr ) {
+        env->ReleaseStringUTFChars( result, result_chars );
+    }
+    if( result != nullptr ) {
+        env->DeleteLocalRef( result );
+    }
+    env->DeleteLocalRef( default_value_arg );
+    env->DeleteLocalRef( settings_name_arg );
+    env->DeleteLocalRef( activity );
+    env->DeleteLocalRef( clazz );
+    return ans;
+}
+
+void android_apply_system_ui_mode()
+{
+    JNIEnv *env = ( JNIEnv * )GetAndroidJNIEnv();
+    jobject activity = ( jobject )GetAndroidActivity();
+    jclass clazz( env->GetObjectClass( activity ) );
+    jmethodID method_id = env->GetMethodID( clazz, "setSystemUiMode",
+                                            "(Ljava/lang/String;)V" );
+    jstring mode_arg = env->NewStringUTF(
+                           ::get_option<std::string>( "ANDROID_SYSTEM_UI_MODE" ).c_str() );
+    env->CallVoidMethod( activity, method_id, mode_arg );
+    env->DeleteLocalRef( mode_arg );
+    env->DeleteLocalRef( activity );
+    env->DeleteLocalRef( clazz );
 }
 #endif
 
@@ -2939,10 +2982,25 @@ void options_manager::add_options_android()
 
     add_empty_line();
 
-    add( "ANDROID_RENDER_SAFE_AREA", "android", to_translation( "Confine display to safe area" ),
-         to_translation( "If true, keep the game within the screen's safe area so it does not draw under the camera cutout or other unsafe edges.  If false, the game fills the entire screen." ),
-         true
-       );
+    add_option_group( "android", Group( "android_display_opts",
+                                        to_translation( "Android display options" ),
+                                        to_translation( "Options regarding Android system bars and display insets." ) ),
+    [&]( const std::string & page_id ) {
+        add( "ANDROID_SYSTEM_UI_MODE", page_id, to_translation( "Android system bars" ),
+             to_translation( "Controls whether Android status and navigation bars are visible and whether the game may draw behind them.  This does not control Back button handling." ),
+        {
+            { "system_bars", to_translation( "Show system bars" ) },
+            { "fullscreen", to_translation( "Fullscreen" ) },
+            { "edge_to_edge", to_translation( "Edge-to-edge fullscreen" ) }
+        },
+        android_get_default_string_setting( "Android system UI mode", "system_bars" )
+           );
+
+        add( "ANDROID_RENDER_SAFE_AREA", page_id, to_translation( "Confine display to safe area" ),
+             to_translation( "If true, keep the game within the screen's safe area so it does not draw under the camera cutout or other unsafe edges.  If false, the game fills the entire screen.  This does not show or hide Android system bars." ),
+             true
+           );
+    } );
 
     add_empty_line();
 
@@ -3934,6 +3992,9 @@ std::string options_manager::show( bool ingame, const bool world_options_only, b
                 world_generator->active_world->WORLD_OPTIONS = ACTIVE_WORLD_OPTIONS;
                 world_generator->active_world->save();
             }
+#if defined(__ANDROID__)
+            android_apply_system_ui_mode();
+#endif
             g->on_options_changed();
         } else {
             lang_changed = false;
@@ -4137,6 +4198,9 @@ void options_manager::load()
 
 #if defined(SDL_SOUND)
     sounds::sound_enabled = ::get_option<bool>( "SOUND_ENABLED" );
+#endif
+#if defined(__ANDROID__)
+    android_apply_system_ui_mode();
 #endif
 }
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -701,21 +701,23 @@ static uint32_t preview_terminal_change_time = 0;
 
 extern "C" {
 
-    static bool visible_display_frame_dirty = false;
-    static bool has_visible_display_frame = false;
-    static SDL_Rect visible_display_frame;
+    static bool ime_visible_frame_dirty = false;
+    static bool has_ime_visible_frame = false;
+    static bool ime_visible = false;
+    static SDL_Rect ime_visible_frame;
 
-    JNIEXPORT void JNICALL Java_org_libsdl_app_SDLActivity_onNativeVisibleDisplayFrameChanged(
-        JNIEnv *env, jclass jcls, jint left, jint top, jint right, jint bottom )
+    JNIEXPORT void JNICALL Java_com_cleverraven_cataclysmdda_CataclysmDDA_onNativeImeInsetsChanged(
+        JNIEnv *env, jclass jcls, jint left, jint top, jint right, jint bottom, jboolean visible )
     {
         ( void )env; // unused
         ( void )jcls; // unused
-        has_visible_display_frame = true;
-        visible_display_frame_dirty = true;
-        visible_display_frame.x = left;
-        visible_display_frame.y = top;
-        visible_display_frame.w = right - left;
-        visible_display_frame.h = bottom - top;
+        has_ime_visible_frame = true;
+        ime_visible_frame_dirty = true;
+        ime_visible = visible;
+        ime_visible_frame.x = left;
+        ime_visible_frame.y = top;
+        ime_visible_frame.w = std::max( 0, right - left );
+        ime_visible_frame.h = std::max( 0, bottom - top );
     }
 
 } // "C"
@@ -759,19 +761,15 @@ SDL_Rect get_android_render_rect( float DisplayBufferWidth, float DisplayBufferH
         dstrect.y = bounds.y;
     }
 
-    // Make sure the destination rectangle fits within the visible area.
-    // FIXME: has_visible_display_frame is fed by the SDL2 onNativeVisibleDisplayFrameChanged
-    // JNI hook, which the SDL3 Android AAR never calls (it reports insets through
-    // onNativeInsetsChanged and the keyboard as a shown/hidden bool with no rectangle).
-    // So this keyboard-avoidance clamp is inert under SDL3 and needs an IME-inset source.
-    if( get_option<bool>( "ANDROID_KEYBOARD_SCREEN_SCALE" ) && has_visible_display_frame ) {
-        int vdf_right = visible_display_frame.x + visible_display_frame.w;
-        int vdf_bottom = visible_display_frame.y + visible_display_frame.h;
-        if( vdf_right < dstrect.x + dstrect.w ) {
-            dstrect.w = vdf_right - dstrect.x;
+    if( get_option<bool>( "ANDROID_KEYBOARD_SCREEN_SCALE" ) && has_ime_visible_frame &&
+        ime_visible && ime_visible_frame.w > 0 && ime_visible_frame.h > 0 ) {
+        const int ime_right = ime_visible_frame.x + ime_visible_frame.w;
+        const int ime_bottom = ime_visible_frame.y + ime_visible_frame.h;
+        if( ime_right < dstrect.x + dstrect.w ) {
+            dstrect.w = std::max( 1, ime_right - dstrect.x );
         }
-        if( vdf_bottom < dstrect.y + dstrect.h ) {
-            dstrect.h = vdf_bottom - dstrect.y;
+        if( ime_bottom < dstrect.y + dstrect.h ) {
+            dstrect.h = std::max( 1, ime_bottom - dstrect.y );
         }
     }
     return dstrect;
@@ -4636,10 +4634,10 @@ static void CheckMessages()
     bool is_repeat = false;
 
 #if defined(__ANDROID__)
-    if( visible_display_frame_dirty ) {
+    if( ime_visible_frame_dirty ) {
         needupdate = true;
         ui_manager::redraw_invalidated();
-        visible_display_frame_dirty = false;
+        ime_visible_frame_dirty = false;
     }
 
     uint32_t ticks = GetTicks();


### PR DESCRIPTION
#### Summary
Bugfixes "Make Android system bars configurable"

#### Purpose of change

Fixes #87461.

My previous Android SDL3 inset/fullscreen work made the game activity always reapply immersive mode. That fixed the empty top strip, but it also made the launch-time Force fullscreen setting misleading: the game could reserve space for the navigation bar while still hiding the actual bar/button.

This makes the Android system bars an explicit display choice instead of tying that behavior to the old fullscreen checkbox.

#### Describe the solution

Add an Android system UI mode with Show system bars, Fullscreen, and Edge-to-edge fullscreen.

The splash dialog and in-game Android options share the same stored value. Saving options reapplies the mode immediately. Old Force fullscreen preferences migrate to edge-to-edge fullscreen.

Also feed IME insets from Java so keyboard screen scaling works under SDL3, and make the splash settings view scrollable.

#### Describe alternatives you've considered

Keep one Force fullscreen checkbox, but that mixes bar visibility with edge-to-edge layout and still leaves no way to keep the navigation bar visible.

#### Testing

Verified on my phone.

#### Additional context

N/A