### PR TITLE
Make sub post process generator type that applies ter_furn_transform

### DIFF
--- a/doc/JSON/OVERMAP.md
+++ b/doc/JSON/OVERMAP.md
@@ -439,6 +439,7 @@ Each sub-generator object has the following fields:
 |    Field              |                                           Description                                 |
 | --------------------- | ------------------------------------------------------------------------------------- |
 | `type`                | Required.  One of the types listed below.                                             |
+| `ter_furn_transform_used` | Used only if `type` is `ter_furn_transform`.                                      |
 | `attempts`            | Number of times this effect is attempted.  Default 0.                                 |
 | `chance`              | Per-attempt probability.  Meaning varies by type (see below).  Default 0.             |
 | `min_intensity`       | Minimum intensity for the effect.  Default 0.                                         |
@@ -493,6 +494,7 @@ falls through to the original per-OMT fresh-roll behavior.  No migration needed.
 | `add_fire`        | Places fire fields.  Chance is computed from `scaling_days_end` (fires stop spawning after that many days since the cataclysm).  `min_intensity`/`max_intensity` control fire strength.  `chance` must be 0 (it is derived internally). |
 | `pre_burn`        | Replaces an entire OMT with burnt terrain variants -- walls become `t_wall_burnt`, floors become `t_floor_burnt`, furniture and items are destroyed.  Chance is computed from `scaling_days_start`/`scaling_days_end` and intensity.  Stairs (GOES_UP/GOES_DOWN) are preserved.  `chance` must be 0 (it is derived internally). |
 | `place_blood`     | Places blood streaks, pools, and splatter.  `chance` is permille [0-1000] per attempt.  Outdoor blood fades over 30 days. |
+| `ter_furn_transform`  | Applies `ter_furn_transform_used` on every tile in map |
 | `aftershock_ruin`  | Runs the Aftershock ruin generator.  All numeric fields are ignored. |
 
 ### Built-in generators

--- a/src/mapgen_post_process.cpp
+++ b/src/mapgen_post_process.cpp
@@ -20,6 +20,7 @@
 #include "item.h"
 #include "item_stack.h"
 #include "json.h"
+#include "magic_ter_furn_transform.h"
 #include "map.h"
 #include "map_scale_constants.h"
 #include "mapdata.h"
@@ -96,6 +97,7 @@ std::string enum_to_string<sub_generator_type>( sub_generator_type data )
         case sub_generator_type::pre_burn: return "pre_burn";
         case sub_generator_type::place_blood: return "place_blood";
         case sub_generator_type::aftershock_ruin: return "aftershock_ruin";
+        case sub_generator_type::ter_furn_transform: return "ter_furn_transform";
         // *INDENT-ON*
         case sub_generator_type::last:
             break;
@@ -136,6 +138,7 @@ void pp_sub_generator::load( const JsonObject &jo )
 {
     mandatory( jo, false, "type", type );
     optional( jo, false, "attempts", attempts, 0 );
+    optional( jo, false, "ter_furn_transform_used", ter_furn_transform_used );
     optional( jo, false, "chance", chance, 0 );
     optional( jo, false, "min_intensity", min_intensity, 0 );
     optional( jo, false, "max_intensity", max_intensity, 0 );
@@ -251,9 +254,21 @@ void pp_sub_generator::check( const std::string &ctx ) const
                           ctx, tname );
             }
             break;
+        case sub_generator_type::ter_furn_transform:
+            if( attempts != 0 || chance != 0 || min_intensity != 0 ||
+                max_intensity != 0 || scaling_days_start != 0 || scaling_days_end != 0 ) {
+                debugmsg( "pp_generator '%s' %s: all numeric fields ignored for this type",
+                          ctx, tname );
+            }
+            break;
         case sub_generator_type::last:
             debugmsg( "pp_generator '%s': invalid sub_generator_type 'last'", ctx );
             break;
+    }
+
+    if( ter_furn_transform_used.has_value() && type != sub_generator_type::ter_furn_transform ) {
+        debugmsg( "pp_generator '%s': 'ter_furn_transform_used' cannot be used outside of 'ter_furn_transform' type",
+                  ctx );
     }
 
     if( min_intensity > max_intensity && max_intensity != 0 ) {
@@ -758,6 +773,19 @@ static void execute_aftershock_ruin( map &md, const tripoint_abs_omt &p,
     }
 }
 
