### PR TITLE
Remove the x86 only compiler flag for aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,6 +425,9 @@ endif
 STRIP = $(CROSS)strip
 RC  = $(CROSS)windres
 AR  = $(CROSS)ar
+CXX_TARGET_MACHINE := $(shell $(CXX) -dumpmachine 2>/dev/null)
+# -mcx16 is an x86 compiler flag and breaks ARM/aarch64 builds.
+CX16_TARGETS := x86_64% i686%
 
 LDFLAGS += $(PROFILE)
 
@@ -1041,8 +1044,10 @@ else
 endif
 
 ifeq ($(TARGETSYSTEM),LINUX)
-  CFLAGS += -mcx16
-  CXXFLAGS += -mcx16
+  ifneq ($(filter $(CX16_TARGETS),$(CXX_TARGET_MACHINE)),)
+    CFLAGS += -mcx16
+    CXXFLAGS += -mcx16
+  endif
   BINDIST_EXTRAS += cataclysm-launcher
   ifeq ($(SDL3),1)
     # bundle-sdl3-linux.sh fills bindist/lib/; RUNPATH=$$ORIGIN/lib lets
@@ -1075,8 +1080,10 @@ ifeq ($(TARGETSYSTEM),LINUX)
 endif
 
 ifeq ($(TARGETSYSTEM),CYGWIN)
-  CFLAGS += -mcx16
-  CXXFLAGS += -mcx16
+  ifneq ($(filter $(CX16_TARGETS),$(CXX_TARGET_MACHINE)),)
+    CFLAGS += -mcx16
+    CXXFLAGS += -mcx16
+  endif
   BINDIST_EXTRAS += cataclysm-launcher
   DEFINES += -D_GLIBCXX_USE_C99_MATH_TR1
 endif


### PR DESCRIPTION
#### Summary
Build "Fix Flatpak aarch64 Makefile builds"

#### Purpose of change

The Flatpak build should be able to build CDDA on aarch64. The Makefile unconditionally added `-mcx16` for Linux and Cygwin builds, but that flag is x86-specific, so aarch64 builds fail when the compiler rejects it.

This change keeps the existing x86 behavior while avoiding the unsupported flag on ARM/aarch64 targets.

#### Describe the solution

The Makefile now records the compiler target machine with `$(CXX) -dumpmachine` and defines the target patterns where `-mcx16` is valid. The Linux and Cygwin flag blocks add `-mcx16` only when the compiler target matches an x86 target pattern.

This uses the compiler target rather than the host architecture, so the check also works for cross-compilation.

#### Describe alternatives you've considered

One alternative was to keep patching the Makefile from the Flatpak manifest or build script with `sed`, but that leaves the same issue in other ARM/aarch64 Makefile builds.

Another alternative was to remove `-mcx16` from Linux and Cygwin builds entirely, but that would unnecessarily change the existing x86 build behavior.

Checking `uname -m` was also avoided because it describes the build host, not necessarily the compiler target.

#### Testing

Verified without running build recipes by using a temporary `/tmp` probe Makefile that includes the project Makefile and prints the computed variables.

The probe was run with temporary compiler stubs for:

- `aarch64-unknown-linux-gnu`: confirmed `CFLAGS` and `CXXFLAGS` do not contain `-mcx16`.
- `aarch64-unknown-linux-gnu` through the Makefile clang path: confirmed `CFLAGS` and `CXXFLAGS` do not contain `-mcx16`.
- `x86_64-pc-linux-gnu`: confirmed `CFLAGS` and `CXXFLAGS` still contain `-mcx16`.

Also checked the Cygwin block with the same probe approach:

- x86_64 Cygwin-style target keeps `-mcx16`.
- aarch64 Cygwin-style target does not get `-mcx16`.

#### Additional context

Error in the pipeline: https://github.com/flathub-infra/vorarbeiter/actions/runs/27497743477/job/81274939946#step:17:1278

Related issue: https://github.com/CleverRaven/Cataclysm-DDA/issues/87220