### PR TITLE
Add Vehicle Shape Variants to Food Truck Freezer and Fridge

### DIFF
--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -591,7 +591,33 @@
     "//": "add looks_like so that it rotates properly in vehicles",
     "looks_like": "minifridge",
     "delete": { "flags": [ "APPLIANCE", "CTRL_ELECTRONIC" ] },
-    "copy-from": "ap_big_portable_fridge"
+    "copy-from": "ap_big_portable_fridge",
+    "variants": [
+      {
+        "id": "up",
+        "label": "Up",
+        "symbols": "H",
+        "symbols_broken": "#"
+      },
+      {
+        "id": "down",
+        "label": "Down",
+        "symbols": "H",
+        "symbols_broken": "#"
+      },
+      {
+        "id": "left",
+        "label": "Left",
+        "symbols": "H",
+        "symbols_broken": "#"
+      },
+      {
+        "id": "right",
+        "label": "Right",
+        "symbols": "H",
+        "symbols_broken": "#"
+      }
+    ]
   },
   {
     "type": "vehicle_part",
@@ -611,7 +637,33 @@
     "//": "add looks_like so that it rotates properly in vehicles",
     "looks_like": "minifridge",
     "delete": { "flags": [ "APPLIANCE", "CTRL_ELECTRONIC" ] },
-    "copy-from": "ap_big_portable_freezer"
+    "copy-from": "ap_big_portable_freezer",
+    "variants": [
+      {
+        "id": "up",
+        "label": "Up",
+        "symbols": "H",
+        "symbols_broken": "#"
+      },
+      {
+        "id": "down",
+        "label": "Down",
+        "symbols": "H",
+        "symbols_broken": "#"
+      },
+      {
+        "id": "left",
+        "label": "Left",
+        "symbols": "H",
+        "symbols_broken": "#"
+      },
+      {
+        "id": "right",
+        "label": "Right",
+        "symbols": "H",
+        "symbols_broken": "#"
+      }
+    ]
   },
   {
     "type": "vehicle_part",

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -619,30 +619,10 @@
     "delete": { "flags": [ "APPLIANCE", "CTRL_ELECTRONIC" ] },
     "copy-from": "ap_big_portable_freezer",
     "variants": [
-      {
-        "id": "up",
-        "label": "Up",
-        "symbols": "H",
-        "symbols_broken": "#"
-      },
-      {
-        "id": "down",
-        "label": "Down",
-        "symbols": "H",
-        "symbols_broken": "#"
-      },
-      {
-        "id": "left",
-        "label": "Left",
-        "symbols": "H",
-        "symbols_broken": "#"
-      },
-      {
-        "id": "right",
-        "label": "Right",
-        "symbols": "H",
-        "symbols_broken": "#"
-      }
+      { "id": "up", "label": "Up", "symbols": "H", "symbols_broken": "#" },
+      { "id": "down", "label": "Down", "symbols": "H", "symbols_broken": "#" },
+      { "id": "left", "label": "Left", "symbols": "H", "symbols_broken": "#" },
+      { "id": "right", "label": "Right", "symbols": "H", "symbols_broken": "#" }
     ]
   },
   {

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -593,30 +593,10 @@
     "delete": { "flags": [ "APPLIANCE", "CTRL_ELECTRONIC" ] },
     "copy-from": "ap_big_portable_fridge",
     "variants": [
-      {
-        "id": "up",
-        "label": "Up",
-        "symbols": "H",
-        "symbols_broken": "#"
-      },
-      {
-        "id": "down",
-        "label": "Down",
-        "symbols": "H",
-        "symbols_broken": "#"
-      },
-      {
-        "id": "left",
-        "label": "Left",
-        "symbols": "H",
-        "symbols_broken": "#"
-      },
-      {
-        "id": "right",
-        "label": "Right",
-        "symbols": "H",
-        "symbols_broken": "#"
-      }
+      { "id": "up", "label": "Up", "symbols": "H", "symbols_broken": "#" },
+      { "id": "down", "label": "Down", "symbols": "H", "symbols_broken": "#" },
+      { "id": "left", "label": "Left", "symbols": "H", "symbols_broken": "#" },
+      { "id": "right", "label": "Right", "symbols": "H", "symbols_broken": "#" }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Add shape variants to food truck fridge/freezer for Sprites"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

While playing, noticed the food truck freezer always pointed to north and has no shape variants. Further experimentation found sprites can be tweaked to align in cardinal directions and rotate correctly in the right order.

This will lay the infrastructure for TileSets that use rotating sprites and allow players to choose what cardinal direction their fridge is facing in a vehicle so they can place it anywhere inside. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adding VARIANTS to vehicle_parts to add additional shapes for tileset selection.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Just leaving it how it was, and always having a freezer point forward even if it's placed along the side of a vehicle.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested modified tile_config.json and modified vehicle_parts.json ingame.

Spawned bus and added 4 freezers and fridges, all facing cardinal directions and drove in a circle. Fridges and Freezers retained correct orientation and rotated correctly.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Before Change
<img width="122" height="119" alt="image" src="https://github.com/user-attachments/assets/c4e37206-dc91-41c7-b1ec-c1772fcb2f38" />
Always pointing forward/north

After change:
<img width="568" height="829" alt="image" src="https://github.com/user-attachments/assets/db7a415a-3afe-4746-98d7-5f29ea4e411c" />
<img width="891" height="535" alt="image" src="https://github.com/user-attachments/assets/39025e61-6618-4560-8253-5c36a6242401" />
<img width="560" height="804" alt="image" src="https://github.com/user-attachments/assets/973b49cb-8fd1-4be4-9327-b6956158d464" />
<img width="890" height="491" alt="image" src="https://github.com/user-attachments/assets/956c2cb0-2e34-4ad4-9f67-ff0dee2f59b7" />


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
