### PR TITLE
Renamed `gas mask cartridge` to `CBRN filter canister` in flag name

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2626,7 +2626,7 @@
     "id": "GASFILTER_MED",
     "type": "json_flag",
     "info": "A medium-sized gasmask filter.",
-    "name": "gas mask cartridge"
+    "name": "CBRN filter canister"
   },
   {
     "id": "PANORAMIC_OUTSERT",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #76353.

#### Describe the solution
Renamed `gas mask cartridge` to `CBRN filter canister` in flag name.

#### Describe alternatives you've considered
None.

#### Testing
Got gas mask, checked its `Form factors` section.

#### Additional context
<img width="382" height="89" alt="изображение" src="https://github.com/user-attachments/assets/8e64b8b4-d172-443f-b42e-f3aad63bdd1f" />