### PR TITLE
[Innawood] Overwrite trailhead palette to remove modern items

### DIFF
--- a/data/mods/innawood/mapgen_palettes/trail.json
+++ b/data/mods/innawood/mapgen_palettes/trail.json
@@ -36,7 +36,7 @@
       " ": "t_region_soil",
       ",": [ [ "t_region_groundcover", 2 ], "t_region_soil" ],
       ";": [ "t_region_groundcover", "t_region_soil" ],
-      ".": [ [ "t_region_soil", 5 ], "t_region_groundcover" ],
+      ".": [ [ "t_region_groundcover", 2 ], "t_region_soil" ],
       "b": "t_region_soil",
       "t": "t_trunk",
       "s": "t_region_soil",

--- a/data/mods/innawood/mapgen_palettes/trail.json
+++ b/data/mods/innawood/mapgen_palettes/trail.json
@@ -28,5 +28,43 @@
       "_": { "chunks": [ [ "1x1_t_dirt", 1 ], [ "1x1_predecessor_groundcover", 3 ] ] },
       "~": { "chunks": [ [ "1x1_t_mud", 6 ], [ "1x1_t_dirt", 1 ], [ "1x1_predecessor_groundcover", 1 ] ] }
     }
+  },
+  {
+    "type": "palette",
+    "id": "trailhead",
+    "terrain": {
+      " ": "t_region_soil",
+      ",": [ [ "t_region_groundcover", 2 ], "t_region_soil" ],
+      ";": [ "t_region_groundcover", "t_region_soil" ],
+      ".": [ [ "t_region_soil", 5 ], "t_region_groundcover" ],
+      "b": "t_region_soil",
+      "t": "t_trunk",
+      "s": "t_region_soil",
+      "6": "t_region_soil",
+      "=": "t_region_soil",
+      "-": [ [ "t_region_groundcover", 2 ], "t_region_soil" ],
+      "|": [ [ "t_region_groundcover", 2 ], "t_region_soil" ],
+      "#": [ [ "t_region_groundcover", 2 ], "t_region_soil" ],
+      "B": [ [ "t_region_groundcover", 2 ], "t_region_soil" ],
+      "w": [ [ "t_region_groundcover", 2 ], "t_region_soil" ],
+      "+": [ [ "t_region_groundcover", 2 ], "t_region_soil" ],
+      ":": [ [ "t_region_groundcover", 2 ], "t_region_soil" ],
+      "c": [ [ "t_region_groundcover", 2 ], "t_region_soil" ],
+      "W": [ [ "t_region_groundcover", 2 ], "t_region_soil" ],
+      "T": [ [ "t_region_groundcover", 2 ], "t_region_soil" ],
+      "7": [ "t_region_tree", "t_region_shrub" ],
+      "f": "t_region_soil"
+    },
+    "furniture": {
+      "b": "f_boulder_small",
+      "s": [ [ "f_region_flower", 1 ], [ "f_null", 100 ] ],
+      "B": [ [ "f_region_flower", 1 ], [ "f_null", 100 ] ],
+      "=": [ [ "f_region_flower", 1 ], [ "f_null", 100 ] ],
+      "w": [ [ "f_region_flower", 1 ], [ "f_null", 100 ] ],
+      ",": [ [ "f_region_flower", 1 ], [ "f_null", 100 ] ],
+      ";": [ [ "f_region_flower", 1 ], [ "f_null", 100 ] ],
+      ".": [ [ "f_region_flower", 1 ], [ "f_null", 100 ] ]
+    },
+    "nested": { "6": { "chunks": [ [ "null", 1 ] ] } }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "[Innawood] Overwrite trailhead palette to remove modern items"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The `trailhead` palette still contained modern buildings, meaning you could occasionally get signs and benches Innawood. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Overwrite the `trailhead` palette to remove all references to toilets, benches, windows, etc. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Teleported to some trailheads didn't see anything modern.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
