### PR TITLE
[XedraWood] The Wise are literate, start with hedge magic recipes

### DIFF
--- a/data/mods/XedraWood/effect_on_condition/eoc_game_start.json
+++ b/data/mods/XedraWood/effect_on_condition/eoc_game_start.json
@@ -6,10 +6,7 @@
     "required_event": "game_start",
     "effect": [
       { "u_add_trait": "XEDRA_WOOD_COMPUTER_ILLITERATE" },
-      { 
-        "if": {"not": { "u_has_trait": "WISE_LITERATE" } },
-        "then": { "u_add_trait": "ILLITERATE" }
-      }
+      { "if": { "not": { "u_has_trait": "WISE_LITERATE" } }, "then": { "u_add_trait": "ILLITERATE" } }
     ]
   },
   {

--- a/data/mods/XedraWood/effect_on_condition/eoc_game_start.json
+++ b/data/mods/XedraWood/effect_on_condition/eoc_game_start.json
@@ -4,7 +4,13 @@
     "id": "EOC_XEDRAWOOD_TRADITIONAL_MINDSET",
     "eoc_type": "EVENT",
     "required_event": "game_start",
-    "effect": [ { "u_add_trait": "XEDRA_WOOD_COMPUTER_ILLITERATE" }, { "u_add_trait": "ILLITERATE" } ]
+    "effect": [
+      { "u_add_trait": "XEDRA_WOOD_COMPUTER_ILLITERATE" },
+      { 
+        "if": {"not": { "u_has_trait": "WISE_LITERATE" } },
+        "then": { "u_add_trait": "ILLITERATE" }
+      }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/XedraWood/effects/recipe_effects.json
+++ b/data/mods/XedraWood/effects/recipe_effects.json
@@ -11,5 +11,13 @@
     "rating": "mixed",
     "enchantments": [ { "values": [ { "value": "REGEN_MANA", "multiply": -999 } ] } ],
     "flags": [ "NO_HEDGE_MAGICK" ]
+  },
+  {
+    "id": "effect_xedrawood_hedge_magic_spirit_questing",
+    "type": "effect_type",
+    "name": [ "Spirit-Questing" ],
+    "desc": [ "You are questing in the spirit world." ],
+    "rating": "mixed",
+    "flags": [ "BLIND", "DEAF" ]
   }
 ]

--- a/data/mods/XedraWood/effects/recipe_effects.json
+++ b/data/mods/XedraWood/effects/recipe_effects.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": "effect_xedrawood_hedge_magic_spirit_quest_completed",
+    "type": "effect_type",
+    "name": [ "Underwent Spirit-Quest" ],
+    "desc": [
+      "You underwent a quest to the Unseen World and your spirit is depleted.  You cannot use either the lesser or greater mysteries until it recovers."
+    ],
+    "apply_message": "",
+    "remove_message": "Your spirit has recovered from your quest.",
+    "rating": "mixed",
+    "enchantments": [ { "values": [ { "value": "REGEN_MANA", "multiply": -999 } ] } ],
+    "flags": [ "NO_HEDGE_MAGICK" ]
+  }
+]

--- a/data/mods/XedraWood/effects/recipe_effects.json
+++ b/data/mods/XedraWood/effects/recipe_effects.json
@@ -19,5 +19,26 @@
     "desc": [ "You are questing in the spirit world." ],
     "rating": "mixed",
     "flags": [ "BLIND", "DEAF" ]
+  },
+  {
+    "id": "effect_xedrawood_hedge_magic_spirit_questing_hallu_tracker",
+    "//": "hidden effect, used as a tracker",
+    "type": "effect_type",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
+    "id": "effect_xedrawood_hedge_magic_spirit_questing_thirst_tracker",
+    "//": "hidden effect, used as a tracker",
+    "type": "effect_type",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
+    "id": "effect_xedrawood_hedge_magic_spirit_questing_hunger_tracker",
+    "//": "hidden effect, used as a tracker",
+    "type": "effect_type",
+    "name": [ "" ],
+    "desc": [ "" ]
   }
 ]

