### PR TITLE
feat(ui): maintain highlight position after inventory item use

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2563,6 +2563,14 @@ drop_locations game_menus::inv::pickup( const std::set<tripoint_bub_ms> &targets
     if( info.max_mass != -1_gram ) {
         pick_s.overriden_mass = info.max_mass;
     }
+
+    if( info.highlight ) {
+        // Use `highlight_one_of` instead of `highlight` because
+        // `highlight` doesn't `prepare_layout`, which causes items
+        // to change visual positions after the highlight.
+        pick_s.highlight_one_of( { info.highlight } );
+    }
+
     return pick_s.execute();
 }
 

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -23,6 +23,7 @@
 #include "flexbuffer_json.h"
 #include "game_inventory.h"
 #include "input.h"
+#include "pickup.h"
 #include "input_enums.h"
 #include "inventory.h"
 #include "item.h"
@@ -5012,6 +5013,23 @@ drop_locations pickup_selector::execute()
     return dropped_pos_and_qty;
 }
 
+static item_location get_item_to_highlight_after_use( inventory_column &column,
+        item_location const &loc )
+{
+    bool found = false;
+    for( const inventory_entry *entry : column.get_entries( return_item ) ) {
+        for( const item_location &l : entry->locations ) {
+            if( found ) {
+                return l;
+            }
+            if( l == loc ) {
+                found = true;
+            }
+        }
+    }
+    return item_location::nowhere;
+}
+
 bool pickup_selector::wield( int &count )
 {
     inventory_entry &selected = get_active_column().get_highlighted();
@@ -5027,7 +5045,8 @@ bool pickup_selector::wield( int &count )
 
     if( u.can_wield( *it ).success() ) {
         remove_from_to_use( it );
-        reopen_menu();
+        const item_location next_item = get_item_to_highlight_after_use( get_active_column(), it );
+        reopen_menu( next_item );
         u.assign_activity( wield_activity_actor( it, charges ) );
         return true;
     } else {
@@ -5049,7 +5068,9 @@ bool pickup_selector::wear()
 
     if( u.can_wear( *items.front() ).success() ) {
         remove_from_to_use( items.front() );
-        reopen_menu();
+        const item_location next_item = get_item_to_highlight_after_use( get_active_column(),
+                                        items.front() );
+        reopen_menu( next_item );
         u.assign_activity( wear_activity_actor( items, quantities ) );
         return true;
     } else {
@@ -5059,11 +5080,13 @@ bool pickup_selector::wear()
     return false;
 }
 
-void pickup_selector::reopen_menu()
+void pickup_selector::reopen_menu( const item_location &next_item )
 {
     // copy the member variables to still be valid on call
-    uistate.open_menu = [where = where, to_use = to_use]() {
-        get_player_character().pick_up( game_menus::inv::pickup( where, to_use ) );
+    uistate.open_menu = [where = where, to_use = to_use, next_item]() {
+        Pickup::pick_info pickup_info;
+        pickup_info.highlight = next_item;
+        get_player_character().pick_up( game_menus::inv::pickup( where, to_use, pickup_info ) );
     };
 }
 

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -1192,7 +1192,7 @@ class pickup_selector : public inventory_multiselector
         bool wield( int &count );
         bool wear();
         void remove_from_to_use( item_location &it );
-        void reopen_menu();
+        void reopen_menu( const item_location &next_item );
         const std::set<tripoint_bub_ms> where;
 };
 

--- a/src/pickup.h
+++ b/src/pickup.h
@@ -33,6 +33,8 @@ struct pick_info {
     item_location src_container;
     item_location dst;
 
+    item_location highlight;
+
     int extra_moves_per_distance = 0;
 
     units::volume picked_up_volume = 0_ml;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Preserve highlight location after wearing or wielding from the pickup screen"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Closes #87600

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Find the next item after the worn or wielded item. Reopen the menu with the next item highlighted.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Index based highlighting; location based highlighting reads better.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested with 1 item in the pickup screen, wearing/wielding items from a stack of the same items, wearing/wielding the last item, etc.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
NA
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
