### PR TITLE
Two new aftershock achievements

### DIFF
--- a/data/mods/aftershock_exoplanet/achievements/achievements.json
+++ b/data/mods/aftershock_exoplanet/achievements/achievements.json
@@ -34,7 +34,7 @@
     "id": "afs_achievement_kill_100_uica_soldiers",
     "type": "achievement",
     "name": { "str": "Disposition Matrix" },
-    "description": "It is a necessary part of what we do.  We wont wake up in 10 years time and magically find a galaxy full of friends and 'welcome back' signs.\n<color_c_dark_gray>  - unknown member of Chancellor's Haaland administration, recorded c2392.",
+    "description": "It is a necessary part of what we do.  We won't wake up in 10 years time and magically find a galaxy full of friends and 'welcome back' signs.\n<color_c_dark_gray> - unknown member of Chancellor's Haaland administration, recorded c2392.",
     "requirements": [
       {
         "event_statistic": "num_avatar_uica_soldier_kills",

--- a/data/mods/aftershock_exoplanet/achievements/achievements.json
+++ b/data/mods/aftershock_exoplanet/achievements/achievements.json
@@ -31,6 +31,36 @@
     ]
   },
   {
+    "id": "afs_achievement_kill_100_uica_soldiers",
+    "type": "achievement",
+    "name": { "str": "Disposition Matrix" },
+    "description": "It is a necessary part of what we do.  We wont wake up in 10 years time and magically find a galaxy full of friends and 'welcome back' signs.\n<color_c_dark_gray>  - unknown member of Chancellor's Haaland administration, recorded c2392.",
+    "requirements": [
+      {
+        "event_statistic": "num_avatar_uica_soldier_kills",
+        "is": ">=",
+        "target": 10,
+        "description": "Eliminate 10 UICA soldiers.",
+        "visible": "when_achievement_completed"
+      }
+    ]
+  },
+  {
+    "id": "afs_achievement_kill_independent_merc",
+    "type": "achievement",
+    "name": { "str": "Rules of Engagement" },
+    "description": "Frei en lefdet.\n<color_c_dark_gray>  - common saying between mercenaries.",
+    "requirements": [
+      {
+        "event_statistic": "num_avatar_independent_merc_kills",
+        "is": ">=",
+        "target": 1,
+        "description": "Eliminate another mercenary.",
+        "visible": "when_achievement_completed"
+      }
+    ]
+  },
+  {
     "id": "afs_achievement_crashed_spaceship",
     "type": "achievement",
     "name": { "str": "Falling Star" },

--- a/data/mods/aftershock_exoplanet/achievements/statistics.json
+++ b/data/mods/aftershock_exoplanet/achievements/statistics.json
@@ -59,6 +59,40 @@
     "event_transformation": "avatar_wields_archeotech_gun"
   },
   {
+    "id": "avatar_kills_independent_merc",
+    "type": "event_transformation",
+    "event_type": "character_kills_character",
+    "value_constraints": {
+      "killer": { "equals_statistic": "avatar_id" },
+      "victim_class": { "equals_any": [ "string", [ "NC_AFS_SOLO", "cryo_hacker" ] ] }
+    },
+    "drop_fields": [ "killer", "victim_class" ]
+  },
+  {
+    "id": "num_avatar_independent_merc_kills",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "avatar_kills_independent_merc",
+    "description": { "str": "independent contractor killed", "str_pl": "independent contractors killed" }
+  },
+  {
+    "id": "avatar_kills_uica_soldier",
+    "type": "event_transformation",
+    "event_type": "character_kills_character",
+    "value_constraints": {
+      "killer": { "equals_statistic": "avatar_id" },
+      "victim_class": { "equals_any": [ "string", [ "augustmoon_security", "uica_ground_officer", "uica_ground_soldier" ] ] }
+    },
+    "drop_fields": [ "killer", "victim_class" ]
+  },
+  {
+    "id": "num_avatar_uica_soldier_kills",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "avatar_kills_uica_soldier",
+    "description": { "str": "dead cop" }
+  },
+  {
     "id": "avatar_max_damage",
     "type": "event_statistic",
     "stat_type": "maximum",

--- a/src/event.h
+++ b/src/event.h
@@ -380,10 +380,11 @@ struct event_spec<event_type::character_kills_monster> {
 
 template<>
 struct event_spec<event_type::character_kills_character> {
-    static constexpr std::array<event_field, 3> fields = {{
+    static constexpr std::array<event_field, 4> fields = {{
             { "killer", cata_variant_type::character_id },
             { "victim", cata_variant_type::character_id },
             { "victim_name", cata_variant_type::string },
+            { "victim_class", cata_variant_type::string },
         }
     };
 };

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2836,7 +2836,7 @@ bool game::is_game_over()
         Creature *player_killer = u.get_killer();
         if( player_killer && player_killer->as_character() ) {
             events().send<event_type::character_kills_character>(
-                player_killer->as_character()->getID(), u.getID(), u.get_name() );
+                player_killer->as_character()->getID(), u.getID(), u.get_name(), "" );
         }
         events().send<event_type::character_dies>( u.getID() );
         events().send<event_type::avatar_dies>();

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3297,7 +3297,8 @@ void npc::die( map *here, Creature *nkiller )
     }
 
     if( Character *ch = dynamic_cast<Character *>( killer ) ) {
-        get_event_bus().send<event_type::character_kills_character>( ch->getID(), getID(), get_name() );
+        get_event_bus().send<event_type::character_kills_character>( ch->getID(), getID(), get_name(),
+                myclass.c_str() );
     }
     Character &player_character = get_player_character();
     if( killer == &player_character ) {

--- a/tests/memorial_test.cpp
+++ b/tests/memorial_test.cpp
@@ -128,7 +128,7 @@ TEST_CASE( "memorials", "[memorial]" )
 
     check_memorial<event_type::character_kills_character>(
         m, b, "Killed an innocent person, victim_name, in cold blood and felt terrible "
-        "afterwards.", ch, ch2, "victim_name" );
+        "afterwards.", ch, ch2, "victim_name", "victim_class" );
 
     check_memorial<event_type::character_kills_monster>(
         m, b, "Killed a Kevlar hulk.", ch, mon, 0 );


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Achievements related to fighting NPC factions."

#### Purpose of change
Simple prep work for content that involves fighting NPCs. Lets the character_kills_character event record the classes of the dying npcs, and use that to give achievements. 

#### Describe the solution
Theres two new achievements here:

Rules of engagement: For fighting independent mercs.
Disposition Matrix: For fighting UICA.

#### Testing
Tested the Rules of engagement event applied.