### PR TITLE
Fix SDL3 numpad repeat on macOS

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -4062,6 +4062,48 @@ static int sdl_keysym_to_curses( const CataKeysym &keysym )
     }
 }
 
+static int sdl_keypad_scancode_to_keycode( SDL_Scancode scancode )
+{
+    // SDL3 reports keypad digits as regular digit key values. The scancode
+    // still preserves keypad identity, including repeat events on macOS.
+    switch( scancode ) {
+        case SDL_SCANCODE_KP_DIVIDE:
+            return keycode::kp_divide;
+        case SDL_SCANCODE_KP_MULTIPLY:
+            return keycode::kp_multiply;
+        case SDL_SCANCODE_KP_MINUS:
+            return keycode::kp_minus;
+        case SDL_SCANCODE_KP_PLUS:
+            return keycode::kp_plus;
+        case SDL_SCANCODE_KP_ENTER:
+            return keycode::kp_enter;
+        case SDL_SCANCODE_KP_1:
+            return keycode::kp_1;
+        case SDL_SCANCODE_KP_2:
+            return keycode::kp_2;
+        case SDL_SCANCODE_KP_3:
+            return keycode::kp_3;
+        case SDL_SCANCODE_KP_4:
+            return keycode::kp_4;
+        case SDL_SCANCODE_KP_5:
+            return keycode::kp_5;
+        case SDL_SCANCODE_KP_6:
+            return keycode::kp_6;
+        case SDL_SCANCODE_KP_7:
+            return keycode::kp_7;
+        case SDL_SCANCODE_KP_8:
+            return keycode::kp_8;
+        case SDL_SCANCODE_KP_9:
+            return keycode::kp_9;
+        case SDL_SCANCODE_KP_0:
+            return keycode::kp_0;
+        case SDL_SCANCODE_KP_PERIOD:
+            return keycode::kp_period;
+        default:
+            return 0;
+    }
+}
+
 static input_event sdl_keysym_to_keycode_evt( const CataKeysym &keysym )
 {
     switch( keysym.sym ) {
@@ -4073,6 +4115,7 @@ static input_event sdl_keysym_to_keycode_evt( const CataKeysym &keysym )
         case SDLK_RALT:
             return input_event();
     }
+
     input_event evt;
     evt.type = input_event_t::keyboard_code;
     if( keysym.mod & KMOD_CTRL ) {
@@ -4084,7 +4127,8 @@ static input_event sdl_keysym_to_keycode_evt( const CataKeysym &keysym )
     if( keysym.mod & KMOD_SHIFT ) {
         evt.modifiers.emplace( keymod_t::shift );
     }
-    evt.sequence.emplace_back( keysym.sym );
+    const int keypad_keycode = sdl_keypad_scancode_to_keycode( keysym.scancode );
+    evt.sequence.emplace_back( keypad_keycode ? keypad_keycode : keysym.sym );
     return evt;
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix SDL3 numpad repeat on macOS"

#### Purpose of change

Fixes #87512.

On SDL3, numpad digit key events can arrive with regular digit key values, while the scancode still says the key came from the numpad. Our keycode-mode bindings use `KEYPAD_*`, so held numpad movement on macOS could stop after the first event.

#### Describe the solution

Map SDL numpad scancodes back to internal numpad keycodes before building keyboard-code input events. Non-numpad keys still use the SDL key value.

#### Describe alternatives you've considered

Letting numpad digits collapse to top-row digits would keep the old path smaller. It also keeps the bug.

#### Testing

Verified numpad keeps working on Linux.

#### Additional context

ImGui's SDL3 backend uses the same scancode approach for numpad identity.