### PR TITLE
Skip SDL frameworks for macOS curses release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -483,7 +483,7 @@ jobs:
       - name: Build CDDA (osx, curses)
         if: runner.os == 'macOS' && matrix.tiles != 1
         run: |
-          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.sound }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 FRAMEWORK=1 UNIVERSAL_BINARY=1 WARN_STALE_DATA=1 dmgdist
+          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.sound }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 UNIVERSAL_BINARY=1 WARN_STALE_DATA=1 dmgdist
           mv Cataclysm.dmg cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
       - name: Build CDDA (osx, SDL3)
         if: runner.os == 'macOS' && matrix.sdl3 == 1


### PR DESCRIPTION
#### Summary
Build "Skip SDL frameworks for macOS curses release"

#### Purpose of change
The macOS curses release job failed while looking for SDL frameworks in the terminal-only build:
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/27102033046/job/79987107925

#### Describe the solution
The macOS curses release step no longer asks the Makefile to use framework packaging. The SDL3 macOS release path is unchanged.

#### Describe alternatives you've considered
N/A

#### Testing
Fork release job passed:
https://github.com/dobbry-vechur/Cataclysm-DDA/actions/runs/27103358384/job/79988079694

#### Additional context
N/A