### PR TITLE
Fx stacking elevators to nowhere

### DIFF
--- a/data/json/mapgen/microlab/microlab_portal/microlab_portal_unique.json
+++ b/data/json/mapgen/microlab/microlab_portal/microlab_portal_unique.json
@@ -150,6 +150,7 @@
       ],
       "palettes": [ "microlab_generic" ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "set": [ { "square": "trap_remove", "id": "tr_null", "x": 0, "y": 0, "x2": 23, "y2": 23 } ],
       "terrain": { ".": "t_nether_glass_floor", "2": "t_door_glass_frosted_lab_o" }
     }
   },


### PR DESCRIPTION
#### Summary
Bugfixes "Fix stacking elevators to nowhere inside portal labs."

#### Purpose of change
#87760 Revealed that the traps meant to spawn in the elevator chunk still exist after the elevator chunk places, allowing the update to trigger up to 3 additional times.

This is undesirable, since after the first trigger, each of them prints a confusing 'Your surrounding shifts' message, with your surroundings not actually shifting at all.

#### Describe the solution
Mapgen updates can now remove traps, take advantage of that,


#### Testing
Trigger one of the traps, the rest are removed.

#### Additional context
Its still a bad idea to leave stuff over in the phyisics lab, don't do it.