### PR TITLE
Lose mutation category eoc

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effect_on_condition.json
+++ b/data/mods/Xedra_Evolved/effects/effect_on_condition.json
@@ -120,7 +120,7 @@
     "type": "effect_on_condition",
     "id": "xe_test_remove_category",
     "effect": [
-      { "u_remove_category": "URSINE" }
+      { "u_lose_category": "URSINE" }
     ]
   }
 ]

--- a/data/mods/Xedra_Evolved/effects/effect_on_condition.json
+++ b/data/mods/Xedra_Evolved/effects/effect_on_condition.json
@@ -119,8 +119,6 @@
   {
     "type": "effect_on_condition",
     "id": "xe_test_remove_category",
-    "effect": [
-      { "u_lose_category": "URSINE" }
-    ]
+    "effect": [ { "u_lose_category": "URSINE" } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/effects/effect_on_condition.json
+++ b/data/mods/Xedra_Evolved/effects/effect_on_condition.json
@@ -115,5 +115,12 @@
       },
       { "u_add_trait": "EATER_SIXTH_SENSE" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "xe_test_remove_category",
+    "effect": [
+      { "u_remove_category": "URSINE" }
+    ]
   }
 ]

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -3540,6 +3540,27 @@ mutation, stored in `mutation_id`  context value, is removed from character:
 ```
 
 
+#### `u_lose_category`, `npc_lose_category`
+Character or NPC will have all traits of the specified category removed, if they have them
+
+| Syntax | Optionality | Value  | Info |
+| --- | --- | --- | --- |
+| "u_lose_category" / "npc_lose_category" | **mandatory** | string or [variable object](#variable-object) | id of mutation category to be removed; if character or NPC has no such mutation, nothing happens |
+
+##### Valid talkers:
+
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------ | --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+
+##### Examples
+
+`URSINE` mutations are removed from character:
+```jsonc
+{ "u_lose_category": "URSINE" }
+```
+
+
 #### `u_lose_effect`, `npc_lose_effect`
 Remove effect from character or NPC, if it has one
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -8494,6 +8494,7 @@ parsers = {
     { "u_lose_var", "npc_lose_var", jarg::string, &talk_effect_fun::f_remove_var },
     { "u_add_trait", "npc_add_trait", jarg::member, &talk_effect_fun::f_add_trait },
     { "u_lose_trait", "npc_lose_trait", jarg::member, &talk_effect_fun::f_remove_trait },
+    { "u_lose_category", "npc_lose_category", jarg::member, &talk_effect_fun::f_remove_category },
     { "u_deactivate_trait", "npc_deactivate_trait", jarg::member, &talk_effect_fun::f_deactivate_trait },
     { "u_activate_trait", "npc_activate_trait", jarg::member, &talk_effect_fun::f_activate_trait },
     { "u_mutate", "npc_mutate", jarg::member | jarg::array, &talk_effect_fun::f_mutate },

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3650,7 +3650,7 @@ talk_effect_fun_t::func f_remove_category( const JsonObject &jo,
 {
     str_or_var category = get_str_or_var( jo.get_member( member ), member, true );
 
-    return [is_npc, category]( dialogue const &d ) {
+    return [is_npc, category]( dialogue const & d ) {
         Character *ch = d.actor( is_npc )->get_character();
 
         const mutation_category_id cat_id( category.evaluate( d ) );
@@ -3661,8 +3661,8 @@ talk_effect_fun_t::func f_remove_category( const JsonObject &jo,
             const mutation_branch &branch = mut.obj();
 
             if( std::find( branch.category.begin(),
-               branch.category.end(),
-               cat_id ) != branch.category.end() ) {
+                           branch.category.end(),
+                           cat_id ) != branch.category.end() ) {
                 to_remove.push_back( mut );
             }
         }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3643,6 +3643,34 @@ talk_effect_fun_t::func f_remove_trait( const JsonObject &jo, std::string_view m
     };
 }
 
+talk_effect_fun_t::func f_remove_category( const JsonObject &jo,
+        std::string_view member,
+        std::string_view,
+        bool is_npc )
+{
+    str_or_var category = get_str_or_var( jo.get_member( member ), member, true );
+
+    return [is_npc, category]( dialogue const &d ) {
+        Character *ch = d.actor( is_npc );
+
+        const mutation_category_id cat_id( category.evaluate( d ) );
+
+        std::vector<trait_id> to_remove;
+
+        for( const trait_id &mut : ch->get_mutations() ) {
+            const mutation_branch &branch = mut.obj();
+
+            if( branch.category.count( cat_id ) > 0 ) {
+                to_remove.push_back( mut );
+            }
+        }
+
+        for( const trait_id &mut : to_remove ) {
+            ch->unset_mutation( mut );
+        }
+    };
+}
+
 talk_effect_fun_t::func f_learn_martial_art( const JsonObject &jo, std::string_view member,
         std::string_view, bool is_npc )
 {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3651,7 +3651,7 @@ talk_effect_fun_t::func f_remove_category( const JsonObject &jo,
     str_or_var category = get_str_or_var( jo.get_member( member ), member, true );
 
     return [is_npc, category]( dialogue const &d ) {
-        Character *ch = d.actor( is_npc );
+        Character *ch = d.actor( is_npc )->get_character();
 
         const mutation_category_id cat_id( category.evaluate( d ) );
 
@@ -3660,7 +3660,9 @@ talk_effect_fun_t::func f_remove_category( const JsonObject &jo,
         for( const trait_id &mut : ch->get_mutations() ) {
             const mutation_branch &branch = mut.obj();
 
-            if( branch.category.count( cat_id ) > 0 ) {
+            if( std::find( branch.category.begin(),
+               branch.category.end(),
+               cat_id ) != branch.category.end() ) {
                 to_remove.push_back( mut );
             }
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Remove Mutation Category EOC"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adds the function to remove all traits from a given category at once. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds c++ and a test eoc to prove it works.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned in a new character, gave it all three ursine titled traits, ran the xe_test eoc and no longer had any of the ursine mutations.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
