### PR TITLE
Craftable Luties

### DIFF
--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -499,14 +499,24 @@
     "skills_required": [ [ "gun", 2 ] ],
     "difficulty": 5,
     "time": "16 h",
-    "book_learn": [ [ "text_gunsmith", 3 ], [ "textbook_anarch", 4], [ "manual_smg", 4 ] ],
+    "book_learn": [ [ "text_gunsmith", 3 ], [ "textbook_anarch", 4 ], [ "manual_smg", 4 ] ],
     "qualities": [ { "id": "DRILL", "level": 3 }, { "id": "SAW_M", "level": 2 }, { "id": "HAMMER", "level": 3 } ],
-    "tools": [ [ [ "metal_file", -1 ] ], [ [ "angle_grinder", 100 ] ], [ [ "belt_grinder", 100 ] ], [ [ "pin_reamer", -1 ] ], [ [ "bench_vise", -1 ] ] ],
-    "proficiencies": [
-      { "proficiency": "prof_gunsmithing_improv" }, 
-      { "proficiency": "prof_gunsmithing_basic" }
+    "tools": [
+      [ [ "metal_file", -1 ] ],
+      [ [ "angle_grinder", 100 ] ],
+      [ [ "belt_grinder", 100 ] ],
+      [ [ "pin_reamer", -1 ] ],
+      [ [ "bench_vise", -1 ] ]
     ],
-    "components": [ [ [ "pipe", 2 ] ], [ [ "sheet_metal", 5 ] ], [ [ "nuts_bolts", 15 ] ], [ [ "scrap", 33 ] ], [ [ "qt_wire", 1 ] ], [ [ "spring_medium", 1 ] ] ]
+    "proficiencies": [ { "proficiency": "prof_gunsmithing_improv" }, { "proficiency": "prof_gunsmithing_basic" } ],
+    "components": [
+      [ [ "pipe", 2 ] ],
+      [ [ "sheet_metal", 5 ] ],
+      [ [ "nuts_bolts", 15 ] ],
+      [ [ "scrap", 33 ] ],
+      [ [ "qt_wire", 1 ] ],
+      [ [ "spring_medium", 1 ] ]
+    ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -528,14 +528,24 @@
     "skills_required": [ [ "gun", 2 ] ],
     "difficulty": 5,
     "time": "16 h",
-    "book_learn": [ [ "text_gunsmith", 3 ], [ "textbook_anarch", 4], [ "manual_smg", 4 ] ],
+    "book_learn": [ [ "text_gunsmith", 3 ], [ "textbook_anarch", 4 ], [ "manual_smg", 4 ] ],
     "qualities": [ { "id": "DRILL", "level": 3 }, { "id": "SAW_M", "level": 2 }, { "id": "HAMMER", "level": 3 } ],
-    "tools": [ [ [ "metal_file", -1 ] ], [ [ "angle_grinder", 100 ] ], [ [ "belt_grinder", 100 ] ], [ [ "pin_reamer", -1 ] ], [ [ "bench_vise", -1 ] ] ],
-    "proficiencies": [
-      { "proficiency": "prof_gunsmithing_improv" }, 
-      { "proficiency": "prof_gunsmithing_basic" }
+    "tools": [
+      [ [ "metal_file", -1 ] ],
+      [ [ "angle_grinder", 100 ] ],
+      [ [ "belt_grinder", 100 ] ],
+      [ [ "pin_reamer", -1 ] ],
+      [ [ "bench_vise", -1 ] ]
     ],
-    "components": [ [ [ "pipe", 2 ] ], [ [ "sheet_metal", 5 ] ], [ [ "nuts_bolts", 15 ] ], [ [ "scrap", 33 ] ], [ [ "qt_wire", 1 ] ], [ [ "spring_medium", 1 ] ] ]
+    "proficiencies": [ { "proficiency": "prof_gunsmithing_improv" }, { "proficiency": "prof_gunsmithing_basic" } ],
+    "components": [
+      [ [ "pipe", 2 ] ],
+      [ [ "sheet_metal", 5 ] ],
+      [ [ "nuts_bolts", 15 ] ],
+      [ [ "scrap", 33 ] ],
+      [ [ "qt_wire", 1 ] ],
+      [ [ "spring_medium", 1 ] ]
+    ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -462,6 +462,63 @@
   },
   {
     "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "smg_9mm",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_RANGED",
+    "skill_used": "fabrication",
+    "skills_required": [ [ "gun", 2 ] ],
+    "difficulty": 5,
+    "time": "16 h",
+    "book_learn": [ [ "text_gunsmith", 3 ], [ "textbook_anarch", 4], [ "manual_smg", 4 ] ],
+    "qualities": [ { "id": "DRILL", "level": 3 }, { "id": "SAW_M", "level": 2 }, { "id": "HAMMER", "level": 3 } ],
+    "tools": [ [ [ "metal_file", -1 ] ], [ [ "angle_grinder", 100 ] ], [ [ "belt_grinder", 100 ] ], [ [ "pin_reamer", -1 ] ], [ [ "bench_vise", -1 ] ] ],
+    "proficiencies": [
+      { "proficiency": "prof_gunsmithing_improv" }, 
+      { "proficiency": "prof_gunsmithing_basic" }
+    ],
+    "components": [ [ [ "pipe", 2 ] ], [ [ "sheet_metal", 5 ] ], [ [ "nuts_bolts", 15 ] ], [ [ "scrap", 33 ] ], [ [ "qt_wire", 1 ] ], [ [ "spring_medium", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "smg_40",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_RANGED",
+    "skill_used": "fabrication",
+    "skills_required": [ [ "gun", 2 ] ],
+    "difficulty": 5,
+    "time": "16 h",
+    "book_learn": [ [ "text_gunsmith", 3 ], [ "textbook_anarch", 4], [ "manual_smg", 4 ] ],
+    "qualities": [ { "id": "DRILL", "level": 3 }, { "id": "SAW_M", "level": 2 }, { "id": "HAMMER", "level": 3 } ],
+    "tools": [ [ [ "metal_file", -1 ] ], [ [ "angle_grinder", 100 ] ], [ [ "belt_grinder", 100 ] ], [ [ "pin_reamer", -1 ] ], [ [ "bench_vise", -1 ] ] ],
+    "proficiencies": [
+      { "proficiency": "prof_gunsmithing_improv" }, 
+      { "proficiency": "prof_gunsmithing_basic" }
+    ],
+    "components": [ [ [ "pipe", 2 ] ], [ [ "sheet_metal", 5 ] ], [ [ "nuts_bolts", 15 ] ], [ [ "scrap", 33 ] ], [ [ "qt_wire", 1 ] ], [ [ "spring_medium", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "smg_45",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_RANGED",
+    "skill_used": "fabrication",
+    "skills_required": [ [ "gun", 2 ] ],
+    "difficulty": 5,
+    "time": "16 h",
+    "book_learn": [ [ "text_gunsmith", 3 ], [ "textbook_anarch", 4], [ "manual_smg", 4 ] ],
+    "qualities": [ { "id": "DRILL", "level": 3 }, { "id": "SAW_M", "level": 2 }, { "id": "HAMMER", "level": 3 } ],
+    "tools": [ [ [ "metal_file", -1 ] ], [ [ "angle_grinder", 100 ] ], [ [ "belt_grinder", 100 ] ], [ [ "pin_reamer", -1 ] ], [ [ "bench_vise", -1 ] ] ],
+    "proficiencies": [
+      { "proficiency": "prof_gunsmithing_improv" }, 
+      { "proficiency": "prof_gunsmithing_basic" }
+    ],
+    "components": [ [ [ "pipe", 2 ] ], [ [ "sheet_metal", 5 ] ], [ [ "nuts_bolts", 15 ] ], [ [ "scrap", 33 ] ], [ [ "qt_wire", 1 ] ], [ [ "spring_medium", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "briefcase_smg",
     "category": "CC_WEAPON",

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -470,14 +470,24 @@
     "skills_required": [ [ "gun", 2 ] ],
     "difficulty": 5,
     "time": "16 h",
-    "book_learn": [ [ "text_gunsmith", 3 ], [ "textbook_anarch", 4], [ "manual_smg", 4 ] ],
+    "book_learn": [ [ "text_gunsmith", 3 ], [ "textbook_anarch", 4 ], [ "manual_smg", 4 ] ],
     "qualities": [ { "id": "DRILL", "level": 3 }, { "id": "SAW_M", "level": 2 }, { "id": "HAMMER", "level": 3 } ],
-    "tools": [ [ [ "metal_file", -1 ] ], [ [ "angle_grinder", 100 ] ], [ [ "belt_grinder", 100 ] ], [ [ "pin_reamer", -1 ] ], [ [ "bench_vise", -1 ] ] ],
-    "proficiencies": [
-      { "proficiency": "prof_gunsmithing_improv" }, 
-      { "proficiency": "prof_gunsmithing_basic" }
+    "tools": [
+      [ [ "metal_file", -1 ] ],
+      [ [ "angle_grinder", 100 ] ],
+      [ [ "belt_grinder", 100 ] ],
+      [ [ "pin_reamer", -1 ] ],
+      [ [ "bench_vise", -1 ] ]
     ],
-    "components": [ [ [ "pipe", 2 ] ], [ [ "sheet_metal", 5 ] ], [ [ "nuts_bolts", 15 ] ], [ [ "scrap", 33 ] ], [ [ "qt_wire", 1 ] ], [ [ "spring_medium", 1 ] ] ]
+    "proficiencies": [ { "proficiency": "prof_gunsmithing_improv" }, { "proficiency": "prof_gunsmithing_basic" } ],
+    "components": [
+      [ [ "pipe", 2 ] ],
+      [ [ "sheet_metal", 5 ] ],
+      [ [ "nuts_bolts", 15 ] ],
+      [ [ "scrap", 33 ] ],
+      [ [ "qt_wire", 1 ] ],
+      [ [ "spring_medium", 1 ] ]
+    ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Make the three Luty SMG variants craftable"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The reason Luties weren't craftable before was due to lack of certain tools which have by and large been implemented at this point.  Ergo, no reason to have them be uncraftable anymore.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Made a crafting recipe for all three and added it to a few books I thought appropriate.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

My math might be off on the material requirement, but they should be close enough, I rounded up just to be safe.  Still, if someone else has a better idea of what the material cost should be, feel free to let me know.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Made a debug character with the appropriate skills, and spawned the appropriate books.  Crafting recipes appeared as intended.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

If I feel especially motivated I may expand further on homemade SMGs in the future, as there's nothing particularly special about the Luty design other than the fact that it's been codified in writing, it's just a direct blowback SMG.  If anyone has any knowledge about electrochemical rifling, feel free to shoot me a message on the Discord.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
