### PR TITLE
Android: virtual keyboard ownership and character creator shortcut bar

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -709,6 +709,18 @@ bool cataimgui::client::want_capture_keyboard()
     return ImGui::GetCurrentContext() != nullptr && ImGui::GetIO().WantCaptureKeyboard;
 }
 
+bool cataimgui::client::want_text_input()
+{
+    return ImGui::GetCurrentContext() != nullptr && ImGui::GetIO().WantTextInput;
+}
+
+void cataimgui::client::clear_text_focus()
+{
+    if( ImGui::GetCurrentContext() != nullptr ) {
+        ImGui::ClearActiveID();
+    }
+}
+
 static ImGuiKey cata_key_to_imgui( int cata_key )
 {
     switch( cata_key ) {

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -128,6 +128,10 @@ class client
         static bool want_capture_mouse();
         // True if an ImGui text field or shortcut has keyboard focus.
         static bool want_capture_keyboard();
+        // True if an ImGui text-entry widget is focused and wants character input.
+        static bool want_text_input();
+        // Drop the active ImGui item so a focused text widget releases input.
+        static void clear_text_focus();
 };
 
 #ifndef TUI

--- a/src/input_context.h
+++ b/src/input_context.h
@@ -95,6 +95,29 @@ class input_context
             register_action( "toggle_language_to_en" );
         }
 