--- a/data/mods/XedraWood/items/books.json
+++ b/data/mods/XedraWood/items/books.json
@@ -5,7 +5,7 @@
     "category": "manuals",
     "id": "magical_grimoire_apprentice",
     "name": { "str": "apprentice's grimoire", "str_pl": "copies of apprentice's grimoire" },
-    "description": "A compilation of your elementary magical observations.  This would be extremely useful as a reference material.",
+    "description": "A compilation of your elementary magical observations, a series of diagrams, maps, drawings of leaves and the sky and the moon, and ticks to mark times and numbers you've counted.  This would be extremely useful as a reference material.",
     "weight": "920 g",
     "volume": "750 ml",
     "material": [ "paper" ],
@@ -19,5 +19,13 @@
     "intelligence": 11,
     "time": "60 m",
     "read_fun": -2
+  },
+  {
+    "type": "ITEM",
+    "subtypes": [ "BOOK" ],
+    "category": "manuals",
+    "id": "magical_grimoire_apprentice_wise",
+    "name": { "str": "apprentice's grimoire", "str_pl": "copies of apprentice's grimoire" },
+    "description": "Written in the runes of the wise, this contains the rituals and supplications necessary to unlock the secrets of the lesser mysteries.",
   }
 ]

--- a/data/mods/XedraWood/items/books.json
+++ b/data/mods/XedraWood/items/books.json
@@ -25,7 +25,8 @@
     "subtypes": [ "BOOK" ],
     "category": "manuals",
     "id": "magical_grimoire_apprentice_wise",
+    "copy-from": "magical_grimoire_apprentice",
     "name": { "str": "apprentice's grimoire", "str_pl": "copies of apprentice's grimoire" },
-    "description": "Written in the runes of the wise, this contains the rituals and supplications necessary to unlock the secrets of the lesser mysteries.",
+    "description": "Written using the runes of the wise, this contains the rituals and supplications necessary to unlock the secrets of the lesser mysteries."
   }
 ]

--- a/data/mods/XedraWood/mapgen/wise_one_dwellings/wise_one_hut.json
+++ b/data/mods/XedraWood/mapgen/wise_one_dwellings/wise_one_hut.json
@@ -82,7 +82,7 @@
         { "item": "fire_drill_large", "x": 13, "y": 10, "chance": 100 },
         { "item": "oil_lamp_clay", "x": 11, "y": 13, "chance": 100 },
         { "item": "primitive_axe", "x": 12, "y": 10, "chance": 100 },
-        { "item": "log", "x": 12, "y": 11, "chance": 100, "repeat": [ 75, 150 ] },
+        { "item": "firewood", "x": 12, "y": 11, "chance": 100, "repeat": [ 75, 150 ] },
         { "item": "clay_pot", "x": 16, "y": 7, "chance": 100 }
       ]
     }

--- a/data/mods/XedraWood/player/activities.json
+++ b/data/mods/XedraWood/player/activities.json
@@ -25,6 +25,7 @@
     "verb": "seeking knowledge from the Unseen World",
     "rooted": true,
     "based_on": "time",
+    "can_resume": false,
     "completion_eoc": "EOC_XEDRAWOOD_HEDGE_MAGIC_SPIRIT_QUEST_FINALIZATION"
   },
   {
@@ -35,16 +36,35 @@
       "difficulty": 14
     },
     "effect": [
-      "u_cancel_activity",
       { "run_eocs": "EOC_RESEARCH_THAUMATURGY_GAIN_SPELL" },
       { "u_message": "Your spirit returns with knowledge from the Unseen World.", "type": "good" },
       { "math": [ "u_val('mana') = 0" ] },
-      { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "7 days" }
+      { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "7 days" },
+      { "u_remove_effect": "effect_xedrawood_hedge_magic_spirit_questing" }
     ],
     "false_effect": [
       { "u_message": "Your spirit returns in failure.  You have gained no new knowledge from your quest.", "type": "good" },
       { "math": [ "u_val('mana') = 0" ] },
-      { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "7 days" }
+      { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "7 days" },
+      { "u_remove_effect": "effect_xedrawood_hedge_magic_spirit_questing" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_XEDRAWOOD_HEDGE_MAGIC_SPIRIT_QUEST_CANCEL",
+    "eoc_type": "EVENT",
+    "required_event": "character_finished_activity",
+    "condition": {
+      "and": [
+        { "compare_string": [ "ACT_XEDRAWOOD_HEDGE_MAGIC_SPIRIT_QUEST", { "context_val": "activity" } ] },
+        { "u_has_effect": "effect_xedrawood_hedge_magic_spirit_questing" }
+      ]
+    },
+    "effect": [
+      { "u_message": "You break off your quest into the spirit world.", "type": "good" },
+      { "math": [ "u_val('mana') = 0" ] },
+      { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "2 days" },
+      { "u_remove_effect": "effect_xedrawood_hedge_magic_spirit_questing" }
     ]
   }
 ]

