### PR TITLE
Remove "Sweetened Coffee Milk"'s "Iced Coffee" conditional_names

### DIFF
--- a/data/json/items/comestibles/drink.json
+++ b/data/json/items/comestibles/drink.json
@@ -360,7 +360,7 @@
     "name": { "str_sp": "sweetened coffee substitute with milk" },
     "calories": 88,
     "extend": { "flags": [ "EATEN_COLD" ] },
-    "description": "The morning ritual of the post-apocalyptic world.  Brewed from the Kentucky coffeetree, this drink has no actual caffeine, but serves as a replacement for those who dearly miss the aroma of real coffee.",
+    "description": "The morning ritual of the post-apocalyptic world.  Brewed from the Kentucky coffeetree, this drink has no actual caffeine, but serves as a replacement for those who dearly miss the aroma of real coffee. Can also be served cold.",
     "fun": 4
   },
   {
@@ -1751,7 +1751,7 @@
     "name": { "str_sp": "sweetened coffee milk" },
     "calories": 88,
     "extend": { "flags": [ "EATEN_COLD" ] },
-    "description": "Coffee syrup mixed into milk.  It's been the state drink of Rhode Island since 1993.  With added sweetener for those who like it even sweeter.",
+    "description": "Coffee syrup mixed into milk.  It's been the state drink of Rhode Island since 1993.  With added sweetener for those who like it even sweeter. Can also be served cold.",
     "price": "4 USD 90 cent",
     "price_postapoc": "60 cent",
     "fun": 14

--- a/data/json/items/comestibles/drink.json
+++ b/data/json/items/comestibles/drink.json
@@ -360,7 +360,7 @@
     "name": { "str_sp": "sweetened coffee substitute with milk" },
     "calories": 88,
     "extend": { "flags": [ "EATEN_COLD" ] },
-    "description": "The morning ritual of the post-apocalyptic world.  Brewed from the Kentucky coffeetree, this drink has no actual caffeine, but serves as a replacement for those who dearly miss the aroma of real coffee. Can also be served cold.",
+    "description": "The morning ritual of the post-apocalyptic world.  Brewed from the Kentucky coffeetree, this drink has no actual caffeine, but serves as a replacement for those who dearly miss the aroma of real coffee.  Can also be served cold.",
     "fun": 4
   },
   {
@@ -1751,7 +1751,7 @@
     "name": { "str_sp": "sweetened coffee milk" },
     "calories": 88,
     "extend": { "flags": [ "EATEN_COLD" ] },
-    "description": "Coffee syrup mixed into milk.  It's been the state drink of Rhode Island since 1993.  With added sweetener for those who like it even sweeter. Can also be served cold.",
+    "description": "Coffee syrup mixed into milk.  It's been the state drink of Rhode Island since 1993.  With added sweetener for those who like it even sweeter.  Can also be served cold.",
     "price": "4 USD 90 cent",
     "price_postapoc": "60 cent",
     "fun": 14

--- a/data/json/items/comestibles/drink.json
+++ b/data/json/items/comestibles/drink.json
@@ -358,10 +358,9 @@
     "id": "milk_coffee_substitute_sweetened",
     "copy-from": "milk_coffee_substitute",
     "name": { "str_sp": "sweetened coffee substitute with milk" },
-    "conditional_names": [ { "type": "FLAG", "condition": "COLD", "name": { "str_sp": "iced coffee substitute" } } ],
     "calories": 88,
     "extend": { "flags": [ "EATEN_COLD" ] },
-    "description": "The morning ritual of the post-apocalyptic world.  Brewed from the Kentucky coffeetree, this drink has no actual caffeine, but serves as a replacement for those who dearly miss the aroma of real coffee.  Can also be served cold as iced coffee.",
+    "description": "The morning ritual of the post-apocalyptic world.  Brewed from the Kentucky coffeetree, this drink has no actual caffeine, but serves as a replacement for those who dearly miss the aroma of real coffee.",
     "fun": 4
   },
   {
@@ -1750,10 +1749,9 @@
     "id": "milk_coffee_sweetened",
     "copy-from": "milk_coffee",
     "name": { "str_sp": "sweetened coffee milk" },
-    "conditional_names": [ { "type": "FLAG", "condition": "COLD", "name": { "str_sp": "iced coffee" } } ],
     "calories": 88,
     "extend": { "flags": [ "EATEN_COLD" ] },
-    "description": "Coffee syrup mixed into milk.  It's been the state drink of Rhode Island since 1993.  With added sweetener for those who like it even sweeter.  Can also be served cold as iced coffee.",
+    "description": "Coffee syrup mixed into milk.  It's been the state drink of Rhode Island since 1993.  With added sweetener for those who like it even sweeter.",
     "price": "4 USD 90 cent",
     "price_postapoc": "60 cent",
     "fun": 14


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Doesnt make sence that putting coffee flavored milk into fridge then suddently it become coffee. The description says "Coffee syrup mixed into milk", and it should stayed milk

#### Describe the solution
Removed the COLD conditional_names for "Sweetened Coffee Milk" and the coffee substitute variant

#### Describe alternatives you've considered
Change "Coffee Milk" to "Milk Coffee"...? (or "Latte" perhaps.) Will need to rewrite the description tho

#### Testing
none

#### Additional context
none