### PR TITLE
Fix potassium chloride powder spawning multiple containers

### DIFF
--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -238,7 +238,7 @@
       { "group": "calciumcarbide_small_bottle_part", "prob": 10 },
       { "group": "zincpowder_small_bottle_part", "prob": 10 },
       { "group": "manganesedioxide_small_bottle_part", "prob": 5 },
-      { "item": "chem_potassium_chloride", "prob": 5, "count": [ 100, -1 ] },
+      { "group": "potassiumchloride_small_bottle_part", "prob": 5 },
       { "item": "chem_muriatic_acid", "prob": 15 },
       { "item": "denat_alcohol", "prob": 6 },
       { "item": "methed_alcohol", "prob": 4 },

--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -296,7 +296,7 @@
       [ "chem_saltpetre", 15 ],
       { "item": "chem_nitric_acid", "prob": 15, "charges": [ 1, -1 ] },
       { "item": "chem_muriatic_acid", "prob": 20, "charges": [ 1, -1 ] },
-      { "item": "chem_potassium_chloride", "prob": 5, "count": [ 100, -1 ] },
+      { "group": "potassiumchloride_small_bottle_part", "prob": 5 },
       { "item": "chem_potassium_hydroxide", "prob": 10, "count": [ 100, -1 ] },
       { "item": "chem_zinc_oxide", "prob": 10, "count": [ 100, -1 ] },
       { "group": "chromiumoxide_small_bottle_part", "prob": 10 },

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -110,7 +110,7 @@
     "id": "potassiumchloride_small_bottle_part",
     "type": "item_group",
     "container-item": "bottle_plastic_355ml",
-    "//": "8 oz glass flask, opened with a variable amount",
+    "//": "8 oz bottle, opened with a variable amount",
     "items": [ { "item": "chem_potassium_chloride", "count": [ 2, 355 ] } ]
   },
   {

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -99,7 +99,7 @@
     "//": "8 oz glass flask, opened with a variable amount",
     "items": [ { "item": "chem_zinc_powder", "count": [ 2, 175 ] } ]
   },
-   {
+  {
     "id": "potassiumchloride_small_bottle",
     "type": "item_group",
     "container-item": "bottle_plastic_355ml",

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -109,7 +109,7 @@
   {
     "id": "potassiumchloride_small_bottle_part",
     "type": "item_group",
-    "container-item": "flask_glass",
+    "container-item": "bottle_plastic_355ml",
     "//": "8 oz glass flask, opened with a variable amount",
     "items": [ { "item": "chem_potassium_chloride", "count": [ 2, 355 ] } ]
   },

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -99,6 +99,20 @@
     "//": "8 oz glass flask, opened with a variable amount",
     "items": [ { "item": "chem_zinc_powder", "count": [ 2, 175 ] } ]
   },
+   {
+    "id": "potassiumchloride_small_bottle",
+    "type": "item_group",
+    "container-item": "bottle_plastic_355ml",
+    "//": "8 oz bottle, filled 80% as new",
+    "items": [ { "item": "chem_potassium_chloride", "count": 355 } ]
+  },
+  {
+    "id": "potassiumchloride_small_bottle_part",
+    "type": "item_group",
+    "container-item": "flask_glass",
+    "//": "8 oz glass flask, opened with a variable amount",
+    "items": [ { "item": "chem_potassium_chloride", "count": [ 2, 355 ] } ]
+  },
   {
     "id": "redphosphorus_small_bottle",
     "type": "item_group",

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -740,8 +740,7 @@
     "material": [ "dense_powder" ],
     "volume": "1 ml",
     "weight": "1984 mg",
-    "//": "density: 1.984 g/cm3",
-    "container": "bottle_plastic_small"
+    "//": "density: 1.984 g/cm3"
   },
   {
     "type": "ITEM",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix Potassium Chloride Powder Spawns"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Discovered another malfunctioning spawn, similar to previous powder fixes. Items spawning in multiple containers, each containing a single unit of the chemical
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

As in previous implementations, itemgroup created for the affected powder. Loot Tables with original ITEM spawn were adjusted to use a variably filled container from almost empty to full. Spawn Probability was unchanged, and set to the original prob.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

No alternatives available but to correct the spawning behavior
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Modified Jsons in TEST-CDDA, eventually force spawned Chem Lab to force Potassium Chloride to spawn. Spawning was correct with a single container, containing multiple potassium chloride instead of multiple containers containing one potassium chloride

I did attempt to locate a small lab that displayed the same spawning behavior, but apparently it is one of the rarer chemicals to spawn in microlabs

#### Additional context

BEFORE FIX
<img width="957" height="1046" alt="image" src="https://github.com/user-attachments/assets/fdd5811a-9dca-4ab7-a407-e3e591758ea4" />

AFTER FIX
<img width="543" height="153" alt="image" src="https://github.com/user-attachments/assets/a9b5a228-23ea-4c7e-804d-c8242f11d370" />



<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
