### PR TITLE
refactor: early returns, logical equivalence, superfluous empty => return

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -681,38 +681,33 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
 
 void activity_handlers::travel_do_turn( player_activity *act, Character *you )
 {
-    if( !you->omt_path.empty() ) {
-        you->omt_path.pop_back();
-        if( you->omt_path.empty() ) {
-            you->add_msg_if_player( m_info, _( "You have reached your destination." ) );
-            act->set_to_null();
-            ui::omap::force_quit();
-            return;
-        }
-        const tripoint_abs_omt next_omt = you->omt_path.back();
-        tripoint_abs_ms waypoint;
-        if( you->omt_path.size() == 1 ) {
-            // if next omt is the final one, target its midpoint
-            waypoint = midpoint( project_bounds<coords::ms>( next_omt ) );
-        } else {
-            // otherwise target the middle of the edge nearest to our current location
-            const tripoint_abs_ms cur_omt_mid = midpoint( project_bounds<coords::ms>
-                                                ( you->pos_abs_omt() ) );
-            waypoint = clamp( cur_omt_mid, project_bounds<coords::ms>( next_omt ) );
-        }
-        map &here = get_map();
-        tripoint_bub_ms centre_sub = here.get_bub( waypoint );
-        const std::vector<tripoint_bub_ms> route_to =
-            here.route( *you, pathfinding_target::radius( centre_sub, 2 ) );
-        if( !route_to.empty() ) {
-            const activity_id act_travel = ACT_TRAVELLING;
-            you->set_destination( route_to, player_activity( act_travel ) );
-        } else {
-            you->add_msg_if_player( m_warning, _( "You cannot reach that destination." ) );
-            ui::omap::force_quit();
-        }
-    } else {
+    if( you->omt_path.size() <= 1 ) {
+        you->omt_path.clear();  // in case the size was 1
         you->add_msg_if_player( m_info, _( "You have reached your destination." ) );
+        act->set_to_null();
+        ui::omap::force_quit();
+        return;
+    }
+    you->omt_path.pop_back();
+    const tripoint_abs_omt next_omt = you->omt_path.back();
+    tripoint_abs_ms waypoint;
+    if( you->omt_path.size() == 1 ) {
+        // if next omt is the final one, target its midpoint
+        waypoint = midpoint( project_bounds<coords::ms>( next_omt ) );
+    } else {
+        // otherwise target the middle of the edge nearest to our current location
+        const tripoint_abs_ms cur_omt_mid = midpoint( project_bounds<coords::ms>
+                                            ( you->pos_abs_omt() ) );
+        waypoint = clamp( cur_omt_mid, project_bounds<coords::ms>( next_omt ) );
+    }
+    map &here = get_map();
+    tripoint_bub_ms centre_sub = here.get_bub( waypoint );
+    const std::vector<tripoint_bub_ms> route_to =
+        here.route( *you, pathfinding_target::radius( centre_sub, 2 ) );
+    if( !route_to.empty() ) {
+        you->set_destination( route_to, player_activity( ACT_TRAVELLING ) );
+    } else {
+        you->add_msg_if_player( m_warning, _( "You cannot reach that destination." ) );
         ui::omap::force_quit();
     }
     act->set_to_null();

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -450,20 +450,16 @@ item_location Character::i_add( item it, bool /* should_stack */, const item *av
     invalidate_leak_level_cache();
     item_location added = try_add( it, avoid, original_inventory_item, allow_wield,
                                    ignore_pkt_settings );
-    if( added == item_location::nowhere ) {
-        if( !allow_wield || !wield( it ) ) {
-            if( allow_drop ) {
-                return item_location( map_cursor( pos_abs() ), &get_map().add_item_or_charges( pos_bub(),
-                                      it ) );
-            } else {
-                return added;
-            }
-        } else {
-            return item_location( *this, &weapon );
-        }
-    } else {
+    if( added != item_location::nowhere ) {
         return added;
     }
+    if( allow_wield && wield( it ) ) {
+        return item_location( *this, &weapon );
+    }
+    if( !allow_drop ) {
+        return added;
+    }
+    return item_location( map_cursor( pos_abs() ), &get_map().add_item_or_charges( pos_bub(), it ) );
 }
 
 item_location Character::i_add( item it, int &copies_remaining,

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -4656,26 +4656,27 @@ void inventory_multiselector::deselect_contained_items()
         inventory_items.push_back( loc_front );
     }
     for( item_location loc_container : inventory_items ) {
-        if( !loc_container->empty() ) {
-            for( inventory_column *col : get_all_columns() ) {
-                for( inventory_entry *selected : col->get_entries( []( const inventory_entry & entry ) {
-                return entry.chosen_count > 0;
-            } ) ) {
-                    if( !selected->is_item() ) {
-                        continue;
-                    }
-                    bool deselected = false;
-                    for( const item *item_contained : loc_container->all_items_ptr() ) {
-                        for( const item_location &selected_loc : selected->locations ) {
-                            if( selected_loc.get_item() == item_contained ) {
-                                set_chosen_count( *selected, 0 );
-                                deselected = true;
-                                break;
-                            }
-                        }
-                        if( deselected ) {
+        if( loc_container->empty() ) {
+            continue;
+        }
+        for( inventory_column *col : get_all_columns() ) {
+            for( inventory_entry *selected : col->get_entries( []( const inventory_entry & entry ) {
+            return entry.chosen_count > 0;
+        } ) ) {
+                if( !selected->is_item() ) {
+                    continue;
+                }
+                bool deselected = false;
+                for( const item *item_contained : loc_container->all_items_ptr() ) {
+                    for( const item_location &selected_loc : selected->locations ) {
+                        if( selected_loc.get_item() == item_contained ) {
+                            set_chosen_count( *selected, 0 );
+                            deselected = true;
                             break;
                         }
+                    }
+                    if( deselected ) {
+                        break;
                     }
                 }
             }
@@ -5096,9 +5097,8 @@ void pickup_selector::remove_from_to_use( item_location &it )
         if( iter->first == it ) {
             to_use.erase( iter );
             return;
-        } else {
-            iter++;
         }
+        ++iter;
     }
 }
 

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -604,23 +604,16 @@ item_contents::item_contents( const std::vector<pocket_data> &pockets )
 
 bool item_contents::empty_with_no_mods() const
 {
-    return contents.empty() ||
-    std::all_of( contents.begin(), contents.end(), []( const item_pocket & p ) {
+    return std::all_of( contents.begin(), contents.end(), []( const item_pocket & p ) {
         return p.is_default_state();
     } );
 }
 
 bool item_contents::empty() const
 {
-    if( contents.empty() ) {
-        return true;
-    }
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( pocket_type::MOD ) ) {
-            // item mods aren't really contents per se
-            continue;
-        }
-        if( !pocket.empty() ) {
+        // item mods aren't really contents per se
+        if( !pocket.is_type( pocket_type::MOD ) && !pocket.empty() ) {
             return false;
         }
     }
@@ -629,14 +622,8 @@ bool item_contents::empty() const
 
 bool item_contents::empty_container() const
 {
-    if( contents.empty() ) {
-        return true;
-    }
     for( const item_pocket &pocket : contents ) {
-        if( !pocket.is_type( pocket_type::CONTAINER ) ) {
-            continue;
-        }
-        if( !pocket.empty() ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) && !pocket.empty() ) {
             return false;
         }
     }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -435,7 +435,7 @@ void Character::randomize( const bool random_scenario, bool play_now )
         outfit = gender_selection;
     }
     if( !MAP_SHARING::isSharing() ) {
-        play_now ? pick_name() : pick_name( true );
+        pick_name( !play_now );
     } else {
         name = MAP_SHARING::getUsername();
     }

--- a/src/uilist.cpp
+++ b/src/uilist.cpp
@@ -87,8 +87,8 @@ void uilist_impl::draw_controls()
         ImGui::TableSetupColumn( "menu", ImGuiTableColumnFlags_WidthFixed, parent.calculated_menu_size.x );
         ImGui::TableSetupColumn( "right", ImGuiTableColumnFlags_WidthFixed, parent.extra_space_right );
 
-        ImGui::TableSetColumnEnabled( 0, parent.extra_space_left < 1.0f ? false : true );
-        ImGui::TableSetColumnEnabled( 2, parent.extra_space_right < 1.0f ? false : true );
+        ImGui::TableSetColumnEnabled( 0, parent.extra_space_left >= 1.0f );
+        ImGui::TableSetColumnEnabled( 2, parent.extra_space_right >= 1.0f );
 
         ImGui::TableNextRow();
         ImGui::TableSetColumnIndex( 1 );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Lower code complexity.
Push my local changes.

#### Describe the solution

1. Use early return to lower `if else` nesting.
3. Remove the special cases of `contents.empty()`:
   - `std::all_of` returns true for `{}` (empty list).
   - Before for cycle followed by `return true`.
5. replace `a ? play(true) : play(false)` with `play(a)`.

#### Describe alternatives you've considered

#### Testing

I had the changes locally for quite a while.

#### Additional context

