### PR TITLE
Fix pixel minimap grid lines and GCC9 build

### DIFF
--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -192,43 +192,26 @@ class pixel_minimap::shared_texture_pool
         std::vector<size_t> inactive_index;
 };
 
-struct pixel_minimap::submap_cache {
-    //the color stored for each submap tile
-    std::array<SDL_Color, SEEX *SEEY> minimap_colors = {};
-    //checks if the submap has been looked at by the minimap routine
-    bool touched = false;
-    //the texture updates are drawn to
-    SDL_Texture_Ptr chunk_tex;
-    //the submap being handled
-    size_t texture_index = 0;
-    //the list of updates to apply to the texture
-    //reduces render target switching to once per submap
-    std::vector<point> update_list;
-    //flag used to indicate that the texture needs to be cleared before first use
-    bool ready = false;
-    shared_texture_pool &pool;
+//reserve the SEEX * SEEY submap tiles
+pixel_minimap::submap_cache::submap_cache( shared_texture_pool &pool ) :
+    pool( pool )
+{
+    chunk_tex = pool.request_tex( texture_index );
+}
 
-    //reserve the SEEX * SEEY submap tiles
-    explicit submap_cache( shared_texture_pool &pool ) :
-        pool( pool ) {
-        chunk_tex = pool.request_tex( texture_index );
-    }
+//handle the release of the borrowed texture
+pixel_minimap::submap_cache::~submap_cache()
+{
+    pool.release_tex( texture_index, std::move( chunk_tex ) );
+}
 
-    //handle the release of the borrowed texture
-    ~submap_cache() {
-        pool.release_tex( texture_index, std::move( chunk_tex ) );
-    }
+SDL_Color &pixel_minimap::submap_cache::color_at( const point &p )
+{
+    cata_assert( p.x >= 0 && p.x < SEEX );
+    cata_assert( p.y >= 0 && p.y < SEEY );
 
-    submap_cache( const submap_cache & ) = delete;
-    submap_cache( submap_cache && ) = default;
-
-    SDL_Color &color_at( const point &p ) {
-        cata_assert( p.x >= 0 && p.x < SEEX );
-        cata_assert( p.y >= 0 && p.y < SEEY );
-
-        return minimap_colors[p.y * SEEX + p.x];
-    }
-};
+    return minimap_colors[p.y * SEEX + p.x];
+}
 
 pixel_minimap::pixel_minimap( const SDL_Renderer_Ptr &renderer,
                               const GeometryRenderer_Ptr &geometry ) :

--- a/src/pixel_minimap.h
+++ b/src/pixel_minimap.h
@@ -2,10 +2,14 @@
 #ifndef CATA_SRC_PIXEL_MINIMAP_H
 #define CATA_SRC_PIXEL_MINIMAP_H
 
+#include <array>
+#include <cstddef>
 #include <memory>
 #include <unordered_map>
+#include <vector>
 
 #include "coordinates.h"
+#include "map_scale_constants.h"
 #include "point.h"
 #include "sdl_wrappers.h"
 #include "sdl_geometry.h"
@@ -54,7 +58,33 @@ class pixel_minimap
         }
 
     private:
-        struct submap_cache;
+        // Texture pool, defined in the .cpp; forward declared so submap_cache can hold a ref.
+        class shared_texture_pool;
+
+        struct submap_cache {
+            //the color stored for each submap tile
+            std::array<SDL_Color, SEEX *SEEY> minimap_colors = {};
+            //checks if the submap has been looked at by the minimap routine
+            bool touched = false;
+            //the texture updates are drawn to
+            SDL_Texture_Ptr chunk_tex;
+            //the submap being handled
+            size_t texture_index = 0;
+            //the list of updates to apply to the texture
+            //reduces render target switching to once per submap
+            std::vector<point> update_list;
+            //flag used to indicate that the texture needs to be cleared before first use
+            bool ready = false;
+            shared_texture_pool &pool;
+
+            explicit submap_cache( shared_texture_pool &pool );
+            ~submap_cache();
+
+            submap_cache( const submap_cache & ) = delete;
+            submap_cache( submap_cache && ) = default;
+
+            SDL_Color &color_at( const point &p );
+        };
 
         submap_cache &get_cache_at( const tripoint_abs_sm &abs_sm_pos );
 
@@ -94,8 +124,6 @@ class pixel_minimap
 
         std::unique_ptr<pixel_minimap_projector> projector;
 
-        //the minimap texture pool which is used to reduce new texture allocation spam
-        class shared_texture_pool;
         std::unique_ptr<shared_texture_pool> tex_pool;
 
         std::unordered_map<tripoint_abs_sm, submap_cache> cache;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -304,6 +304,22 @@ static point compute_drawable_dims()
     return point{ pw, ph };
 }
 
