### PR TITLE
fix feather volume and weight

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -720,7 +720,7 @@
     "material": [ "down_feathers" ],
     "flags": [ "NO_SALVAGE" ],
     "volume": "1 ml",
-    "weight": "10 mg"
+    "weight": "1 mg"
   },
   {
     "type": "ITEM",

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -704,8 +704,8 @@
     "description": "A feather from a bird.  Useful for fletching arrows.",
     "material": [ "cotton" ],
     "flags": [ "NO_SALVAGE" ],
-    "volume": "250 ml",
-    "weight": "1 g"
+    "volume": "1 ml",
+    "weight": "10 mg"
   },
   {
     "type": "ITEM",


### PR DESCRIPTION
#### Summary
Bugfixes "Fix feather volume and weight"

#### Purpose of change

This partially fixes #87640. In #87006 and #87008, feathers and down feathers were both changes from charged items with stack size 100 to individual items, but the weight and volume values were left with the same values as the 100 stack. The volume of down feathers was fixed in #87177, but not the weight. Neither the weight nor mass of feathers has been addressed yet.

This makes dealing with feathers produced in butchering really painful, because they easily take up 10s of L from one bird and can require multiple trips to transport.

#### Describe the solution

Reduce feather volume and weight by a factor of 100. Reduce down feather weight by a factor of 10 (we can't do 100 because 1mg is the smallest weight supported for a single item)

#### Describe alternatives you've considered

N/A

#### Testing

Confirmed that butchering one bird produces 30+ L of feathers before this change, and ~1L after.

#### Additional context

This does not address the other problem reported in both #87640 and #87641, that feathers and ashes being decharged makes it very slow to pick up amounts generated in common situations. I'm not sure what the right approach for that is, if there is one.