### PR TITLE
refactor death message, corpse spawn and death drops suppresion vars

### DIFF
--- a/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
+++ b/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
@@ -573,13 +573,13 @@
           {
             "if": "u_is_avatar",
             "then": [ { "run_eocs": "EOC_MOM_OUBLIETTE_MONSTER_PICK_DIMENSION" } ],
-            "else": [ { "u_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": false } } ]
+            "else": [ { "u_die": { "remove_corpse": true, "supress_message": true } } ]
           }
         ]
       },
       {
         "if": { "and": [ "u_is_monster", { "math": [ "_damage_done", ">=", "u_hp('ALL')" ] } ] },
-        "then": [ { "u_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": false } } ]
+        "then": [ { "u_die": { "remove_corpse": true, "supress_message": true } } ]
       }
     ],
     "false_effect": { "u_message": "You feel a strange, inward force.", "type": "neutral" }

--- a/data/mods/MindOverMatter/powers/photokinesis_eocs.json
+++ b/data/mods/MindOverMatter/powers/photokinesis_eocs.json
@@ -193,6 +193,6 @@
     "type": "effect_on_condition",
     "id": "EOC_PHOTOKIN_LIGHT_ARMY_DISAPPEAR_MONSTERS",
     "condition": "has_alpha",
-    "effect": [ { "u_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": true } } ]
+    "effect": [ { "u_die": { "remove_corpse": true, "supress_message": true } } ]
   }
 ]

--- a/data/mods/MindOverMatter/powers/teleportation_eoc.json
+++ b/data/mods/MindOverMatter/powers/teleportation_eoc.json
@@ -318,7 +318,7 @@
       {
         "if": { "math": [ "u_psi_teleporter_damage > u_health_comparison" ] },
         "then": [
-          { "u_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": true } },
+          { "u_die": { "remove_corpse": true, "supress_message": true } },
           { "npc_message": "With a tremendous mental exertion, you hurl your target…elsewhere." }
         ]
       }
@@ -342,7 +342,7 @@
         "if": { "math": [ "u_psi_teleporter_damage > u_health_comparison" ] },
         "then": [
           { "npc_message": "With a tremendous mental exertion, you hurl your target…elsewhere." },
-          { "u_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": false } }
+          { "u_die": { "remove_corpse": true, "supress_message": true } }
         ]
       }
     ]

--- a/data/mods/Sky_Island/effectoncondition/items_spells.json
+++ b/data/mods/Sky_Island/effectoncondition/items_spells.json
@@ -143,7 +143,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_SKY_ISLAND_EVICT_HOSTILES",
-    "effect": [ { "u_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": true } } ]
+    "effect": [ { "u_die": { "remove_corpse": true, "supress_message": true } } ]
   },
   {
     "id": "island_close_tear_and_portal",

--- a/data/mods/TEST_DATA/monsters.json
+++ b/data/mods/TEST_DATA/monsters.json
@@ -224,6 +224,13 @@
   },
   {
     "type": "MONSTER",
+    "id": "mon_test_no_drop",
+    "copy-from": "mon_test_zombie",
+    "name": { "str": "zombie" },
+    "death_drops": {  }
+  },
+  {
+    "type": "MONSTER",
     "id": "mon_test_bovine",
     "name": { "str_sp": "monster producing cattle samples when dissected" },
     "description": "An 8-legged beast of rugged greenish skin.",

--- a/data/mods/Xedra_Evolved/eocs/eoc_strange_events.json
+++ b/data/mods/Xedra_Evolved/eocs/eoc_strange_events.json
@@ -144,7 +144,7 @@
         "type": "mixed"
       },
       { "u_add_trait": "XE_FACTION_CAMP_BROWNIE_BLESSING" },
-      { "npc_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": true } }
+      { "npc_die": { "remove_corpse": true, "supress_message": true } }
     ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -3160,10 +3160,7 @@
     "type": "effect_on_condition",
     "id": "EOC_MENTOR_VANISH",
     "condition": { "u_has_trait": "MENTOR_PEACE" },