--- a/data/mods/XedraWood/player/activities.json
+++ b/data/mods/XedraWood/player/activities.json
@@ -36,17 +36,28 @@
       "difficulty": 14
     },
     "effect": [
-      { "run_eocs": "EOC_RESEARCH_THAUMATURGY_GAIN_SPELL" },
-      { "u_message": "Your spirit returns with knowledge from the Unseen World.", "type": "good" },
-      { "math": [ "u_val('mana') = 0" ] },
-      { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "7 days" },
-      { "u_lose_effect": "effect_xedrawood_hedge_magic_spirit_questing" }
-    ],
-    "false_effect": [
-      { "u_message": "Your spirit returns in failure.  You have gained no new knowledge from your quest.", "type": "bad" },
-      { "math": [ "u_val('mana') = 0" ] },
-      { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "7 days" },
-      { "u_lose_effect": "effect_xedrawood_hedge_magic_spirit_questing" }
+      {
+        "math": [
+          "_roll_results = (u_skill('deduction') + (u_skill('speech') / 2) + rng(-2,8) + rng(-2,8)) + (u_effect_intensity('effect_xedrawood_hedge_magic_spirit_questing_hallu_tracker') > -1 ? 1 : 0) + (u_effect_intensity('effect_xedrawood_hedge_magic_spirit_questing_thirst_tracker') > -1 ? 1 : 0) + (u_effect_intensity('effect_xedrawood_hedge_magic_spirit_questing_hunger_tracker') > -1 ? 1 : 0)"
+        ]
+      },
+      { "message": "You rolled a <context_val:roll_results> vs difficulty 15.", "type": "debug" },
+      {
+        "if": { "roll_contested": { "math": [ "_roll_results" ] }, "difficulty": 15 },
+        "then": [
+          { "run_eocs": "EOC_RESEARCH_THAUMATURGY_GAIN_SPELL" },
+          { "u_message": "Your spirit returns with knowledge from the Unseen World.", "type": "good" },
+          { "math": [ "u_val('mana') = 0" ] },
+          { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "7 days" },
+          { "u_lose_effect": "effect_xedrawood_hedge_magic_spirit_questing" }
+        ],
+        "else": [
+          { "u_message": "Your spirit returns in failure.  You have gained no new knowledge from your quest.", "type": "bad" },
+          { "math": [ "u_val('mana') = 0" ] },
+          { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "7 days" },
+          { "u_lose_effect": "effect_xedrawood_hedge_magic_spirit_questing" }
+        ]
+      }
     ]
   },
   {

--- a/data/mods/XedraWood/player/activities.json
+++ b/data/mods/XedraWood/player/activities.json
@@ -42,9 +42,9 @@
       { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "7 days" }
     ],
     "false_effect": [
-      { "u_message": "Your spirit returns in failure.  You have gained nothing from your quest.", "type": "good" },
+      { "u_message": "Your spirit returns in failure.  You have gained no new knowledge from your quest.", "type": "good" },
       { "math": [ "u_val('mana') = 0" ] },
-      { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "3- days" }
+      { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "7 days" }
     ]
   }
 ]

--- a/data/mods/XedraWood/player/activities.json
+++ b/data/mods/XedraWood/player/activities.json
@@ -17,5 +17,34 @@
       { "u_lose_effect": "effect_pattern_tattoo_meditation" },
       { "u_message": "Replete with anima, you cease your meditations.", "type": "good" }
     ]
