### PR TITLE
Monster teeth traps now trigger `caltrops` trap function

### DIFF
--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -1007,7 +1007,7 @@
     "visibility": 6,
     "avoidance": 8,
     "difficulty": 0,
-    "action": "glass",
+    "action": "caltrops",
     "drops": [ "nm_teeth" ],
     "vehicle_data": { "sound_volume": 10, "sound": "Crunch!" }
   },
@@ -1022,7 +1022,7 @@
     "visibility": 6,
     "avoidance": 6,
     "difficulty": 0,
-    "action": "caltrops_glass",
+    "action": "caltrops",
     "drops": [ "caltrops_teeth" ],
     "vehicle_data": { "damage": 600 }
   },

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -357,12 +357,13 @@ bool trapfunc::board( const tripoint_bub_ms &p, Creature *c, item * )
         return false;
     }
     map &here = get_map();
+    const std::string trap_name = here.tr_at( p ).name();
     // Only a chance to step on the board, dependent on size
     if( !x_in_y( occupied_tile_fraction( c->get_size() ), 1.0f ) ) {
         return false;
     }
-    c->add_msg_if_player( m_bad, _( "You step on a %s!" ), here.tr_at( p ).name() );
-    c->add_msg_if_npc( _( "%s steps on a %s!" ), c->disp_name( false, true ), here.tr_at( p ).name() );
+    c->add_msg_if_player( m_bad, _( "You step on a %s!" ), trap_name );
+    c->add_msg_if_npc( _( "%s steps on a %s!" ), c->disp_name( false, true ), trap_name );
     if( c->has_effect( effect_ridden ) ) {
         monster *z = c->as_monster();
         mount_step_on_trap_make_slow_give_msg( z, p );
@@ -380,9 +381,9 @@ bool trapfunc::board( const tripoint_bub_ms &p, Creature *c, item * )
         here.remove_trap( p );
         if( !c->is_avatar() ) {
             add_msg_if_player_sees( p, _( "%s destroys a %s as they move over it!" ),
-                                    c->disp_name( false, true ), here.tr_at( p ).name() );
+                                    c->disp_name( false, true ), trap_name );
         } else {
-            add_msg( _( "You destroy the %s as you step on it!" ), here.tr_at( p ).name() );
+            add_msg( _( "You destroy the %s as you step on it!" ), trap_name );
         }
     } else if( x_in_y( 40, 100 ) ) {
         // 40% chance disarm trap
@@ -397,13 +398,13 @@ bool trapfunc::caltrops( const tripoint_bub_ms &p, Creature *c, item * )
         return false;
     }
     map &here = get_map();
+    const std::string trap_name = here.tr_at( p ).name();
     // Only a chance to step on the caltrop, dependent on size
     if( !x_in_y( occupied_tile_fraction( c->get_size() ), 1.0f ) ) {
         return false;
     }
-    c->add_msg_if_player( m_bad, _( "You step on a sharp %s!" ), here.tr_at( p ).name() );
-    c->add_msg_if_npc( _( "%s steps on a sharp %s!" ), c->disp_name( false, true ),
-                       here.tr_at( p ).name() );
+    c->add_msg_if_player( m_bad, _( "You step on a sharp %s!" ), trap_name );
+    c->add_msg_if_npc( _( "%s steps on a sharp %s!" ), c->disp_name( false, true ), trap_name );
     if( c->has_effect( effect_ridden ) ) {
         monster *z = c->as_monster();
         mount_step_on_trap_make_slow_give_msg( z, p );
@@ -421,9 +422,9 @@ bool trapfunc::caltrops( const tripoint_bub_ms &p, Creature *c, item * )
         here.remove_trap( p );
         if( !c->is_avatar() ) {
             add_msg_if_player_sees( p, _( "%s destroys a %s as they move over it!" ),
-                                    c->disp_name( false, true ), here.tr_at( p ).name() );
+                                    c->disp_name( false, true ), trap_name );
         } else {
-            add_msg( _( "You destroy the %s as you step on it!" ), here.tr_at( p ).name() );
+            add_msg( _( "You destroy the %s as you step on it!" ), trap_name );
         }
     } else if( x_in_y( 20, 100 ) ) {
         // 20% chance disarm trap


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #76323.

#### Describe the solution
Changed loose monster teeth and monster teeth caltrops `action` from `glass` and `caltrops_glass` to `caltrops` as both of these traps resemble metal caltrops rather than scattered glass or glass caltrops.

Also, while I'm here, I cached trap name for `caltrops` and `board` traps to avoid "use after removal" case, i.e. so the game doesn't print `"You destroy the none as you step on it!"`.

#### Describe alternatives you've considered
None.

#### Testing
Placed loose monster teeth and monster teeth caltrops traps. Stepped on it. Checked the messages.

#### Additional context
<img width="337" height="104" alt="изображение" src="https://github.com/user-attachments/assets/3dea90e6-2596-4a00-964c-2d2e29cfe069" />