### PR TITLE
Properly package the evacuation protein bars

### DIFF
--- a/data/json/itemgroups/Food/snacks.json
+++ b/data/json/itemgroups/Food/snacks.json
@@ -526,10 +526,17 @@
   },
   {
     "type": "item_group",
-    "id": "protein_bar_box_small",
+    "id": "full_box_of_evacuation_protein_bar",
     "subtype": "collection",
     "container-item": "box_small",
     "entries": [ { "item": "protein_bar_evac", "count": 12 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "box_of_evacuation_protein_bar",
+    "subtype": "collection",
+    "container-item": "box_small",
+    "entries": [ { "item": "protein_bar_evac", "count": [ 1, 12 ] } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Locations_MapExtras/airdrop.json
+++ b/data/json/itemgroups/Locations_MapExtras/airdrop.json
@@ -23,7 +23,7 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      { "group": "protein_bar_box_small", "prob": 60, "count": [ 1, 8 ] },
+      { "group": "full_box_of_evacuation_protein_bar", "prob": 60, "count": [ 1, 8 ] },
       { "item": "toilet_paper", "count": [ 0, 10 ], "prob": 50 },
       { "group": "soap_packed", "count": [ 0, 1 ], "prob": 50 },
       { "item": "large_tent_kit", "count": [ 0, 3 ], "prob": 50 },
@@ -36,7 +36,7 @@
     "type": "item_group",
     "subtype": "collection",
     "container-item": "box_medium",
-    "entries": [ { "group": "protein_bar_box_small", "count": 8 } ]
+    "entries": [ { "group": "full_box_of_evacuation_protein_bar", "count": 8 } ]
   },
   {
     "id": "bottle_pur_tablets",

--- a/data/json/itemgroups/SUS/evac_shelter.json
+++ b/data/json/itemgroups/SUS/evac_shelter.json
@@ -78,13 +78,7 @@
             "prob": 30
           },
           { "item": "water_clean", "count": [ 6, 12 ], "prob": 20 },
-          {
-            "collection": [
-              { "item": "protein_bar_evac", "count": 12, "container-item": "box_small" },
-              { "item": "protein_bar_evac", "count": [ 8, 12 ], "container-item": "box_small" }
-            ],
-            "prob": 60
-          },
+          { "group": "full_box_of_evacuation_protein_bar", "prob": 60 },
           {
             "collection": [
               { "item": "extinguisher", "prob": 70, "charges": 100 },
@@ -147,13 +141,7 @@
             ],
             "prob": 50
           },
-          {
-            "collection": [
-              { "item": "protein_bar_evac", "count": [ 1, 12 ], "container-item": "box_small" },
-              { "item": "protein_bar_evac", "count": [ 0, 11 ], "container-item": "box_small" }
-            ],
-            "prob": 60
-          },
+          { "group": "box_of_evacuation_protein_bar", "prob": 60 },
           {
             "collection": [
               { "item": "extinguisher", "prob": 50, "charges": 100 },

--- a/data/json/itemgroups/stashes.json
+++ b/data/json/itemgroups/stashes.json
@@ -399,7 +399,7 @@
       { "group": "pemmican_ziploc_gallon_irradiated", "count": 2 },
       { "group": "hardtack_ziploc_gallon", "count": 2 },
       { "group": "can_beans_can_food_big_12", "count": 3 },
-      { "group": "protein_bar_box_small", "count": 4 }
+      { "group": "full_box_of_evacuation_protein_bar", "count": 4 }
     ]
   },
   {

--- a/data/json/mapgen/dumpsite.json
+++ b/data/json/mapgen/dumpsite.json
@@ -63,7 +63,7 @@
         { "item": "oa_ig_rd_metal_trash", "chance": 1 },
         { "item": "hardware", "chance": 1 },
         { "item": "misc_smoking", "chance": 1 },
-        { "item": "protein_bar_box_small", "chance": 1 },
+        { "item": "box_of_evacuation_protein_bar", "chance": 1 },
         { "item": "oa_ig_ash_pile", "chance": 1 }
       ]
     }

--- a/data/json/mapgen/landfill.json
+++ b/data/json/mapgen/landfill.json
@@ -55,7 +55,7 @@
           { "item": "chem_home", "chance": 1 },
           { "item": "hardware", "chance": 2 },
           { "item": "misc_smoking", "chance": 1 },
-          { "item": "protein_bar_box_small", "chance": 1 },
+          { "item": "box_of_evacuation_protein_bar", "chance": 1 },
           { "item": "tools_home", "chance": 1 }
         ]
       }
