### PR TITLE
Use CMake FreeType target for ImGui

### DIFF
--- a/src/third-party/CMakeLists.txt
+++ b/src/third-party/CMakeLists.txt
@@ -106,11 +106,14 @@ if (TILES)
                 )
         endif ()
         set(_imgui_freetype_sources "")
+        set(_imgui_freetype_libraries "")
         if (NOT ANDROID)
+            find_package(Freetype REQUIRED)
             set(_imgui_freetype_sources
                 imgui/imgui_freetype.cpp
                 imgui/imgui_freetype.h
                 )
+            set(_imgui_freetype_libraries Freetype::Freetype)
         endif ()
         add_library(
                 imgui
@@ -139,22 +142,12 @@ if (TILES)
                 ${CMAKE_CURRENT_SOURCE_DIR}
                 )
 
-        if (USE_SDL3)
-            if (NOT ANDROID)
-                target_include_directories(
-                        imgui
-                        SYSTEM
-                        PRIVATE
-                        ${FREETYPE_INCLUDE_DIRS}
-                        )
-            endif ()
-        else ()
+        if (NOT USE_SDL3)
             target_include_directories(
                     imgui
                     SYSTEM
                     PRIVATE
                     ${SDL2_INCLUDE_DIR}/..
-                    ${FREETYPE_INCLUDE_DIRS}
                     )
         endif ()
 
@@ -170,24 +163,24 @@ if (TILES)
             elseif (NOT DYNAMIC_LINKING)
                 target_link_libraries(imgui PUBLIC
                     $<IF:$<TARGET_EXISTS:SDL3::SDL3-static>,SDL3::SDL3-static,SDL3::SDL3>
-                    $<TARGET_NAME_IF_EXISTS:PkgConfig::Freetype>
+                    ${_imgui_freetype_libraries}
                 )
             else()
                 target_link_libraries(imgui PUBLIC
                     SDL3::SDL3
-                    freetype
+                    ${_imgui_freetype_libraries}
                 )
             endif ()
         else ()
             if (NOT DYNAMIC_LINKING)
                 target_link_libraries(imgui PUBLIC
                     SDL2::SDL2-static
-                    $<TARGET_NAME_IF_EXISTS:PkgConfig::Freetype>
+                    ${_imgui_freetype_libraries}
                 )
             else()
                 target_link_libraries(imgui PUBLIC
                     SDL2::SDL2
-                    freetype
+                    ${_imgui_freetype_libraries}
                 )
             endif ()
         endif ()


### PR DESCRIPTION
#### Summary
Build "Use CMake FreeType target for ImGui"

#### Purpose of change

#87440 replaced the hardcoded FreeType include path with `${FREETYPE_INCLUDE_DIRS}`. That only works when something has filled that variable.

The SDL2 CMake tiles build uses dynamic linking, so `FindSDL2_ttf.cmake` never runs its FreeType discovery branch. `imgui_freetype.cpp` then compiles without the FreeType include directory and cannot find `ft2build.h`.

#### Describe the solution

Find FreeType directly when vendored ImGui builds its FreeType backend, and link ImGui against `Freetype::Freetype`.

Keep Android on the existing no-FreeType path. Drop the manual FreeType include variable from the ImGui include list, since the imported target provides it.

#### Describe alternatives you've considered

Reverting #87440 would get Linux green again, but it puts the Windows hardcoded include problem back. That's a lateral move.

#### Testing

Configured the tiled CMake build that reproduced the failure and built the ImGui target. The ImGui compile command includes the FreeType include directory.

#### Additional context

N/A