+#if !defined(__ANDROID__)
+// Present rect in drawable px: largest integer buffer multiple that fits
+// (absorbs SCALING_FACTOR + HiDPI), top-left, remainder border. A fractional
+// fit would grid the minimap. Inverted by window_to_display_buffer_coords.
+static SDL_Rect get_display_buffer_render_rect()
+{
+    const point b = compute_display_buffer_dims();
+    const point d = compute_drawable_dims();
+    if( b.x <= 0 || b.y <= 0 ) {
+        return SDL_Rect{ 0, 0, 0, 0 };
+    }
+    const int scale = std::max( 1, std::min( d.x / b.x, d.y / b.y ) );
+    return SDL_Rect{ 0, 0, b.x * scale, b.y * scale };
+}
+#endif
+
 // Test-only injected drawable pixels. The headless dummy backend reports backing
 // pixels equal to the logical window, so a DPI-only change cannot be produced
 // through SDL; a non-negative override stands in. Inert at the -1 default.
@@ -1027,7 +1043,14 @@ void refresh_display()
                        TERMINAL_HEIGHT * fontheight );
     RenderCopy( renderer, display_buffer, NULL, &dstrect );
 #else
-    RenderCopy( renderer, display_buffer, nullptr, nullptr );
+    // Integer-scaled top-left blit; remainder is border. A null full-window blit
+    // would fractionally scale and grid the minimap.
+    const SDL_Rect dstrect = get_display_buffer_render_rect();
+    if( dstrect.w > 0 && dstrect.h > 0 ) {
+        RenderCopy( renderer, display_buffer, nullptr, &dstrect );
+    } else {
+        RenderCopy( renderer, display_buffer, nullptr, nullptr );
+    }
 #endif
 
 #if defined(__ANDROID__)
@@ -1127,12 +1150,20 @@ SDL_Point window_to_display_buffer_coords( SDL_Point window_pt )
     int win_w = 0;
     int win_h = 0;
     GetWindowSize( window.get(), &win_w, &win_h );
-    if( win_w <= 0 || win_h <= 0 ) {
+    const point draw = compute_drawable_dims();
+    const SDL_Rect dst = get_display_buffer_render_rect();
+    if( win_w <= 0 || win_h <= 0 || draw.x <= 0 || draw.y <= 0 || dst.w <= 0 || dst.h <= 0 ) {
         return window_pt;
     }
+    // Invert the present rect: logical coords to drawable px, then through the
+    // rect to buffer px. Points past it land in the border.
+    const point p{
+        static_cast<int>( static_cast<int64_t>( window_pt.x ) * draw.x / win_w ),
+        static_cast<int>( static_cast<int64_t>( window_pt.y ) * draw.y / win_h )
+    };
     return SDL_Point{
-        static_cast<int>( static_cast<int64_t>( window_pt.x ) * buf_w / win_w ),
-        static_cast<int>( static_cast<int64_t>( window_pt.y ) * buf_h / win_h )
+        static_cast<int>( static_cast<int64_t>( p.x - dst.x ) * buf_w / dst.w ),
+        static_cast<int>( static_cast<int64_t>( p.y - dst.y ) * buf_h / dst.h )
     };
 #endif
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix black grid lines on the pixel minimap"

#### Purpose of change

Black grid lines across the pixel minimap, worse after resizing the window.

The desktop present blits the cell-aligned display buffer to the window with a null dstrect. When the window isn't an exact cell multiple (any resize leaves a sub-cell remainder), SDL stretches it by a fractional ratio, and nearest sampling drops and duplicates whole rows and columns. The minimap's 1px dot lattice makes that obvious as grids. Fixes #87679.

Also a GCC9-only build break from #87652: it switched the submap cache to std::unordered_map, which needs submap_cache complete at the member, but the header only forward declared it.

#### Describe the solution

Minimap grid:
- New get_display_buffer_render_rect: largest integer multiple of the buffer that fits the drawable, top-left, remainder as border.
- Integer multiple absorbs both SCALING_FACTOR and HiDPI, so the present is exact, never fractional.
- window_to_display_buffer_coords inverts the same rect, so mouse input stays aligned.

Build break:
- Move submap_cache into pixel_minimap.h, with ctor, dtor, and color_at out of line.

#### Describe alternatives you've considered

Tried SDL3 INTEGER_SCALE logical presentation, but it only runs at SCALING_FACTOR > 1 and the bug hits at 1x. Reverting the cache to std::map also fixes the build, but the header move keeps the unordered_map.

#### Testing

Verified in-game with random window sizes on Linux and on Android.

#### Additional context

N/A