@@ -115,7 +115,7 @@
           { "item": "chem_home", "chance": 1 },
           { "item": "hardware", "chance": 2 },
           { "item": "misc_smoking", "chance": 1 },
-          { "item": "protein_bar_box_small", "chance": 1 },
+          { "item": "box_of_evacuation_protein_bar", "chance": 1 },
           { "item": "tools_home", "chance": 1 }
         ]
       },
@@ -178,7 +178,7 @@
           { "item": "chem_home", "chance": 1 },
           { "item": "hardware", "chance": 2 },
           { "item": "misc_smoking", "chance": 1 },
-          { "item": "protein_bar_box_small", "chance": 1 },
+          { "item": "box_of_evacuation_protein_bar", "chance": 1 },
           { "item": "tools_home", "chance": 1 }
         ]
       },
@@ -239,7 +239,7 @@
           { "item": "chem_home", "chance": 1 },
           { "item": "hardware", "chance": 2 },
           { "item": "misc_smoking", "chance": 1 },
-          { "item": "protein_bar_box_small", "chance": 1 },
+          { "item": "box_of_evacuation_protein_bar", "chance": 1 },
           { "item": "tools_home", "chance": 1 }
         ]
       },
@@ -302,7 +302,7 @@
           { "item": "chem_home", "chance": 1 },
           { "item": "hardware", "chance": 2 },
           { "item": "misc_smoking", "chance": 1 },
-          { "item": "protein_bar_box_small", "chance": 1 },
+          { "item": "box_of_evacuation_protein_bar", "chance": 1 },
           { "item": "tools_home", "chance": 1 }
         ]
       }

--- a/data/json/mapgen_palettes/dump.json
+++ b/data/json/mapgen_palettes/dump.json
@@ -33,7 +33,7 @@
         { "item": "chem_home", "chance": 5 },
         { "item": "SUS_trash_hardware", "chance": 10 },
         { "item": "misc_smoking", "chance": 10 },
-        { "item": "protein_bar_box_small", "chance": 5 },
+        { "item": "box_of_evacuation_protein_bar", "chance": 5 },
         { "item": "tools_home", "chance": 10 }
       ],
       "&": [
@@ -51,7 +51,7 @@
         { "item": "chem_home", "chance": 1 },
         { "item": "SUS_trash_hardware", "chance": 5 },
         { "item": "misc_smoking", "chance": 5 },
-        { "item": "protein_bar_box_small", "chance": 5 },
+        { "item": "box_of_evacuation_protein_bar", "chance": 5 },
         { "item": "tools_home", "chance": 5 }
       ],
       "P": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
1. The evac shelter SUS itemgroups are (badly) packaging the protein bar inside themselves, see `SUS_evac_shelter_cabinet`, using container-item instead of entry-wrapper.
2. The SUS itemgroups should not try to package protein bars themselves since we already have protein bar itemgroups doing the packaging, namely `protein_bar_box_small`.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Replace the entry in both `SUS_evac_shelter_cabinet` groups with a reference to the protein bar box itemgroup definition.
- Add a box definition, one is for spawning full ones, the other for partially opened ones.
- The "looted" cabinet spawns the latter, the other the former.
- Misc changes to related itemgroups, changing them to the newly created partially looted box when appropriate.
- Changed the itemgroup name for the sake of clarity, no need for migration in any case.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I spawned in the evacuee scenario and checked the cupboards.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Fixes #87568
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