-    "effect": [
-      { "u_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": true } },
-      { "npc_message": "%1$s vanishes in a fine mist." }
-    ],
+    "effect": [ { "u_die": { "remove_corpse": true, "supress_message": true } }, { "npc_message": "%1$s vanishes in a fine mist." } ],
     "false_effect": [
       {
         "u_message": "You're not a mentor, so you're not supposed to see this.  Please open a GitHub bug report.",

--- a/data/mods/Xedra_Evolved/npc/strange_events/faction_camp_brownie.json
+++ b/data/mods/Xedra_Evolved/npc/strange_events/faction_camp_brownie.json
@@ -44,12 +44,12 @@
         "text": "I will.  Get out.",
         "topic": "TALK_DONE",
         "condition": { "u_has_trait": "UNKNOWING_CHANGELING_NOBLE" },
-        "effect": { "npc_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": true } }
+        "effect": { "npc_die": { "remove_corpse": true, "supress_message": true } }
       },
       {
         "text": "Well, goodbye.",
         "topic": "TALK_DONE",
-        "effect": { "npc_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": true } }
+        "effect": { "npc_die": { "remove_corpse": true, "supress_message": true } }
       }
     ]
   },
@@ -63,7 +63,7 @@
       {
         "text": "Wait, I-",
         "topic": "TALK_DONE",
-        "effect": { "npc_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": true } }
+        "effect": { "npc_die": { "remove_corpse": true, "supress_message": true } }
       }
     ]
   },
@@ -77,7 +77,7 @@
       {
         "text": "Farewell then.",
         "topic": "TALK_DONE",
-        "effect": { "npc_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": true } }
+        "effect": { "npc_die": { "remove_corpse": true, "supress_message": true } }
       }
     ]
   },
@@ -91,7 +91,7 @@
       {
         "text": "Farewell then.",
         "topic": "TALK_DONE",
-        "effect": { "npc_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": true } }
+        "effect": { "npc_die": { "remove_corpse": true, "supress_message": true } }
       }
     ]
   }

--- a/data/mods/Xedra_Evolved/npc/vampire_mentor.json
+++ b/data/mods/Xedra_Evolved/npc/vampire_mentor.json
@@ -141,7 +141,7 @@
         "topic": "TALK_DONE",
         "condition": { "u_has_any_trait": [ "VAMPIRE_ANATHEMA", "BLOODTHORNE_DRUID_SYMBIOTIC_PLANT" ] },
         "effect": [
-          { "npc_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": true } },
+          { "npc_die": { "remove_corpse": true, "supress_message": true } },
           { "u_message": "The mentor vanishes in a fine mist." }
         ]
       },
@@ -238,7 +238,7 @@
         "topic": "TALK_DONE",
         "effect": [
           "hostile",
-          { "npc_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": true } },
+          { "npc_die": { "remove_corpse": true, "supress_message": true } },
           { "u_message": "The mentor vanishes in a fine mist." }
         ]
       },
@@ -569,7 +569,7 @@
         "topic": "TALK_DONE",
         "effect": [
           "hostile",
-          { "npc_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": true } },
+          { "npc_die": { "remove_corpse": true, "supress_message": true } },
           { "u_message": "The mentor vanishes in a fine mist." }
         ]
       },
@@ -600,7 +600,7 @@
         "topic": "TALK_DONE",
         "effect": [
           "hostile",
-          { "npc_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": true } },
+          { "npc_die": { "remove_corpse": true, "supress_message": true } },
           { "u_message": "The mentor vanishes in a fine mist." }
         ]
       },

--- a/data/mods/Xedra_Evolved/npc/vampire_mission_target.json
+++ b/data/mods/Xedra_Evolved/npc/vampire_mission_target.json
@@ -154,7 +154,7 @@
         "effect": [
           { "u_sell_item": "blood_treatment", "count": 1 },
           { "u_add_var": "completed_hunter_cure_target", "value": "yes" },
-          { "npc_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": true } },
+          { "npc_die": { "remove_corpse": true, "supress_message": true } },
           { "u_message": "<npc_name> thanks you for the cure and departs.", "popup": true }
         ]
       }
