### PR TITLE
Spore dust warning

### DIFF
--- a/data/json/fields/debris.json
+++ b/data/json/fields/debris.json
@@ -81,7 +81,7 @@
         "sym": "%",
         "color": "light_gray",
         "transparent": true,
-        "dangerous": false,
+        "dangerous": true,
         "concentration": 1,
         "effects": [
           {


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Makes stepping on spore dust field gives warning when stepped on.

#### Describe the solution

`"dangerous": false` -> `"dangerous": true`

#### Describe alternatives you've considered

No

#### Testing
<img width="360" height="195" alt="Screenshot_20260618_121500" src="https://github.com/user-attachments/assets/07e2a061-0a02-45b1-bb01-12351efea367" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
