### PR TITLE
Allow 1L Copper Ingots to be made with Copper

### DIFF
--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -414,7 +414,7 @@
     "using": [ [ "forging_standard", 1 ], [ "bronzesmithing_tools", 1 ] ],
     "tools": [ [ [ "casting_mold", -1 ] ] ],
     "book_learn": [ [ "metal_casting_book", 2 ] ],
-    "components": [ [ [ "scrap_copper", 36 ], [ "copper", 1800 ]  ] ]
+    "components": [ [ [ "scrap_copper", 36 ], [ "copper", 1800 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -414,7 +414,7 @@
     "using": [ [ "forging_standard", 1 ], [ "bronzesmithing_tools", 1 ] ],
     "tools": [ [ [ "casting_mold", -1 ] ] ],
     "book_learn": [ [ "metal_casting_book", 2 ] ],
-    "components": [ [ [ "scrap_copper", 36 ] ] ]
+    "components": [ [ [ "scrap_copper", 36 ], [ "copper", 1800 ]  ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
Balance "Allow copper ingots in 1l_copper recipe"

#### Purpose of change

Added a new entry to the "1l_copper" recipe to allow "copper" to be used in addition to "scrap_copper". I set the value to 1800, which matches the copper value of scrap copper. Copper builds up in large amounts lately, and our only options are to hoard thousands of it or take a long time mashing them together with a hammer which takes about 30 minutes in-game per scrap.

#### Describe the solution

Copper ingots require melting copper together in a furnace. I see no difference in melting a block of smashed copper bits and unsmashed copper bits

#### Describe alternatives you've considered

Reducing the crafting time of the scrap copper doesn't seem proper.

#### Testing

Seems to work fine

#### Additional context

This is my first time doing a pull request. If something goes wrong, I would appreciate some advice on where I messed up.