@@ -183,7 +183,7 @@
         "effect": [
           { "u_sell_item": "blood_treatment", "count": 1 },
           { "u_add_var": "completed_hunter_cure_target", "value": "yes" },
-          { "npc_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": true } },
+          { "npc_die": { "remove_corpse": true, "supress_message": true } },
           { "u_message": "<npc_name> reluctantly takes the cure and departs.", "popup": true }
         ]
       }

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -5036,7 +5036,6 @@ If the target is an item, it will be deleted.
 | --- | --- | --- | --- |
 | "remove_corpse" | optional | bool | default false; if true, the corpse and all inside of it won't be spawned on death |
 | "supress_message" | optional | bool | default false; if true, death would omit death message |
-| "remove_from_creature_tracker" | optional | bool | default false; if true, and talker is monster, the monster instead removed from creature tracker, resulting not only in monster disappearing without message and corpse, but also bypasses any death effect they could fire before their death |
 
 ##### Valid talkers:
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -1291,6 +1291,15 @@ class Creature : public viewer
 
         time_point last_updated;
 
+    public:
+        // if false, the message from this creature dying is not printed
+        bool death_message = true;
+        // if false, prevent creature from leaving any corpse after it's death
+        bool spawn_corpse = true;
+        // drop everything this creature has in inventory
+        bool death_drops = true;
+
+    protected:
         bool fake = false;
         Creature();
         Creature( const Creature & );

--- a/src/creature.h
+++ b/src/creature.h
@@ -1294,7 +1294,7 @@ class Creature : public viewer
     public:
         // if false, the message from this creature dying is not printed
         bool death_message = true;
-        // if false, prevent creature from leaving any corpse after it's death
+        // if false, prevent creature from leaving any corpse after its death
         bool spawn_corpse = true;
         // drop everything this creature has in inventory
         bool death_drops = true;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1462,7 +1462,7 @@ void game::catch_a_monster( monster *fish, const tripoint_bub_ms &pos, Character
         u.add_msg_if_player( m_good, _( "You caught a %s." ), fish->type->nname() );
     }
     //quietly kill the caught
-    fish->no_corpse_quiet = true;
+    fish->spawn_corpse = false;
     fish->die( &here, p );
 }
 
@@ -4938,7 +4938,7 @@ bool game::revive_corpse( const tripoint_bub_ms &p, item &it, int radius )
         return false;
     }
 
