### PR TITLE
Woodworking axe faults

### DIFF
--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -17,6 +17,7 @@
     "qualities": [ [ "CUT", 1 ], [ "AXE", 3 ], [ "BUTCHER", -36 ] ],
     "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP" ],
     "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "SHEATH_AXE", "NO_SALVAGE" ],
+    "faults": [ { "fault_group": "handle_long" }, { "fault_group": "blade_general_no_tip" } ],
     "//": "Wood axes also lack the ability to hook appropriately in combat, for the same reason they work well against trees.  Straight axe head instead of curved.",
     "weapon_category": [ "GREAT_AXES" ],
     "melee_damage": { "bash": 14, "cut": 28 }
@@ -277,6 +278,7 @@
     "color": "brown",
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "AXE", "level": 1, "speed": 2.2 }, { "id": "BUTCHER", "level": -44 } ],
     "flags": [ "BELT_CLIP", "NONCONDUCTIVE", "SHEATH_AXE" ],
+    "faults": [ { "fault_group": "handle_short" }, { "fault_group": "blade_general_no_tip" } ],
     "weapon_category": [ "HAND_AXES" ],
     "melee_damage": { "bash": 7, "cut": 14 }
   },
@@ -299,6 +301,7 @@
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "AXE", "level": 2, "speed": 1.5 }, { "id": "BUTCHER", "level": -30 } ],
     "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP" ],
     "flags": [ "NONCONDUCTIVE", "SHEATH_AXE" ],
+    "faults": [ { "fault_group": "handle_short" }, { "fault_group": "blade_general_no_tip" } ],
     "melee_damage": { "bash": 12, "cut": 24 }
   },
   {
@@ -318,6 +321,7 @@
     "longest_side": "38 cm",
     "to_hit": { "grip": "weapon", "length": "short", "surface": "line", "balance": "neutral" },
     "flags": [ "DURABLE_MELEE", "BELT_CLIP", "NONCONDUCTIVE", "SHEATH_AXE" ],
+    "faults": [ { "fault_group": "handle_short" }, { "fault_group": "blade_general_no_tip" } ],
     "weapon_category": [ "HAND_AXES" ],
     "qualities": [
       { "id": "CUT", "level": 1 },


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Adds some faults to the woodworking related axe and hatchets.

#### Describe the solution

Gives bronze axe, copper hatchet, hatchet, and wood axe.

#### Describe alternatives you've considered

Nah.

#### Testing
<img width="679" height="643" alt="Screenshot_20260616_101235" src="https://github.com/user-attachments/assets/c3c686e6-1da5-44b7-9c6a-f52deb694f08" />
<img width="732" height="612" alt="Screenshot_20260616_101225" src="https://github.com/user-attachments/assets/8e38bd1a-0105-4795-b2dd-236276d636bf" />
<img width="739" height="593" alt="Screenshot_20260616_101216" src="https://github.com/user-attachments/assets/06159831-0e41-4e21-8985-c46e136255f5" />
<img width="771" height="608" alt="Screenshot_20260616_101207" src="https://github.com/user-attachments/assets/b4970578-e092-4b36-a7ad-633df4f515c4" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
