### PR TITLE
reflavor and tweak labyrinth Laser-Assisted Reading Device CBM

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1763,7 +1763,12 @@
     "description": "Your head is implanted with a low-power reading light and a short-distance laser scanner, allowing you to upload digital images of books straight into your brain's optic lobe and language centers.  When active, you read slightly faster, and can read in the dark.",
     "occupied_bodyparts": [ [ "head", 1 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
-    "enchantments": [ { "condition": "ACTIVE", "values": [ { "value": "READING_SPEED_MULTIPLIER", "multiply": -0.2 }, { "value": "LUMINATION", "add": 10 } ] } ],
+    "enchantments": [
+      {
+        "condition": "ACTIVE",
+        "values": [ { "value": "READING_SPEED_MULTIPLIER", "multiply": -0.2 }, { "value": "LUMINATION", "add": 10 } ]
+      }
+    ],
     "act_cost": "2 J",
     "react_cost": "2 J",
     "time": "1 s"

--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1760,13 +1760,12 @@
     "//": "Only found in netherum labyrinth",
     "type": "bionic",
     "name": { "str": "Laser-Assisted Reading Device" },
-    "description": "Who needs a reading lamp when you don't need your eyes?  Your head has a short-distance laser scanner implant, allowing you to upload digital images of books straight into your brains optic lobe and language centers.  When active, you read slightly faster, and can read in the dark.",
+    "description": "Your head is implanted with a low-power reading light and a short-distance laser scanner, allowing you to upload digital images of books straight into your brain's optic lobe and language centers.  When active, you read slightly faster, and can read in the dark.",
     "occupied_bodyparts": [ [ "head", 1 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
-    "active_flags": [ "READ_IN_DARKNESS" ],
-    "enchantments": [ { "condition": "ACTIVE", "values": [ { "value": "READING_SPEED_MULTIPLIER", "multiply": -0.1 } ] } ],
-    "act_cost": "1 J",
-    "react_cost": "1 J",
+    "enchantments": [ { "condition": "ACTIVE", "values": [ { "value": "READING_SPEED_MULTIPLIER", "multiply": -0.2 }, { "value": "LUMINATION", "add": 10 } ] } ],
+    "act_cost": "2 J",
+    "react_cost": "2 J",
     "time": "1 s"
   },
   {

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -1628,7 +1628,7 @@
     "subtypes": [ "BIONIC_ITEM" ],
     "name": { "str": "Laser-Assisted Reading Device CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "Who needs a reading lamp when you don't need your eyes?  This is a short-distance laser scanner implant which allows one to upload digital images of books straight into your brains optic lobe and language centers.  When active, one can read slightly faster, and can read in the dark.",
+    "description": "This implant serves as a reading light and a short-distance laser scanner, allowing one to upload digital images of books straight into the brain's optic lobe and language centers.  When active, one can read slightly faster, and can read in the dark.",
     "price": "2 kUSD 200 USD",
     "weight": "1000 g",
     "difficulty": 3


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Tweaks the `Laser-Assisted Reading Device CBM`, only found in the labyrinth.  Originally it was just flavored/design as a scanner than kinda worked in the dark.  I like the idea of it being a light+scanner better, with higher power consumption and slightly more benefit.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Turns it from just a scanner to a reading lamp + scanner.  Doubles power consumption.  Doubles the reading bonus.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Keeping the original flavor.  I guess this makes it use-able as just a light, but it's a rather inefficient one, so that's fine with me.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Read with it

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

fixes #87211 (well, really makes it no longer applicable)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
