### PR TITLE
[XE] Fix the fruit's music lasting forever.

### DIFF
--- a/data/mods/Xedra_Evolved/items/comestibles/goblin_fruits.json
+++ b/data/mods/Xedra_Evolved/items/comestibles/goblin_fruits.json
@@ -565,7 +565,11 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_GOBLIN_FRUIT_MUSIC_REMOVE",
-    "effect": [ { "u_message": "The song in your head fades.", "type": "info" }, { "u_lose_trait": "GOBLIN_FRUIT_MUSIC" } ]
+    "effect": [
+      { "u_message": "The song in your head fades.", "type": "info" },
+      { "u_lose_trait": "GOBLIN_FRUIT_MUSIC" },
+      { "u_consume_item": "internal_mp3_fruit_on" }
+    ]
   },
   {
     "type": "ITEM",


### PR DESCRIPTION
#### Summary
Mods "[XE] Fix the fruit's music lasting forever."

#### Purpose of change

Fixes #87619

#### Describe the solution

Makes the music removal EOC remove the item.

#### Describe alternatives you've considered

Find how to make the mutation system remove active versions of mutation-granted items when losing said mutations. Since I never touched to that system, I'm doing a Json fix.

#### Testing

Game loads
The mp3-like item is removed by the removal EOC, stopping the effec.

#### Additional context