### PR TITLE
Labyrinth computers modify furniture `n_` vals before mapgen updates

### DIFF
--- a/data/json/npcs/exodii/netherum/labyrinth_computers.json
+++ b/data/json/npcs/exodii/netherum/labyrinth_computers.json
@@ -134,13 +134,13 @@
     "responses": [
       {
         "text": "Unlock connected doors",
-        "effect": [ { "run_eocs": [ "EOC_LS_Unlock", "EOC_LS_Passcode_Generator" ] }, { "math": [ "n_LS_door_requests = 1" ] } ],
+        "effect": [ { "math": [ "n_LS_door_requests = 1" ] }, { "run_eocs": [ "EOC_LS_Unlock", "EOC_LS_Passcode_Generator" ] } ],
         "topic": "COMP_LS_Passcode_Door2",
         "condition": { "math": [ "n_LS_door_requests < 1" ] }
       },
       {
         "text": "Lock connected doors",
-        "effect": [ { "run_eocs": [ "EOC_LS_Lock" ] }, { "math": [ "n_LS_door_requests += 1" ] } ],
+        "effect": [ { "math": [ "n_LS_door_requests += 1" ] }, { "run_eocs": [ "EOC_LS_Lock" ] } ],
         "topic": "COMP_LS_Passcode_Door3",
         "condition": { "math": [ "n_LS_door_requests == 1" ] }
       },
@@ -215,10 +215,6 @@
     "type": "talk_topic",
     "id": [
       "COMP_LS_Bridge_control_deadend_1",
-      "COMP_LS_Bridge_control_deadend_1_Extend_passcode0",
-      "COMP_LS_Bridge_control_deadend_1_Extend_passcode1",
-      "COMP_LS_Bridge_control_deadend_1_Extend_passcode2",
-      "COMP_LS_Bridge_control_deadend_1_Extend_passcode3",
       "COMP_LS_Bridge_control_deadend_1_Retract",
       "COMP_LS_Bridge_control_deadend_1_Extend_nopasscode"
     ],
@@ -226,7 +222,6 @@
       {
         "text": "Enter the Thief's Passcode to extend the bridge.",
         "effect": [
-          { "run_eocs": "EOC_LS_Bridge_control_deadend_1_Passcode0" },
           { "math": [ "n_LS_bridge_requests = 1" ] },
           { "u_lose_trait": "LS_Passcode_0" }
         ],
@@ -236,7 +231,6 @@
       {
         "text": "Enter the Circle of Wings Passcode to extend the bridge.",
         "effect": [
-          { "run_eocs": "EOC_LS_Bridge_control_deadend_1_Passcode1" },
           { "math": [ "n_LS_bridge_requests = 1" ] },
           { "u_lose_trait": "LS_Passcode_1" }
         ],
@@ -246,7 +240,6 @@
       {
         "text": "Enter the Hard Nails Passcode to extend the bridge.",
         "effect": [
-          { "run_eocs": "EOC_LS_Bridge_control_deadend_1_Passcode2" },
           { "math": [ "n_LS_bridge_requests = 1" ] },
           { "u_lose_trait": "LS_Passcode_2" }
         ],
@@ -256,7 +249,6 @@
       {
         "text": "Enter the Laughing Man Passcode to extend the bridge.",
         "effect": [
-          { "run_eocs": "EOC_LS_Bridge_control_deadend_1_Passcode3" },
           { "math": [ "n_LS_bridge_requests = 1" ] },
           { "u_lose_trait": "LS_Passcode_3" }
         ],
@@ -294,22 +286,26 @@
   {
     "type": "talk_topic",
     "id": "COMP_LS_Bridge_control_deadend_1_Extend_passcode0",
-    "dynamic_line": "&<color_light_green> @User > bridge --update=extend --pass=\"<ls_passcode0>\"\n<color_light_green>Command accepted.\n<color_light_green>Extending bridge.\n<color_light_green>Watch your step.\n\n<color_light_green> @User > _</color>"
+    "dynamic_line": "&<color_light_green> @User > bridge --update=extend --pass=\"<ls_passcode0>\"\n<color_light_green>Command accepted.\n<color_light_green>Extending bridge.\n<color_light_green>Watch your step.\n\n<color_light_green> @User > _</color>",
+    "responses": [ { "text": "Log off.", "effect": { "run_eocs": "EOC_LS_Bridge_control_deadend_1_Passcode0" }, "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
     "id": "COMP_LS_Bridge_control_deadend_1_Extend_passcode1",
-    "dynamic_line": "&<color_light_green> @User > bridge --update=extend --pass=\"<ls_passcode1>\"\n<color_light_green>Command accepted.\n<color_light_green>Extending bridge.\n<color_light_green>You are free.\n\n<color_light_green> @User > _</color>"
+    "dynamic_line": "&<color_light_green> @User > bridge --update=extend --pass=\"<ls_passcode1>\"\n<color_light_green>Command accepted.\n<color_light_green>Extending bridge.\n<color_light_green>You are free.\n\n<color_light_green> @User > _</color>",
+    "responses": [ { "text": "Log off.", "effect": { "run_eocs": "EOC_LS_Bridge_control_deadend_1_Passcode1" }, "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
     "id": "COMP_LS_Bridge_control_deadend_1_Extend_passcode2",
-    "dynamic_line": "&<color_light_green> @User > bridge --update=extend --pass=\"<ls_passcode2>\"\n<color_light_green>Command accepted.\n<color_light_green>Extending bridge.\n<color_light_green>Kick some ass.\n\n<color_light_green> @User > _</color>"
+    "dynamic_line": "&<color_light_green> @User > bridge --update=extend --pass=\"<ls_passcode2>\"\n<color_light_green>Command accepted.\n<color_light_green>Extending bridge.\n<color_light_green>Kick some ass.\n\n<color_light_green> @User > _</color>",
+    "responses": [ { "text": "Log off.", "effect": { "run_eocs": "EOC_LS_Bridge_control_deadend_1_Passcode2" }, "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
     "id": "COMP_LS_Bridge_control_deadend_1_Extend_passcode3",
-    "dynamic_line": "&<color_light_green> @User > bridge --update=extend --pass=\"<ls_passcode3>\"\n<color_light_green>Command accepted.\n<color_light_green>Extending bridge.\n<color_light_green>Asshole.\n\n<color_light_green> @User > _</color>"
+    "dynamic_line": "&<color_light_green> @User > bridge --update=extend --pass=\"<ls_passcode3>\"\n<color_light_green>Command accepted.\n<color_light_green>Extending bridge.\n<color_light_green>Asshole.\n\n<color_light_green> @User > _</color>",
+    "responses": [ { "text": "Log off.", "effect": { "run_eocs": "EOC_LS_Bridge_control_deadend_1_Passcode3" }, "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/exodii/netherum/labyrinth_computers.json
+++ b/data/json/npcs/exodii/netherum/labyrinth_computers.json
@@ -130,17 +130,18 @@
   },
   {
     "type": "talk_topic",
-    "id": [ "COMP_LS_Passcode_Door", "COMP_LS_Passcode_Door2", "COMP_LS_Passcode_Door3" ],
+    "id": "COMP_LS_Passcode_Door",
+    "dynamic_line": "&You see a strangely mundane black computer screen, with a blinking green cursor awaiting input.\n\n<color_light_green> @User > _</color>",
     "responses": [
       {
         "text": "Unlock connected doors",
-        "effect": [ { "math": [ "n_LS_door_requests = 1" ] }, { "run_eocs": [ "EOC_LS_Unlock", "EOC_LS_Passcode_Generator" ] } ],
+        "effect": { "math": [ "n_LS_door_requests = 1" ] },
         "topic": "COMP_LS_Passcode_Door2",
         "condition": { "math": [ "n_LS_door_requests < 1" ] }
       },
       {
         "text": "Lock connected doors",
-        "effect": [ { "math": [ "n_LS_door_requests += 1" ] }, { "run_eocs": [ "EOC_LS_Lock" ] } ],
+        "effect": { "math": [ "n_LS_door_requests += 1" ] },
         "topic": "COMP_LS_Passcode_Door3",
         "condition": { "math": [ "n_LS_door_requests == 1" ] }
       },
@@ -159,18 +160,17 @@
   },
   {
     "type": "talk_topic",
-    "id": "COMP_LS_Passcode_Door",
-    "dynamic_line": "&You see a strangely mundane black computer screen, with a blinking green cursor awaiting input.\n\n<color_light_green> @User > _</color>"
-  },
-  {
-    "type": "talk_topic",
     "id": "COMP_LS_Passcode_Door2",
-    "dynamic_line": "&<color_light_green> @User > doorstatus --update=unlock\n<color_light_green>Command accepted.\n<color_light_green>Nearby doors unlocked.\n<color_light_green>Thank you for using AltarOS.\n\n<color_light_green> @User > _"
+    "dynamic_line": "&<color_light_green> @User > doorstatus --update=unlock\n<color_light_green>Command accepted.\n<color_light_green>Nearby doors unlocked.\n<color_light_green>Thank you for using AltarOS.\n\n<color_light_green> @User > _",
+    "responses": [
+      { "text": "Log off.", "effect": { "run_eocs": [ "EOC_LS_Unlock", "EOC_LS_Passcode_Generator" ] }, "topic": "TALK_DONE" }
+    ]
   },
   {
     "type": "talk_topic",
     "id": "COMP_LS_Passcode_Door3",
-    "dynamic_line": "&<color_light_green> @User > doorstatus --update=lock\n<color_light_green>Command accepted.\n<color_light_green>Nearby doors locked.\n<color_light_green>Warning: What is done cannot be undone.  This does not represent a return to how things were.  You can never go back.\n\n<color_light_green> @User > _"
+    "dynamic_line": "&<color_light_green> @User > doorstatus --update=lock\n<color_light_green>Command accepted.\n<color_light_green>Nearby doors locked.\n<color_light_green>Warning: What is done cannot be undone.  This does not represent a return to how things were.  You can never go back.\n\n<color_light_green> @User > _",
+    "responses": [ { "text": "Log off.", "effect": { "run_eocs": [ "EOC_LS_Lock" ] }, "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
@@ -192,8 +192,7 @@
         "effect": [
           { "math": [ "u_vitamin('blood') -= -12500" ] },
           { "math": [ "u_vitamin('redcells') -= -12500" ] },
-          { "math": [ "n_LS_door_requests += 1" ] },
-          { "run_eocs": [ "EOC_LS_ReallyUnlock" ] }
+          { "math": [ "n_LS_door_requests += 1" ] }
         ]
       },
       { "text": "Log off.", "topic": "TALK_DONE" }
@@ -203,7 +202,7 @@
     "type": "talk_topic",
     "id": "COMP_LS_Passcode_Door4blood",
     "dynamic_line": "&As it enters your skin, the thin needle seems to pulse, greedily gulping from your offered hand, and you feel abruptly dizzy and lightheaded.  It feels like it took a *lot* of blood.\n\n<color_light_green> @User > Inflict --damage=lifeblood\n<color_light_green>Processing contribution of reality ||||||||| 100%\n<color_light_green>Nearby doors unlocked.\n\n<color_light_green> @User > _",
-    "responses": [ { "text": "Log off.", "topic": "TALK_DONE" } ]
+    "responses": [ { "text": "Log off.", "effect": { "run_eocs": [ "EOC_LS_ReallyUnlock" ] }, "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
@@ -221,37 +220,25 @@
     "responses": [
       {
         "text": "Enter the Thief's Passcode to extend the bridge.",
-        "effect": [
-          { "math": [ "n_LS_bridge_requests = 1" ] },
-          { "u_lose_trait": "LS_Passcode_0" }
-        ],
+        "effect": [ { "math": [ "n_LS_bridge_requests = 1" ] }, { "u_lose_trait": "LS_Passcode_0" } ],
         "condition": { "and": [ { "math": [ "n_LS_bridge_requests < 1" ] }, { "u_has_trait": "LS_Passcode_0" } ] },
         "topic": "COMP_LS_Bridge_control_deadend_1_Extend_passcode0"
       },
       {
         "text": "Enter the Circle of Wings Passcode to extend the bridge.",
-        "effect": [
-          { "math": [ "n_LS_bridge_requests = 1" ] },
-          { "u_lose_trait": "LS_Passcode_1" }
-        ],
+        "effect": [ { "math": [ "n_LS_bridge_requests = 1" ] }, { "u_lose_trait": "LS_Passcode_1" } ],
         "condition": { "and": [ { "math": [ "n_LS_bridge_requests < 1" ] }, { "u_has_trait": "LS_Passcode_1" } ] },
         "topic": "COMP_LS_Bridge_control_deadend_1_Extend_passcode1"
       },
       {
         "text": "Enter the Hard Nails Passcode to extend the bridge.",
-        "effect": [
-          { "math": [ "n_LS_bridge_requests = 1" ] },
-          { "u_lose_trait": "LS_Passcode_2" }
-        ],
+        "effect": [ { "math": [ "n_LS_bridge_requests = 1" ] }, { "u_lose_trait": "LS_Passcode_2" } ],
         "condition": { "and": [ { "math": [ "n_LS_bridge_requests < 1" ] }, { "u_has_trait": "LS_Passcode_2" } ] },
         "topic": "COMP_LS_Bridge_control_deadend_1_Extend_passcode2"
       },
       {
         "text": "Enter the Laughing Man Passcode to extend the bridge.",
-        "effect": [
-          { "math": [ "n_LS_bridge_requests = 1" ] },
-          { "u_lose_trait": "LS_Passcode_3" }
-        ],
+        "effect": [ { "math": [ "n_LS_bridge_requests = 1" ] }, { "u_lose_trait": "LS_Passcode_3" } ],
         "condition": { "and": [ { "math": [ "n_LS_bridge_requests < 1" ] }, { "u_has_trait": "LS_Passcode_3" } ] },
         "topic": "COMP_LS_Bridge_control_deadend_1_Extend_passcode3"
       },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix var/mapgen-related labyrinth computer crash"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #87665

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

From @RenechCDDA : "I think what's happening is that the rotation guard is not deconstructing in time and does not rotate the SMs back before we call for the computer - which is no longer where it was"

My understanding: When the dialogue effect does both `math` to assign an `n_` value and simultaneously fires an EOC to update the mapgen, _in a rotated map that the computer handling the dialogue is itself in_, it causes a crash because the beta talker basically can't be found, because it's been temporarily rotated for the update, and its location can't be properly resolved.

This fixes it for these terminal by making it no longer relevant.  Now, the first dialogue response to extend the bridge removes the passcode trait and applies the appropriate var to the furniture, and the subsequent dialogue response to log off updates the map.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested terminals in all configurations in a labyrinth.  No more crash (for now...)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Obviously this doesn't fix any underlying problem that may exist with the `rotation_guard`.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
