### PR TITLE
Stop batch crafts vanishing on long unattended steps

### DIFF
--- a/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
+++ b/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
@@ -173,6 +173,8 @@ Each entry in the `"steps"` array is an object with these fields:
 "batch_time_factors": // (Optional)  Same format as recipe-level.
 "attention":          // (Optional)  Either "none" (default) or "unattended".  See "Unattended steps".
 "max_time":           // (Optional)  Duration.  Hard deadline for an unattended step.  Must be > "time".
+                      //             Authored per-unit; the ruin deadline ("max_time" + "grace_period")
+                      //             scales with batch size through "batch_time_factors", like "time".
 "grace_period":       // (Optional)  Duration.  Extra time past "max_time" before the craft is destroyed.
                       //             Only allowed when "max_time" is set.
 "unattend_message":   // (Optional)  Translatable string.  Shown when an unattended step finishes
@@ -253,7 +255,7 @@ When the wall-clock deadline elapses:
 
 - Non-terminal: step advances, distraction fires with `unattend_message` (or a vague log line without a timepiece).  Suppressed if the player is already on this craft.
 - Terminal: craft auto-finalizes at the deadline, so morale, EOCs, heat, and birthday use in-game completion time.
-- `max_time + grace_period` past start: craft is destroyed.
+- `max_time + grace_period` past start: craft is destroyed.  This deadline is batch-scaled the same way as completion, so the ruin window tracks the batch-scaled completion time rather than staying a flat per-unit duration.
 
 If the step's tools or qualities become unavailable, or a charged tool runs short on charges, the step pauses and the deadline slides forward once the requirement is restored.  `crafter_id` is remembered so env-check picks up the crafter's pseudo-tools, bionics, and trait qualities when they are next to the craft.
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1773,11 +1773,24 @@ void craft_stamp_passive_entry( item &craft, const Character &crafter, time_poin
     craft.set_passive_started_at( entry_time );
     craft.set_ready_at( entry_time + time_duration::from_moves( step_moves ) );
     if( cur_step.max_time.has_value() ) {
-        time_duration fail_dur = *cur_step.max_time;
-        if( cur_step.grace_period.has_value() ) {
-            fail_dur += *cur_step.grace_period;
-        }
-        craft.set_fail_at( entry_time + fail_dur );
+        const int batch = craft.get_making_batch_size();
+        const time_duration raw_max = *cur_step.max_time;
+        const time_duration raw_fail = raw_max + cur_step.grace_period.value_or( 0_turns );
+        // Scale max_time+grace by batch like ready_at, ignoring tool/prof
+        // speed.  One apply() call: linear setup offset is not distributive.
+        const int64_t fail_moves = static_cast<int64_t>( cur_step.batch_info.apply(
+                                       static_cast<double>( to_moves<int64_t>( raw_fail ) ), batch ) );
+        const int64_t max_moves = static_cast<int64_t>( cur_step.batch_info.apply(
+                                      static_cast<double>( to_moves<int64_t>( raw_max ) ), batch ) );
+        time_point fail_pt = entry_time + time_duration::from_moves( fail_moves );
+        // Keep ruin strictly after completion; grace window is the marginal
+        // scaled difference, or a floor when there is no grace_period.
+        const int64_t grace_moves = fail_moves - max_moves;
+        const time_duration min_window = grace_moves > 0
+                                         ? time_duration::from_moves( grace_moves )
+                                         : 1_turns;
+        fail_pt = std::max( fail_pt, craft.get_ready_at() + min_window );
+        craft.set_fail_at( fail_pt );
     }
     if( plan.choice == step_choice::set_timer && plan.alarm_offset.has_value() ) {
         craft.set_alarm_at( entry_time + *plan.alarm_offset );

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -642,6 +642,11 @@ void recipe_step::load( const JsonObject &jo, const std::string &recipe_name, in
     mandatory( jo, false, "activity_level", exertion, activity_level_reader{} );
 
     optional( jo, false, "batch_time_factors", batch_info );
+    if( batch_savings::linear *lin = std::get_if<batch_savings::linear>( &batch_info.data ) ) {
+        if( lin->offset > time ) {
+            jo.throw_error( "batch scaling time greater than step time" );
+        }
+    }
     jo.read( "proficiencies", proficiencies );
 
     if( jo.has_member( "components" ) ) {

--- a/tests/craft_attention_test.cpp
+++ b/tests/craft_attention_test.cpp
@@ -34,6 +34,7 @@
 #include "type_id.h"
 
 static const itype_id itype_2x4( "2x4" );
+static const itype_id itype_cudgel( "cudgel" );
 static const itype_id itype_hammer( "hammer" );
 static const itype_id itype_microwave( "microwave" );
 static const itype_id itype_soldering_iron_portable( "soldering_iron_portable" );
@@ -1381,6 +1382,99 @@ TEST_CASE( "craft_actualize_ready_fail_at_precedes_ready",
     craft_resolve_overdue_passive( on_map, calendar::turn + 30_minutes, loc );
 
     CHECK( loc.get_item() == nullptr );
+}
+
+TEST_CASE( "craft_stamp_passive_entry_batch_scales_fail_at",
+           "[craft][attention][fail][batch]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    const recipe &rec = recipe_cudgel_test_timeout_recipe.obj();
+
+    // Single unit: ready_at and fail_at match the per-unit values.
+    SECTION( "batch of one is unchanged" ) {
+        item ingredient( itype_2x4, calendar::turn );
+        item placed( &rec, 1, ingredient );
+        item &on_map = here.add_item( origin, placed );
+        REQUIRE( on_map.is_craft() );
+        REQUIRE( on_map.get_making_batch_size() == 1 );
+        on_map.set_current_step( 1 );
+        on_map.set_crafter_id( u.getID() );
+        on_map.set_step_plans( std::vector<attention_plan>( 2 ) );
+
+        item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+        craft_stamp_passive_entry( on_map, u, calendar::turn, loc );
+
+        // Cure: time 10m -> ready; max_time 20m + grace 5m -> fail 25m.
+        CHECK( on_map.get_ready_at() == calendar::turn + 10_minutes );
+        CHECK( on_map.get_fail_at() == calendar::turn + 25_minutes );
+    }
+
+    // Batch of eight (no batch_time_factors -> none -> x8):
+    //   ready_at = entry + 10m*8 = 80m
+    //   fail_at  = entry + (20m + 5m)*8 = 200m
+    SECTION( "batch of eight scales both deadlines, fail stays after ready" ) {
+        const int batch = 8;
+        item ingredient( itype_2x4, calendar::turn );
+        item placed( &rec, batch, ingredient );
+        item &on_map = here.add_item( origin, placed );
+        REQUIRE( on_map.is_craft() );
+        REQUIRE( on_map.get_making_batch_size() == batch );
+        on_map.set_current_step( 1 );
+        on_map.set_crafter_id( u.getID() );
+        on_map.set_step_plans( std::vector<attention_plan>( 2 ) );
+
+        item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+        craft_stamp_passive_entry( on_map, u, calendar::turn, loc );
+
+        CHECK( on_map.get_ready_at() == calendar::turn + 80_minutes );
+        CHECK( on_map.get_fail_at() == calendar::turn + 200_minutes );
+        // Ruin deadline must stay strictly after completion.
+        CHECK( on_map.get_fail_at() > on_map.get_ready_at() );
+    }
+}
+
+TEST_CASE( "craft_batch_completes_instead_of_vanishing",
+           "[craft][attention][fail][batch]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    const recipe &rec = recipe_cudgel_test_timeout_recipe.obj();
+    const int batch = 8;
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &rec, batch, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+    on_map.set_current_step( 1 );
+    on_map.set_crafter_id( u.getID() );
+    on_map.set_step_plans( std::vector<attention_plan>( 2 ) );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+    craft_stamp_passive_entry( on_map, u, calendar::turn, loc );
+    get_item_wakeups().rebuild_for_item( loc );
+
+    // Past the batch-scaled ready_at (80m) but well before the scaled fail_at
+    // (200m): the step finalizes and spawns the result rather than being
+    // destroyed by a ruin deadline that elapsed before completion.
+    craft_resolve_overdue_passive( on_map, calendar::turn + 81_minutes, loc );
+
+    bool found_cudgel = false;
+    for( const item &it : here.i_at( origin ) ) {
+        if( it.typeId() == itype_cudgel ) {
+            found_cudgel = true;
+        }
+    }
+    CHECK( found_cudgel );
 }
 
 TEST_CASE( "craft_terminal_unattended_liquid_parks_for_collection",


### PR DESCRIPTION
#### Summary
Bugfixes "Batch crafts no longer vanish when an unattended step's timeout is shorter than the batch-scaled craft time"

#### Purpose of change
Fixes #87623. An unattended step's ruin timer (max_time) is a flat per-unit duration, but the step's completion time scales with batch size. Once the batch is big enough that completion lands past the timer, the craft fails before it can finish and the in-progress contents are destroyed.

#### Describe the solution
ready_at already batch-scales; fail_at didn't. Now max_time + grace_period scale through the same batch_time_factors. Scaled as one value, not two, because linear mode's apply() has a setup offset that'd otherwise double-count. Clamped to stay after ready_at in case a slow tool drags completion past the timeout.

Batch 1 is unchanged and scaling only moves the deadline later, so nothing new can vanish.

Also added the linear setup <= step time check to recipe_step::load that root recipes already have; the fix leans on that being true.

#### Describe alternatives you've considered
Scaling fail_at proportional to ready_at, which drags the ruin timer around with your tool and skill speed. Water doesn't evaporate faster because you have a nicer stove.

#### Testing
Two new tests for the scaling and that a batch craft actually completes. Existing craft attention tests pass. Boiled 4L water in-game, got 4L clean water.

#### Additional context
N/A