### PR TITLE
Update Jenny's Quest information to clarify what she wants

### DIFF
--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
@@ -571,7 +571,7 @@
     "id": "MISSION_REFUGEE_Jenny_GET_PNEUMATICS",
     "type": "mission_definition",
     "name": { "str": "Find reference material about air rifles for Jenny." },
-    "description": "Find reference material about air rifles.  <color_yellow>A book that has 'Pneumatic' in its name</color> could be the thing she wants. She probably wants a physical copy, if I can find it. ",
+    "description": "Find reference material about air rifles.  <color_yellow>A book that has 'Pneumatic' in its name</color> could be the thing she wants.  She probably wants a physical copy, if I can find it. ",
     "difficulty": 1,
     "value": 0,
     "goal": "MGOAL_FIND_ITEM",

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
@@ -571,7 +571,7 @@
     "id": "MISSION_REFUGEE_Jenny_GET_PNEUMATICS",
     "type": "mission_definition",
     "name": { "str": "Find reference material about air rifles for Jenny." },
-    "description": "Find reference material about air rifles.  <color_yellow>A book that has 'Pneumatic' in its name</color> could be the thing she wants. She probably wants a physical copy, if I can find it ",
+    "description": "Find reference material about air rifles.  <color_yellow>A book that has 'Pneumatic' in its name</color> could be the thing she wants. She probably wants a physical copy, if I can find it. ",
     "difficulty": 1,
     "value": 0,
     "goal": "MGOAL_FIND_ITEM",

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
@@ -571,7 +571,7 @@
     "id": "MISSION_REFUGEE_Jenny_GET_PNEUMATICS",
     "type": "mission_definition",
     "name": { "str": "Find reference material about air rifles for Jenny." },
-    "description": "Find reference material about air rifles.  <color_yellow>A book that has 'Pneumatic' in its name</color> could be the thing she wants.",
+    "description": "Find reference material about air rifles.  <color_yellow>A book that has 'Pneumatic' in its name</color> could be the thing she wants. She probably wants a physical copy, if I can find it ",
     "difficulty": 1,
     "value": 0,
     "goal": "MGOAL_FIND_ITEM",


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Update Jenny's Quest tracker information regarding what she wants"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

In regards to Issue #87604, it isn't very clear that Jenny wants a PHYSICAL copy in game, but the code requires bringing her a physical copy. This changes the quest tracking language to give a hint that she wants a physical copy and not a digital version.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

All we did is add the following to the end of the quest tracker information as a hint. "She probably wants a physical copy, if I can find it"

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Short of finding a way for the code to check and accept a digital storage item containing the book, it's simpler to clarify the goal in the quest tracker information to be more clear that Jenny want's a good ol fashioned book she can reference while designing. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Since it's a simple change to the quest language and doesn't affect any interactions code wise, spawns or anything code related. No testing was performed as we just updated quest information. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
