### PR TITLE
Refugee Center Teamster be able to self-defend themselves.

### DIFF
--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
@@ -6,7 +6,7 @@
     "name_suffix": "Teamster",
     "class": "NC_TEAMSTER",
     "attitude": 0,
-    "mission": 3,
+    "mission": 7,
     "death_eocs": [ "GODCO_TRADER_MISSION_DEATHFAIL" ],
     "chat": "TALK_FREE_MERCHANT_TEAMSTER",
     "faction": "free_merchants"


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Found out the teamster has `"mission": 3`, which is meant for shopkeepers. For some reason it makes them not able to defend themselves and also they dont sell anything so why it got that? So i changed it.


#### Describe the solution

3 --> 7

#### Describe alternatives you've considered
None

#### Testing
They actually walks around and shoots at the zeds during the back bay zed mission as opposed to them standing there waiting to die by zombies.
<img width="847" height="841" alt="Screenshot_20260609_155538" src="https://github.com/user-attachments/assets/974e4f9b-24ab-490f-b3c2-6e06d7f3e070" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
