### PR TITLE
Fix - nanomaterial canister spawning in microlabs

### DIFF
--- a/data/json/mapgen/microlab/microlab_special_tiles.json
+++ b/data/json/mapgen/microlab/microlab_special_tiles.json
@@ -363,7 +363,7 @@
       "palettes": [ "microlab" ],
       "furniture": { "K": "f_rack", "C": "f_machinery_electronic", "A": "f_machinery_heavy" },
       "terrain": { "G": "t_card_science", "`": "t_nanofab", "/": "t_nanofab_body" },
-      "item": { "r": { "item": "standard_template_construct" }, "K": { "item": "nanomaterial","repeat": [ 25, 75 ] } },
+      "item": { "r": { "item": "standard_template_construct" }, "K": { "item": "nanomaterial", "repeat": [ 25, 75 ] } },
       "monster": { "T": { "monster": "mon_turret_rifle", "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 30, 90 ] } ] } } },
       "place_monsters": [ { "monster": "GROUP_LAB", "chance": 2, "x": [ 2, 21 ], "y": [ 2, 21 ], "repeat": [ 1, 5 ] } ],
       "place_monster": [ { "monster": "mon_mech_lifter", "x": 17, "y": 13, "chance": 75 } ]

--- a/data/json/mapgen/microlab/microlab_special_tiles.json
+++ b/data/json/mapgen/microlab/microlab_special_tiles.json
@@ -363,7 +363,7 @@
       "palettes": [ "microlab" ],
       "furniture": { "K": "f_rack", "C": "f_machinery_electronic", "A": "f_machinery_heavy" },
       "terrain": { "G": "t_card_science", "`": "t_nanofab", "/": "t_nanofab_body" },
-      "item": { "r": { "item": "standard_template_construct" }, "K": { "item": "nanomaterial" } },
+      "item": { "r": { "item": "standard_template_construct" }, "K": { "item": "nanomaterial","repeat": [ 25, 75 ] } },
       "monster": { "T": { "monster": "mon_turret_rifle", "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 30, 90 ] } ] } } },
       "place_monsters": [ { "monster": "GROUP_LAB", "chance": 2, "x": [ 2, 21 ], "y": [ 2, 21 ], "repeat": [ 1, 5 ] } ],
       "place_monster": [ { "monster": "mon_mech_lifter", "x": 17, "y": 13, "chance": 75 } ]


### PR DESCRIPTION
…ng 2 canisters to spawn per nanofab lab. Added variable rate for random amount

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix Nanomaterial Canisters only spawning 1, for a total of 2 nanomaterial per lab"

Spawntable for Nanomaterial Canister adjusted, and added variation of spawn amount. Some labs will be poorly stocked and some with a (slight) large amount at best rolls for loot amount. 

This should correct Issue #87588 

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The De-Charge fix appears to have also affected Nanomaterial Canisters. This will allow more than 2 per lab to spawn, and still need to visit several nanofab micro labs to gather enough nanomaterial for high-end equipment.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Current spawn, only spawns 1 in each of the microlab, for a total of 2 nanomaterial canisters per lab. With recipes that take anywhere from 5 nanomaterial to several hundred, it would be impossible to gather enough nanomaterial for even the smallest nanomaterial printer recipe.

This has been corrected to use a variable spawn rate, so some microlabs may have more, some will have very little. Survivors of the Cataclysm may have to locate several of these speciality labs within the wasteland for some of XEDRA's more powerful nanoprinted equipment
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Using a fixed amount to spawn, but that would lead to a predictable amount in each. By having it variable, there's no guarantee if this lab will have a lot, or a little, or somewhere in between. 
Other alternative would be not to fix it, and Survivors would have to locate and find tens if not hundreds of these labs to acquire enough nanomaterial. 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

In Test World, teleported to microlab with Nanofabricator. 
Checked shelving to ensure more than 1 nanomaterial canister spawned.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
BEFORE FIX
<img width="477" height="151" alt="image" src="https://github.com/user-attachments/assets/dc880619-eda3-4532-9170-066a8fb7bf1f" />

AFTER FIX:
<img width="607" height="127" alt="image" src="https://github.com/user-attachments/assets/3e4ea801-7a2c-42b7-a633-42f48f5131b0" />


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
