### PR TITLE
[Xedra Evolved] Regularize changeling goblin fruit glamours

### DIFF
--- a/data/mods/Xedra_Evolved/spells/changeling_spells.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_spells.json
@@ -639,15 +639,19 @@
     "spell_class": "CHANGELING_MAGIC",
     "teachable": false,
     "flags": [ "SOMATIC", "VERBAL", "NO_LEGS", "NO_HANDS" ],
-    "max_level": { "math": [ "int_to_level(1)" ] },
+    "max_level": 1,
     "difficulty": 8,
-    "base_casting_time": 180000,
-    "final_casting_time": 100,
-    "casting_time_increment": -6000,
+    "base_casting_time": {
+      "math": [
+        "max(( 180000 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 2500) - (u_skill('gramarye') * 4500)), 100)"
+      ]
+    },
     "magic_type": "xe_fey_magick",
-    "base_energy_cost": 450,
-    "final_energy_cost": 350,
-    "energy_increment": -4
+    "base_energy_cost": {
+      "math": [
+        "max(( 450 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 2) - (u_skill('gramarye') * 5)), 350)"
+      ]
+    }
   },
   {
     "id": "brownie_cultivate_goblin_fruit",
@@ -662,15 +666,19 @@
     "spell_class": "CHANGELING_MAGIC",
     "teachable": false,
     "flags": [ "SOMATIC", "VERBAL", "NO_LEGS", "NO_HANDS" ],
-    "max_level": { "math": [ "int_to_level(1)" ] },
+    "max_level": 1,
     "difficulty": 8,
-    "base_casting_time": 180000,
-    "final_casting_time": 100,
-    "casting_time_increment": -6000,
+    "base_casting_time": {
+      "math": [
+        "max(( 180000 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_BROWNIE') * 2500) - (u_skill('gramarye') * 4500)), 100)"
+      ]
+    },
     "magic_type": "xe_fey_magick",
-    "base_energy_cost": 450,
-    "final_energy_cost": 350,
-    "energy_increment": -4
+    "base_energy_cost": {
+      "math": [
+        "max(( 450 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_BROWNIE') * 2) - (u_skill('gramarye') * 5)), 350)"
+      ]
+    }
   },
   {
     "id": "pooka_cultivate_goblin_fruit",
@@ -685,15 +693,17 @@
     "spell_class": "CHANGELING_MAGIC",
     "teachable": false,
     "flags": [ "SOMATIC", "VERBAL", "NO_LEGS", "NO_HANDS" ],
-    "max_level": { "math": [ "int_to_level(1)" ] },
+    "max_level": 1,
     "difficulty": 8,
-    "base_casting_time": 180000,
-    "final_casting_time": 100,
-    "casting_time_increment": -6000,
+    "base_casting_time": {
+      "math": [
+        "max(( 180000 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 2500) - (u_skill('gramarye') * 4500)), 100)"
+      ]
+    },
     "magic_type": "xe_fey_magick",
-    "base_energy_cost": 450,
-    "final_energy_cost": 350,
-    "energy_increment": -4
+    "base_energy_cost": {
+      "math": [ "max(( 450 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 2) - (u_skill('gramarye') * 5)), 350)" ]
+    }
   },
   {
     "id": "trow_cultivate_goblin_fruit",
@@ -708,15 +718,17 @@
     "spell_class": "CHANGELING_MAGIC",
     "teachable": false,
     "flags": [ "SOMATIC", "VERBAL", "NO_LEGS", "NO_HANDS" ],
-    "max_level": { "math": [ "int_to_level(1)" ] },
+    "max_level": 1,
     "difficulty": 8,
-    "base_casting_time": 180000,
-    "final_casting_time": 100,
-    "casting_time_increment": -6000,
+    "base_casting_time": {
+      "math": [
+        "max(( 180000 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_TROW') * 2500) - (u_skill('gramarye') * 4500)), 100)"
+      ]
+    },
     "magic_type": "xe_fey_magick",
-    "base_energy_cost": 450,
-    "final_energy_cost": 350,
-    "energy_increment": -4
+    "base_energy_cost": {
+      "math": [ "max(( 450 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_TROW') * 2) - (u_skill('gramarye') * 5)), 350)" ]
+    }
   },
   {
     "id": "noble_cultivate_goblin_fruit",
@@ -731,14 +743,14 @@
     "spell_class": "CHANGELING_MAGIC",
     "teachable": false,
     "flags": [ "SOMATIC", "VERBAL", "NO_LEGS", "NO_HANDS" ],
-    "max_level": { "math": [ "int_to_level(1)" ] },
+    "max_level": 1,
     "difficulty": 8,
-    "base_casting_time": 180000,
-    "final_casting_time": 100,
-    "casting_time_increment": -6000,
+    "base_casting_time": {
+      "math": [ "max(( 180000 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 2500) - (u_skill('gramarye') * 4500)), 100)" ]
+    },
     "magic_type": "xe_fey_magick",
-    "base_energy_cost": 450,
-    "final_energy_cost": 350,
-    "energy_increment": -4
+    "base_energy_cost": {
+      "math": [ "max(( 450 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 2) - (u_skill('gramarye') * 5)), 350)" ]
+    }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Regularize changeling goblin fruit glamours"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The changeling goblin fruit glamours had levels you could raise, unlike other glamours.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Set their level to 1 and derive their traits from the sum total of appropriate category changeling mutations and gramarye skill. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I assume the way they worked was derived from the Paraclesian goblin fruit glamours but I'm going to change the scaling on that one too. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
