### PR TITLE
Worn flotation vest won't let you drown anymore

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -86,6 +86,7 @@ static const itype_id itype_underbrush( "underbrush" );
 
 static const json_character_flag json_flag_CANNOT_ATTACK( "CANNOT_ATTACK" );
 static const json_character_flag json_flag_CANNOT_MOVE( "CANNOT_MOVE" );
+static const json_character_flag json_flag_FLOTATION( "FLOTATION" );
 static const json_character_flag json_flag_ITEM_WATERPROOFING( "ITEM_WATERPROOFING" );
 static const json_character_flag json_flag_WATERWALKING( "WATERWALKING" );
 
@@ -661,7 +662,7 @@ void avatar_action::swim( map &m, avatar &you, const tripoint_bub_ms &p )
     int movecost = you.swim_speed();
     you.practice( skill_swimming, you.is_underwater() ? 2 : 1 );
     if( ( movecost >= 500 || you.has_effect( effect_winded ) ) &&
-        !you.has_flag( json_flag_WATERWALKING ) ) {
+        !you.has_flag( json_flag_WATERWALKING ) && !you.worn_with_flag( json_flag_FLOTATION ) ) {
         if( !you.is_underwater() &&
             !( you.shoe_type_count( itype_swim_fins ) == 2 ||
                ( you.shoe_type_count( itype_swim_fins ) == 1 && one_in( 2 ) ) ) ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Worn flotation vest won't let you drown anymore"

#### Purpose of change
* Closes #86892.

#### Describe the solution
Added check for worn items with `FLOTATION` flag when checking if you would sink like a rock.

#### Describe alternatives you've considered
None.

#### Testing
Put on flotation vest, jumped into water, swim until my stamina ran out. My character stays afloat even with zero stamina.

#### Additional context
None.