+  },
+  {
+    "id": "ACT_XEDRAWOOD_HEDGE_MAGIC_SPIRIT_QUEST",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "seeking knowledge from the Unseen World",
+    "rooted": true,
+    "based_on": "time",
+    "completion_eoc": "EOC_XEDRAWOOD_HEDGE_MAGIC_SPIRIT_QUEST_FINALIZATION"
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_XEDRAWOOD_HEDGE_MAGIC_SPIRIT_QUEST_FINALIZATION",
+    "condition": {
+      "roll_contested": { "math": [ "u_skill('deduction') + (u_skill('speech') / 2) + rng(-2,8) + rng(-2,8)" ] },
+      "difficulty": 14
+    },
+    "effect": [
+      "u_cancel_activity",
+      { "run_eocs": "EOC_RESEARCH_THAUMATURGY_GAIN_SPELL" },
+      { "u_message": "Your spirit returns with knowledge from the Unseen World.", "type": "good" },
+      { "math": [ "u_val('mana') = 0" ] },
+      { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "7 days" }
+    ],
+    "false_effect": [
+      { "u_message": "Your spirit returns in failure.  You have gained nothing from your quest.", "type": "good" },
+      { "math": [ "u_val('mana') = 0" ] },
+      { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "3- days" }
+    ]
   }
 ]

--- a/data/mods/XedraWood/player/activities.json
+++ b/data/mods/XedraWood/player/activities.json
@@ -40,13 +40,13 @@
       { "u_message": "Your spirit returns with knowledge from the Unseen World.", "type": "good" },
       { "math": [ "u_val('mana') = 0" ] },
       { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "7 days" },
-      { "u_remove_effect": "effect_xedrawood_hedge_magic_spirit_questing" }
+      { "u_lose_effect": "effect_xedrawood_hedge_magic_spirit_questing" }
     ],
     "false_effect": [
-      { "u_message": "Your spirit returns in failure.  You have gained no new knowledge from your quest.", "type": "good" },
+      { "u_message": "Your spirit returns in failure.  You have gained no new knowledge from your quest.", "type": "bad" },
       { "math": [ "u_val('mana') = 0" ] },
       { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "7 days" },
-      { "u_remove_effect": "effect_xedrawood_hedge_magic_spirit_questing" }
+      { "u_lose_effect": "effect_xedrawood_hedge_magic_spirit_questing" }
     ]
   },
   {
@@ -61,10 +61,10 @@
       ]
     },
     "effect": [
-      { "u_message": "You break off your quest into the spirit world.", "type": "good" },
+      { "u_message": "You break off your quest into the spirit world.", "type": "mixed" },
       { "math": [ "u_val('mana') = 0" ] },
       { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_quest_completed", "duration": "2 days" },
-      { "u_remove_effect": "effect_xedrawood_hedge_magic_spirit_questing" }
+      { "u_lose_effect": "effect_xedrawood_hedge_magic_spirit_questing" }
     ]
   }
 ]

--- a/data/mods/XedraWood/player/professions.json
+++ b/data/mods/XedraWood/player/professions.json
@@ -251,7 +251,7 @@
       { "id": "hedge_no_nightmares", "level": 1 },
       { "id": "hedge_astral_projection", "level": 1 }
     ],
-    "traits": [ "WITCHSIGHT", "HEDGE_MAGIC", "INSOMNIA" ],
+    "traits": [ "WITCHSIGHT", "WISE_LITERATE", "HEDGE_MAGIC", "INSOMNIA" ],
     "proficiencies": [ "prof_wound_care", "prof_occult_exploration", "prof_thaumatology" ],
     "hobbies": [
       "hobby_species_gracken",
@@ -294,7 +294,16 @@
       { "id": "forest_unity_nature", "level": 4 },
       { "id": "forest_traverse_the_wilds", "level": 2 }
     ],
