### PR TITLE
add `set_trap`, `set_terrain`, `set_furniture` dialogie effects, update _set_field

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -605,7 +605,7 @@
     "id": "EOC_PORTAL_SMOKE",
     "effect": [
       { "u_message": "A million tiny pinpricks in space open for an instant, and smoke fills the air.", "type": "bad" },
-      { "u_set_field": "fd_smoke", "outdoor_only": true },
+      { "u_set_field": "fd_smoke", "outdoor_only": true, "radius": 150 },
       { "math": [ "u_ire -= 1" ] }
     ]
   },

--- a/data/mods/MindOverMatter/effectoncondition/eoc_awakening.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_awakening.json
@@ -953,7 +953,7 @@
       { "u_add_effect": "effect_pyrokin_fever_burning", "duration": { "math": [ "ps_str * time(' 45 s')" ] } },
       { "u_add_effect": "effect_pyrokin_overload", "duration": { "math": [ "ps_str * time(' 2 h')" ] } },
       { "u_add_effect": "downed", "duration": { "math": [ "ps_str * time(' 1 s')" ] } },
-      { "u_set_field": "fd_hot_air3", "outdoor_only": true },
+      { "u_set_field": "fd_hot_air3", "outdoor_only": true, "radius": 2 },
       { "math": [ "u_val('stamina') -= 4000" ] }
     ]
   },

--- a/data/mods/desert_region/weather/weather_eoc.json
+++ b/data/mods/desert_region/weather/weather_eoc.json
@@ -164,7 +164,10 @@
     "global": true,
     "condition": { "is_weather": "dust_storm" },
     "deactivate_condition": { "not": { "is_weather": "dust_storm" } },
