### PR TITLE
Gasoline spoilage, part 1: Newly-spawned vehicles with gas engines will be spawned with expired gas in their tanks past maximum gas shelf time

### DIFF
--- a/data/core/external_options.json
+++ b/data/core/external_options.json
@@ -520,5 +520,12 @@
     "//": "The maximum number of overmaps that an intersection can deviate from its gridded position. Cannot be greater than or equal to row / 2 or column / 2, may cause bugs for > row / 4, column / 4.",
     "stype": "int",
     "value": 2
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "GASOLINE_SHELF_TIME",
+    "//": "Maximum shelf time (in days) for E10 ethanol-gasoline blend. After this time gasoline engines won't start at all on this fuel.",
+    "stype": "int",
+    "value": 180
   }
 ]

--- a/data/core/external_options.json
+++ b/data/core/external_options.json
@@ -520,12 +520,5 @@
     "//": "The maximum number of overmaps that an intersection can deviate from its gridded position. Cannot be greater than or equal to row / 2 or column / 2, may cause bugs for > row / 4, column / 4.",
     "stype": "int",
     "value": 2
-  },
-  {
-    "type": "EXTERNAL_OPTION",
-    "name": "GASOLINE_SHELF_TIME",
-    "//": "Maximum shelf time (in days) for E10 ethanol-gasoline blend. After this time gasoline engines won't start at all on this fuel.",
-    "stype": "int",
-    "value": 180
   }
 ]

--- a/data/json/items/fuel.json
+++ b/data/json/items/fuel.json
@@ -173,6 +173,18 @@
     "effects": [ "FLAME", "STREAM", "IGNITE" ]
   },
   {
+    "id": "gasoline_dead",
+    "type": "ITEM",
+    "subtypes": [ "AMMO" ],
+    "name": { "str_sp": "expired gasoline" },
+    "copy-from": "gasoline",
+    "description": "It's hard to recognize gasoline in this flakes-filled brown sludge with a pungent, sour smell.  It cannot be used to start engines.",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "ammo_type": "flammable",
+    "range": 0
+  },
+  {
     "id": "lamp_oil",
     "type": "ITEM",
     "subtypes": [ "AMMO" ],

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -55,6 +55,9 @@ constexpr int VEHICLE_HANDLING_PENALTY = 80;
 // Amount by which to charge an item for each unit of plutonium cell.
 constexpr int PLUTONIUM_CHARGES = 500;
 
+// Maximum shelf time for E10 ethanol-gasoline blend. After this time gasoline engines won't start at all on this fuel.
+constexpr time_duration GASOLINE_SHELF_TIME = 180_days;
+
 // "Natural" damage nullification for durable veh parts, even if no damage reduction is defined
 constexpr int VEH_PART_DMG_REDUCTION_FROM_DURABILITY_CAP = 20;
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -120,8 +120,6 @@ static const itype_id itype_craft( "craft" );
 static const itype_id itype_disassembly( "disassembly" );
 static const itype_id itype_efile_photos( "efile_photos" );
 static const itype_id itype_efile_recipes( "efile_recipes" );
-static const itype_id itype_gasoline( "gasoline" );
-static const itype_id itype_gasoline_dead( "gasoline_dead" );
 static const itype_id itype_joint_lit( "joint_lit" );
 static const itype_id itype_stock_none( "stock_none" );
 
@@ -4857,12 +4855,6 @@ bool item::process_internal( map &here, Character *carrier, const tripoint_bub_m
                 }
             }
             return false;
-        }
-        if( typeId() == itype_gasoline ) {
-            if( calendar::turn - calendar::turn_zero >= time_duration::from_days(
-                    get_option<int>( "GASOLINE_SHELF_TIME" ) ) ) {
-                convert( itype_gasoline_dead, carrier );
-            }
         }
     }
     return false;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -120,6 +120,8 @@ static const itype_id itype_craft( "craft" );
 static const itype_id itype_disassembly( "disassembly" );
 static const itype_id itype_efile_photos( "efile_photos" );
 static const itype_id itype_efile_recipes( "efile_recipes" );