-    "traits": [ "XEDRAWOOD_THE_WISE", "WITCHSIGHT", "HEDGE_MAGIC", "FOREST_MAGIC", "ELFAEYES", "ANIMALEMPATH2", "SEASONAL_AFFECTIVE" ],
+    "traits": [
+      "XEDRAWOOD_THE_WISE",
+      "WISE_LITERATE",
+      "WITCHSIGHT",
+      "HEDGE_MAGIC",
+      "FOREST_MAGIC",
+      "ELFAEYES",
+      "ANIMALEMPATH2",
+      "SEASONAL_AFFECTIVE"
+    ],
     "proficiencies": [ "prof_wound_care", "prof_occult_exploration", "prof_thaumatology" ],
     "recipes": [ "q_staff_of_the_wise" ],
     "hobbies": [

--- a/data/mods/XedraWood/player/professions.json
+++ b/data/mods/XedraWood/player/professions.json
@@ -260,6 +260,14 @@
       "hates_books",
       "witch_sight"
     ],
+    "recipes": [
+      "assemble_forest_research_materials",
+      "assemble_earth_research_materials",
+      "assemble_moon_research_materials",
+      "assemble_sky_research_materials",
+      "assemble_sea_research_materials",
+      "learn_hedge_magic_spell"
+    ],
     "whitelist_hobbies": false,
     "items": {
       "both": {
@@ -271,7 +279,7 @@
           { "item": "footrags_leather" },
           { "item": "water_clean", "charges": 6, "container-item": "waterskin" },
           { "item": "grass_keffiyeh" },
-          { "item": "magical_grimoire_apprentice", "container-item": "straw_basket" },
+          { "item": "magical_grimoire_apprentice_wise", "container-item": "straw_basket" },
           { "item": "primitive_knife", "container-item": "sheath_birchbark" }
         ]
       }
@@ -305,7 +313,15 @@
       "SEASONAL_AFFECTIVE"
     ],
     "proficiencies": [ "prof_wound_care", "prof_occult_exploration", "prof_thaumatology" ],
-    "recipes": [ "q_staff_of_the_wise" ],
+    "recipes": [ 
+      "q_staff_of_the_wise",
+      "assemble_forest_research_materials",
+      "assemble_earth_research_materials",
+      "assemble_moon_research_materials",
+      "assemble_sky_research_materials",
+      "assemble_sea_research_materials",
+      "learn_hedge_magic_spell"
+    ],
     "hobbies": [
       "hobby_species_gracken",
       "hobby_species_changeling_noble",
@@ -322,7 +338,7 @@
           { "item": "pants_leather" },
           { "item": "leathersandals" },
           { "item": "water_clean", "charges": 6, "container-item": "waterskin" },
-          { "item": "magical_grimoire_apprentice", "container-item": "straw_basket" },
+          { "item": "magical_grimoire_apprentice_wise", "container-item": "straw_basket" },
           { "item": "q_staff_of_the_wise" },
           { "item": "primitive_knife", "container-item": "sheath_birchbark" }
         ]

--- a/data/mods/XedraWood/player/professions.json
+++ b/data/mods/XedraWood/player/professions.json
@@ -244,7 +244,12 @@
     "name": "Apprentice to the Wise",
     "description": "From your birth, you were in contact with the spirit world.  You were trained in the ways of the spirits and mediated between them and your tribe.  In time, one of the Wise came to your village to induct you into the deeper mysteries, but they vanished before completing your training.  Now that you're alone, you'll need to contact the spirits of this new place and learn their ways.",
     "points": 3,
-    "skills": [ { "level": 1, "name": "firstaid" }, { "level": 3, "name": "deduction" }, { "level": 1, "name": "survival" } ],
+    "skills": [
+      { "level": 1, "name": "firstaid" },
+      { "level": 3, "name": "deduction" },
+      { "level": 1, "name": "survival" },
+      { "level": 3, "name": "speech" }
+    ],
     "spells": [
       { "id": "hedge_ward_off_rain", "level": 1 },
       { "id": "hedge_light_fire", "level": 1 },
@@ -253,20 +258,13 @@
     ],
     "traits": [ "WITCHSIGHT", "WISE_LITERATE", "HEDGE_MAGIC", "INSOMNIA" ],
     "proficiencies": [ "prof_wound_care", "prof_occult_exploration", "prof_thaumatology" ],
