### PR TITLE
Replace Z-Level view violation debugmsg with add_msg_debug

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2202,7 +2202,7 @@ bool monster::melee_attack( Creature &target, float accuracy )
         return false;
     }
     if( !sees( here, target ) && !target.is_hallucination() ) {
-        debugmsg( "Z-Level view violation: %s tried to attack %s.", disp_name(), target.disp_name() );
+        add_msg_debug( debugmode::DF_MONSTER, "Z-Level view violation: %s tried to attack %s.", disp_name(), target.disp_name() );
         return false;
     }
     // Prevent monsters from attacking THROUGH terrain if they are submerged under it & target isn't.

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2202,7 +2202,8 @@ bool monster::melee_attack( Creature &target, float accuracy )
         return false;
     }
     if( !sees( here, target ) && !target.is_hallucination() ) {
-        add_msg_debug( debugmode::DF_MONSTER, "Z-Level view violation: %s tried to attack %s.", disp_name(), target.disp_name() );
+        add_msg_debug( debugmode::DF_MONSTER, "Z-Level view violation: %s tried to attack %s.",
+                       disp_name(), target.disp_name() );
         return false;
     }
     // Prevent monsters from attacking THROUGH terrain if they are submerged under it & target isn't.

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2202,8 +2202,10 @@ bool monster::melee_attack( Creature &target, float accuracy )
         return false;
     }
     if( !sees( here, target ) && !target.is_hallucination() ) {
-        add_msg_debug( debugmode::DF_MONSTER, "Z-Level view violation: %s tried to attack %s.",
-                       disp_name(), target.disp_name() );
+        add_msg_debug( debugmode::DF_MONSTER,
+                       "Visibility/LOS mismatch: %s %s tried to melee-attack %s %s.",
+                       disp_name(), pos_abs().to_string_writable(),
+                       target.disp_name(), target.pos_abs().to_string_writable() );
         return false;
     }
     // Prevent monsters from attacking THROUGH terrain if they are submerged under it & target isn't.


### PR DESCRIPTION
#### Summary
Bugfixes "Don't popup Z-Level view violation debugmsg"

#### Purpose of change

This case is safe in most situations; it may trigger by a monster trying to attack an invisible creature (e.g. star vampire). I think it's only be used for debugging purposes and should not appear on the screen.

Closes #85727, closes #80356, closes #87308.

#### Describe the solution

- Use add_msg_debug instead of debugmsg, so it won't popup.
- Update message to "Visibility/LOS mismatch: _name (pos)_ tried to melee-attack _target (pos)_." It maybe not a Z-level problem.

#### Describe alternatives you've considered

Remove entire if statement and let creature attack when not see? Not sure that would break what.

#### Testing


#### Additional context


