### PR TITLE
[Xedra Evolved] Update Pooka Raven, Bat & Bear Shapeshift calorie calculation to not affect weariness

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -1257,7 +1257,7 @@
               { "run_eocs": "EOC_SHAPESHIFTING_ARMOR_CHECK_SUBSUME_INTO_FORM" },
               { "u_add_trait": "VAMPIRE_BAT_FORM_TRAITS" },
               { "u_add_trait": "ECHOLOCATION" },
-              { "math": [ "u_calories() /= 4" ] },
+              { "math": [ "u_calories('dont_affect_weariness': true) /= 4" ] },
               {
                 "u_message": "Your fingers lengthen as flaps of skin grow between them and as your legs shorten, you take to the air.",
                 "type": "good"
@@ -1280,7 +1280,7 @@
             "effect": [
               { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
               { "u_lose_trait": "ECHOLOCATION" },
-              { "math": [ "u_calories() *= 4" ] },
+              { "math": [ "u_calories('dont_affect_weariness': true) *= 4" ] },
               { "u_lose_trait": "VAMPIRE_BAT_FORM_TRAITS" },
               {
                 "u_message": "Your body shifts and your fingers separate as you return to your previous form.",
@@ -1319,7 +1319,7 @@
               { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
               { "run_eocs": "EOC_SHAPESHIFTING_ARMOR_CHECK_SUBSUME_INTO_FORM" },
               { "u_add_trait": "TURN_INTO_RAVEN_TRAITS" },
-              { "math": [ "u_calories() /= 4" ] },
+              { "math": [ "u_calories('dont_affect_weariness': true) /= 4" ] },
               {
                 "u_message": "Your body shifts and warps as your fingers extend into wings and feathers burst from your skin as you take to the air.",
                 "type": "good"
@@ -1341,7 +1341,7 @@
             "condition": { "u_has_trait": "TURN_INTO_RAVEN_TRAITS" },
             "effect": [
               { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
-              { "math": [ "u_calories() *= 4" ] },
+              { "math": [ "u_calories('dont_affect_weariness': true) *= 4" ] },
               { "u_lose_trait": "TURN_INTO_RAVEN_TRAITS" },
               {
                 "u_message": "Your body shifts and your feathers vanish as you return to your previous form.",
@@ -1380,7 +1380,7 @@
               { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
               { "run_eocs": "EOC_SHAPESHIFTING_ARMOR_CHECK_SUBSUME_INTO_FORM" },
               { "u_add_trait": "TURN_INTO_BEAR_TRAITS" },
-              { "math": [ "u_calories() *= 3" ] },
+              { "math": [ "u_calories('dont_affect_weariness': true) *= 3" ] },
               {
                 "u_message": "Your body shifts and expands as fur sprouts from your skin and your mouth and teeth lengthen.",
                 "type": "good"
@@ -1402,7 +1402,7 @@
             "condition": { "u_has_trait": "TURN_INTO_BEAR_TRAITS" },
             "effect": [
               { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
-              { "math": [ "u_calories() /= 3" ] },
+              { "math": [ "u_calories('dont_affect_weariness': true) /= 3" ] },
               { "u_lose_trait": "TURN_INTO_BEAR_TRAITS" },
               {
                 "u_message": "Your body shifts and contracts and you return to your humanoid form.",


### PR DESCRIPTION
#### Summary
Bugfixes "[Xedra Evolved] Shapeshifting into either a Raven, Bat or Bear would cause weariness to tank. This fixes that."

#### Purpose of change
Transforming with either Spirit of the Raven, Spirit of the Bat or Spirit of the Bear would cause your weariness to tank from the calorie calculations, often putting you at extreme weariness from fresh.

#### Describe the solution
Changed calorie calculations to not affect weariness.

#### Describe alternatives you've considered
Not fixing the bug?

#### Testing
1. Downloaded the latest experimental version
2. Created a world with default mods + Xedra Evolved
3. Created default character
4. Gave myself Pooka trait and Spirit of the Raven, Bat & Bear
5. Tested each Spirit trait, which caused extreme weariness on either transformation(raven, bat) or de-transformation(bear). Note that de-transforming won't fix weariness, it stays bugged and has to be recovered normally
6. Quit game & implemented bugfix
7. Tested Spirit traits again, this time with no weariness issues

#### Additional context
This is my first time contributing, so apologies if I did something wrong.