### PR TITLE
Fix labyrinth treasure room terminals

### DIFF
--- a/data/json/mapgen/netherum/labyrinth_mapgen_treasure_rooms.json
+++ b/data/json/mapgen/netherum/labyrinth_mapgen_treasure_rooms.json
@@ -12,7 +12,7 @@
         "!vvvvvvvv      vvvvvvvv!",
         "!vvvvvvvv      vvvvvvvv!",
         "!vvvvvvvv      vvvvvvvv!",
-        "!vvvvvvvvvv...Ç((vvvvvv!",
+        "!vvvvvvvvvv...X((vvvvvv!",
         "!vvvvvvvvvvvvvv((vvvvvv!",
         "!vvvvvvvvvvvvvvvvvvvvvv!",
         "!vvvvvv||||++||||vvvvvv!",
@@ -33,8 +33,9 @@
       ],
       "palettes": [ "labyrinthine_base_palette" ],
       "nested": { "1": { "chunks": [ [ "ls_ns_6x6hall_basic", 50 ], [ "ls_ns_6x6hall_fancy", 50 ] ] } },
+      "terrain": { "X": "t_nl_metal_floor" },
       "computers": {
-        "Ç": { "name": "Bridge Controls", "eocs": [ "EOC_LS_Computer" ], "chat_topics": [ "COMP_LS_Bridge_control_deadend_1" ] }
+        "X": { "name": "Bridge Controls", "eocs": [ "EOC_LS_Computer" ], "chat_topics": [ "COMP_LS_Bridge_control_deadend_1" ] }
       }
     }
   },

--- a/data/json/npcs/exodii/netherum/labyrinth_computers.json
+++ b/data/json/npcs/exodii/netherum/labyrinth_computers.json
@@ -134,25 +134,25 @@
     "responses": [
       {
         "text": "Unlock connected doors",
-        "effect": [ { "run_eocs": [ "EOC_LS_Unlock", "EOC_LS_Passcode_Generator" ] }, { "math": [ "npc_LS_door_requests", "=", "1" ] } ],
+        "effect": [ { "run_eocs": [ "EOC_LS_Unlock", "EOC_LS_Passcode_Generator" ] }, { "math": [ "n_LS_door_requests = 1" ] } ],
         "topic": "COMP_LS_Passcode_Door2",
-        "condition": { "math": [ "npc_LS_door_requests", "<", "1" ] }
+        "condition": { "math": [ "n_LS_door_requests < 1" ] }
       },
       {
         "text": "Lock connected doors",
-        "effect": [ { "run_eocs": [ "EOC_LS_Lock" ] }, { "math": [ "npc_LS_door_requests += 1" ] } ],
+        "effect": [ { "run_eocs": [ "EOC_LS_Lock" ] }, { "math": [ "n_LS_door_requests += 1" ] } ],
         "topic": "COMP_LS_Passcode_Door3",
-        "condition": { "math": [ "npc_LS_door_requests", "==", "1" ] }
+        "condition": { "math": [ "n_LS_door_requests == 1" ] }
       },
       {
         "text": "Unlock connected doors",
         "topic": "COMP_LS_Passcode_Door4",
-        "condition": { "math": [ "npc_LS_door_requests", "==", "2" ] }
+        "condition": { "math": [ "n_LS_door_requests == 2" ] }
       },
       {
         "text": "Now all the doors are *gone*, what the hell.",
         "topic": "COMP_LS_Passcode_Door5",
-        "condition": { "math": [ "npc_LS_door_requests", "==", "3" ] }
+        "condition": { "math": [ "n_LS_door_requests == 3" ] }
       },
       { "text": "Log off.", "topic": "TALK_DONE" }
     ]
@@ -192,7 +192,7 @@
         "effect": [
           { "math": [ "u_vitamin('blood') -= -12500" ] },
           { "math": [ "u_vitamin('redcells') -= -12500" ] },
-          { "math": [ "npc_LS_door_requests += 1" ] },
+          { "math": [ "n_LS_door_requests += 1" ] },
           { "run_eocs": [ "EOC_LS_ReallyUnlock" ] }
         ]
       },
@@ -227,55 +227,55 @@
         "text": "Enter the Thief's Passcode to extend the bridge.",
         "effect": [
           { "run_eocs": "EOC_LS_Bridge_control_deadend_1_Passcode0" },
-          { "math": [ "npc_LS_bridge_requests", "=", "1" ] },
+          { "math": [ "n_LS_bridge_requests = 1" ] },
           { "u_lose_trait": "LS_Passcode_0" }
         ],
