### PR TITLE
[Innawood] Fix ravine cutouts

### DIFF
--- a/data/mods/innawood/mapgen/ravine_mutable.json
+++ b/data/mods/innawood/mapgen/ravine_mutable.json
@@ -35,7 +35,7 @@
         "south": { "id": "ravine_to_ravine", "type": "available", "alternatives": [ "ravine_to_edge" ] },
         "west": { "id": "ravine_to_ravine", "type": "available", "alternatives": [ "ravine_to_edge" ] }
       },
-      "ravine_edge_ground": { "overmap": "ravine_edge_ground_north", "north": { "id": "ravine_to_ravine" } },
+      "ravine_straight_ground": { "overmap": "ravine_straight_ground_north", "north": { "id": "ravine_to_ravine" } },
       "ravine_corner_ground": {
         "overmap": "ravine_corner_ground_north",
         "north": { "id": "ravine_to_ravine", "alternatives": [ "ravine_to_edge" ] },
@@ -56,11 +56,11 @@
       "ravine_filler": { "overmap": "open_air" },
       "ravine_root_filler": { "overmap": "open_air", "above": { "id": "ravine_to_bottom", "alternatives": [ "ravine_to_edge" ] } },
       "ravine_bottom": { "overmap": "ravine_bottom_forest" },
-      "ravine_edge": { "overmap": "ravine_edge_north" },
+      "ravine_straight": { "overmap": "ravine_straight_north" },
       "ravine_corner": { "overmap": "ravine_corner_north" },
       "ravine_2way": { "overmap": "ravine_2way_east" },
       "ravine_3way": { "overmap": "ravine_3way_north" },
-      "ravine_edge_bottom": { "overmap": "ravine_edge_bottom_north" },
+      "ravine_straight_bottom": { "overmap": "ravine_straight_bottom_north" },
       "ravine_corner_bottom": { "overmap": "ravine_corner_bottom_north" },
       "ravine_2way_bottom": { "overmap": "ravine_2way_bottom_east" },
       "ravine_3way_bottom": { "overmap": "ravine_3way_bottom_north" }
@@ -177,9 +177,9 @@
         {
           "name": "ravine edge",
           "chunk": [
-            { "overmap": "ravine_edge_ground", "pos": [ 0, 0, 0 ] },
-            { "overmap": "ravine_edge", "pos": [ 0, 0, -1 ] },
-            { "overmap": "ravine_edge_bottom", "pos": [ 0, 0, -2 ] }
+            { "overmap": "ravine_straight_ground", "pos": [ 0, 0, 0 ] },
+            { "overmap": "ravine_straight", "pos": [ 0, 0, -1 ] },
+            { "overmap": "ravine_straight_bottom", "pos": [ 0, 0, -2 ] }
           ],
           "weight": 1
         }
@@ -240,36 +240,36 @@
   {
     "type": "mapgen",
     "//": "z0",
-    "om_terrain": "ravine_edge_ground",
+    "om_terrain": "ravine_straight_ground",
     "object": {
       "fallback_predecessor_mapgen": "forest",
-      "palettes": [ "ravine_edge_parameters" ],
-      "place_nested": [ { "chunks": [ { "param": "variant", "fallback": "24x24_ravine_edge_v1" } ], "x": 0, "y": 0 } ]
+      "palettes": [ "ravine_straight_parameters" ],
+      "place_nested": [ { "chunks": [ { "param": "variant", "fallback": "24x24_ravine_straight_v1" } ], "x": 0, "y": 0 } ]
     }
   },
   {
     "type": "mapgen",
     "//": "z-1",
-    "om_terrain": "ravine_edge",
+    "om_terrain": "ravine_straight",
     "object": {
       "predecessor_mapgen": "open_air",
-      "palettes": [ "ravine_edge_parameters" ],
-      "place_nested": [ { "chunks": [ { "param": "variant", "fallback": "24x24_ravine_edge_v1" } ], "x": 0, "y": 0 } ]
+      "palettes": [ "ravine_straight_parameters" ],
+      "place_nested": [ { "chunks": [ { "param": "variant", "fallback": "24x24_ravine_straight_v1" } ], "x": 0, "y": 0 } ]
     }
   },
   {
     "type": "mapgen",
     "//": "z-2",
-    "om_terrain": "ravine_edge_bottom",
+    "om_terrain": "ravine_straight_bottom",
     "object": {
       "predecessor_mapgen": "forest",
-      "palettes": [ "ravine_edge_parameters" ],
-      "place_nested": [ { "chunks": [ { "param": "variant", "fallback": "24x24_ravine_edge_v1" } ], "x": 0, "y": 0 } ]
+      "palettes": [ "ravine_straight_parameters" ],
+      "place_nested": [ { "chunks": [ { "param": "variant", "fallback": "24x24_ravine_straight_v1" } ], "x": 0, "y": 0 } ]
     }
   },
   {
     "type": "mapgen",
-    "nested_mapgen_id": "24x24_ravine_edge_v1",
+    "nested_mapgen_id": "24x24_ravine_straight_v1",
     "object": {
       "mapgensize": [ 24, 24 ],
       "rows": [
@@ -303,7 +303,7 @@
   },
   {
     "type": "mapgen",
-    "nested_mapgen_id": "24x24_ravine_edge_v2",
+    "nested_mapgen_id": "24x24_ravine_straight_v2",
     "object": {
       "mapgensize": [ 24, 24 ],
       "rows": [

--- a/data/mods/innawood/mapgen_palettes/ravine.json
+++ b/data/mods/innawood/mapgen_palettes/ravine.json
@@ -13,12 +13,12 @@
   },
   {
     "type": "palette",
-    "id": "ravine_edge_parameters",
+    "id": "ravine_straight_parameters",
     "parameters": {
       "variant": {
         "type": "nested_mapgen_id",
         "scope": "omt_stack",
-        "default": { "distribution": [ "24x24_ravine_edge_v1", "24x24_ravine_edge_v2" ] }
+        "default": { "distribution": [ "24x24_ravine_straight_v1", "24x24_ravine_straight_v2" ] }
       }
     }
   }

--- a/data/mods/innawood/migration/terrain.json
+++ b/data/mods/innawood/migration/terrain.json
@@ -1,0 +1,20 @@
+[
+  {
+    "type": "oter_id_migration",
+    "//": "Migrated in 0.J experimental",
+    "oter_ids": {
+      "ravine_edge_ground_north": "ravine_straight_ground_north",
+      "ravine_edge_ground_west": "ravine_straight_ground_west",
+      "ravine_edge_ground_east": "ravine_straight_ground_east",
+      "ravine_edge_ground_south": "ravine_straight_ground_south",
+      "ravine_edge_north": "ravine_straight_north",
+      "ravine_edge_west": "ravine_straight_west",
+      "ravine_edge_east": "ravine_straight_east",
+      "ravine_edge_south": "ravine_straight_south",
+      "ravine_edge_bottom_north": "ravine_straight_bottom_north",
+      "ravine_edge_bottom_west": "ravine_straight_bottom_west",
+      "ravine_edge_bottom_east": "ravine_straight_bottom_east",
+      "ravine_edge_bottom_south": "ravine_straight_bottom_south"
+    }
+  }
+]

--- a/data/mods/innawood/overmap/overmap_terrain.json
+++ b/data/mods/innawood/overmap/overmap_terrain.json
@@ -51,18 +51,18 @@
     "id": [
       "ravine_2way",
       "ravine_3way",
-      "ravine_edge",
+      "ravine_straight",
       "ravine_corner",
       "ravine_2way_bottom",
       "ravine_3way_bottom",
-      "ravine_edge_bottom",
+      "ravine_straight_bottom",
       "ravine_corner_bottom"
     ],
     "copy-from": "generic_ravine"
   },
   {
     "type": "overmap_terrain",
-    "id": [ "ravine_2way_ground", "ravine_3way_ground", "ravine_edge_ground", "ravine_corner_ground" ],
+    "id": [ "ravine_2way_ground", "ravine_3way_ground", "ravine_straight_ground", "ravine_corner_ground" ],
     "copy-from": "generic_ravine",
     "see_cost": "all_clear",
     "flags": [ "REQUIRES_PREDECESSOR" ]

--- a/data/mods/innawood/region_settings/region_settings/region_overlay.json
+++ b/data/mods/innawood/region_settings/region_settings/region_overlay.json
@@ -115,7 +115,15 @@
     "id": "biome_forest_thick_default",
     "copy-from": "biome_forest_thick_default",
     "extend": {
-      "terrains": [ "ravine", "ravine_2way", "ravine_3way", "ravine_edge", "ravine_corner", "ravine_edge_ground", "ravine_bottom_forest" ]
+      "terrains": [
+        "ravine",
+        "ravine_2way",
+        "ravine_3way",
+        "ravine_edge",
+        "ravine_corner",
+        "ravine_straight_ground",
+        "ravine_bottom_forest"
+      ]
     }
   },
   {
@@ -123,7 +131,15 @@
     "id": "biome_forest_default",
     "copy-from": "biome_forest_default",
     "extend": {
-      "terrains": [ "ravine", "ravine_2way", "ravine_3way", "ravine_edge", "ravine_corner", "ravine_edge_ground", "ravine_bottom_forest" ]
+      "terrains": [
+        "ravine",
+        "ravine_2way",
+        "ravine_3way",
+        "ravine_edge",
+        "ravine_corner",
+        "ravine_straight_ground",
+        "ravine_bottom_forest"
+      ]
     }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "[Innawood] Fix ravine cutouts"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Ravines no longer generate with giant empty patches but still had little cutaways. I presume this is because of the way Aftershock ravines use hardcode to generate, since removing `_edge` from the id fixes them

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Using the idea from TLG of renaming the OMT to fix it, rename the OMT to fix it (from _edge to _straight, since it's the straightaways instead of the corners). Migrate the terrain

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

No more weird cutouts. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
