### PR TITLE
Move vanity traits to cosmetic category

### DIFF
--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -94,6 +94,7 @@
     "starting_trait": true,
     "valid": false,
     "player_display": true,
+    "vanity": true,
     "variants": [
       { "id": "black", "name": { "str": "Hair: black, crew-cut" }, "description": "Crewcut black hair style.", "weight": 1 },
       {
@@ -157,6 +158,7 @@
     "starting_trait": true,
     "valid": false,
     "player_display": true,
+    "vanity": true,
     "variants": [
       { "id": "black", "name": { "str": "Hair: black, afro" }, "description": "'Fro black hair style.", "weight": 1 },
       { "id": "blond", "name": { "str": "Hair: blond, afro" }, "description": "'Fro blond hair style.", "weight": 1 },
@@ -214,6 +216,7 @@
     "starting_trait": true,
     "valid": false,
     "player_display": true,
+    "vanity": true,
     "variants": [
       {
         "id": "black",
@@ -287,6 +290,7 @@
     "starting_trait": true,
     "valid": false,
     "player_display": true,
+    "vanity": true,
     "variants": [
       {
         "id": "black",
@@ -360,6 +364,7 @@
     "starting_trait": true,
     "valid": false,
     "player_display": true,
+    "vanity": true,
     "variants": [
       {
         "id": "black",
@@ -433,6 +438,7 @@
     "starting_trait": true,
     "valid": false,
     "player_display": true,
+    "vanity": true,
     "variants": [
       {
         "id": "black",
@@ -506,6 +512,7 @@
     "starting_trait": true,
     "valid": false,
     "player_display": true,
+    "vanity": true,
     "variants": [
       {
         "id": "black",
@@ -579,6 +586,7 @@
     "starting_trait": true,
     "valid": false,
     "player_display": true,
+    "vanity": true,
     "variants": [
       {
         "id": "black",
@@ -652,6 +660,7 @@
     "starting_trait": true,
     "valid": false,
     "player_display": true,
+    "vanity": true,
     "variants": [
       { "id": "black", "name": { "str": "Hair: black, mohawk" }, "description": "Mohawk black hair style.", "weight": 1 },
       {
@@ -700,6 +709,7 @@
     "starting_trait": true,
     "valid": false,
     "player_display": true,
+    "vanity": true,
     "variants": [
       { "id": "black", "name": { "str": "Hair: black, mohawk" }, "description": "You have a long black mohawk.", "weight": 1 },
       {
@@ -768,6 +778,7 @@
     "starting_trait": true,
     "valid": false,
     "player_display": true,
+    "vanity": true,
     "variants": [
       {
         "id": "black",

--- a/src/character_creator_ui.h
+++ b/src/character_creator_ui.h
@@ -10,6 +10,7 @@ const int CHARACTER_CREATOR_TAB_COUNT = 7;
 const int CHARACTER_CREATOR_SUMMARY_LINES = 5;
 const ImGuiTableFlags_ CHARACTER_CREATOR_TABLE_FLAGS = ImGuiTableFlags_ScrollY;
 const translation CHARACTER_CREATOR_UILIST_ALL = to_translation( "ALL" );
+const translation CHARACTER_CREATOR_TRAITS_COSMETIC = to_translation( "COSMETIC" );
 const translation CHARACTER_CREATOR_TRAITS_POSITIVE = to_translation( "POSITIVE" );
 const translation CHARACTER_CREATOR_TRAITS_NEGATIVE = to_translation( "NEGATIVE" );
 const translation CHARACTER_CREATOR_TRAITS_NEUTRAL = to_translation( "NEUTRAL" );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2515,7 +2515,11 @@ void character_creator_ui::setup_new_uilist()
                         if( key == CHARACTER_CREATOR_TRAITS_NEGATIVE.translated() && entry_trait->points < 0 ) {
                             return true;
                         }
-                        if( key == CHARACTER_CREATOR_TRAITS_NEUTRAL.translated() && entry_trait->points == 0 ) {
+                        if( key == CHARACTER_CREATOR_TRAITS_NEUTRAL.translated() && entry_trait->points == 0 &&
+                            !entry_trait->vanity ) {
+                            return true;
+                        }
+                        if( key == CHARACTER_CREATOR_TRAITS_COSMETIC.translated() && entry_trait->vanity ) {
                             return true;
                         }
                     }
@@ -2530,6 +2534,8 @@ void character_creator_ui::setup_new_uilist()
                                           CHARACTER_CREATOR_TRAITS_NEGATIVE.translated() );
                 new_uilist->add_category( CHARACTER_CREATOR_TRAITS_NEUTRAL.translated(),
                                           CHARACTER_CREATOR_TRAITS_NEUTRAL.translated() );
+                new_uilist->add_category( CHARACTER_CREATOR_TRAITS_COSMETIC.translated(),
+                                          CHARACTER_CREATOR_TRAITS_COSMETIC.translated() );
                 break;
             }
             case CHARCREATOR_SKILLS: {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Move vanity traits to cosmetic category
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a Cosmetic Tab
Put traits with point cost 0 and not vanity in Neutral
Put traits with vanity true in Cosmetic
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<img width="633" height="208" alt="image" src="https://github.com/user-attachments/assets/ab26f610-3a4a-464d-818d-5c1a286248fd" />

<img width="1093" height="1224" alt="image" src="https://github.com/user-attachments/assets/b476e2d1-9957-4f6b-ba24-db66e399d8b3" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
