### PR TITLE
Fix exodii limb armor, nuke acid armor

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1862,9 +1862,9 @@
       { "mutations": [ "EXODII_CYBERFRAME_LARGE" ] }
     ],
     "protec": [
-      [ "head_bionic_basic", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30, "acid": 30 } ],
-      [ "mouth_bionic_basic", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30, "acid": 30 } ],
-      [ "torso_bionic_basic", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30, "acid": 30 } ]
+      [ "head_bionic_basic", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30 } ],
+      [ "mouth_bionic_basic", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30 } ],
+      [ "torso_bionic_basic", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30 } ]
     ]
   },
   {
@@ -1876,8 +1876,8 @@
     "replaced_bodyparts": [ "leg_l", "foot_l" ],
     "enchantments": [ { "modified_bodyparts": [ { "gain": "leg_bionic_basic_l" }, { "gain": "foot_bionic_basic_l" } ] } ],
     "protec": [
-      [ "leg_bionic_basic_l", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30, "acid": 30 } ],
-      [ "foot_bionic_basic_l", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30, "acid": 30 } ]
+      [ "leg_bionic_basic_l", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30 } ],
+      [ "foot_bionic_basic_l", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30 } ]
     ]
   },
   {
@@ -1889,8 +1889,8 @@
     "replaced_bodyparts": [ "leg_r", "foot_r" ],
     "enchantments": [ { "modified_bodyparts": [ { "gain": "leg_bionic_basic_r" }, { "gain": "foot_bionic_basic_r" } ] } ],
     "protec": [
-      [ "leg_bionic_basic_r", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30, "acid": 30 } ],
-      [ "foot_bionic_basic_r", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30, "acid": 30 } ]
+      [ "leg_bionic_basic_r", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30 } ],
+      [ "foot_bionic_basic_r", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30 } ]
     ]
   },
   {
@@ -1904,7 +1904,7 @@
       { "modified_bodyparts": [ { "gain": "bionic_treads_leg" } ] },
       { "values": [ { "value": "MOVECOST_OBSTACLE_MOD", "multiply": 6 } ] }
     ],
-    "protec": [ [ "bionic_treads_leg", { "bash": 20, "cut": 20, "bullet": 15, "stab": 20, "acid": 30 } ] ]
+    "protec": [ [ "bionic_treads_leg", { "bash": 20, "cut": 20, "bullet": 15, "stab": 20 } ] ]
   },
   {
     "id": "bio_exodii_arm_bionic_basic_armored_left",
@@ -1915,8 +1915,8 @@
     "replaced_bodyparts": [ "arm_l", "hand_l" ],
     "enchantments": [ { "modified_bodyparts": [ { "gain": "arm_bionic_basic_l" }, { "gain": "hand_bionic_basic_l" } ] } ],
     "protec": [
-      [ "arm_bionic_basic_l", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30, "acid": 30 } ],
-      [ "hand_bionic_basic_l", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30, "acid": 30 } ]
+      [ "arm_bionic_basic_l", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30 } ],
+      [ "hand_bionic_basic_l", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30 } ]
     ]
   },
   {
@@ -1928,8 +1928,8 @@
     "replaced_bodyparts": [ "arm_r", "hand_r" ],
     "enchantments": [ { "modified_bodyparts": [ { "gain": "arm_bionic_basic_r" }, { "gain": "hand_bionic_basic_r" } ] } ],
     "protec": [
-      [ "arm_bionic_basic_l", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30, "acid": 30 } ],
-      [ "hand_bionic_basic_l", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30, "acid": 30 } ]
+      [ "arm_bionic_basic_r", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30 } ],
+      [ "hand_bionic_basic_r", { "bash": 30, "cut": 30, "bullet": 25, "stab": 30 } ]
     ]
   },
   {
@@ -1940,9 +1940,9 @@
     "cant_remove_reason": "Cyberframes cannot be removed, only swapped via specialized surgery.  Removing it would kill you.",
     "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 2 }, { "value": "DEXTERITY", "add": 4 } ] } ],
     "protec": [
-      [ "head_bionic_basic", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5, "acid": 30 } ],
-      [ "mouth_bionic_basic", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5, "acid": 30 } ],
-      [ "torso_bionic_basic", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5, "acid": 30 } ]
+      [ "head_bionic_basic", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5 } ],
+      [ "mouth_bionic_basic", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5 } ],
+      [ "torso_bionic_basic", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5 } ]
     ]
   },
   {
@@ -1954,8 +1954,8 @@
     "replaced_bodyparts": [ "leg_l", "foot_l" ],
     "enchantments": [ { "modified_bodyparts": [ { "gain": "leg_bionic_basic_l" }, { "gain": "foot_bionic_basic_l" } ] } ],
     "protec": [
-      [ "leg_bionic_basic_l", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5, "acid": 30 } ],
-      [ "foot_bionic_basic_l", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5, "acid": 30 } ]
+      [ "leg_bionic_basic_l", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5 } ],
+      [ "foot_bionic_basic_l", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5 } ]
     ]
   },
   {
@@ -1967,8 +1967,8 @@
     "replaced_bodyparts": [ "leg_r", "foot_r" ],
     "enchantments": [ { "modified_bodyparts": [ { "gain": "leg_bionic_basic_r" }, { "gain": "foot_bionic_basic_r" } ] } ],
     "protec": [
-      [ "leg_bionic_basic_r", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5, "acid": 30 } ],
-      [ "foot_bionic_basic_r", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5, "acid": 30 } ]
+      [ "leg_bionic_basic_r", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5 } ],
+      [ "foot_bionic_basic_r", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5 } ]
     ]
   },
   {
@@ -1980,8 +1980,8 @@
     "replaced_bodyparts": [ "arm_l", "hand_l" ],
     "enchantments": [ { "modified_bodyparts": [ { "gain": "arm_bionic_basic_l" }, { "gain": "hand_bionic_basic_l" } ] } ],
     "protec": [
-      [ "arm_bionic_basic_l", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5, "acid": 30 } ],
-      [ "hand_bionic_basic_l", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5, "acid": 30 } ]
+      [ "arm_bionic_basic_l", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5 } ],
+      [ "hand_bionic_basic_l", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5 } ]
     ]
   },
   {
@@ -1993,8 +1993,8 @@
     "replaced_bodyparts": [ "arm_r", "hand_r" ],
     "enchantments": [ { "modified_bodyparts": [ { "gain": "arm_bionic_basic_r" }, { "gain": "hand_bionic_basic_r" } ] } ],
     "protec": [
-      [ "arm_bionic_basic_l", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5, "acid": 30 } ],
-      [ "hand_bionic_basic_l", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5, "acid": 30 } ]
+      [ "arm_bionic_basic_r", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5 } ],
+      [ "hand_bionic_basic_r", { "bash": 5, "cut": 5, "bullet": 2, "stab": 5 } ]
     ]
   },
   {

--- a/data/json/mutations/cybernetic_traits.json
+++ b/data/json/mutations/cybernetic_traits.json
@@ -232,8 +232,7 @@
         "cut": 30,
         "bash": 30,
         "stab": 30,
-        "bullet": 25,
-        "acid": 30
+        "bullet": 25
       }
     ],
     "cancels": [ "BENDY1", "BENDY2", "BENDY3", "INTERSTICE_POSTURE", "INTERSTICE_POSTURE_2" ]
