### PR TITLE
fix: reopen AIM after eating or bandaging from AIM

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5825,7 +5825,11 @@ void consume_activity_actor::finish( player_activity &act, Character & )
         uistate.consume_uistate.consume_menu_selected_items = { consume_loc };
     }
 
-    if( !avatar_action::eat_here( player_character ) && reprompt_consume_menu ) {
+    if( !avatar_action::eat_here( player_character ) && reprompt_consume_menu
+        // Don't overrite an open_menu that something else already claimed (e.g. AIM.do_return_entry);
+        // otherwise that menu is left alive but never re-displayed, leaving a stray ui_adaptor that redraws spuriously.
+        && !uistate.open_menu
+      ) {
         uistate.open_menu = []() {
             avatar_action::eat_or_use( get_avatar(),
                                        game_menus::inv::consume( uistate.consume_uistate.consume_menu_comestype ) );
@@ -10420,7 +10424,11 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
     act.set_to_null();
     act.values.clear();
 
-    if( who.is_avatar() ) {
+    if( who.is_avatar()
+        // Don't overrite an open_menu that something else already claimed (e.g. AIM.do_return_entry);
+        // otherwise that menu is left alive but never re-displayed, leaving a stray ui_adaptor that redraws spuriously.
+        && !uistate.open_menu
+      ) {
         uistate.open_menu = []() {
             avatar_action::eat_or_use( get_avatar(),
                                        game_menus::inv::consume( uistate.consume_uistate.consume_menu_comestype ) );


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Fix the following issue:
1. `/` Open AIM.
2. Select `demihuman flesh` (it has a high morale penalty) in your inventory.
3. `e`xamine it.
4. `E`at it.
5. Observe: waring "Are you sure?"
6. `ESC` (no).
7. AIM seemingly closes.
8. Walk around a bit.
9. Observe: AIM pops up and hides again.

#### Describe the solution

Don't reopen the eating menu (dont overwrite `open_menu`), when `open_menu` is already in use.

Eating:
 - When eating from AIM, AIM will be reopened.
 - When eating from Eat menu, eat menu will be reopened.

Bandaging:
 - When bandaging from AIM, AIM will be reopened.
 - When bandaging from Use item, Consume item menu will be opened.


#### Describe alternatives you've considered

Closing the AIM instead and opening the menu. I prefer to return to AIM.

#### Testing

Tried the things.

#### Additional context

Mentioned here:
 -  https://github.com/CleverRaven/Cataclysm-DDA/issues/87232#issuecomment-4643876075

Used LLM Claude 4.8. Checked the results.
