### PR TITLE
Fix description text going off screen in character creation

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -125,9 +125,8 @@ static constexpr int RANDOM_START_LOC_ENTRY = INT_MIN;
 
 static void draw_colored_text_wrap( const std::string &original_text, nc_color color )
 {
-   
     const float avail = ImGui::GetContentRegionAvail().x;
-    const float padding = ImGui::GetStyle().ItemSpacing.x + 4.0f; // small safety margin
+    const float padding = ImGui::GetStyle().ItemSpacing.x + 4.0f;
     const float wrap_width = std::max( 1.0f, avail - padding );
     cataimgui::draw_colored_text( original_text, color, wrap_width );
 }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -125,7 +125,11 @@ static constexpr int RANDOM_START_LOC_ENTRY = INT_MIN;
 
 static void draw_colored_text_wrap( const std::string &original_text, nc_color color )
 {
-    cataimgui::draw_colored_text( original_text, color, ImGui::GetContentRegionAvail().x );
+   
+    const float avail = ImGui::GetContentRegionAvail().x;
+    const float padding = ImGui::GetStyle().ItemSpacing.x + 4.0f; // small safety margin
+    const float wrap_width = std::max( 1.0f, avail - padding );
+    cataimgui::draw_colored_text( original_text, color, wrap_width );
 }
 
 static bool cities_enabled()


### PR DESCRIPTION
Fixes #87596

In character creation, the description text was overflowing the visible 
area because the wrap width had no padding. I added a small margin 
subtracted from the available width so the text stays inside the window.

#### Summary
Build "Fix description text overflow in character creation"