### PR TITLE
[0.I] Fix MSXotto+ lingering experimental bits in layering.json

### DIFF
--- a/gfx/MshockXotto+/layering.json
+++ b/gfx/MshockXotto+/layering.json
@@ -67,39 +67,6 @@
       ]
     },
     {
-      "context": "f_indoor_flagpole_wooden",
-      "item_variants": [
-        {
-          "item": "state_flag",
-          "sprite": [ { "id": "state_flag", "weight": 1 } ],
-          "layer": 90,
-          "offset_x": 18,
-          "offset_y": -25
-        },
-        {
-          "item": "pride_flag",
-          "sprite": [ { "id": "pride_flag", "weight": 1 } ],
-          "layer": 90,
-          "offset_x": 18,
-          "offset_y": -25
-        },
-        {
-          "item": "american_flag",
-          "sprite": [ { "id": "american_flag", "weight": 1 } ],
-          "layer": 90,
-          "offset_x": 18,
-          "offset_y": -25
-        },
-        {
-          "item": "national_flag",
-          "sprite": [ { "id": "national_flag", "weight": 1 } ],
-          "layer": 90,
-          "offset_x": 18,
-          "offset_y": -25
-        }
-      ]
-    },
-    {
       "context": "f_wooden_flagpole",
       "item_variants": [
         {


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Found out there is some lingering bits in layering.json that is meant to be in post-0.I experimental, so i yeet that bits.
#### Describe the solution

Yeet said experimental-only bits

#### Describe alternatives you've considered

No

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