+        // Make a persistent input_context the stack top for this scope, so the
+        // Android shortcut bar (which reads the stack top) shows its actions
+        // even when the screen redraws before polling input.
+        class scoped_activation
+        {
+            public:
+                explicit scoped_activation( input_context &ctx ) {
+                    ( void )ctx;
+#if defined(__ANDROID__) || defined(TILES)
+                    input_context_stack.push( ctx.handle );
+#endif
+                }
+                ~scoped_activation() {
+#if defined(__ANDROID__) || defined(TILES)
+                    input_context_stack.pop();
+#endif
+                }
+                scoped_activation( const scoped_activation & ) = delete;
+                scoped_activation &operator=( const scoped_activation & ) = delete;
+                scoped_activation( scoped_activation && ) = delete;
+                scoped_activation &operator=( scoped_activation && ) = delete;
+        };
+
         input_context( const input_context &other ) {
             reassign( other );
         }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2881,9 +2881,11 @@ bool character_creator_ui::display()
 
     while( !cc_uistate.finished_character_creator ) {
 
+        input_context &current_tab_input = get_current_tab_input();
+        input_context::scoped_activation active_tab_context( current_tab_input );
+
         ui_manager::redraw();
         std::shared_ptr<uilist> current_tab_uilist = get_current_tab_uilist();
-        input_context &current_tab_input = get_current_tab_input();
         if( current_tab_uilist ) {
             cc_uilist_current = current_tab_uilist->create_or_get_ui();
             if( current_tab_uilist->query_setup() ) {

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -4584,12 +4584,36 @@ void draw_terminal_size_preview()
     }
 }
 
+// Mark the frame dirty after an Android keyboard / shortcut-bar state change so
+// the strip is rebuilt to reflect the new state on the next draw pass.
+static void android_request_repaint()
+{
+    needupdate = true;
+    ui_manager::redraw_invalidated();
+}
+
+// The SDL "text input active" flag can be set while the keyboard never actually
+// appeared on screen, which would wrongly hide the shortcut strip. Trust the
+// platform IME-insets report once we have one; fall back to the SDL flag only
+// until the first report arrives.
+static bool android_keyboard_occludes_shortcuts()
+{
+    if( !IsTextInputActive( ::window.get() ) ) {
+        return false;
+    }
+    SDL_Rect frame;
+    bool has_frame = false;
+    bool visible = false;
+    visible_frame_inbox.read_frame( frame, has_frame, visible );
+    return has_frame ? ( visible && frame.h > 0 ) : true;
+}
+
 // Draw quick shortcuts on top of the game view
 void draw_quick_shortcuts()
 {
 
     if( !quick_shortcuts_enabled ||
-        IsTextInputActive( ::window.get() ) ||
+        android_keyboard_occludes_shortcuts() ||
         ( get_option<bool>( "ANDROID_HIDE_HOLDS" ) && !is_quick_shortcut_touch && finger_down_time > 0 &&
           GetTicks() - finger_down_time >= static_cast<uint32_t>(
               get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) ) { // player is swipe + holding in a direction
@@ -4945,6 +4969,16 @@ bool is_string_input( input_context &ctx )
            || category == "HELP_KEYBINDINGS";
 }
 
+// True when the soft keyboard is legitimately wanted for this context and CDDA
+// must not auto-hide it or convert keystrokes to quick shortcuts: a legacy
+// string-input/curses context, an inventory quantity field, or a focused ImGui
+// text widget (ImGui drives SDL text-input itself; CDDA defers to it).
+static bool android_wants_text_input( input_context &ctx )
+{
+    return is_string_input( ctx ) || ctx.allow_text_entry
+           || cataimgui::client::want_text_input();
+}
+
 int get_key_event_from_string( const std::string &str )
 {
     if( !str.empty() ) {
@@ -5157,8 +5191,7 @@ static void CheckMessages()
 
         // If we were in an allow_text_entry input context, and text input is still active, and we're auto-managing keyboard, hide it.
         if( touch_input_context.allow_text_entry &&
-            !new_input_context->allow_text_entry &&
-            !is_string_input( *new_input_context ) &&
+            !android_wants_text_input( *new_input_context ) &&
             IsTextInputActive( ::window.get() ) &&
             get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
             focus_aware_stop_text_input();
@@ -5362,6 +5395,7 @@ static void CheckMessages()
             if( !quick_shortcuts_toggle_handled ) {
                 quick_shortcuts_enabled = !quick_shortcuts_enabled;
                 quick_shortcuts_toggle_handled = true;
+                android_request_repaint();
                 refresh_display();
 
                 // Display an Android toast message
@@ -5548,7 +5582,7 @@ static void CheckMessages()
                             last_input = input_event( lc, input_event_t::keyboard_char );
 #if defined(__ANDROID__)
                             if( !android_is_hardware_keyboard_available() ) {
-                                if( !is_string_input( touch_input_context ) && !touch_input_context.allow_text_entry ) {
+                                if( !android_wants_text_input( touch_input_context ) ) {
                                     if( get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
                                         focus_aware_stop_text_input();
                                     }
@@ -5558,7 +5592,7 @@ static void CheckMessages()
                                         !inp_mngr.get_keyname( lc, input_event_t::keyboard_char ).empty() ) {
                                         qsl.remove( last_input );
                                         add_quick_shortcut( qsl, last_input, false, true );
-                                        ui_manager::redraw_invalidated();
+                                        android_request_repaint();
                                         refresh_display();
                                     }
                                 } else if( lc == '\n' || lc == KEY_ESCAPE ) {
@@ -5580,11 +5614,17 @@ static void CheckMessages()
                     if( GetKeysym( ev ).sym == SDLK_AC_BACK ) {
                         if( ticks - ac_back_down_time <= static_cast<uint32_t>
                             ( get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
-                            if( IsTextInputActive( ::window.get() ) ) {
+                            if( cataimgui::client::want_text_input() ) {
+                                // ImGui owns the keyboard while a text widget is
+                                // focused. Defocus it so ImGui releases text input
+                                // and the keyboard dismisses.
+                                cataimgui::client::clear_text_focus();
+                            } else if( IsTextInputActive( ::window.get() ) ) {
                                 focus_aware_stop_text_input();
                             } else {
                                 focus_aware_start_text_input();
                             }
+                            android_request_repaint();
                         }
                         ac_back_down_time = 0;
                     }
@@ -5616,7 +5656,7 @@ static void CheckMessages()
                             last_input = input_event( lc, input_event_t::keyboard_char );
 #if defined(__ANDROID__)
                             if( !android_is_hardware_keyboard_available() ) {
-                                if( !is_string_input( touch_input_context ) && !touch_input_context.allow_text_entry ) {
+                                if( !android_wants_text_input( touch_input_context ) ) {
                                     if( get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
                                         focus_aware_stop_text_input();
                                     }
@@ -5625,7 +5665,7 @@ static void CheckMessages()
                                                                  touch_input_context.get_category() )];
                                     qsl.remove( last_input );
                                     add_quick_shortcut( qsl, last_input, false, true );
-                                    ui_manager::redraw_invalidated();
+                                    android_request_repaint();
                                     refresh_display();
                                 } else if( lc == '\n' || lc == KEY_ESCAPE ) {
                                     if( get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
@@ -5992,8 +6032,8 @@ static void CheckMessages()
                         is_three_finger_touch = false;
                         finger_down_time = 0;
                         finger_repeat_time = 0;
-                        needupdate = true; // ensure virtual joystick and quick shortcuts are updated properly
-                        ui_manager::redraw_invalidated();
+                        // ensure virtual joystick and quick shortcuts are updated properly
+                        android_request_repaint();
                         refresh_display(); // as above, but actually redraw it now as well
                     } else if( slot == 1 ) {
                         if( is_two_finger_touch ) {


### PR DESCRIPTION
#### Summary
Interface "Fix Android virtual keyboard and quick shortcut bar on ImGui screens"

#### Purpose of change
The Android soft keyboard and the quick shortcut bar both fought ImGui. Worst case was character creation: keyboard wouldn't come up, and the shortcut bar was just gone. Fixes #79616.

#### Describe the solution
Two things.

ImGui owns SDL text input when a text widget is focused, so the game stops fighting it: no per-key auto-hide or shortcut-stealing, the back button defocuses the widget to dismiss the keyboard, and the shortcut bar hides on actual IME visibility instead of the SDL text-input flag. Also fixed a missing repaint after the back-button keyboard toggle that left the bar stale.

The character creator keeps its tab input contexts as persistent members, so the Android bar (which reads the top of the input context stack) never saw them. Added `input_context::scoped_activation` to push the active tab context to the top while the creator redraws and polls.

#### Describe alternatives you've considered
Could have had the Android bar peek at ImGui directly, but that's a second input-routing model. "Active context is the stack top" is the better invariant.

#### Testing
Verified on my Pixel 10. Keyboard opens and dismisses in character creation, name field typing works, shortcut bar shows in the creator and survives keyboard toggles, main menu bar unchanged.

#### Additional context
Also covers the keyboard-in-character-creation report in #86938 and the stale-bar-after-keyboard-close in #70958 (both already closed).