### PR TITLE
Remove `NO_RELOAD` off small spool and wire spool

### DIFF
--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -5421,8 +5421,7 @@
         "transparent": true,
         "moves": 200
       }
-    ],
-    "flags": [ "NO_RELOAD" ]
+    ]
   },
   {
     "id": "spool_welding",
@@ -5446,8 +5445,7 @@
         "moves": 800,
         "volume_multiplier": 0.3
       }
-    ],
-    "flags": [ "NO_RELOAD" ]
+    ]
   },
   {
     "id": "tube_welding_rod",


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Ya can infact respool wires back into the spool, not like respooling it require the thing to be sticky or anything.

#### Describe the solution
Remove `NO_RELOAD` flag on small spool and wire spool

#### Describe alternatives you've considered

Replace it with `NO_UNLOAD`?

#### Testing
<img width="274" height="227" alt="Screenshot_20260621_023549" src="https://github.com/user-attachments/assets/a39def47-e910-4dcb-950d-984004b205e1" />
<img width="346" height="261" alt="Screenshot_20260621_023611" src="https://github.com/user-attachments/assets/2eccf555-ad7d-4f81-bcde-7e742f2f8d49" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