+static void execute_ter_furn_transform( map &md,
+                                        std::list<tripoint_bub_ms> &all_points_in_map,
+                                        const pp_sub_generator &sg )
+{
+    if( !sg.ter_furn_transform_used.has_value() ) {
+        return;
+    }
+
+    for( tripoint_bub_ms current_tile : all_points_in_map ) {
+        sg.ter_furn_transform_used.value()->transform( md, current_tile );
+    }
+}
+
 void pp_sub_decision::serialize( JsonOut &jsout ) const
 {
     jsout.start_array();
@@ -893,6 +921,9 @@ void pp_generator::execute( map &md, const tripoint_abs_omt &p,
                 break;
             case sub_generator_type::aftershock_ruin:
                 execute_aftershock_ruin( md, p, dec );
+                break;
+            case sub_generator_type::ter_furn_transform:
+                execute_ter_furn_transform( md, all_points_in_map, sg );
                 break;
             case sub_generator_type::last:
                 debugmsg( "Invalid sub_generator_type in pp_generator '%s'", id.str() );

--- a/src/mapgen_post_process.h
+++ b/src/mapgen_post_process.h
@@ -25,6 +25,7 @@ enum class sub_generator_type : int {
     pre_burn,
     place_blood,
     aftershock_ruin,
+    ter_furn_transform,
     last
 };
 
@@ -52,7 +53,6 @@ struct enum_traits<pp_sub_generator_scope> {
 // A single sub-generator entry within a pp_generator.
 // Not a generic_factory type -- loaded as an embedded sub-object of pp_generator.
 struct pp_sub_generator {
-    sub_generator_type type = sub_generator_type::bash_damage;
     int attempts = 0;
     int chance = 0;           // per-attempt probability; meaning is type-dependent
     // (percent [0-100] for bash/move, permille [0-1000] for blood,
@@ -61,7 +61,11 @@ struct pp_sub_generator {
     int max_intensity = 0;
     int scaling_days_start = 0;
     int scaling_days_end = 0;
+    sub_generator_type type = sub_generator_type::bash_damage;
     pp_sub_generator_scope scope = pp_sub_generator_scope::omt;
+
+    // only used in sub_generator_type::ter_furn_transform
+    std::optional<ter_furn_transform_id> ter_furn_transform_used;
 
     void load( const JsonObject &jo );
     void check( const std::string &ctx ) const;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Post-process generators are a thing, but barely exposed to json. I figures the good first step would be connecting them to already existing ter_furn_transform
#### Describe the solution
Do exactly it
I still want to figure in which way it can be improved
Also i observed some crash in adjacent code, although didn't figure the reason of it yet
#### Testing
json used for tests (replacing riot damage to not deal with manually placing generators):
```json
  {
    "type": "ter_furn_transform",
    "id": "super_fungalize",
    "terrain": [
      { "result": [ [ "t_fungus", 1 ] ], "valid_flags": [ "DIGGABLE" ] },
      { "result": [ [ "t_shrub_fungal", 2 ], [ "t_marloss", 1 ] ], "valid_flags": [ "SHRUB" ] },
      { "result": [ [ "t_fungus_mound", 1 ] ], "valid_flags": [ "THIN_OBSTACLE" ] },
      { "result": [ [ "t_fungus", 2 ], [ "t_fungus_floor_sup", 1 ] ], "valid_flags": [ "FLAT" ] },
      { "result": [ [ "t_fungus_wall_transformed", 2 ], [ "t_fungus_wall", 1 ] ], "valid_flags": [ "WALL" ] }
    ],
    "furniture": [
      {
        "result": [ [ "f_fungal_mass", 1 ], [ "f_fungal_tangle", 1 ], [ "f_fungal_clump", 1 ] ],
        "valid_flags": [ "ORGANIC" ]
      }
    ]
  },
  {
    "type": "pp_generator",
    "id": "riot_damage",
    "//": "Applied to city buildings via post_process_generators field on oter_type_t.",
    "sub_generators": [ { "type": "ter_furn_transform", "ter_furn_transform_used": "super_fungalize" } ]
  }
```

<img width="2093" height="1366" alt="image" src="https://github.com/user-attachments/assets/85fa1bb5-c4ea-4b57-859d-90e47f1b1ac8" />

#### Additional context
Suggestions?