### PR TITLE
Enable Linux SDL3 desktop backends

### DIFF
--- a/.github/actions/setup-sdl3-stack/action.yml
+++ b/.github/actions/setup-sdl3-stack/action.yml
@@ -20,10 +20,11 @@ runs:
         sudo apt-get update
         sudo apt-get install -y libflac-dev libogg-dev libvorbis-dev libmpg123-dev libwavpack-dev \
             libfreetype-dev libharfbuzz-dev libjpeg-dev libpng-dev libwebp-dev libtiff-dev \
-            libpulse-dev pkg-config cmake \
+            libasound2-dev libpulse-dev pkg-config cmake \
             libx11-dev libxext-dev libxcursor-dev libxi-dev libxfixes-dev libxrandr-dev \
-            libxrender-dev libxss-dev libxtst-dev libxkbcommon-dev libwayland-dev \
-            libdecor-0-dev libdrm-dev libgbm-dev libudev-dev libpipewire-0.3-dev \
+            libxrender-dev libxss-dev libxtst-dev libxkbcommon-dev libwayland-dev libwayland-bin \
+            wayland-protocols libdecor-0-dev libdrm-dev libgbm-dev libudev-dev \
+            libegl-dev libgl-dev libgles-dev libvulkan-dev libpipewire-0.3-dev \
             libdbus-1-dev libibus-1.0-dev
 
     - name: Restore SDL3 stack cache
@@ -50,6 +51,33 @@ runs:
         cmake -S sdl3_src -B sdl3_build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+            -DSDL_DEPS_SHARED=ON \
+            -DSDL_AUDIO=ON \
+            -DSDL_ALSA=ON \
+            -DSDL_ALSA_SHARED=ON \
+            -DSDL_DBUS=ON \
+            -DSDL_GPU=ON \
+            -DSDL_IBUS=ON \
+            -DSDL_KMSDRM=ON \
+            -DSDL_KMSDRM_SHARED=ON \
+            -DSDL_LIBUDEV=ON \
+            -DSDL_OPENGL=ON \
+            -DSDL_OPENGLES=ON \
+            -DSDL_PIPEWIRE=ON \
+            -DSDL_PIPEWIRE_SHARED=ON \
+            -DSDL_PULSEAUDIO=ON \
+            -DSDL_PULSEAUDIO_SHARED=ON \
+            -DSDL_RENDER=ON \
+            -DSDL_RENDER_GPU=ON \
+            -DSDL_RENDER_VULKAN=ON \
+            -DSDL_VIDEO=ON \
+            -DSDL_VULKAN=ON \
+            -DSDL_WAYLAND=ON \
+            -DSDL_WAYLAND_SHARED=ON \
+            -DSDL_WAYLAND_LIBDECOR=ON \
+            -DSDL_WAYLAND_LIBDECOR_SHARED=ON \
+            -DSDL_X11=ON \
+            -DSDL_X11_SHARED=ON \
             -DBUILD_SHARED_LIBS=ON
         cmake --build sdl3_build -j"$(nproc)"
         cmake --install sdl3_build

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -125,7 +125,7 @@ jobs:
     - name: setup SDL3 stack
       uses: ./.github/actions/setup-sdl3-stack
       with:
-        cache-key: sdl3-stack-strict-sdl-3.4.10-image-3.4.4-ttf-3.2.2-mixer-3.2.4-ubuntu-24.04-v1
+        cache-key: sdl3-stack-strict-sdl-3.4.10-image-3.4.4-ttf-3.2.2-mixer-3.2.4-ubuntu-24.04-v2
         prefix: ${{ runner.workspace }}/sdl3_prefix
     - name: download plugin from the previous job in this workflow run
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -277,7 +277,7 @@ jobs:
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && matrix.tiles == 1 && matrix.sdl3 == 1 }}
       uses: ./.github/actions/setup-sdl3-stack
       with:
-        cache-key: sdl3-stack-strict-sdl-3.4.10-image-3.4.4-ttf-3.2.2-mixer-3.2.4-ubuntu-24.04-v1
+        cache-key: sdl3-stack-strict-sdl-3.4.10-image-3.4.4-ttf-3.2.2-mixer-3.2.4-ubuntu-24.04-v2
         prefix: ${{ runner.workspace }}/sdl3_prefix
     - name: install recent ccache on ubuntu
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,7 +266,7 @@ jobs:
         if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm && matrix.sdl3 == 1
         uses: ./.github/actions/setup-sdl3-stack
         with:
-          cache-key: sdl3-stack-strict-sdl-3.4.10-image-3.4.4-ttf-3.2.2-mixer-3.2.4-ubuntu-24.04-v1
+          cache-key: sdl3-stack-strict-sdl-3.4.10-image-3.4.4-ttf-3.2.2-mixer-3.2.4-ubuntu-24.04-v2
           prefix: ${{ runner.workspace }}/sdl3_prefix
           stage-licenses: "true"
       - name: Install Emscripten (WebAssembly)


### PR DESCRIPTION
#### Summary
Build "Enable Linux SDL3 desktop backends"

#### Purpose of change

Linux SDL3 release builds can miss backend support when SDL auto-detection does not find every optional dependency. That can leave the bundled SDL3 without Wayland support and force users back to X11.

#### Describe the solution

Install the Linux development packages SDL needs for Wayland, EGL, OpenGL/GLES, Vulkan, ALSA, and the existing desktop backends.

Pass explicit SDL3 CMake options for the shared backend model.

Bump the shared Linux SDL3 cache key.

#### Describe alternatives you've considered

Bundling Wayland, Vulkan, and audio runtime libraries. That is the host platform stack.

#### Testing

Built in fork CI, downloaded the Linux bindist, and launched it in a Wayland session without forcing X11.

#### Additional context

N/A