### PR TITLE
instead of adding a switch in distraction manager excluded all summoning spells from checking the damage on self

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3026,7 +3026,7 @@ target_handler::trajectory target_ui::run()
                 continue;
             }
             bool can_skip_confirm = mode == TargetMode::Spell && ( casting->damage( player_character ) <= 0 ||
-                                    casting->effect() == "pickup" );
+                                    casting->effect() == "pickup" || casting->effect() == "summon" );
             if( !can_skip_confirm && !confirm_non_enemy_target() ) {
                 continue;
             }


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Continuation of  discussion in https://github.com/CleverRaven/Cataclysm-DDA/pull/87739

#### Describe the solution

Since summoning spells like the following uses `min_damage` and `max_damage` fields as a # of creatures to summon targeting on summoning AOE self wrongly displays "Really attack yourself?" prompt.

https://github.com/CleverRaven/Cataclysm-DDA/blob/7ea471471f41ff2c658f4b6ca6d8a0d490beae46/data/mods/Magiclysm/Spells/animist.json#L680-L708

This PR just excludes all summoning spells from entering `confirm_non_enemy_target()` function

#### Describe alternatives you've considered

Alternative was a "masochism mode" switch in distraction manager proposed in https://github.com/CleverRaven/Cataclysm-DDA/pull/87739