### PR TITLE
Fix black powder volume & weight being excessive for actual use

### DIFF
--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -1132,8 +1132,8 @@
     "color": "dark_gray",
     "description": "A handful of black gunpowder, a mix of saltpeter, charcoal, and sulfur.  Pretty useless for making modern cartridges, as the soot produced when it burns will quickly clog any firearm, but it could be used to make some vicious bombs.",
     "material": [ "powder" ],
-    "volume": "89 ml",
-    "weight": "151 mg",
+    "volume": "1 ml",
+    "weight": "900 mg",
     "container": "bag_plastic_small"
   },
   {

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -1133,7 +1133,7 @@
     "description": "A handful of black gunpowder, a mix of saltpeter, charcoal, and sulfur.  Pretty useless for making modern cartridges, as the soot produced when it burns will quickly clog any firearm, but it could be used to make some vicious bombs.",
     "material": [ "powder" ],
     "volume": "1 ml",
-    "weight": "900 mg",
+    "weight": "1800 mg",
     "container": "bag_plastic_small"
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Adjust Black Powder volume and weight to adjust for de-charge changes"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Per Issue report #87646 , Black Powder volumes are extremely large in relation to what they are used for.
Many other powders are measured in 1ml in the jsons.

Some recipes may need to be updated to properly reflect grain loads for survivor reloading of ammunition, based off the 1ml per 1 unit of Black powder



<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adjust volume and weight per ml to be more in line with the weight of blackpowder per ml. Since generally the load measurement of blackpowder and other gunpowders are in grains, but the jsons don't operate off of grains, it operates off of milliliters, which are also a volumetric measurement, as is measuring in grains. The density of the actual powder itself would change the actual WEIGHT per ml.

Using https://www.muzzleloadingforum.com/threads/blackpowder-density.44034/#post-516284 as a reference that mentions basic density for blackpowder being 1.6-1.8 grams per centimeter cubed, and 1 cubic centimeter, we can define 1ml of blackpowder as weight 1800mg or 1.8 grams.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Since we are just updating the weight/volume fields, no testing needs to be performed. I did verify that the updated weight and volume would not overflow the small plastic bag it SHOULD spawn in, and it falls within maximum weight allowed when filled to maximum volume. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
