### PR TITLE
feat(ui): implement non-sticky fast scroll

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5960,6 +5960,12 @@ std::optional<tripoint_bub_ms> game::look_around()
     return result.position;
 }
 
+static bool should_quit_look_around_mode_after_action( const std::string &action )
+{
+    return action == "QUIT" || action == "CONFIRM" || action == "SELECT" || action == "TRAVEL_TO" ||
+           action == "throw_blind" || action == "throw_blind_wielded";
+}
+
 look_around_result game::look_around(
     const bool show_window, tripoint_bub_ms &center, const tripoint_bub_ms &start_point,
     bool has_first_point,
@@ -5979,6 +5985,7 @@ look_around_result game::look_around(
     int &lz = lp.z();
 
     int soffset = get_option<int>( "FAST_SCROLL_OFFSET" );
+    bool sticky_fast_scroll = get_option<bool>( "STICKY_FAST_SCROLL" );
     static bool fast_scroll = false;
 
     std::unique_ptr<ui_adaptor> ui;
@@ -6284,8 +6291,11 @@ look_around_result game::look_around(
             zoom_out();
             mark_main_ui_adaptor_resize();
         }
-    } while( action != "QUIT" && action != "CONFIRM" && action != "SELECT" && action != "TRAVEL_TO" &&
-             action != "throw_blind" && action != "throw_blind_wielded" );
+
+        if( fast_scroll && !sticky_fast_scroll && should_quit_look_around_mode_after_action( action ) ) {
+            fast_scroll = false;
+        }
+    } while( !should_quit_look_around_mode_after_action( action ) );
 
     if( center.z() != old_levz ) {
         here.invalidate_map_cache( old_levz );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2217,6 +2217,16 @@ void options_manager::add_options_interface()
              1, 50, 5
            );
 
+        add( "STICKY_FAST_SCROLL", page_id, to_translation( "Sticky fast scroll" ),
+             to_translation( "If true, fast scroll will stay enabled after looking around." ),
+             true
+           );
+
+        add( "STICKY_FAST_SCROLL_OVERMAP", page_id, to_translation( "Sticky fast scroll (overmap)" ),
+             to_translation( "If true, fast scroll will stay enabled after exiting the overmap." ),
+             true
+           );
+
         add( "MENU_SCROLL", page_id, to_translation( "Centered menu scrolling" ),
              to_translation( "If true, menus will start scrolling in the center of the list, and keep the list centered." ),
              true

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -2066,6 +2066,11 @@ static bool try_travel_to_destination( avatar &player_character, const tripoint_
     return false;
 }
 
+static bool should_quit_overmap_mode_after_action( const std::string &action )
+{
+    return action == "QUIT" || action == "CONFIRM";
+}
+
 static tripoint_abs_omt display()
 {
     // HACK: Remove saved land use code uistate for people who might have accidentally turned it on previously, before it was debug-only
@@ -2169,6 +2174,7 @@ static tripoint_abs_omt display()
     std::string action;
     data.show_explored = true;
     int fast_scroll_offset = get_option<int>( "FAST_SCROLL_OFFSET" );
+    bool sticky_fast_scroll = get_option<bool>( "STICKY_FAST_SCROLL_OVERMAP" );
     std::optional<tripoint_rel_omt> mouse_pos;
     std::chrono::time_point<std::chrono::steady_clock> last_blink = std::chrono::steady_clock::now();
     std::chrono::time_point<std::chrono::steady_clock> last_advance = std::chrono::steady_clock::now();
@@ -2396,7 +2402,12 @@ static tripoint_abs_omt display()
             }
             last_blink = now;
         }
-    } while( action != "QUIT" && action != "CONFIRM" );
+
+        if( uistate.overmap_fast_scroll && !sticky_fast_scroll &&
+            should_quit_overmap_mode_after_action( action ) ) {
+            uistate.overmap_fast_scroll = false;
+        }
+    } while( !should_quit_overmap_mode_after_action( action ) );
     if( !keep_overmap_ui ) {
         ui::omap::force_quit();
     } else {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Ability to disable sticky fast scroll"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Closes #87550 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add two options under QoL features to disable sticky fast scroll in game and on the overmap

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

NA

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested with all combinations of the two options turned on and off.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
NA
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
