### PR TITLE
Fix farming supply store sand&soil bags spawning multiple containers, containing 1 unit of sand/soil

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -2057,9 +2057,7 @@
     "subtype": "collection",
     "items": [
       { "group": "sandbag", "prob": 50 },
-      { "group": "sandbag_canvas", "prob": 50 },
       { "group": "earthbag", "prob": 50 },
-      { "group": "earthbag_canvas", "prob": 50 }
     ]
   },
   {

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -2055,10 +2055,7 @@
     "id": "farm_supply_soil_and_sand",
     "type": "item_group",
     "subtype": "collection",
-    "items": [
-      { "group": "sandbag", "prob": 50 },
-      { "group": "earthbag", "prob": 50 }
-    ]
+    "items": [ { "group": "sandbag", "prob": 50 }, { "group": "earthbag", "prob": 50 } ]
   },
   {
     "id": "farm_supply_rocks",

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -2056,9 +2056,10 @@
     "type": "item_group",
     "subtype": "collection",
     "items": [
-      { "item": "material_sand", "prob": 50, "count": 500, "container-item": "bag_canvas" },
       { "group": "sandbag", "prob": 50 },
-      { "item": "material_soil", "prob": 50, "count": 500, "container-item": "bag_canvas" }
+      { "group": "sandbag_canvas", "prob": 50 },
+      { "group": "earthbag", "prob": 50 },
+      { "group": "earthbag_canvas", "prob": 50 },
     ]
   },
   {

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -2059,7 +2059,7 @@
       { "group": "sandbag", "prob": 50 },
       { "group": "sandbag_canvas", "prob": 50 },
       { "group": "earthbag", "prob": 50 },
-      { "group": "earthbag_canvas", "prob": 50 },
+      { "group": "earthbag_canvas", "prob": 50 }
     ]
   },
   {

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -2057,7 +2057,7 @@
     "subtype": "collection",
     "items": [
       { "group": "sandbag", "prob": 50 },
-      { "group": "earthbag", "prob": 50 },
+      { "group": "earthbag", "prob": 50 }
     ]
   },
   {

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -224,6 +224,18 @@
     "items": [ { "item": "material_sand", "count": [ 400, 2500 ] } ]
   },
   {
+    "id": "sandbag_canvas",
+    "type": "item_group",
+    "container-item": "bag_canvas",
+    "items": [ { "item": "material_sand", "count": 500 } ]
+  },
+  {
+    "id": "sandbag_canvas_part",
+    "type": "item_group",
+    "container-item": "bag_canvas",
+    "items": [ { "item": "material_sand", "count": [ 100, 500 ] } ]
+  },
+  {
     "id": "gravelbag",
     "type": "item_group",
     "container-item": "bag_durasack",
@@ -246,6 +258,19 @@
     "type": "item_group",
     "container-item": "bag_durasack",
     "items": [ { "item": "material_soil", "count": [ 1, 3 ] } ]
+  },
+  
+  {
+    "id": "earthbag_canvas",
+    "type": "item_group",
+    "container-item": "bag_canvas",
+    "items": [ { "item": "material_soil", "count": 2 } ]
+  },
+  {
+    "id": "earthbag_canvas_part",
+    "type": "item_group",
+    "container-item": "bag_canvas",
+    "items": [ { "item": "material_soil", "count": [ 1, 2 ] } ]
   },
   {
     "id": "concrete_bag",

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -224,18 +224,6 @@
     "items": [ { "item": "material_sand", "count": [ 400, 2500 ] } ]
   },
   {
-    "id": "sandbag_canvas",
-    "type": "item_group",
-    "container-item": "bag_canvas",
-    "items": [ { "item": "material_sand", "count": 500 } ]
-  },
-  {
-    "id": "sandbag_canvas_part",
-    "type": "item_group",
-    "container-item": "bag_canvas",
-    "items": [ { "item": "material_sand", "count": [ 100, 500 ] } ]
-  },
-  {
     "id": "gravelbag",
     "type": "item_group",
     "container-item": "bag_durasack",
@@ -258,19 +246,6 @@
     "type": "item_group",
     "container-item": "bag_durasack",
     "items": [ { "item": "material_soil", "count": [ 1, 3 ] } ]
-  },
-  
-  {
-    "id": "earthbag_canvas",
-    "type": "item_group",
-    "container-item": "bag_canvas",
-    "items": [ { "item": "material_soil", "count": 2 } ]
-  },
-  {
-    "id": "earthbag_canvas_part",
-    "type": "item_group",
-    "container-item": "bag_canvas",
-    "items": [ { "item": "material_soil", "count": [ 1, 2 ] } ]
   },
   {
     "id": "concrete_bag",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix Farming Supply Store Sand/Soil Bag Spawns"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Farming Supply Store was spawning multiple bags of 1 sand or 1 soil each, as reported in #87535 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Replacing spawn table entries for Items and pointing them to item groups. Sandbag and Soilbag in durable plastic bags which are commonly found in Hardware/Home Improvement stores

Reference from Google image search of "soil bag"
<img width="698" height="453" alt="image" src="https://github.com/user-attachments/assets/56dcfdb2-caf6-4432-94c9-4b2e0765af7d" />


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

No alternatives really exist but to correct how the spawns were setup to avoid container-spam

#### Testing

Spawned new world and teleported to Farming Supply Store. Verified that no more container-spam existed, and packaged bags were correctly spawning

#### Additional context
BEFORE FIX
<img width="849" height="319" alt="image" src="https://github.com/user-attachments/assets/84ca374d-3f7f-4dcb-b152-ca0b35526011" />
AFTER FIX (Please disregard canvas bags. These have not been included as there exists no commercially available sand or soil in canvas bags)
<img width="553" height="253" alt="image" src="https://github.com/user-attachments/assets/fd62291c-41aa-4546-a745-e07bbbc11669" />


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
