### PR TITLE
remove apparently broken stalebot clauses

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,9 +12,6 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - name: get-time
-        run: |
-          echo "time=$(date +%I)" >> $GITHUB_ENV
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # main
         id: stale
         with:
@@ -22,13 +19,12 @@ jobs:
           stale-pr-label: stale
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions. Please do not bump or comment on this issue unless you are actively working on it. Stale issues, and stale issues that are closed are still considered.'
           stale-pr-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions. Please do not bump or comment on this issue unless you are actively working on it. Stale issues, and stale issues that are closed are still considered.'
-          days-before-stale: ${{ contains(fromJson('["01", "02", "03", "04", "05", "06"]'), env.time) && 30 || 15 }}
-          days-before-close: ${{ contains(fromJson('["01", "02", "03", "04", "05", "06"]'), env.time) && 30 || 15 }}
+          days-before-stale: 30
+          days-before-close: 30
           start-date: '2020-05-07'
           operations-per-run: 110
           exempt-issue-labels: 'Accessibility,<Bug>,<Bugfix>,<Crash / Freeze>,Organization: Bounty,Good First Issue,Help Wanted,(P1 - Critical),(P2 - High),(P3 - Medium),(P4 - Low),(P5 - Long-term),(S2 - Confirmed),0.G String Freeze,0.G Feature Freeze,0.G Content Freeze'
           exempt-pr-labels: '<Bug>,<Bugfix>,<Crash / Freeze>,Organization: Bounty,Good First Issue,(P1 - Critical),(P2 - High),(P3 - Medium),(P4 - Low),(P5 - Long-term),(S2 - Confirmed),0.G String Freeze,0.G Feature Freeze,0.G Content Freeze'
-          any-of-labels: ${{ contains(fromJson('["01", "02", "03", "04", "05", "06"]'), env.time) && '' || '<Suggestion / Discussion>' }}
           exempt-all-milestones: true
           exempt-all-assignees: true
       - name: Print outputs


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The goal here was to process "suggestion" labeled issues at an accelerated schedule,  but at some point this stopped working and seems to be preventing closure at all.

What it looks like from the logs is it's treating an empty string as a valid label to match against instead of a nil list as intended.  I'm not totally sure if this was always broken or broken with an upstream change,  but the solution is the same either way,  remove the nice-to-have feature that is causing the breakage

#### Describe the solution
Just fall back to a static time for all issues.