### PR TITLE
AIM hide action menu

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2257,6 +2257,9 @@ int game::inventory_item_menu( item_location locThisItem,
                 ui = nullptr;
             }
 
+#if defined(TILES)
+            action_menu.set_hide( true );
+#endif
             switch( cMenu ) {
                 case 'a': {
                     contents_change_handler handler;
@@ -2264,13 +2267,7 @@ int game::inventory_item_menu( item_location locThisItem,
                     if( locThisItem.get_item()->type->has_use() &&
                         !locThisItem.get_item()->item_has_uses_recursive( true ) ) { // NOLINT(bugprone-branch-clone)
                         // Item has uses and none of its contents (if any) has uses.
-#if defined(TILES)
-                        action_menu.set_hide( true );
-#endif
                         avatar_action::use_item( u, locThisItem );
-#if defined(TILES)
-                        action_menu.set_hide( false );
-#endif
                     } else if( locThisItem.get_item()->item_has_uses_recursive() ) {
                         game::item_action_menu( locThisItem );
                     } else if( locThisItem.get_item()->has_relic_activation() &&
@@ -2418,6 +2415,9 @@ int game::inventory_item_menu( item_location locThisItem,
                 default:
                     break;
             }
+#if defined(TILES)
+            action_menu.set_hide( false );
+#endif
         } while( !exit );
     }
     return cMenu;


### PR DESCRIPTION
#### Summary
Bugfixes "Hide AIM action menu"

#### Purpose of change

Reload menu is overlapped by AIM action menu, as reported here https://github.com/CleverRaven/Cataclysm-DDA/issues/87232#issuecomment-4643411250

I went through all the actions and noticed other menus (all non-ImGui menus) have the same problem. And with ImGui menus, it is weird that the action menu stays here, since AIM hides.

#### Describe the solution

Always hide the AIM action menu when taking some action.

Continuation of
 - #87299

#### Describe alternatives you've considered

More nuance. It would be more complex and unnecessary.

#### Testing

<img width="2557" height="677" alt="image" src="https://github.com/user-attachments/assets/f4a65c2a-d648-46da-a30d-6d6e5715af95" />

#### Additional context