### PR TITLE
Fix SDL3 tint rows after sprite shader draws

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -14,6 +14,7 @@
 #include <optional>
 #include <set>
 #include <sstream>
+#include <stdexcept>
 #include <tuple>
 #include <unordered_set>
 #include <variant>
@@ -1151,6 +1152,19 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
             // dawn/dusk light, etc). Tint eligibility and color were precomputed
             // in the per-tile prepass above; row_tinted holds only eligible tiles.
             if( !row_tinted.empty() ) {
+#if SDL_MAJOR_VERSION >= 3
+                // Sprite rendering can leave a variant shader bound across same-variant
+                // runs. The tint overlay is plain renderer geometry/copy work, so it must
+                // start from null GPU render state or SDL3 may apply the sprite shader to
+                // only part of a row depending on which sprite path was hit first.
+                if( cata_shader::variant_pass *vp = get_shared_variant_pass() ) {
+                    if( !vp->flush() ) {
+                        display_buffer_scope_signal_recovery_required();
+                        throw std::runtime_error(
+                            "cata_tiles::draw: variant_pass flush failed before tint overlay; renderer in undefined state" );
+                    }
+                }
+#endif
                 const int zlev_base = ( cur_zlevel - center.z() ) * zlevel_height;
                 if( iso ) {
                     // Iso: flat tint rect over the tile footprint (unchanged


### PR DESCRIPTION
#### Summary
Bugfixes "Fix SDL3 colored light tint rows"

#### Purpose of change

SDL3 colored light tinting could fail for the left side of a row until a sprite path changed renderer state. This was very visible during dawn and dusk tinting.

Fixes #87539.

#### Describe the solution

Flush the SDL3 tile variant shader state before drawing the colored-light tint overlay. The tint overlay uses plain renderer geometry and texture copies, so it needs a null GPU render state instead of inheriting the sprite shader bind.

#### Describe alternatives you've considered

N/A

#### Testing

Verified in-game during sunset. Broken before, fixed after.

#### Additional context

N/A