+    "recipes": [ "learn_hedge_magic_spells_wise" ],
     "hobbies": [
       "hobby_species_gracken",
       "hobby_species_changeling_noble",
       "hobby_species_changeling_commoner",
       "hates_books",
       "witch_sight"
-    ],
-    "recipes": [
-      "assemble_forest_research_materials",
-      "assemble_earth_research_materials",
-      "assemble_moon_research_materials",
-      "assemble_sky_research_materials",
-      "assemble_sea_research_materials",
-      "learn_hedge_magic_spell"
     ],
     "whitelist_hobbies": false,
     "items": {
@@ -292,12 +290,18 @@
     "description": "You passed your apprenticeship among the Wise, learning the lesser mysteries and undergoing the ordeal to bond your soul with that of the Forest.  You succeeded where many of your fellow apprentices failed and began to learn the deeper mysteries under the tutelage of your master.  Now you're on your own, but your knowledge will guide your way forward.",
     "flags": [ "SCEN_ONLY" ],
     "points": 10,
-    "skills": [ { "level": 2, "name": "firstaid" }, { "level": 5, "name": "deduction" }, { "level": 3, "name": "survival" } ],
+    "skills": [
+      { "level": 2, "name": "firstaid" },
+      { "level": 5, "name": "deduction" },
+      { "level": 3, "name": "survival" },
+      { "level": 4, "name": "speech" }
+    ],
     "spells": [
       { "id": "hedge_increase_healing_rate", "level": 1 },
       { "id": "hedge_make_plants_grow", "level": 1 },
       { "id": "hedge_extinguish_fire_spell", "level": 1 },
       { "id": "hedge_prevent_wild_animal_attacks", "level": 1 },
+      { "id": "hedge_astral_projection", "level": 1 },
       { "id": "forest_commanding_grasses", "level": 5 },
       { "id": "forest_unity_nature", "level": 4 },
       { "id": "forest_traverse_the_wilds", "level": 2 }
@@ -313,15 +317,7 @@
       "SEASONAL_AFFECTIVE"
     ],
     "proficiencies": [ "prof_wound_care", "prof_occult_exploration", "prof_thaumatology" ],
-    "recipes": [ 
-      "q_staff_of_the_wise",
-      "assemble_forest_research_materials",
-      "assemble_earth_research_materials",
-      "assemble_moon_research_materials",
-      "assemble_sky_research_materials",
-      "assemble_sea_research_materials",
-      "learn_hedge_magic_spell"
-    ],
+    "recipes": [ "q_staff_of_the_wise", "learn_hedge_magic_spells_wise" ],
     "hobbies": [
       "hobby_species_gracken",
       "hobby_species_changeling_noble",

--- a/data/mods/XedraWood/player/traits.json
+++ b/data/mods/XedraWood/player/traits.json
@@ -45,6 +45,15 @@
   },
   {
     "type": "mutation",
+    "id": "WISE_LITERATE",
+    "name": { "str": "Rune-Lore" },
+    "description": "You know the secret signs and runes used by the Wise to pass messages and record information.",
+    "cancels": [ "ILLITERATE" ],
+    "points": 0,
+    "valid": false
+  },
+  {
+    "type": "mutation",
     "id": "TATTOOS_BASIC_TRAIT",
     "name": { "str": "Anima Attunement" },
     "description": "You have been attuned to anima and can make use of tattoo patterns.  You regain anima quickly while meditating, moderately while asleep, and very slowly while awake.",

--- a/data/mods/XedraWood/recipes/hedge_recipes.json
+++ b/data/mods/XedraWood/recipes/hedge_recipes.json
@@ -357,6 +357,12 @@
           },
           { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_questing", "duration": "9 hours" },
           { "u_assign_activity": "ACT_XEDRAWOOD_HEDGE_MAGIC_SPIRIT_QUEST", "duration": "8 hours" }
+        ],
+        "false_effect": [
+          {
+            "u_message": "Your spirit has still not recovered.  You must wait before attempting another spirit-quest.",
+            "type": "bad"
+          }
         ]
       }
     ]