-    critter.no_extra_death_drops = true;
+    critter.death_drops = false;
     critter.add_effect( effect_downed, 5_turns, true );
 
     if( it.get_var( "no_ammo" ) == "no_ammo" ) {

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1367,8 +1367,8 @@ static bool add_summoned_mon( const tripoint_bub_ms &pos, const time_duration &t
     if( !permanent ) {
         spawned_mon.set_summon_time( time );
     }
-    spawned_mon.no_extra_death_drops = !sp.has_flag( spell_flag::SPAWN_WITH_DEATH_DROPS );
-    spawned_mon.no_corpse_quiet = sp.has_flag( spell_flag::NO_CORPSE_QUIET );
+    spawned_mon.death_drops = sp.has_flag( spell_flag::SPAWN_WITH_DEATH_DROPS );
+    spawned_mon.spawn_corpse = !sp.has_flag( spell_flag::NO_CORPSE_QUIET );
     spawned_mon.set_summoner( &caster );
     return true;
 }
@@ -2087,7 +2087,7 @@ void spell_effect::slime_split_on_death( const spell &sp, Creature &caster,
                     const int used_mass = std::min( mass, slime_id->speed - 15 );
                     mass -= used_mass;
                     blob->set_speed_base( used_mass );
-                    blob->no_extra_death_drops = !sp.has_flag( spell_flag::SPAWN_WITH_DEATH_DROPS );
+                    blob->death_drops = sp.has_flag( spell_flag::SPAWN_WITH_DEATH_DROPS );
                     summoned_slimes.push_back( mon.get() );
                     if( mass < mon_blob_small->speed / 2 ) {
                         break;

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2009,8 +2009,8 @@ bool mattack::depart( monster *z )
     } else {
         add_msg_if_player_sees( *z, m_info, _( "The %s departs." ), z->name() );
     }
-    z->no_corpse_quiet = true;
-    z->no_extra_death_drops = true;
+    z->spawn_corpse = false;
+    z->death_drops = false;
     z->die( &here, nullptr );
     return true;
 }
@@ -2596,8 +2596,8 @@ bool mattack::photograph( monster *z )
             if( one_in( 3 ) ) {
                 add_msg( m_info, _( "The %s flashes a LED and departs.  Human officer on scene." ),
                          z->name() );
-                z->no_corpse_quiet = true;
-                z->no_extra_death_drops = true;
+                z->spawn_corpse = false;
+                z->death_drops = false;
                 z->die( &here, nullptr );
                 return false;
             } else {
@@ -2616,8 +2616,8 @@ bool mattack::photograph( monster *z )
             if( one_in( 4 ) ) {
                 add_msg( m_info, _( "The %s flashes a LED and departs.  Human officer on scene." ),
                          z->name() );
-                z->no_corpse_quiet = true;
-                z->no_extra_death_drops = true;
+                z->spawn_corpse = false;
+                z->death_drops = false;
                 z->die( &here, nullptr );
                 return false;
             } else {
@@ -2634,8 +2634,8 @@ bool mattack::photograph( monster *z )
             if( one_in( 3 ) ) {
                 add_msg( m_info, _( "The %s flashes a LED and departs.  SWAT's working the area." ),
                          z->name() );
-                z->no_corpse_quiet = true;
-                z->no_extra_death_drops = true;
+                z->spawn_corpse = false;
+                z->death_drops = false;
                 z->die( &here, nullptr );
                 return false;
             } else {
@@ -2651,8 +2651,8 @@ bool mattack::photograph( monster *z )
         // And you're wearing your badge
         if( player_character.is_wearing( itype_badge_marshal ) ) {
             add_msg( m_info, _( "The %s flashes a LED and departs.  The Feds got this." ), z->name() );
-            z->no_corpse_quiet = true;
-            z->no_extra_death_drops = true;
+            z->spawn_corpse = false;
+            z->death_drops = false;
             z->die( &here, nullptr );
             return false;
         }
@@ -4610,7 +4610,7 @@ bool mattack::zombie_fuse( monster *z )
                                 critter->name(), z->name() );
     }
     critter->death_drops = false;
-    critter->quiet_death = true;
+    critter->death_message = false;
     critter->die( &here, z );
     return true;
 }
@@ -4649,7 +4649,7 @@ bool mattack::eat_clone( monster *z )
                             _( "An orifice on the side of %s swells and splits open, and a monstrous tongue reaches out grabbing the nearest Daitya clone and sucking it back inside the Daitya!" ),
                             z->name() );
 
