### PR TITLE
Fix - Saltpeter Powder Spawning Multiple Containers containing 1 unit each

### DIFF
--- a/data/json/itemgroups/Agriculture_Forage_Excavation/agriculture.json
+++ b/data/json/itemgroups/Agriculture_Forage_Excavation/agriculture.json
@@ -69,7 +69,7 @@
       { "group": "fertilizer_commercial_bag_canvas_60", "prob": 30 },
       [ "fungicide", 20 ],
       { "group": "insecticide_bag_plastic", "prob": 30 },
-      { "item": "chem_saltpetre", "prob": 15, "count": [ 10, 50 ] },
+      { "group": "saltpeter_canvas_bag_part", "prob": 15},
       [ "sickle", 40 ],
       { "group": "tools_toolbox", "prob": 10 },
       [ "bullwhip", 30 ],

--- a/data/json/itemgroups/Agriculture_Forage_Excavation/agriculture.json
+++ b/data/json/itemgroups/Agriculture_Forage_Excavation/agriculture.json
@@ -69,7 +69,7 @@
       { "group": "fertilizer_commercial_bag_canvas_60", "prob": 30 },
       [ "fungicide", 20 ],
       { "group": "insecticide_bag_plastic", "prob": 30 },
-      { "group": "saltpeter_canvas_bag_part", "prob": 15},
+      { "group": "saltpeter_canvas_bag_part", "prob": 15 },
       [ "sickle", 40 ],
       { "group": "tools_toolbox", "prob": 10 },
       [ "bullwhip", 30 ],

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -2179,7 +2179,7 @@
       { "group": "zincpowder_small_bottle_part", "prob": 10 },
       { "item": "chem_zinc_oxide", "prob": 5, "count": [ 100, -1 ] },
       { "group": "manganesedioxide_small_bottle_part", "prob": 10 },
-      { "group": "saltpeter_canvas_bag_part", "prob": 10,      
+      { "group": "saltpeter_canvas_bag_part", "prob": 10 },      
       { "group": "calciumcarbide_small_bottle_part", "prob": 10 },
       { "group": "calciumcarbonate_small_bottle_part", "prob": 10 },
       { "item": "denat_alcohol", "prob": 6, "charges": [ 250, -1 ] },

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -2179,7 +2179,7 @@
       { "group": "zincpowder_small_bottle_part", "prob": 10 },
       { "item": "chem_zinc_oxide", "prob": 5, "count": [ 100, -1 ] },
       { "group": "manganesedioxide_small_bottle_part", "prob": 10 },
-      { "item": "chem_saltpetre", "prob": 10, "count": [ 1, 50 ] },
+      { "group": "saltpeter_canvas_bag_part", "prob": 10,      
       { "group": "calciumcarbide_small_bottle_part", "prob": 10 },
       { "group": "calciumcarbonate_small_bottle_part", "prob": 10 },
       { "item": "denat_alcohol", "prob": 6, "charges": [ 250, -1 ] },

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -2179,7 +2179,7 @@
       { "group": "zincpowder_small_bottle_part", "prob": 10 },
       { "item": "chem_zinc_oxide", "prob": 5, "count": [ 100, -1 ] },
       { "group": "manganesedioxide_small_bottle_part", "prob": 10 },
-      { "group": "saltpeter_canvas_bag_part", "prob": 10 },      
+      { "group": "saltpeter_canvas_bag_part", "prob": 10 },
       { "group": "calciumcarbide_small_bottle_part", "prob": 10 },
       { "group": "calciumcarbonate_small_bottle_part", "prob": 10 },
       { "item": "denat_alcohol", "prob": 6, "charges": [ 250, -1 ] },

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -2088,7 +2088,7 @@
     "items": [
       { "group": "quicklime_bag", "prob": 85 },
       { "group": "quicklime_barrel", "prob": 20 },
-      { "item": "chem_saltpetre", "prob": 15, "count": [ 10, 50 ] }
+      { "group": "saltpeter_canvas_bag_part", "prob": 15}
     ]
   },
   {

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -2088,7 +2088,7 @@
     "items": [
       { "group": "quicklime_bag", "prob": 85 },
       { "group": "quicklime_barrel", "prob": 20 },
-      { "group": "saltpeter_canvas_bag_part", "prob": 15}
+      { "group": "saltpeter_canvas_bag_part", "prob": 15 }
     ]
   },
   {

--- a/data/json/itemgroups/SUS/alien.json
+++ b/data/json/itemgroups/SUS/alien.json
@@ -132,7 +132,7 @@
           { "group": "salt_various", "prob": 100 },
           { "group": "pepper_various", "prob": 95 },
           { "group": "sugar_jar_glass_sealed_10_140", "prob": 25 },
-          { "item": "chem_saltpetre", "count": [ 2, -1 ], "prob": 10 },
+          { "group": "saltpeter_canvas_bag_part", "prob": 10},
           { "group": "yeast_various", "prob": 30 }
         ],
         "prob": 50

--- a/data/json/itemgroups/SUS/alien.json
+++ b/data/json/itemgroups/SUS/alien.json
@@ -132,7 +132,7 @@
           { "group": "salt_various", "prob": 100 },
           { "group": "pepper_various", "prob": 95 },
           { "group": "sugar_jar_glass_sealed_10_140", "prob": 25 },
-          { "group": "saltpeter_canvas_bag_part", "prob": 10},
+          { "group": "saltpeter_canvas_bag_part", "prob": 10 },
           { "group": "yeast_various", "prob": 30 }
         ],
         "prob": 50