--- a/data/mods/XedraWood/recipes/hedge_recipes.json
+++ b/data/mods/XedraWood/recipes/hedge_recipes.json
@@ -342,7 +342,10 @@
       {
         "id": "EOC_RESEARCH_THAUMATURGY_THE_WISE_STUDY",
         "condition": { "math": [ "u_val('mana') > 0" ] },
-        "effect": [ { "u_assign_activity": "ACT_XEDRAWOOD_HEDGE_MAGIC_SPIRIT_QUEST", "duration": "8 hours" } ]
+        "effect": [
+          { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_questing", "duration": "9 hours" },
+          { "u_assign_activity": "ACT_XEDRAWOOD_HEDGE_MAGIC_SPIRIT_QUEST", "duration": "8 hours" }
+        ]
       }
     ]
   }

--- a/data/mods/XedraWood/recipes/hedge_recipes.json
+++ b/data/mods/XedraWood/recipes/hedge_recipes.json
@@ -2,7 +2,7 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "name": "research thaumaturgy",
+    "name": "delve into the lesser mysteries",
     "id": "study_hedge_magic",
     "description": "There's power in the natural world.  You can see that now.  Using your compiled notes and studying previous observations, you're sure you can find out how to access it.",
     "category": "CC_XEDRA",
@@ -50,7 +50,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "name": "assemble forest research materials",
     "id": "assemble_forest_research_materials",
-    "description": "Conduct observation of the trees and grass and study herbs to develop a corpus of research for thaumaturgy.  You must be in a forest to conduct your research.",
+    "description": "Conduct observation of the trees and grass and study herbs to develop a corpus of research for the lesser mysteries.  You must be in a forest to conduct your research.",
     "category": "CC_XEDRA",
     "subcategory": "CSC_XEDRA_RESEARCH",
     "difficulty": 5,
@@ -88,7 +88,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "name": "assemble earth research materials",
     "id": "assemble_earth_research_materials",
-    "description": "Conduct observation of the soil quality and study magical minerals to develop a corpus of research for thaumaturgy.  You must be underground to conduct your research.",
+    "description": "Conduct observation of the soil quality and study magical minerals to develop a corpus of research for lesser mysteries.  You must be underground to conduct your research.",
     "category": "CC_XEDRA",
     "subcategory": "CSC_XEDRA_RESEARCH",
     "difficulty": 5,
@@ -126,7 +126,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "name": "assemble moon research materials",
     "id": "assemble_moon_research_materials",
-    "description": "Conduct observation of the moon and study astrological charts to develop a corpus of research for thaumaturgy.  You must be outdoors at night to conduct your research.",
+    "description": "Conduct observation of the moon and study astrological charts to develop a corpus of research for lesser mysteries.  You must be outdoors at night to conduct your research.",
     "category": "CC_XEDRA",
     "subcategory": "CSC_XEDRA_RESEARCH",
     "difficulty": 5,
@@ -164,7 +164,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "name": "assemble sky research materials",
     "id": "assemble_sky_research_materials",
-    "description": "Conduct observation of the sky and study weather recordings develop a corpus of research for thaumaturgy.  You must be outdoors on a day with clouds to conduct your research.",
+    "description": "Conduct observation of the sky and study weather recordings develop a corpus of research for lesser mysteries.  You must be outdoors on a day with clouds to conduct your research.",
     "category": "CC_XEDRA",
     "subcategory": "CSC_XEDRA_RESEARCH",
     "difficulty": 5,
@@ -202,7 +202,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "name": "assemble sea research materials",
     "id": "assemble_sea_research_materials",
-    "description": "Conduct observation of the waves and study tidal records to develop a corpus of research for thaumaturgy.",
+    "description": "Conduct observation of the waves and study tidal records to develop a corpus of research for lesser mysteries.  You must be near a large body of water to conduct your research.",
     "category": "CC_XEDRA",
     "subcategory": "CSC_XEDRA_RESEARCH",
     "difficulty": 5,
@@ -317,8 +317,32 @@
             "true_eocs": [  ],
             "false_eocs": [ "EOC_RESEARCH_THAUMATURGY_OUT" ]
           },
