### PR TITLE
Add dylibbundler dep to MacOS docs

### DIFF
--- a/doc/c++/COMPILING.md
+++ b/doc/c++/COMPILING.md
@@ -611,6 +611,10 @@ The Cataclysm source is compiled using `make`.
 
 In addition to the options above, there is an `app` make target which will package the tiles build into `Cataclysm.app`, a complete tiles build in a Mac application that can run without Terminal.
 
+For Homebrew, install `dylibbundler` before using the `app` target:
+
+    brew install dylibbundler
+
 For more info, see the comments in the [Makefile](../../Makefile).
 
 ### Make examples


### PR DESCRIPTION
#### Summary
Build "Document dylibbundler for macOS app builds"

#### Purpose of change

Closes #76616.

The macOS `app` target uses `dylibbundler`, but the developer docs did not mention installing it.

#### Describe the solution

Add a Homebrew install command for `dylibbundler` next to the `app` target docs.

#### Describe alternatives you've considered

N/A

#### Testing

N/A

#### Additional context

N/A