-        "condition": { "and": [ { "math": [ "npc_LS_bridge_requests", "<", "1" ] }, { "u_has_trait": "LS_Passcode_0" } ] },
+        "condition": { "and": [ { "math": [ "n_LS_bridge_requests < 1" ] }, { "u_has_trait": "LS_Passcode_0" } ] },
         "topic": "COMP_LS_Bridge_control_deadend_1_Extend_passcode0"
       },
       {
         "text": "Enter the Circle of Wings Passcode to extend the bridge.",
         "effect": [
           { "run_eocs": "EOC_LS_Bridge_control_deadend_1_Passcode1" },
-          { "math": [ "npc_LS_bridge_requests", "=", "1" ] },
+          { "math": [ "n_LS_bridge_requests = 1" ] },
           { "u_lose_trait": "LS_Passcode_1" }
         ],
-        "condition": { "and": [ { "math": [ "npc_LS_bridge_requests", "<", "1" ] }, { "u_has_trait": "LS_Passcode_1" } ] },
+        "condition": { "and": [ { "math": [ "n_LS_bridge_requests < 1" ] }, { "u_has_trait": "LS_Passcode_1" } ] },
         "topic": "COMP_LS_Bridge_control_deadend_1_Extend_passcode1"
       },
       {
         "text": "Enter the Hard Nails Passcode to extend the bridge.",
         "effect": [
           { "run_eocs": "EOC_LS_Bridge_control_deadend_1_Passcode2" },
-          { "math": [ "npc_LS_bridge_requests", "=", "1" ] },
+          { "math": [ "n_LS_bridge_requests = 1" ] },
           { "u_lose_trait": "LS_Passcode_2" }
         ],
-        "condition": { "and": [ { "math": [ "npc_LS_bridge_requests", "<", "1" ] }, { "u_has_trait": "LS_Passcode_2" } ] },
+        "condition": { "and": [ { "math": [ "n_LS_bridge_requests < 1" ] }, { "u_has_trait": "LS_Passcode_2" } ] },
         "topic": "COMP_LS_Bridge_control_deadend_1_Extend_passcode2"
       },
       {
         "text": "Enter the Laughing Man Passcode to extend the bridge.",
         "effect": [
           { "run_eocs": "EOC_LS_Bridge_control_deadend_1_Passcode3" },
-          { "math": [ "npc_LS_bridge_requests", "=", "1" ] },
+          { "math": [ "n_LS_bridge_requests = 1" ] },
           { "u_lose_trait": "LS_Passcode_3" }
         ],
-        "condition": { "and": [ { "math": [ "npc_LS_bridge_requests", "<", "1" ] }, { "u_has_trait": "LS_Passcode_3" } ] },
+        "condition": { "and": [ { "math": [ "n_LS_bridge_requests < 1" ] }, { "u_has_trait": "LS_Passcode_3" } ] },
         "topic": "COMP_LS_Bridge_control_deadend_1_Extend_passcode3"
       },
       {
         "text": "Try to extend the bridge to the treasure room.",
-        "condition": { "math": [ "npc_LS_bridge_requests", "<", "1" ] },
+        "condition": { "math": [ "n_LS_bridge_requests < 1" ] },
         "topic": "COMP_LS_Bridge_control_deadend_1_Extend_nopasscode"
       },
       {
         "text": "Retract the bridge",
         "topic": "COMP_LS_Bridge_control_deadend_1_Retract",
-        "condition": { "math": [ "npc_LS_bridge_requests", ">", "1" ] }
+        "condition": { "math": [ "n_LS_bridge_requests", ">", "1" ] }
       },
       {
         "text": "[Computers] Try to find a way to force it.",
-        "condition": { "and": [ { "math": [ "u_skill('computer')", ">", "2" ] }, { "math": [ "npc_LS_bridge_requests", "==", "2" ] } ] },
+        "condition": { "and": [ { "math": [ "u_skill('computer') > 2" ] }, { "math": [ "n_LS_bridge_requests == 2" ] } ] },
         "topic": "COMP_LS_Bridge_control_deadend_1_force"
       },
       { "text": "Log off.", "topic": "TALK_DONE" }
@@ -315,7 +315,7 @@
     "type": "talk_topic",
     "id": "COMP_LS_Bridge_control_deadend_1_Retract",
     "dynamic_line": "&<color_light_green> @User > bridge --update=retract\n<color_light_green>Error: Insufficient confidence.\n<color_light_green>What is done cannot be undone.\n\n<color_light_green> @User > _</color>",
-    "speaker_effect": { "effect": { "math": [ "npc_LS_bridge_requests", "=", "2" ] } }
+    "speaker_effect": { "effect": { "math": [ "n_LS_bridge_requests = 2" ] } }
   },
   {
     "type": "talk_topic",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Labyrinth treasure room terminals work, and don't crash"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The terminals at treasure rooms, from the original playtest, were not assigning vars properly, and were broken after the first use, universally.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Switched `npc_` prefix of the relevant dialogue vars to `n_` so they are saved to the correct terminal.

Fixed a triple-definition for the terminal, which defined furniture, terrain, and computer, and then caused the game to crash when trying to assign an `n_` var

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Teleported around labyrinths and used passcodes.  Only works 1 per terminal, as designed.  But terminals operate independently if there are more than one per map, and if you regenerate the maps by exiting/entering.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
