### PR TITLE
Show required proficiencies in table

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1472,7 +1472,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
 // --- draw_modifier_table ---
 
 void crafting_ui_impl::draw_modifier_table( const recipe &recp,
-        const availability &/*avail*/, int batch_size )
+        const availability &avail, int batch_size )
 {
     // Helper: time impact as percentage. Input is a time multiplier
     // (>1 = slower, <1 = faster). Shows "+50%" (red) or "-20%" (green).
@@ -1594,32 +1594,45 @@ void crafting_ui_impl::draw_modifier_table( const recipe &recp,
         // --- Proficiencies ---
         {
             const auto &profs = recp.get_proficiencies();
-            bool has_profs = std::any_of( profs.begin(), profs.end(),
-            []( const recipe_proficiency & p ) {
-                return !p.required;
-            } );
-            if( has_profs ) {
+            if( !profs.empty() ) {
                 section_label( _( "Proficiencies" ) );
             }
 
-            for( const recipe_proficiency &prof : profs ) {
-                if( prof.required ) {
-                    continue;
+            const auto crafter_or_helper_has_proficiency = [&avail]( const proficiency_id & prof ) {
+                if( avail.crafter.has_proficiency( prof ) ) {
+                    return true;
                 }
-                bool known = crafter->has_proficiency( prof.id );
+                std::vector<Character *> helpers = avail.crafter.get_crafting_group();
+                return std::any_of( helpers.begin(), helpers.end(), [&prof]( const Character * helper ) {
+                    return helper->has_proficiency( prof );
+                } );
+            };
+
+            for( const recipe_proficiency &prof : profs ) {
+                bool known = crafter_or_helper_has_proficiency( prof.id );
                 ImGui::TableNextRow();
                 ImGui::TableNextColumn();
                 ImGui::Indent( row_indent );
 
-                if( known ) {
-                    nc_color dim = c_dark_gray;
-                    ImGui::TextColored( cataimgui::imvec4_from_color( dim ), "%s",
+                if( prof.required ) {
+                    nc_color col = known ? c_dark_gray : c_red;
+                    ImGui::TextColored( cataimgui::imvec4_from_color( col ), "%s",
                                         prof.id->name().c_str() );
                     ImGui::Unindent( row_indent );
-                    ImGui::TableNextColumn();
-                    ImGui::TextColored( cataimgui::imvec4_from_color( dim ), "-" );
-                    ImGui::TableNextColumn();
-                    ImGui::TextColored( cataimgui::imvec4_from_color( dim ), "-" );
+                    if( known ) {
+                        dash_cell();
+                    } else {
+                        ImGui::TableNextColumn();
+                        ImGui::TextColored( cataimgui::imvec4_from_color( col ), "%s",
+                                            _( "required" ) );
+                    }
+                    dash_cell();
+                } else if( known ) {
+                    ImGui::TextColored( cataimgui::imvec4_from_color( c_dark_gray ), "%s",
+                                        prof.id->name().c_str() );
+                    ImGui::Unindent( row_indent );
+                    dash_cell();
+                    dash_cell();
                 } else {
                     ImGui::TextColored( cataimgui::imvec4_from_color( c_white ), "%s",
                                         prof.id->name().c_str() );


### PR DESCRIPTION
#### Summary
Interface "Show required crafting proficiencies in recipe details"

#### Purpose of change
Fixes #87513.

Required recipe proficiencies were only shown in the missing-proficiency warning. They were skipped in the expanded crafting details table.

#### Describe the solution
Show required proficiencies in the Proficiencies section too.

Known required proficiencies show as usual. Missing required proficiencies show as red with `required` in the time column.

#### Describe alternatives you've considered
N/A

#### Testing
<img width="966" height="653" alt="2026-06-08_20-00" src="https://github.com/user-attachments/assets/b25aa68a-e242-409c-9938-6cefdb9bffd9" />
<img width="895" height="640" alt="2026-06-08_19-55" src="https://github.com/user-attachments/assets/5f27d4b9-833d-4af8-bd40-587ec3c8d8e3" />


#### Additional context
N/A