-          { "u_message": "You learn a secret of thaumaturgy.", "type": "good" }
+          { "u_message": "You learn a secret of the lesser mysteries.", "type": "good" }
         ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "spirit-quest to unlock the lesser mysteries",
+    "//": "In the future maybe use dimension mechanics, once we can do independent time passing, that way it's not just a dice roll in the background",
+    "id": "learn_hedge_magic_spells_wise",
+    "description": "Enter a trance and cast your spirit forth, seeking guidance in the Unseen World to unlock a secret of the lesser mysteries.  Doing so will debilitate you for a time afterward, rendering you unable to call on either the lesser or greater mysteries.",
+    "category": "CC_XEDRA",
+    "subcategory": "CSC_XEDRA_RESEARCH",
+    "difficulty": 5,
+    "skill_used": "deduction",
+    "time": "0 s",
+    "proficiencies": [
+      { "proficiency": "prof_occult_exploration", "required": true },
+      { "proficiency": "prof_thaumatology", "required": true }
+    ],
+    "result_eocs": [
+      {
+        "id": "EOC_RESEARCH_THAUMATURGY_THE_WISE_STUDY",
+        "condition": { "math": [ "u_val('mana') > 0" ] },
+        "effect": [ { "u_assign_activity": "ACT_XEDRAWOOD_HEDGE_MAGIC_SPIRIT_QUEST", "duration": "8 hours" } ]
       }
     ]
   }

--- a/data/mods/XedraWood/recipes/hedge_recipes.json
+++ b/data/mods/XedraWood/recipes/hedge_recipes.json
@@ -343,6 +343,18 @@
         "id": "EOC_RESEARCH_THAUMATURGY_THE_WISE_STUDY",
         "condition": { "math": [ "u_val('mana') > 0" ] },
         "effect": [
+          {
+            "if": { "u_has_any_effect": [ "hallu", "datura" ] },
+            "then": { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_questing_hallu_tracker", "duration": "9 hours" }
+          },
+          {
+            "if": { "math": [ "u_val('instant_thirst') > 240" ] },
+            "then": { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_questing_thirst_tracker", "duration": "9 hours" }
+          },
+          {
+            "if": { "u_has_any_effect": [ "hunger_near_starving", "hunger_starving", "hunger_famished" ] },
+            "then": { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_questing_hunger_tracker", "duration": "9 hours" }
+          },
           { "u_add_effect": "effect_xedrawood_hedge_magic_spirit_questing", "duration": "9 hours" },
           { "u_assign_activity": "ACT_XEDRAWOOD_HEDGE_MAGIC_SPIRIT_QUEST", "duration": "8 hours" }
         ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[XedraWood] The Wise are literate, start with hedge magic recipes"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #87693

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a trait to the Apprentice to the Wise and the Brother/Sister to the Trees that prevents illiteracy from being applied to them. Make sure they innately know the recipes for learning hedge magic and give them a copy-from version of the apprentice grimoire with a different description. Also edit the other apprentice grimoire to imply that it doesn't have any writing in it.

Add a separate recipe for the Wise to study hedge magic--it requires no physical materials (it's a spirit quest instead), but takes all your mana, sets mana regen to zero for ~~two~~ one week and prevents you from using hedge magick.  You need to pass a roll that relies on your Occult skill and, to a lesser extent, your Social skill. It _is_ possible to succeed through luck if you have both skills at 0, but you won't because to get this recipe you need to start with a profession that has it. 

(In the future maybe I'll use dimension mechanics so you can actually do the spirit quest, once time can pass independently among dimensions. I could make it a dialogue-based text adventure but I suspect people would hate it if I e..g randomized the spirit you're dealing with's stats.)

You can do various spirit-quest preparation things, like motifying your flesh (high hunger and thirst values) or taking hallucinogenic drugs to increase your success chance.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spirit-quest works and can succeed. It can be cancelled. Consequences exist.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Also spirit quest to gain additional Forest Magic spells? Maybe another PR. 

One week might seem like a long time but it only stops you from using magic, it doesn't do anything to your weariness or physical abilities. And if we had speedy time passing mechanics I'd probably make it longer. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
