### PR TITLE
Add Flathub download link to packaging page

### DIFF
--- a/pages/packaging.md
+++ b/pages/packaging.md
@@ -31,4 +31,6 @@ Ncurses and tiles versions are available in the [official repos](https://src.fed
 
 `sudo dnf install cataclysm-dda`
 
+### Flatpak
 
+Download from [Flathub](https://flathub.org/apps/org.cataclysmdda.CataclysmDDA).


### PR DESCRIPTION
#### Summary

Content "Add Flathub download link to packaging page"

#### Purpose of change

The packaging page currently lists several ways to install Cataclysm: Dark Days Ahead, but does not mention the Flatpak package available on Flathub.

This change makes it easier for users who prefer Flatpak to find the official Flathub download page.

#### Describe the solution

Added a new `Flatpak` section to `pages/packaging.md` with a link to the Cataclysm: DDA page on Flathub.

#### Describe alternatives you've considered

Leaving the page unchanged was considered, but adding the Flathub link makes the packaging page more complete and easier to use.

#### Testing

Not run; this is a documentation-only change.