### PR TITLE
[MoM] Premonition warns you about the Quiet Farmhouse

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
@@ -182,16 +182,23 @@
       { "mapgen_update": "vitrified_sky", "target_var": { "global_val": "vitrified_sky_2" } },
       { "u_location_variable": { "u_val": "vitrifaction_entry" }, "z_adjust": 6 },
       { "u_teleport": { "u_val": "vitrifaction_entry" }, "fail_message": "Oops!", "force": true },
-      {
-        "u_message": "You arrive at the farmhouse, after what feels like an eternity.  It's not quite what you were expecting, but it's very peaceful.",
-        "type": "good",
-        "popup": true
-      },
+      { "run_eocs": "EOC_quietfarm_nearby_popup_welcome_message" },
       { "math": [ "u_vitri_vitrified = 1" ] },
       { "math": [ "u_vitri_glassed = 0" ] },
       { "math": [ "u_vitri_glass_entered = 2" ] },
       { "u_add_effect": "VITRIFYING", "duration": "PERMANENT", "intensity": { "math": [ "u_vitri_vitrified" ] } },
       { "run_eocs": "EOC_vitrified_farm_explore", "time_in_future": "1 minutes" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_quietfarm_nearby_popup_welcome_message",
+    "effect": [
+      {
+        "u_message": "You arrive at the farmhouse, after what feels like an eternity.  It's not quite what you were expecting, but it's very peaceful.",
+        "type": "good",
+        "popup": true
+      }
     ]
   },
   {

--- a/data/mods/MindOverMatter/effectoncondition/eoc_premonition_instances.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_premonition_instances.json
@@ -475,5 +475,51 @@
       },
       { "math": [ "u_government_assassins_sent += 2" ] }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MOM_PREMONITION_QUIET_FARMSTEAD_WARNING",
+    "global": true,
+    "eoc_type": "EVENT",
+    "required_event": "avatar_enters_omt",
+    "condition": {
+      "and": [
+        { "u_has_effect": "effect_clair_premonition" },
+        { "not": { "u_has_effect": "effect_premonition_quiet_farm_limiter" } },
+        { "not": { "u_has_trait": "NOT_GLASS" } },
+        {
+          "or": [
+            { "u_near_om_location": "unvitrified_farm_1", "range": 2 },
+            { "u_near_om_location": "unvitrified_farm_0", "range": 2 }
+          ]
+        }
+      ]
+    },
+    "effect": [
+      {
+        "u_message": "As you approach the farmhouse the hair rises on the back of your neck.  Despite the calm appearance you have a distinct sense of danger here.  Things are not as they seem.",
+        "popup": true
+      },
+      { "u_add_effect": "effect_premonition_quiet_farm_limiter", "duration": "24 hours" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_quietfarm_nearby_popup_welcome_message",
+    "condition": { "not": { "u_has_effect": "effect_clair_premonition" } },
+    "effect": [
+      {
+        "u_message": "You arrive at the farmhouse, after what feels like an eternity.  It's not quite what you were expecting, but it's very peaceful.",
+        "type": "good",
+        "popup": true
+      }
+    ],
+    "false_effect": [
+      {
+        "u_message": "You arrive at the farmhouse, after what feels like an eternity.  Despite the peaceful surroundings, your sense of danger only grows.  Something is very wrong here.",
+        "type": "mixed",
+        "popup": true
+      }
+    ]
   }
 ]

--- a/data/mods/MindOverMatter/effects/effects_other.json
+++ b/data/mods/MindOverMatter/effects/effects_other.json
@@ -39,5 +39,12 @@
     "desc": [ "" ],
     "rating": "good",
     "flags": [ "BLOCK_HUGE_ATTACKS" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_premonition_quiet_farm_limiter",
+    "//": "Hidden effect, used as a limiter",
+    "name": [ "" ],
+    "desc": [ "" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Premonition warns you about the Quiet Farmhouse"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Premonition is the power to let you know if things are a little...off

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

If you have Premonition concentrated on, when you approach the farmhouse you get a message that it's clearly dangerous. Also, the message when you enter it is different.

There's a limiter effect so you don't get the message multiple times, and you never get it again after you solve the puzzle. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