-    "effect": [ { "u_message": "Dust", "type": "bad" }, { "u_set_field": "fd_dust_storm", "outdoor_only": true, "intensity": 3 } ]
+    "effect": [
+      { "u_message": "Dust", "type": "bad" },
+      { "u_set_field": "fd_dust_storm", "outdoor_only": true, "intensity": 3, "radius": 150 }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -5589,17 +5589,89 @@ Spawn 2 hallucination `portal_person`s, outdoor, 3-5 tiles around the player, fo
 }
 ```
 
+#### `set_trap`
+Spawn a trap around target coordinates.
+
+| Syntax | Optionality | Value  | Info |
+| --- | --- | --- | --- |
+| "set_trap" | **mandatory** | string or [variable object](#variable-object) | id of trap to spawn |
+| "location" | **mandatory** | [variable object](#variable-object) | the trap would spawn from this location |
+| "radius" | optional | int, [variable object](#variable-object) or value between two | default 1; radius in which all traps will be spawned |
+| "square" | optional | boolean | default false; if true, the field spawned will be a square, otherwise it will be a circle |
+
+##### Examples
+Select the area, and spawn bear traps 5 tiles around it
+```jsonc
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PLACE_TRAP",
+    "effect": [
+      { "u_query_tile": "anywhere", "target_var": { "context_val": "pos" }, "message": "Select point" },
+      { "set_trap": "tr_beartrap", "location": { "context_val": "pos" }, "radius": 5 }
+    ]
+  }
+```
+
+#### `set_terrain`
+Spawn a terrain around target coordinates.
+
+| Syntax | Optionality | Value  | Info |
+| --- | --- | --- | --- |
+| "set_terrain" | **mandatory** | string or [variable object](#variable-object) | id of terrain to spawn |
+| "location" | **mandatory** | [variable object](#variable-object) | the trap would spawn from this location |
+| "radius" | optional | int, [variable object](#variable-object) or value between two | default 1; radius in which all terrain will be spawned |
+| "avoid_creatures" | optional | boolean | default false; if true, terrain will not be spawned if some other creature stands on it |
+| "square" | optional | boolean | default false; if true, the field spawned will be a square, otherwise it will be a circle |
+
+##### Examples
+Select the area, and spawn thin ice 5 tiles around it
+```jsonc
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PLACE_TERRAIN",
+    "effect": [
+      { "u_query_tile": "anywhere", "target_var": { "context_val": "pos" }, "message": "Select point" },
+      { "set_terrain": "t_ice_sh_thin", "location": { "context_val": "pos" }, "radius": 5 }
+    ]
+  }
+```
+
+#### `set_furniture`
+Spawn a furniture around target coordinates.
+
+| Syntax | Optionality | Value  | Info |
+| --- | --- | --- | --- |
+| "set_furniture" | **mandatory** | string or [variable object](#variable-object) | id of furniture to spawn |
+| "location" | **mandatory** | [variable object](#variable-object) | the trap would spawn from this location |
+| "radius" | optional | int, [variable object](#variable-object) or value between two | default 1; radius in which all furniture will be spawned |
+| "avoid_creatures" | optional | boolean | default false; if true, furniture will not be spawned if some other creature stands on it |
+| "square" | optional | boolean | default false; if true, the field spawned will be a square, otherwise it will be a circle |
+
+##### Examples
+Select the area, and spawn tables 5 tiles around it
+```jsonc
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PLACE_FURNITURE",
+    "effect": [
+      { "u_query_tile": "anywhere", "target_var": { "context_val": "pos" }, "message": "Select point" },
+      { "set_furniture": "f_table", "location": { "context_val": "pos" }, "radius": 5 }
+    ]
+  }
+```
+
 #### `u_set_field`, `npc_set_field`
-spawn a field in a square around player. it is recommended to not use it in favor of `u_transform_radius` or `u_emit` if possible
+Spawn a field around player or target coordinates.
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- |
 | "u_set_field", "npc_set_field" | **mandatory** | string or [variable object](#variable-object) | id of field to spawn around the player |
-| "intensity" | optional | int, [variable object](#variable-object) or value between two | default 1; intensity of field to spawn |
-| "radius" | optional | int, [variable object](#variable-object) or value between two | default 10000000; radius of a field to spawn |
-| "age" | optional | int, duration, [variable object](#variable-object) or value between two | how long the field would last |
+| "intensity" | optional | int, [variable object](#variable-object) or value between two | default 1; intensity of field to spawn. Each field evaluate intensity separately, so `[1, 5]` would spawn fields of intensity from 1 to 5 |
+| "radius" | optional | int, [variable object](#variable-object) or value between two | default 1; radius of a field to spawn |
+| "age" | optional | int, duration, [variable object](#variable-object) or value between two | default 1 second; how long the field would last. Each field evaluate age separately |
 | "outdoor_only"/ "indoor_only" | optional | boolean | default false; if used, field would be spawned only outside or only inside buildings |
 | "hit_player" | optional | boolean | default true; if field spawn where the player is, process like player stepped on this field |
+| "square" | optional | boolean | default false; if true, the field spawned will be a square, otherwise it will be a circle |
 | "target_var" | optional | [variable object](#variable-object) | if used, the field would spawn from this location instead of you or NPC |
 
 ##### Examples

--- a/src/map.h
+++ b/src/map.h
@@ -2354,6 +2354,7 @@ class map
         // Clips the area to map bounds
         tripoint_range<tripoint_bub_ms> points_in_rectangle(
             const tripoint_bub_ms &from, const tripoint_bub_ms &to ) const;
+        // despite named "radius", returns a square
         tripoint_range<tripoint_bub_ms> points_in_radius(
             const tripoint_bub_ms &center, size_t radius, size_t radiusz = 0 ) const;
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -83,6 +83,7 @@
 #include "item_location.h"
 #include "itype.h"
 #include "kill_tracker.h"
+#include "line.h"
 #include "localized_comparator.h"
 #include "magic.h"
 #include "magic_teleporter_list.h"
@@ -94,8 +95,8 @@
 #include "mapgen_functions.h"
 #include "mapgendata.h"
 #include "martialarts.h"
-#include "math_parser_type.h"
 #include "math_parser_diag_value.h"
+#include "math_parser_type.h"
 #include "memory_fast.h"
 #include "messages.h"
 #include "mission.h"
@@ -142,8 +143,8 @@
 #include "translation_gendered.h"
 #include "translations.h"
 #include "trap.h"
-#include "uilist.h"
 #include "ui_manager.h"
+#include "uilist.h"
 #include "uistate.h"
 #include "units.h"
 #include "veh_type.h"
@@ -7924,39 +7925,136 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
     };
 }
 
+talk_effect_fun_t::func f_set_trap( const JsonObject &jo, std::string_view member,
+                                    std::string_view )
+{
+    str_or_var trap = get_str_or_var( jo.get_member( member ), member, true );
+    var_info location;
+    mandatory( jo, false, "location", location );
+
+    dbl_or_var dov_radius = get_dbl_or_var( jo, "radius", false, 1 );
+    const bool square = jo.get_bool( "square", false );
+
+    return [trap, dov_radius, location, square]( dialogue const & d ) {
+
+        map &here = get_map();
+        const tripoint_abs_ms loc = read_var_value( location, d ).tripoint();
+        const int radius =  dov_radius.evaluate( d );
+        const trap_id tr = trap_id( trap.evaluate( d ) );
+        tripoint_range<tripoint_bub_ms> points( tripoint_bub_ms::zero, tripoint_bub_ms::zero );
+
+        if( square ) {
+            points = points_in_radius( here.get_bub( loc ), radius );
+        } else {
+            points = points_in_radius_circ( here.get_bub( loc ), radius );
+        }
+
+        for( const tripoint_bub_ms &dest : points ) {
+            here.trap_set( dest, tr );
+        }
+    };
+}
+
+talk_effect_fun_t::func f_set_terrain( const JsonObject &jo, std::string_view member,
+                                       std::string_view )
+{
+    str_or_var ter = get_str_or_var( jo.get_member( member ), member, true );
+    var_info location;
+    mandatory( jo, false, "location", location );
+    dbl_or_var dov_radius = get_dbl_or_var( jo, "radius", false, 1 );
+    bool avoid_creatures = jo.get_bool( "avoid_creatures", false );
+    const bool square = jo.get_bool( "square", false );
+
+    return [ter, dov_radius, avoid_creatures, location, square]( dialogue const & d ) {
+
+        map &here = get_map();
+        const tripoint_abs_ms loc = read_var_value( location, d ).tripoint();
+        const int radius =  dov_radius.evaluate( d );
+        const ter_id t = ter_id( ter.evaluate( d ) );
+
+        tripoint_range<tripoint_bub_ms> points( tripoint_bub_ms::zero, tripoint_bub_ms::zero );
+
+        if( square ) {
+            points = points_in_radius( here.get_bub( loc ), radius );
+        } else {
+            points = points_in_radius_circ( here.get_bub( loc ), radius );
+        }
+
+        for( const tripoint_bub_ms &dest : points ) {
+            here.ter_set( dest, t, avoid_creatures );
+        }
+    };
+}
+
+talk_effect_fun_t::func f_set_furniture( const JsonObject &jo, std::string_view member,
+        std::string_view )
+{
+    str_or_var furn = get_str_or_var( jo.get_member( member ), member, true );
+    var_info location;
+    mandatory( jo, false, "location", location );
+    dbl_or_var dov_radius = get_dbl_or_var( jo, "radius", false, 1 );
+    bool avoid_creatures = jo.get_bool( "avoid_creatures", false );
+    const bool square = jo.get_bool( "square", false );
+
+    return [furn, dov_radius, avoid_creatures, location, square]( dialogue const & d ) {
+
+        map &here = get_map();
+        const tripoint_abs_ms loc = read_var_value( location, d ).tripoint();
+        const int radius =  dov_radius.evaluate( d );
+        const furn_id f = furn_id( furn.evaluate( d ) );
+
+        tripoint_range<tripoint_bub_ms> points( tripoint_bub_ms::zero, tripoint_bub_ms::zero );
+
+        if( square ) {
+            points = points_in_radius( here.get_bub( loc ), radius );
+        } else {
+            points = points_in_radius_circ( here.get_bub( loc ), radius );
+        }
+
+        for( const tripoint_bub_ms &dest : points ) {
+            here.furn_set( dest, f, false, avoid_creatures );
+        }
+    };
+}
+
 talk_effect_fun_t::func f_field( const JsonObject &jo, std::string_view member,
                                  std::string_view, bool is_npc )
 {
     str_or_var new_field = get_str_or_var( jo.get_member( member ), member, true );
     dbl_or_var dov_intensity = get_dbl_or_var( jo, "intensity", false, 1 );
     duration_or_var dov_age = get_duration_or_var( jo, "age", false, 1_turns );
-    dbl_or_var dov_radius = get_dbl_or_var( jo, "radius", false, 10000000 );
+    dbl_or_var dov_radius = get_dbl_or_var( jo, "radius", false, 1 );
 
     const bool outdoor_only = jo.get_bool( "outdoor_only", false );
     const bool indoor_only = jo.get_bool( "indoor_only", false );
     const bool hit_player = jo.get_bool( "hit_player", true );
+    const bool square = jo.get_bool( "square", false );
 
     std::optional<var_info> target_var;
     optional( jo, false, "target_var", target_var );
 
     return [new_field, dov_intensity, dov_age, dov_radius, outdoor_only,
-               hit_player, target_var, is_npc, indoor_only]( dialogue & d ) {
+               hit_player, square, target_var, is_npc, indoor_only]( dialogue & d ) {
+
         map &here = get_map();
-
-        int radius = dov_radius.evaluate( d );
-        int intensity = dov_intensity.evaluate( d );
-
+        const int radius = dov_radius.evaluate( d );
+        const field_type_str_id field = field_type_str_id( new_field.evaluate( d ) );
         tripoint_abs_ms target_pos = d.actor( is_npc )->pos_abs();
         if( target_var.has_value() ) {
             target_pos = read_var_value( *target_var, d ).tripoint();
         }
-        for( const tripoint_bub_ms &dest : here.points_in_radius( here.get_bub( target_pos ),
-                radius ) ) {
-            if( ( !outdoor_only || here.is_outside( dest ) ) && ( !indoor_only ||
-                    !here.is_outside( dest ) ) ) {
-                here.add_field( dest, field_type_str_id( new_field.evaluate( d ) ), intensity,
-                                dov_age.evaluate( d ),
-                                hit_player );
+
+        tripoint_range<tripoint_bub_ms> points( tripoint_bub_ms::zero, tripoint_bub_ms::zero );
+        if( square ) {
+            points = points_in_radius( here.get_bub( target_pos ), radius );
+        } else {
+            points = points_in_radius_circ( here.get_bub( target_pos ), radius );
+        }
+
+        for( const tripoint_bub_ms &dest : points ) {
+            if( ( !outdoor_only || here.is_outside( dest ) ) &&
+                ( !indoor_only || !here.is_outside( dest ) ) ) {
+                here.add_field( dest, field, dov_intensity.evaluate( d ), dov_age.evaluate( d ), hit_player );
             }
         }
     };
@@ -8407,6 +8505,9 @@ parsers = {
     { "u_die", "npc_die", jarg::object, &talk_effect_fun::f_die_advanced},
     { "u_spawn_monster", "npc_spawn_monster", jarg::member, &talk_effect_fun::f_spawn_monster },
     { "u_spawn_npc", "npc_spawn_npc", jarg::member, &talk_effect_fun::f_spawn_npc },
+    { "set_trap", jarg::member, &talk_effect_fun::f_set_trap },
+    { "set_terrain", jarg::member, &talk_effect_fun::f_set_terrain },
+    { "set_furniture", jarg::member, &talk_effect_fun::f_set_furniture },
     { "u_set_field", "npc_set_field", jarg::member, &talk_effect_fun::f_field },
     { "u_emit", "npc_emit", jarg::member, &talk_effect_fun::f_emit },
     { "u_teleport", "npc_teleport", jarg::object, &talk_effect_fun::f_teleport },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Proper resolution of #87574
Closes #87574
#### Describe the solution
expose trap, terrain and furniture setting functions to eoc
update set_field function
#### Describe alternatives you've considered
there is also points_on_radius_circ() which i presume allows a 1 tile ring shape, that can be exposed as well; also points_in_radius_where(), which in theory allows all sorts of whack shapes, but making lambdas for it is tricky
#### Testing
```
  {
    "type": "effect_on_condition",
    "id": "EOC_TEST",
    "effect": [
      { "u_query_tile": "anywhere", "target_var": { "context_val": "pos" }, "message": "Select point" },
      { "set_trap": "tr_beartrap", "location": { "context_val": "pos" }, "radius": 3 },
      { "u_set_field": "fd_mechanical_fluid", "radius": 5, "target_var": { "context_val": "pos" } },
      { "set_furniture": "f_table", "location": { "context_val": "pos" }, "radius": 7 },
      { "set_terrain": "t_clay", "location": { "context_val": "pos" }, "radius": 9 }
    ]
  }
```
<img width="674" height="650" alt="image" src="https://github.com/user-attachments/assets/19e3a70d-1a16-4bfc-b505-95700bf1d6c9" />
