### PR TITLE
[XedraWood] Refactor random encounter EoCs to make it XedraWood unique

### DIFF
--- a/data/json/monster_special_attacks/monster_gun.json
+++ b/data/json/monster_special_attacks/monster_gun.json
@@ -203,7 +203,6 @@
     ],
     "skill": "throw",
     "ammo": [ "bone_dart" ],
-    "ammo_effects": [ "NEVER_MISFIRES" ],
     "clip_size": 1,
     "weight": "540 g",
     "volume": "750 ml",

--- a/data/mods/XedraWood/encounters/base_eoc.json
+++ b/data/mods/XedraWood/encounters/base_eoc.json
@@ -18,18 +18,21 @@
         { "u_near_om_location": { "context_val": "omt" }, "range": 30 },
         { "math": [ "time_since('cataclysm', 'unit':'days') >= _days_till_spawn" ] },
         { "math": [ "time_since(u_timer_XedraWood_RandEnc) >= time('1 d')" ] },
-        { "not": { "u_near_om_location": { "context_val": "omt" }, "range": 2 } },
         { "get_condition": "random_enc_condition" }
       ]
     },
     "effect": [
       { "u_message": "lizardfolk encounter has met its conditions!" },
-      { "mapgen_update": [ { "context_val": "map_update" } ], "om_terrain": { "context_val": "omt" } },
-      { "math": [ "u_timer_XedraWood_RandEnc = time('now')" ] },
       {
         "u_location_variable": { "global_val": "XedraWood_randenc_loc" },
-        "target_params": { "om_terrain": { "context_val": "omt" } }
+        "target_params": { "om_terrain": { "context_val": "omt" }, "random": true, "search_range": 30, "min_distance": 3 }
       },
+      {
+        "mapgen_update": [ { "context_val": "map_update" } ],
+        "om_terrain": { "context_val": "omt" },
+        "target_var": { "global_val": "XedraWood_randenc_loc" }
+      },
+      { "math": [ "u_timer_XedraWood_RandEnc = time('now')" ] },
       { "math": [ "XedraWood_RandEnc = 1" ] },
       { "copy_var": { "context_val": "omt" }, "target_var": { "global_val": "XedraWood_random_encounter_omt" } },
       {

--- a/data/mods/XedraWood/encounters/base_eoc.json
+++ b/data/mods/XedraWood/encounters/base_eoc.json
@@ -22,6 +22,7 @@
       ]
     },
     "effect": [
+      { "u_message": "XedraWood random encounter has met its conditions.", "type": "debug" },
       {
         "u_location_variable": { "global_val": "XedraWood_randenc_loc" },
         "target_params": { "om_terrain": { "context_val": "omt" }, "random": true, "search_range": 30, "min_distance": 3 }
@@ -38,7 +39,8 @@
         "copy_var": { "context_val": "map_removal" },
         "target_var": { "global_val": "XedraWood_random_encounter_map_remove" }
       }
-    ]
+    ],
+    "false_effect": { "u_message": "XedraWood random encounter has not met its conditions.", "type": "debug" }
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/XedraWood/encounters/base_eoc.json
+++ b/data/mods/XedraWood/encounters/base_eoc.json
@@ -1,0 +1,53 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_XE_RandEnc",
+    "//": "Just a copy of the base RandEnc so they can run concurrently",
+    "condition": {
+      "and": [
+        { "expects_vars": [ "map_update", "omt", "map_removal", "chance", "days_till_spawn" ] },
+        { "one_in_chance": { "context_val": "chance" } },
+        { "u_near_om_location": { "context_val": "omt" }, "range": 30 },
+        { "math": [ "time_since('cataclysm', 'unit':'days') >= _days_till_spawn" ] },
+        { "math": [ "time_since(u_timer_XedraWood_RandEnc) >= time('1 d')" ] },
+        { "not": { "u_near_om_location": { "context_val": "omt" }, "range": 2 } },
+        { "get_condition": "random_enc_condition" }
+      ]
+    },
+    "effect": [
+      { "mapgen_update": [ { "context_val": "map_update" } ], "om_terrain": { "context_val": "omt" } },
+      { "math": [ "u_timer_XedraWood_RandEnc = time('now')" ] },
+      {
+        "u_location_variable": { "global_val": "XedraWood_randenc_loc" },
+        "target_params": { "om_terrain": { "context_val": "omt" } }
+      },
+      { "math": [ "XedraWood_RandEnc = 1" ] },
+      { "copy_var": { "context_val": "omt" }, "target_var": { "global_val": "XedraWood_random_encounter_omt" } },
+      {
+        "copy_var": { "context_val": "map_removal" },
+        "target_var": { "global_val": "XedraWood_random_encounter_map_remove" }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_RandEnc_remove",
+    "recurrence": 200,
+    "global": true,
+    "condition": {
+      "and": [
+        { "math": [ "time_since(u_timer_XedraWood_RandEnc) > time('2 h')" ] },
+        { "not": { "u_near_om_location": { "global_val": "XedraWood_random_encounter_omt" }, "range": 2 } },
+        { "math": [ "XedraWood_RandEnc == 1" ] }
+      ]
+    },
+    "effect": [
+      {
+        "mapgen_update": [ { "global_val": "XedraWood_random_encounter_map_remove" } ],
+        "om_terrain": { "global_val": "XedraWood_random_encounter_omt" },
+        "target_var": { "global_val": "XedraWood_randenc_loc" }
+      },
+      { "math": [ "XedraWood_RandEnc = 0" ] }
+    ]
+  }
+]