@@ -323,8 +322,7 @@
         "cut": 5,
         "bash": 5,
         "stab": 5,
-        "bullet": 2,
-        "acid": 30
+        "bullet": 2
       }
     ],
     "cancels": [ "BENDY1", "BENDY2", "BENDY3", "INTERSTICE_POSTURE", "INTERSTICE_POSTURE_2" ]
@@ -360,7 +358,6 @@
         "bash": 15,
         "stab": 15,
         "bullet": 10,
-        "acid": 25,
         "electric": 0
       }
     ]
@@ -389,8 +386,7 @@
         "cut": 5,
         "bash": 5,
         "stab": 5,
-        "bullet": 2,
-        "acid": 30
+        "bullet": 2
       }
     ]
   },
@@ -418,8 +414,7 @@
         "cut": 5,
         "bash": 5,
         "stab": 5,
-        "bullet": 2,
-        "acid": 30
+        "bullet": 2
       }
     ]
   },
@@ -457,8 +452,7 @@
         "cut": 5,
         "bash": 5,
         "stab": 5,
-        "bullet": 2,
-        "acid": 30
+        "bullet": 2
       }
     ],
     "cancels": [
@@ -513,8 +507,7 @@
         "cut": 5,
         "bash": 5,
         "stab": 5,
-        "bullet": 2,
-        "acid": 30
+        "bullet": 2
       }
     ]
   },
@@ -542,8 +535,7 @@
         "cut": 5,
         "bash": 5,
         "stab": 5,
-        "bullet": 2,
-        "acid": 30
+        "bullet": 2
       }
     ]
   },
@@ -582,8 +574,7 @@
         "cut": 5,
         "bash": 5,
         "stab": 5,
-        "bullet": 2,
-        "acid": 30
+        "bullet": 2
       }
     ],
     "cancels": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes part of #87511

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Fixes the typo that left one of the bionic arms unarmored.

Removed their acid armor, because the metals are probably not extremely corrosion resistant.  Makes space for alternative limbs made of rubber and plastic and stuff that might be corrosion resistant, so that's cool.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked in game - armored all over now.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This doesn't address why acid pools are causing pain on bionic limbs.  Haven't tracked down if it's the hardcoded acid damage, or the effect, that's doing it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
