### PR TITLE
Revert "Fix hardcoded FreeType include path for Windows CMake builds "

### DIFF
--- a/src/third-party/CMakeLists.txt
+++ b/src/third-party/CMakeLists.txt
@@ -145,7 +145,7 @@ if (TILES)
                         imgui
                         SYSTEM
                         PRIVATE
-                        ${FREETYPE_INCLUDE_DIRS}
+                        /usr/include/freetype2
                         )
             endif ()
         else ()
@@ -154,7 +154,7 @@ if (TILES)
                     SYSTEM
                     PRIVATE
                     ${SDL2_INCLUDE_DIR}/..
-                    ${FREETYPE_INCLUDE_DIRS}
+                    /usr/include/freetype2
                     )
         endif ()
 


### PR DESCRIPTION
Reverts CleverRaven/Cataclysm-DDA#87440 - it broke GCC9 builds

From PR itself: https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/27015000124/job/79880586254

The same problem is in every build in the master now.