--- a/data/mods/XedraWood/encounters/base_eoc.json
+++ b/data/mods/XedraWood/encounters/base_eoc.json
@@ -1,7 +1,15 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_XE_RandEnc",
+    "id": "EOC_XedraWood_RandEnc_Set_Initial_RandEnc_Time",
+    "eoc_type": "EVENT",
+    "required_event": "game_start",
+    "condition": "u_is_avatar",
+    "effect": { "math": [ "u_timer_XedraWood_RandEnc = time('now')" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_XedraWood_RandEnc",
     "//": "Just a copy of the base RandEnc so they can run concurrently",
     "condition": {
       "and": [
@@ -15,6 +23,7 @@
       ]
     },
     "effect": [
+      { "u_message": "lizardfolk encounter has met its conditions!" },
       { "mapgen_update": [ { "context_val": "map_update" } ], "om_terrain": { "context_val": "omt" } },
       { "math": [ "u_timer_XedraWood_RandEnc = time('now')" ] },
       {

--- a/data/mods/XedraWood/encounters/base_eoc.json
+++ b/data/mods/XedraWood/encounters/base_eoc.json
@@ -22,7 +22,6 @@
       ]
     },
     "effect": [
-      { "u_message": "lizardfolk encounter has met its conditions!" },
       {
         "u_location_variable": { "global_val": "XedraWood_randenc_loc" },
         "target_params": { "om_terrain": { "context_val": "omt" }, "random": true, "search_range": 30, "min_distance": 3 }

--- a/data/mods/XedraWood/encounters/lizardfolk_hunting_party.json
+++ b/data/mods/XedraWood/encounters/lizardfolk_hunting_party.json
@@ -7,7 +7,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_XEDRAWOOD_LIZARDFOLK_HUNTING_PARTY_SWAMP_RANDENC",
-    "recurrence": 1,
+    "recurrence": 21600,
     "global": true,
     "condition": { "math": [ "XedraWood_RandEnc != 1" ] },
     "effect": [

--- a/data/mods/XedraWood/encounters/lizardfolk_hunting_party.json
+++ b/data/mods/XedraWood/encounters/lizardfolk_hunting_party.json
@@ -7,12 +7,12 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_XEDRAWOOD_LIZARDFOLK_HUNTING_PARTY_SWAMP_RANDENC",
-    "recurrence": 21600,
+    "recurrence": 1,
     "global": true,
     "condition": { "math": [ "XedraWood_RandEnc != 1" ] },
     "effect": [
       { "set_condition": "random_enc_condition", "condition": { "not": { "is_season": "winter" } } },
-      { "u_message": "lizardfolk encounter has triggered!" },
+      { "u_message": "lizardfolk encounter has triggered!", "type": "debug" },
       {
         "run_eocs": "EOC_XedraWood_RandEnc",
         "variables": {

--- a/data/mods/XedraWood/encounters/lizardfolk_hunting_party.json
+++ b/data/mods/XedraWood/encounters/lizardfolk_hunting_party.json
@@ -7,18 +7,19 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_XEDRAWOOD_LIZARDFOLK_HUNTING_PARTY_SWAMP_RANDENC",
-    "recurrence": 21600,
+    "recurrence": 1,
     "global": true,
     "condition": { "math": [ "XedraWood_RandEnc != 1" ] },
     "effect": [
       { "set_condition": "random_enc_condition", "condition": { "not": { "is_season": "winter" } } },
+      { "u_message": "lizardfolk encounter has triggered!" },
       {
         "run_eocs": "EOC_XedraWood_RandEnc",
         "variables": {
           "omt": "forest_water",
           "map_update": "nest_RandEnc_lizardfolk_hunting_party_add",
           "map_removal": "nest_RandEnc_lizardfolk_hunting_party_remove",
-          "chance": 10,
+          "chance": 1,
           "days_till_spawn": 0
         }
       }

--- a/data/mods/XedraWood/encounters/lizardfolk_hunting_party.json
+++ b/data/mods/XedraWood/encounters/lizardfolk_hunting_party.json
@@ -9,11 +9,11 @@
     "id": "EOC_XEDRAWOOD_LIZARDFOLK_HUNTING_PARTY_SWAMP_RANDENC",
     "recurrence": 21600,
     "global": true,
-    "condition": { "math": [ "RandEnc != 1" ] },
+    "condition": { "math": [ "XedraWood_RandEnc != 1" ] },
     "effect": [
       { "set_condition": "random_enc_condition", "condition": { "not": { "is_season": "winter" } } },
       {
-        "run_eocs": "EOC_RandEnc",
+        "run_eocs": "EOC_XedraWood_RandEnc",
         "variables": {
           "omt": "forest_water",
           "map_update": "nest_RandEnc_lizardfolk_hunting_party_add",

--- a/data/mods/XedraWood/monsters/monster_special_attacks.json
+++ b/data/mods/XedraWood/monsters/monster_special_attacks.json
@@ -7,7 +7,6 @@
     "name": { "str": "barbed javelin" },
     "description": "Fake gun that fires barbed javelins.",
     "flags": [ "NEVER_JAMS", "NONCONDUCTIVE", "NO_REPAIR", "WATERPROOF_GUN", "NO_SALVAGE", "NO_UNLOAD", "NO_TURRET" ],
-    "ammo_effects": [ "NEVER_MISFIRES" ],
     "skill": "rifle",
     "durability": 10,
     "range": 10,
@@ -34,7 +33,6 @@
       "WATERPROOF_GUN",
       "NEVER_JAMS"
     ],
-    "ammo_effects": [ "NEVER_MISFIRES" ],
     "skill": "archery",
     "min_strength": 8,
     "ammo": [ "arrow" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[XedraWood] Refactor random encounter EoCs to make it XedraWood unique"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I thought it better that each mod has its own random encounter controller EoC since the location is stored in a global val, so the more we have the more they collide. This does mean you'll have more random encounters if you're running more mods...but on the other hand, by default they're placed within 30 OMTs, last an hour or two, and fire once per day, so you're not going to be running into them all the time. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add `EOC_XedraWood_RandEnc`, which works like `EOC_RandEnc` except it's set for XedraWood and its global variables have XedraWood prefixes. Set `EOC_XEDRAWOOD_LIZARDFOLK_HUNTING_PARTY_SWAMP_RANDENC` to call this EoC. 

Rework the EoC so that it does a search for an appropriate terrain even if you're in the same terrain type, as long as you're not within 3 OMTs of the location (by mission-searching for the terrain first with a min-radius of 3 and removing the condition check). 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Added some debug messages and tested it until it worked. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
