### PR TITLE
fix: Crash in any ImGui window on alt + F4

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -42,6 +42,12 @@ class game;
 
 extern std::unique_ptr<game> g;
 
+/**
+ * Shutdown, orderly.
+ * `s == 2` prompts for confirmation; any other value exits without prompting.
+ */
+void exit_handler( int s );
+
 extern const int savegame_version;
 extern int savegame_loading_version;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,6 +143,9 @@ namespace
 // Used only if AttachConsole() works
 FILE *CONOUT;
 #endif
+
+}  // namespace
+
 void exit_handler( int s )
 {
     const int old_timeout = inp_mngr.get_timeout();
@@ -168,6 +171,9 @@ void exit_handler( int s )
     ui_manager::redraw_invalidated();
     catacurses::doupdate();
 }
+
+namespace
+{
 
 struct arg_handler {
     //! Handler function to be invoked when this argument is encountered. The handler will be

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -6108,8 +6108,7 @@ static void CheckMessages()
         try_sdl_update();
     }
     if( quit ) {
-        catacurses::endwin();
-        exit( 0 );
+        exit_handler( 0 );
     }
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Crash in any ImGui window on alt + F4"

#### Purpose of change

 - Fixes #87475

#### Describe the solution

1. Expose graceful exit handler.
2. Use the graceful exit handler.

#### Describe alternatives you've considered

#### Testing

See the issue. Also,
1. Loaded a save
2. `/` AIM
3. Select demihuman flesh.
4. `e`xamine.
5. `E`at (ImGui popup: "Are you sure?")
6. Observe
   - before: crash
   - after: no crash.

#### Additional context

Used LLM Claude 4.8. Checked the results.

Note:
 - LLM: `wincurse.cpp` (Windows non‑tiles/curses build) has the same raw `exit(0)` on `WM_DESTROY`; I left it alone since it doesn't include `game.h` and running the full `exit_handler` from inside a WndProc is a riskier, untested change outside this issue's scope.
 - Me: Untestable for me, I cannot run without tiles on Windows.
