### PR TITLE
document that only liquid comestibles are counted by charges

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -1109,7 +1109,7 @@ class item : public visitable
 
         /**
          * Return true if this item's type is counted by charges
-         * (true for stackable, ammo, or comestible)
+         * (true for stackable, ammo, or non-solid comestible)
          */
         bool count_by_charges() const;
 


### PR DESCRIPTION


#### Summary
Infrastructure "Document that only non-solid comestibles are counted by charges"

#### Purpose of change

The doc comment on `item::count_by_charges` states that stackable, ammo, and comestible items are counted by charges. This is misleading, because solid comestibles are not counted by charges. This confused me when debugging detergent issues.

#### Describe the solution

Fix the doc comment.

#### Describe alternatives you've considered

N/A

#### Testing

N/A

#### Additional context

N/A