-    nearest_clone->quiet_death = true;
+    nearest_clone->death_message = false;
     nearest_clone->death_drops = false;
     nearest_clone->die( &here, z );
 

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -43,11 +43,11 @@ static const species_id species_ZOMBIE( "ZOMBIE" );
 
 item_location mdeath::normal( map *here, monster &z )
 {
-    if( z.no_corpse_quiet ) {
+    if( !z.spawn_corpse ) {
         return {};
     }
 
-    if( !z.quiet_death && !z.has_flag( mon_flag_QUIETDEATH ) ) {
+    if( z.death_message && !z.has_flag( mon_flag_QUIETDEATH ) ) {
         if( z.type->in_species( species_ZOMBIE ) && get_map().inbounds( z.pos_abs() ) ) {
             sfx::play_variant_sound( "mon_death", "zombie_death", sfx::get_heard_volume( z.pos_bub() ) );
         }
@@ -207,7 +207,7 @@ void mdeath::disappear( monster &z )
 void mdeath::broken( map *here, monster &z )
 {
     // Bail out if flagged (simulates eyebot flying away)
-    if( z.no_corpse_quiet ) {
+    if( !z.spawn_corpse ) {
         return;
     }
     std::string item_id;

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -43,10 +43,6 @@ static const species_id species_ZOMBIE( "ZOMBIE" );
 
 item_location mdeath::normal( map *here, monster &z )
 {
-    if( !z.spawn_corpse ) {
-        return {};
-    }
-
     if( z.death_message && !z.has_flag( mon_flag_QUIETDEATH ) ) {
         if( z.type->in_species( species_ZOMBIE ) && get_map().inbounds( z.pos_abs() ) ) {
             sfx::play_variant_sound( "mon_death", "zombie_death", sfx::get_heard_volume( z.pos_bub() ) );
@@ -56,7 +52,7 @@ item_location mdeath::normal( map *here, monster &z )
         add_msg_if_player_sees( z, m_good, _( "The %s dies!" ), z.name() );
     }
 
-    if( z.death_drops ) {
+    if( z.spawn_corpse ) {
         const int max_hp = std::max( z.get_hp_max(), 1 );
         const float overflow_damage = std::max( -z.get_hp(), 0 );
         const float corpse_damage = 2.5 * overflow_damage / max_hp;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -370,7 +370,7 @@ void monster::on_effect_int_change( const efftype_id &/*eid*/, int /*intensity*/
 void monster::poly( const mtype_id &id )
 {
     double hp_percentage = static_cast<double>( hp ) / static_cast<double>( type->hp );
-    if( !no_extra_death_drops ) {
+    if( death_drops ) {
         generate_inventory();
     }
     type = &id.obj();
@@ -3225,7 +3225,7 @@ void monster::die( map *here, Creature *nkiller )
     }
 
     if( death_drops ) {
-        if( !no_extra_death_drops ) {
+        if( death_drops ) {
             drop_items_on_death( here, corpse.get_item() );
         }
         spawn_dissectables_on_death( corpse.get_item() );
@@ -3348,7 +3348,7 @@ void monster::generate_inventory( bool disableDrops )
         }
         inv.push_back( it );
     }
-    no_extra_death_drops = disableDrops;
+    death_drops = !disableDrops;
 }
 
 void monster::drop_items_on_death( map *here, item *corpse ) const

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1261,6 +1261,10 @@ std::vector<std::string> monster::extended_description() const
             tmp.emplace_back( "Lifespan end time: n/a <color_yellow>(indefinite)</color>" );
         }
 
+        tmp.emplace_back( string_format( "death_message: %s", death_message ? "true" : "false" ) );
+        tmp.emplace_back( string_format( "spawn_corpse: %s", spawn_corpse ? "true" : "false" ) );
+        tmp.emplace_back( string_format( "death_drops: %s", death_drops ? "true" : "false" ) );
+
         if( !type->weakpoints.weakpoint_list.empty() ) {
             tmp.emplace_back( colorize( "weakpoints:", c_white ) );
             for( const weakpoint &wp : type->weakpoints.weakpoint_list ) {

--- a/src/monster.h
+++ b/src/monster.h
@@ -567,14 +567,6 @@ class monster : public Creature
         // Names of mission monsters fused with this monster
         std::vector<std::string> mission_fused;
         const mtype *type;
-        // If true, don't spawn loot items as part of death.
-        bool no_extra_death_drops = false;
-        // If true, monster dies quietly and leaves no corpse.
-        bool no_corpse_quiet = false;
-        // Turned to false for simulating monsters during distant missions so they don't drop in sight.
-        bool death_drops = true;
-        // If true, sound and message is suppressed for monster death.
-        bool quiet_death = false;
         bool is_dead() const;
         bool made_footstep = false;
         //if we are a nemesis monster from the 'hunted' trait
@@ -633,6 +625,7 @@ class monster : public Creature
         std::map<std::string, mon_special_attack, std::less<>> special_attacks;
         std::optional<tripoint_abs_ms> goal;
         bool dead = false;
+
         /** Normal upgrades **/
         int next_upgrade_time();
         bool upgrades = false;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3254,7 +3254,7 @@ void npc::die( map *here, Creature *nkiller )
     dead = true;
     Character::die( here, nkiller );
 
-    if( !quiet_death ) {
+    if( death_message ) {
         if( is_hallucination() || lifespan_end ) {
             add_msg_if_player_sees( *this, _( "%s disappears." ), get_name().c_str() );
             return;

--- a/src/npc.h
+++ b/src/npc.h
@@ -1630,8 +1630,6 @@ class npc : public Character
         // times their opinion has increased from chatting, upper bounds on 'forgiveness'
         int opinion_values_raised = 0;
         bool hallucination = false; // If true, NPC is an hallucination
-        bool spawn_corpse = true;
-        bool quiet_death = false; // supress messages about death
         std::vector<npc_need> needs;
         std::optional<int> confident_range_cache;
         // Dummy point that indicates that the goal is invalid.

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5968,7 +5968,6 @@ talk_effect_fun_t::func f_die_advanced( const JsonObject &jo, std::string_view m
     JsonObject job = jo.get_object( member );
     std::optional<bool> remove_corpse;
     std::optional<bool> supress_message;
-    std::optional<bool> remove_from_creature_tracker;
 
     if( job.has_bool( "remove_corpse" ) ) {
         remove_corpse = job.get_bool( "remove_corpse" );
@@ -5976,27 +5975,15 @@ talk_effect_fun_t::func f_die_advanced( const JsonObject &jo, std::string_view m
     if( job.has_bool( "supress_message" ) ) {
         supress_message = job.get_bool( "supress_message" );
     }
-    if( job.has_bool( "remove_from_creature_tracker" ) ) {
-        remove_from_creature_tracker = job.get_bool( "remove_from_creature_tracker" );
-    }
 
-    return [remove_corpse, supress_message, remove_from_creature_tracker,
-                   is_npc]( dialogue const & d ) {
+    return [remove_corpse, supress_message, is_npc]( dialogue const & d ) {
         map &here = get_map();
 
-        if( d.actor( is_npc )->get_monster() ) {
-            monster &mon = *d.actor( is_npc )->get_monster();
-            if( remove_from_creature_tracker ) {
-                get_creature_tracker().remove( mon );
-                return;
-            }
-            mon.death_drops = remove_corpse.has_value() ? !remove_corpse.value() : mon.death_drops;
-            mon.quiet_death = supress_message.has_value() ? supress_message.value() : mon.quiet_death;
-        } else if( d.actor( is_npc )->get_npc() ) {
-            npc &guy_npc = *d.actor( is_npc )->get_npc();
-            guy_npc.spawn_corpse = remove_corpse.has_value() ? !remove_corpse.value() : guy_npc.spawn_corpse;
-            guy_npc.quiet_death = supress_message.has_value() ? supress_message.value() : guy_npc.quiet_death;
-        }
+        Creature *cr = d.actor( is_npc )->get_creature();
+
+        cr->death_message = supress_message.has_value() ? !supress_message.value() : cr->death_message;
+        cr->spawn_corpse = remove_corpse.has_value() ? !remove_corpse.value() : cr->spawn_corpse;
+        cr->death_drops = remove_corpse.has_value() ? !remove_corpse.value() : cr->death_drops;
 
         d.actor( is_npc )->die( &here );
     };
@@ -7793,8 +7780,8 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
                     if( lifespan.value() > 0_seconds ) {
                         spawned->set_summon_time( lifespan.value() );
                         // Temporary monsters shouldn't drop items unless told to
-                        spawned->no_extra_death_drops = !temporary_drop_items;
-                        spawned->no_corpse_quiet = !temporary_drop_items;
+                        spawned->death_drops = temporary_drop_items;
+                        spawned->spawn_corpse = temporary_drop_items;
                     }
                 }
             }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2635,6 +2635,8 @@ void monster::load( const JsonObject &data )
     // for migration, remove in 0.K
     data.read( "no_extra_death_drops", death_drops );
     data.read( "death_drops", death_drops );
+    data.read( "spawn_corpse", spawn_corpse );
+    data.read( "death_message", death_message );
     data.read( "dead", dead );
     data.read( "anger", anger );
     data.read( "morale", morale );
@@ -2722,6 +2724,8 @@ void monster::store( JsonOut &json ) const
     json.member( "mission_ids", mission_ids );
     json.member( "mission_fused", mission_fused );
     json.member( "death_drops", death_drops );
+    json.member( "spawn_corpse", spawn_corpse );
+    json.member( "death_message", death_message );
     json.member( "dead", dead );
     json.member( "anger", anger );
     json.member( "morale", morale );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2632,7 +2632,9 @@ void monster::load( const JsonObject &data )
         }
     }
     data.read( "mission_fused", mission_fused );
-    data.read( "no_extra_death_drops", no_extra_death_drops );
+    // for migration, remove in 0.K
+    data.read( "no_extra_death_drops", death_drops );
+    data.read( "death_drops", death_drops );
     data.read( "dead", dead );
     data.read( "anger", anger );
     data.read( "morale", morale );
@@ -2719,7 +2721,7 @@ void monster::store( JsonOut &json ) const
     json.member( "faction", faction.id().str() );
     json.member( "mission_ids", mission_ids );
     json.member( "mission_fused", mission_fused );
-    json.member( "no_extra_death_drops", no_extra_death_drops );
+    json.member( "death_drops", death_drops );
     json.member( "dead", dead );
     json.member( "anger", anger );
     json.member( "morale", morale );

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -120,7 +120,7 @@ static void check_lethality( const itype_id &explosive_id, const int range, floa
             num_subjects++;
             num_subjects_this_time++;
             monster &new_monster = spawn_test_monster( "mon_zombie", monster_position );
-            new_monster.no_extra_death_drops = true;
+            new_monster.death_drops = false;
         }
         // Set off an explosion
         item grenade( explosive_id );

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -311,7 +311,7 @@ TEST_CASE( "active_monster_drops", "[active_item][map]" )
     REQUIRE( bag_plastic.put_in( cookie, pocket_type::CONTAINER ).success() );
 
     monster &zombo = spawn_test_monster( "mon_zombie", start_loc, true );
-    zombo.no_extra_death_drops = true;
+    zombo.death_drops = false;
     zombo.inv.emplace_back( bag_plastic );
     calendar::turn += time_duration::from_seconds( cookie.processing_speed() + 1 );
     zombo.die( &here, nullptr );

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -310,8 +310,7 @@ TEST_CASE( "active_monster_drops", "[active_item][map]" )
     }
     REQUIRE( bag_plastic.put_in( cookie, pocket_type::CONTAINER ).success() );
 
-    monster &zombo = spawn_test_monster( "mon_zombie", start_loc, true );
-    zombo.death_drops = false;
+    monster &zombo = spawn_test_monster( "mon_test_no_drop", start_loc, true );
     zombo.inv.emplace_back( bag_plastic );
     calendar::turn += time_duration::from_seconds( cookie.processing_speed() + 1 );
     zombo.die( &here, nullptr );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Initially part of #87676, but i had to separate it to preserve the scope
we have a bunch of bools to suppress corpse, message and loot spawn from monsters and from creatures separately, which doesn't work if you are operating them at critter level. No reason to, so refactor
#### Describe the solution
Remove said values from monster and from npc level, add them to creature so both of them will share it from a shared class
Adjust code accordingly
While here, remove `remove_from_creature_tracker` bool from `u_die` eoc, since what it does with remove_corpse and supress_message is completely equal, so there is a little reason to have it as an option
#### Describe alternatives you've considered
Make virtual getter/setter function of creature class, and make override for npcs/monsters where these fields are defined. decided it's not really worth the hassle, and would still require to define it thrice - one virtual in creature, one override in monster, and one override in npc
#### Testing
The game loads, didn't spot any difference