### PR TITLE
fix chem_lead_azide and chem_mercury_fulminate

### DIFF
--- a/data/json/items/resources/chemicals.json
+++ b/data/json/items/resources/chemicals.json
@@ -98,17 +98,16 @@
     "type": "ITEM",
     "id": "chem_mercury_fulminate",
     "category": "chems",
-    "price": "9 USD",
-    "price_postapoc": "1 USD",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
     "name": { "str_sp": "mercury fulminate" },
     "symbol": "=",
     "color": "light_gray",
     "description": "A handful of gray powder that is highly sensitive to friction, heat, and shock.  Often used as a primary explosive, and historically in percussion caps and primers for self-contained firearm ammunition.",
     "material": [ "powder" ],
-    "volume": "250 ml",
+    "volume": "1 ml",
     "weight": "442 mg",
-    "//": "density: 4.42 g/cm3",
-    "container": "bottle_plastic_small"
+    "//": "density: 4.42 g/cm3"
   },
   {
     "type": "ITEM",
@@ -154,17 +153,16 @@
     "type": "ITEM",
     "id": "chem_lead_azide",
     "category": "chems",
-    "price": "9 USD",
-    "price_postapoc": "1 USD",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
     "name": { "str_sp": "lead azide" },
     "symbol": "=",
     "color": "white",
     "description": "A handful of white powder that is used in detonators to detonate secondary explosives.  It replaced mercury fulminate in modern ammunition primers.",
     "material": [ "powder" ],
-    "volume": "250 ml",
+    "volume": "1 ml",
     "weight": "471 mg",
-    "//": "density: 4.71 g/cm3",
-    "container": "bottle_plastic_small"
+    "//": "density: 4.71 g/cm3"
   },
   {
     "type": "ITEM",

--- a/data/json/recipes/chem/chemicals.json
+++ b/data/json/recipes/chem/chemicals.json
@@ -350,7 +350,7 @@
       { "proficiency": "prof_inorganic_chemistry" },
       { "proficiency": "prof_organic_chemistry" }
     ],
-    "charges": 958,
+    "result_mult": 958,
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
     "components": [ [ [ "mercury", 22 ] ], [ [ "chem_nitric_acid", 1 ] ], [ [ "chem_ethanol", 206 ] ] ]
@@ -371,7 +371,7 @@
       { "proficiency": "prof_intro_chem_synth" },
       { "proficiency": "prof_inorganic_chemistry" }
     ],
-    "charges": 1168,
+    "result_mult": 1168,
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 30, "LIST" ] ] ],
     "components": [


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #87569
#### Describe the solution
Adjust stats of both materials
#### Additional context
Yet another material that relied on sub-ml volume provided by charges. each unit supposed to be 0.1 ml, but there is no such, so i made it the nearest possible value, which is 1 ml / piece