--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -293,7 +293,7 @@
       { "prob": 10, "group": "chem_sulphur_bottle_plastic_small_100_inf" },
       [ "chem_aluminium_powder", 10 ],
       [ "chem_hexamine", 10 ],
-      { "group": "saltpeter_canvas_bag_part", "prob": 15},
+      { "group": "saltpeter_canvas_bag_part", "prob": 15 },
       { "item": "chem_nitric_acid", "prob": 15, "charges": [ 1, -1 ] },
       { "item": "chem_muriatic_acid", "prob": 20, "charges": [ 1, -1 ] },
       { "group": "potassiumchloride_small_bottle_part", "prob": 5 },

--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -293,7 +293,7 @@
       { "prob": 10, "group": "chem_sulphur_bottle_plastic_small_100_inf" },
       [ "chem_aluminium_powder", 10 ],
       [ "chem_hexamine", 10 ],
-      [ "chem_saltpetre", 15 ],
+      { "group": "saltpeter_canvas_bag_part", "prob": 15},
       { "item": "chem_nitric_acid", "prob": 15, "charges": [ 1, -1 ] },
       { "item": "chem_muriatic_acid", "prob": 20, "charges": [ 1, -1 ] },
       { "group": "potassiumchloride_small_bottle_part", "prob": 5 },

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -226,6 +226,20 @@
     "items": [ { "item": "magnesium", "count": [ 2, 200 ] } ]
   },
   {
+    "id": "saltpeter_canvas_bag",
+    "type": "item_group",
+    "container-item": "bag_canvas",
+    "//": "15 liter bag, filled 80% as new",
+    "items": [ { "item": "chem_saltpetre", "count": 300 } ]
+  },
+  {
+    "id": "saltpeter_canvas_bag_part",
+    "type": "item_group",
+    "container-item": "bag_canvas",
+    "//": "15 liter bag, opened with a variable amount",
+    "items": [ { "item": "chem_saltpetre", "count": [ 2, 300 ] } ]
+  },
+  {
     "id": "sandbag",
     "type": "item_group",
     "container-item": "bag_durasack",

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -1022,7 +1022,6 @@
     "material": [ "powder_nonflam" ],
     "volume": "50 ml",
     "weight": "5275 mg",
-    "container": "bag_canvas"
   },
   {
     "type": "ITEM",

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -1021,7 +1021,7 @@
     "description": "A handful of saltpeter powder.  Sometimes used as a fertilizer, this ubiquitous nitrate is the principal constituent of black gunpowder and simple rocket propellants, such as rocket candy.",
     "material": [ "powder_nonflam" ],
     "volume": "50 ml",
-    "weight": "5275 mg",
+    "weight": "5275 mg"
   },
   {
     "type": "ITEM",

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -1020,9 +1020,9 @@
     "color": "white",
     "description": "A handful of saltpeter powder.  Sometimes used as a fertilizer, this ubiquitous nitrate is the principal constituent of black gunpowder and simple rocket propellants, such as rocket candy.",
     "material": [ "powder_nonflam" ],
+    "display_type": "BY_WEIGHT",
     "volume": "50 ml",
-    "weight": "5275 mg",
-    "display_type": "BY_WEIGHT"
+    "weight": "5275 mg"
   },
   {
     "type": "ITEM",

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -1021,7 +1021,8 @@
     "description": "A handful of saltpeter powder.  Sometimes used as a fertilizer, this ubiquitous nitrate is the principal constituent of black gunpowder and simple rocket propellants, such as rocket candy.",
     "material": [ "powder_nonflam" ],
     "volume": "50 ml",
-    "weight": "5275 mg"
+    "weight": "5275 mg",
+    "display_type": "BY_WEIGHT"
   },
   {
     "type": "ITEM",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Correct Chem_Saltpetre spawns broken by de-charging"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change


Chem_Saltpetre also appears to have been affected by the de-charge changes, causing multiple containers, all containing 1x saltpeter. 

Spawns were adjusted to use an item group that spawns a variably filled canvas sack.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Creation of the Saltpeter Canvas Sack group, verify the canvas sack can contain a full load of canvas and was within weight limitations. Spawn tables were then adjusted to point to this variably filled sack. A FULL sack item group was also added but not used, but is there in case of any future use required of it (Like a chemical supply warehouse)

Chem_saltpetre is misspelled, but to avoid having to go through every recipe and correct it, this original item_id was retained for the time being. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Not fixing the issue. Free containers!

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Compiled and tested ingame by spawning each itemgroup the item originally was spawned in, 100x for each itemgroup. Verified now getting a single sack with a varying amount of saltpeter powder.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
BEFORE FIX
<img width="516" height="320" alt="image" src="https://github.com/user-attachments/assets/aaffa8cc-71c6-4ece-8bf8-9f3ebb62dc43" />


AFTER FIX
<img width="607" height="526" alt="image" src="https://github.com/user-attachments/assets/3255fafc-3ce8-421c-a1a7-3587a2343639" />


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