+static const itype_id itype_gasoline( "gasoline" );
+static const itype_id itype_gasoline_dead( "gasoline_dead" );
 static const itype_id itype_joint_lit( "joint_lit" );
 static const itype_id itype_stock_none( "stock_none" );
 
@@ -4855,6 +4857,12 @@ bool item::process_internal( map &here, Character *carrier, const tripoint_bub_m
                 }
             }
             return false;
+        }
+        if( typeId() == itype_gasoline ) {
+            if( calendar::turn - calendar::turn_zero >= time_duration::from_days(
+                    get_option<int>( "GASOLINE_SHELF_TIME" ) ) ) {
+                convert( itype_gasoline_dead, carrier );
+            }
         }
     }
     return false;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -111,6 +111,8 @@ static const fault_id fault_tire_treads( "fault_tire_treads" );
 
 static const itype_id fuel_type_animal( "animal" );
 static const itype_id fuel_type_battery( "battery" );
+static const itype_id fuel_type_gasoline( "gasoline" );
+static const itype_id fuel_type_gasoline_dead( "gasoline_dead" );
 static const itype_id fuel_type_mana( "mana" );
 static const itype_id fuel_type_muscle( "muscle" );
 static const itype_id fuel_type_plutonium_cell( "plut_cell" );
@@ -501,6 +503,17 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, veh_spawn_status in
             rng_fuel_amount( pt, itype_battery );
         } else if( pt.is_tank() || pt.is_fuel_store() ) {
             rng_fuel_amount( pt, pt.ammo_current() );
+
+            /*If the vehicle has gasoline engine, and current day equals to or exceeds gasoline shelf time, then replace the gasoline with its expired version.
+            This is to simulate the gasoline going bad after a certain period of time.
+            */
+            if( pt.ammo_current() == fuel_type_gasoline ) {
+                if( calendar::turn - calendar::turn_zero >= time_duration::from_days(
+                        get_option<int>( "GASOLINE_SHELF_TIME" ) ) ) {
+                    pt.ammo_unset();
+                    rng_fuel_amount( pt, fuel_type_gasoline_dead );
+                }
+            }
         }
 
         if( vp.has_feature( "OPENABLE" ) ) { // doors are closed

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -504,12 +504,11 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, veh_spawn_status in
         } else if( pt.is_tank() || pt.is_fuel_store() ) {
             rng_fuel_amount( pt, pt.ammo_current() );
 
-            /*If the vehicle has gasoline engine, and current day equals to or exceeds gasoline shelf time, then replace the gasoline with its expired version.
+            /*If the newly-spawned vehicle has gasoline engine, and current day equals to or exceeds gasoline shelf time, then replace the gasoline with its expired version.
             This is to simulate the gasoline going bad after a certain period of time.
             */
             if( pt.ammo_current() == fuel_type_gasoline ) {
-                if( calendar::turn - calendar::turn_zero >= time_duration::from_days(
-                        get_option<int>( "GASOLINE_SHELF_TIME" ) ) ) {
+                if( calendar::turn - calendar::turn_zero >= GASOLINE_SHELF_TIME ) {
                     pt.ammo_unset();
                     rng_fuel_amount( pt, fuel_type_gasoline_dead );
                 }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -508,7 +508,9 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, veh_spawn_status in
             This is to simulate the gasoline going bad after a certain period of time.
             */
             if( pt.ammo_current() == fuel_type_gasoline ) {
-                if( calendar::turn - calendar::turn_zero >= GASOLINE_SHELF_TIME ) {
+                // Add some randomness to gasoline "creation date", so that not all vehicles will have their gasoline go bad at the same time.
+                time_duration randomness = rng( 0_days, 14_days );
+                if( calendar::turn - calendar::start_of_cataclysm - randomness >= GASOLINE_SHELF_TIME ) {
                     pt.ammo_unset();
                     rng_fuel_amount( pt, fuel_type_gasoline_dead );
                 }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -88,6 +88,7 @@ static const furn_str_id furn_f_plant_unharvested_overgrown( "f_plant_unharveste
 static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );
 
 static const itype_id fuel_type_battery( "battery" );
+static const itype_id fuel_type_gasoline( "gasoline" );
 static const itype_id fuel_type_muscle( "muscle" );
 static const itype_id fuel_type_none( "null" );
 static const itype_id fuel_type_wind( "wind" );
@@ -678,6 +679,10 @@ bool vehicle::start_engine( map &here, vehicle_part &vp )
                 add_msg( _( "You cannot use %s without at least two legs." ), vp.name() );
                 return false;
             }
+        } else if( vpi.fuel_type == fuel_type_gasoline ) {
+            add_msg( _( "The %1$s has %2$s in its tanks, but the fuel is <color_red>expired</color> and can't be used to start the engine." ),
+                     vp.name(), item::nname( vpi.fuel_type ) );
+            return false;
         } else {
             add_msg( _( "Looks like the %1$s is out of %2$s." ), vp.name(),
                      item::nname( vpi.fuel_type ) );


### PR DESCRIPTION
#### Summary
Features "Gasoline spoilage"

#### Purpose of change
First of all, I assume the `gasoline` fuel we see ingame is E10 ethanol-gasoline blend, not an ethanol-free gasoline. Various sources on the Net indicate that this type of gasoline is prone to quick degradation and best used in mere 1 month.

Right now gasoline doesn't spoil with time, so we can always get a perfectly working fuel from some left car many years after the Cataclysm. This is unrealistic and, in my opinion, badly affects the gameplay since there's no reason for finding or crafting alternatives for gasoline engines. Since we can't craft the gasoline, all the gasoline in the world will eventually decay, and understanding this fact is an incentive for search for alternatives.

This PR is a very basic simulation for gasoline spoilage mechanic, basically the first step: just put a hard stop on trying to start the engine with expired gasoline. I plan to extend the mechanic with several stages of decay with various problems to the engine and several ways to cope with these problems. Also make diesel spoil too.

#### Describe the solution
- Added an `expired gasoline` item.
- Added external option for its shelf time. Right now it's 180 days. I'm open to suggestions if it's too low or too high.
- Newly-spawned vehicles with gasoline engines will be spawned with expired gasoline in their tanks if it's 180 or more days after game start.
~All previously-spawned gasoline in the world will turn to expired version after 180 days.~
- At the moment it can't be used to craft anything - I'm not sure if it fits for `molotov`. It's still flammable though and will burn on the ground.
- More importantly, it can't be used to start a vehicle engine. Trying to start an engine will tell the player that despite there's gasoline in tanks, the fuel is expired and thus can't be used to start an engine.
- It also can't be used as fuel for Gasoline Fuel Cell bionic.

#### Describe alternatives you've considered
Some other shelf time. While googling on this matter, I found various times in different sources, from 3 months to (most likely) anecdotal evidence of 4 years.

#### Testing
- Debug-set time to 2 years after game start. Found some car. Examined it and checked that it has expired gasoline in its tank.
- Debug-spawned gasoline in its default container. Advanced time to 1 year ahead. Checked that gasoline in the container is converted to expired version.
- In vanilla there's no way to get both working and expired versions of gasoline to mix them, but if in the future we add crafting of gasoline (or through some mod) adding a single drop of expired gasoline to working one will make the whole mix expired. The vice-versa is also true. This happens due to our current liquid-pouring handling.

#### Additional context
<img width="1174" height="245" alt="изображение" src="https://github.com/user-attachments/assets/c8278bc9-a50a-48c9-aba2-58e8865df0c1" />