### PR TITLE
[Xedra Evolved] Fixed Pooka shapeshifting issues regarding "u_deactivate_trait"

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -849,20 +849,153 @@
     "type": "effect_on_condition",
     "id": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future",
     "effect": [
-      { "u_deactivate_trait": "POOKA_ANTLERS" },
-      { "u_deactivate_trait": "POOKA_HORNS" },
-      { "u_deactivate_trait": "POOKA_FANGS" },
-      { "u_deactivate_trait": "POOKA_SABER_TEETH" },
-      { "u_deactivate_trait": "POOKA_WOLF_EARS" },
-      { "u_deactivate_trait": "POOKA_FELINE_EARS" },
-      { "u_deactivate_trait": "POOKA_CLAWS" },
-      { "u_deactivate_trait": "POOKA_STAINLESS_CLAWS" },
-      { "u_deactivate_trait": "POOKA_URSINE_FUR" },
-      { "u_deactivate_trait": "POOKA_CHITIN" },
-      { "u_deactivate_trait": "POOKA_QUADRUPED" },
-      { "u_deactivate_trait": "POOKA_LEAPING_LEGS" },
-      { "u_deactivate_trait": "POOKA_WOLF_TAIL" },
-      { "u_deactivate_trait": "POOKA_TAIL_LONG" },
+      {
+		    "run_eocs": [
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_ANTLERS",
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_HORNS",
+		    	"EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FANGS",
+	    		"EOC_POOKA_SHAPESHIFTS_DEACTIVATE_SABER_TEETH",
+	    		"EOC_POOKA_SHAPESHIFTS_DEACTIVATE_WOLF_EARS",
+		    	"EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FELINE_EARS",
+		    	"EOC_POOKA_SHAPESHIFTS_DEACTIVATE_CLAWS",
+		    	"EOC_POOKA_SHAPESHIFTS_DEACTIVATE_STAINLESS_CLAWS",
+		    	"EOC_POOKA_SHAPESHIFTS_DEACTIVATE_URSINE_FUR",
+		    	"EOC_POOKA_SHAPESHIFTS_DEACTIVATE_CHITIN",
+		    	"EOC_POOKA_SHAPESHIFTS_DEACTIVATE_QUADRUPED",
+		    	"EOC_POOKA_SHAPESHIFTS_DEACTIVATE_LEAPING_LEGS",
+		    	"EOC_POOKA_SHAPESHIFTS_DEACTIVATE_SKUNK_TAIL",
+	    		"EOC_POOKA_SHAPESHIFTS_DEACTIVATE_WOLF_TAIL",
+	    		"EOC_POOKA_SHAPESHIFTS_DEACTIVATE_TAIL_LONG",
+	    		"EOC_POOKA_SHAPESHIFTS_DEACTIVATE_TAIL_STING"
+		    ]
+	    }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_ANTLERS",
+    "condition": { "u_has_trait": "POOKA_ANTLERS" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_ANTLERS" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_HORNS",
+    "condition": { "u_has_trait": "POOKA_HORNS" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_HORNS" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FANGS",
+    "condition": { "u_has_trait": "POOKA_FANGS" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_FANGS" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_SABER_TEETH",
+    "condition": { "u_has_trait": "POOKA_SABER_TEETH" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_SABER_TEETH" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_WOLF_EARS",
+    "condition": { "u_has_trait": "POOKA_WOLF_EARS" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_WOLF_EARS" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FELINE_EARS",
+    "condition": { "u_has_trait": "POOKA_FELINE_EARS" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_FELINE_EARS" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_CLAWS",
+    "condition": { "u_has_trait": "POOKA_CLAWS" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_CLAWS" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_STAINLESS_CLAWS",
+    "condition": { "u_has_trait": "POOKA_STAINLESS_CLAWS" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_STAINLESS_CLAWS" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_URSINE_FUR",
+    "condition": { "u_has_trait": "POOKA_URSINE_FUR" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_URSINE_FUR" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_CHITIN",
+    "condition": { "u_has_trait": "POOKA_CHITIN" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_CHITIN" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_QUADRUPED",
+    "condition": { "u_has_trait": "POOKA_QUADRUPED" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_QUADRUPED" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_LEAPING_LEGS",
+    "condition": { "u_has_trait": "POOKA_LEAPING_LEGS" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_LEAPING_LEGS" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_SKUNK_TAIL",
+    "condition": { "u_has_trait": "POOKA_SKUNK_TAIL" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_SKUNK_TAIL" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_WOLF_TAIL",
+    "condition": { "u_has_trait": "POOKA_WOLF_TAIL" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_WOLF_TAIL" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_TAIL_LONG",
+    "condition": { "u_has_trait": "POOKA_TAIL_LONG" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_TAIL_LONG" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_TAIL_STING",
+    "condition": { "u_has_trait": "POOKA_TAIL_STING" },
+    "effect": [
       { "u_deactivate_trait": "POOKA_TAIL_STING" }
     ]
   },
@@ -870,7 +1003,7 @@
     "type": "effect_on_condition",
     "id": "EOC_POOKA_ANTLERS_ON",
     "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
-    "effect": [ { "u_deactivate_trait": "POOKA_HORNS" }, { "u_add_trait": "ANTLERS" } ],
+    "effect": [ { "run_eocs": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_HORNS" }, { "u_add_trait": "ANTLERS" } ],
     "false_effect": [
       {
         "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
@@ -888,7 +1021,7 @@
     "type": "effect_on_condition",
     "id": "EOC_POOKA_HORNS_ON",
     "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
-    "effect": [ { "u_deactivate_trait": "POOKA_ANTLERS" }, { "u_add_trait": "HORNS_CURLED" } ],
+    "effect": [ { "run_eocs": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_ANTLERS" }, { "u_add_trait": "HORNS_CURLED" } ],
     "false_effect": [
       {
         "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
@@ -942,7 +1075,7 @@
     "type": "effect_on_condition",
     "id": "EOC_POOKA_WOLF_EARS_ON",
     "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
-    "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "u_deactivate_trait": "POOKA_FELINE_EARS" }, { "u_add_trait": "LUPINE_EARS" } ],
+    "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "run_eocs": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FELINE_EARS" }, { "u_add_trait": "LUPINE_EARS" } ],
     "false_effect": [
       {
         "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
@@ -960,7 +1093,7 @@
     "type": "effect_on_condition",
     "id": "EOC_POOKA_FELINE_EARS_ON",
     "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
-    "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "u_deactivate_trait": "POOKA_WOLF_EARS" }, { "u_add_trait": "FELINE_EARS" } ],
+    "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "run_eocs": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_WOLF_EARS" }, { "u_add_trait": "FELINE_EARS" } ],
     "false_effect": [
       {
         "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
@@ -1032,7 +1165,7 @@
     "type": "effect_on_condition",
     "id": "EOC_POOKA_URSINE_FUR_ON",
     "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
-    "effect": [ { "u_deactivate_trait": "POOKA_CHITIN" }, { "u_add_trait": "URSINE_FUR" } ],
+    "effect": [ { "run_eocs": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_CHITIN" }, { "u_add_trait": "URSINE_FUR" } ],
     "false_effect": [
       {
         "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
@@ -1050,7 +1183,7 @@
     "type": "effect_on_condition",
     "id": "EOC_POOKA_CHITIN_ON",
     "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
-    "effect": [ { "u_deactivate_trait": "POOKA_URSINE_FUR" }, { "u_add_trait": "CHITIN2" } ],
+    "effect": [ { "run_eocs": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_URSINE_FUR" }, { "u_add_trait": "CHITIN2" } ],
     "false_effect": [
       {
         "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
@@ -1068,7 +1201,7 @@
     "type": "effect_on_condition",
     "id": "EOC_POOKA_QUADRUPED_ON",
     "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
-    "effect": [ { "u_deactivate_trait": "POOKA_LEAPING_LEGS" }, { "u_add_trait": "POOKA_QUADRUPED_TRAITS" } ],
+    "effect": [ { "run_eocs": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_LEAPING_LEGS" }, { "u_add_trait": "POOKA_QUADRUPED_TRAITS" } ],
     "false_effect": [
       {
         "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
@@ -1086,7 +1219,7 @@
     "type": "effect_on_condition",
     "id": "EOC_POOKA_LEAPING_LEGS_ON",
     "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
-    "effect": [ { "u_deactivate_trait": "POOKA_QUADRUPED_TRAITS" }, { "u_add_trait": "LEAPING_LEGS" } ],
+    "effect": [ { "run_eocs": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_QUADRUPED" }, { "u_add_trait": "LEAPING_LEGS" } ],
     "false_effect": [
       {
         "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
@@ -1105,9 +1238,13 @@
     "id": "EOC_POOKA_SKUNK_TAIL_ON",
     "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
     "effect": [
-      { "u_deactivate_trait": "POOKA_TAIL_LONG" },
-      { "u_deactivate_trait": "POOKA_TAIL_STING" },
-      { "u_deactivate_trait": "POOKA_TAIL_FLUFFY" },
+      {
+		    "run_eocs": [
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_TAIL_LONG", 
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_TAIL_STING", 
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_WOLF_TAIL" 
+		    ]
+	    },
       { "u_add_trait": "TAIL_SKUNK" }
     ],
     "false_effect": [
@@ -1128,9 +1265,13 @@
     "id": "EOC_POOKA_WOLF_TAIL_ON",
     "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
     "effect": [
-      { "u_deactivate_trait": "POOKA_TAIL_LONG" },
-      { "u_deactivate_trait": "POOKA_TAIL_STING" },
-      { "u_deactivate_trait": "TAIL_SKUNK" },
+      {
+		    "run_eocs": [
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_TAIL_LONG", 
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_TAIL_STING", 
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_SKUNK_TAIL" 
+		    ]
+	    },
       { "u_add_trait": "TAIL_FLUFFY" }
     ],
     "false_effect": [
@@ -1151,9 +1292,13 @@
     "id": "EOC_POOKA_TAIL_LONG_ON",
     "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
     "effect": [
-      { "u_deactivate_trait": "POOKA_WOLF_TAIL" },
-      { "u_deactivate_trait": "POOKA_TAIL_STING" },
-      { "u_deactivate_trait": "POOKA_SKUNK_TAIL" },
+      {
+		    "run_eocs": [
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_WOLF_TAIL", 
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_TAIL_STING", 
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_SKUNK_TAIL" 
+		    ]
+	    },
       { "u_add_trait": "TAIL_LONG" }
     ],
     "false_effect": [
@@ -1174,9 +1319,13 @@
     "id": "EOC_POOKA_TAIL_STING_ON",
     "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
     "effect": [
-      { "u_deactivate_trait": "POOKA_WOLF_TAIL" },
-      { "u_deactivate_trait": "POOKA_TAIL_LONG" },
-      { "u_deactivate_trait": "TAIL_SKUNK" },
+      {
+		    "run_eocs": [
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_WOLF_TAIL", 
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_TAIL_LONG", 
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_SKUNK_TAIL" 
+		    ]
+	    },
       { "u_add_trait": "TAIL_STING" }
     ],
     "false_effect": [
@@ -1228,11 +1377,63 @@
     "condition": { "math": [ "u_val('mana') >= 2" ] },
     "effect": [ { "math": [ "u_val('mana') -= 1" ] } ],
     "false_effect": [
-      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_BAT" },
-      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_RAVEN" },
-      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_BEAR" },
-      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_DEER" },
-      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_WOLF" },
+	    {
+		    "run_eocs": [
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FULL_BAT",
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FULL_RAVEN",
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FULL_BEAR",
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FULL_DEER",
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FULL_WOLF",
+			    "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FULL_COUGAR"
+		    ]
+	    }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FULL_BAT",
+    "condition": { "u_has_trait": "POOKA_SHAPESHIFT_FULL_BAT" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_BAT" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FULL_RAVEN",
+    "condition": { "u_has_trait": "POOKA_SHAPESHIFT_FULL_RAVEN" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_RAVEN" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FULL_BEAR",
+    "condition": { "u_has_trait": "POOKA_SHAPESHIFT_FULL_BEAR" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_BEAR" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FULL_DEER",
+    "condition": { "u_has_trait": "POOKA_SHAPESHIFT_FULL_DEER" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_DEER" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FULL_WOLF",
+    "condition": { "u_has_trait": "POOKA_SHAPESHIFT_FULL_WOLF" },
+    "effect": [
+      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_WOLF" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFTS_DEACTIVATE_FULL_COUGAR",
+    "condition": { "u_has_trait": "POOKA_SHAPESHIFT_FULL_COUGAR" },
+    "effect": [
       { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_COUGAR" }
     ]
   },


### PR DESCRIPTION
#### Summary

Bugfixes "Fixes Pooka shapeshifting giving you unearned traits via u_deactivate_trait + small skunk tail shapeshift fix"

#### Purpose of change

When shapeshifting with Pooka traits, "u_deactivate_trait" is used to turn off competing traits. For example, activating Antlers (shapeshift) will turn off Horns (shapeshift).

The problem is that "u_deactivate_trait" will give the player the trait it's deactivating, even if they didn't originally have it.

So if you, for example, earn the Antlers (shapeshift) trait, then use it, the game will also give you the Horns (shapeshift) trait, even though you didn't earn it.
This bug also caused you to earn all "Spirit of the X" traits upon running out of mana while in a "Spirit of the X" shapeshift.


Also, there was a small issue where if you first activated Skunk Tail (shapeshift), then another tail shapeshift(except long tail), it would cause you to have two tail shapeshifts active at once.

This was caused by faulty trait deactivation, which would attempt to deactivate the Skunk Tail trait instead of the Skunk Tail (shapeshift) trait.

#### Describe the solution

To fix the Pooka shapeshift extra trait issues, checks have been added to ensure that traits are only deactivated if you actually have the trait to begin with.

The skunk tail issue was fixed by changing the deactivated trait to the correct one.

#### Describe alternatives you've considered

You could instead change "u_deactivate_trait" so that attempting to deactivate a trait that you don't own wont give it to you, but I have no idea how to implement this and it might cause issues in other places if functionality relies on this bug/feature.

There's also almost certainly some better way of checking if you own the trait before deactivating it without making a seperate EOC for each individual trait. Maybe by passing the trait id into an EOC, so that only one EOC is needed? Again, this is out of my capabilities, but it could be a better solution that doesn't potentially break functionality like changing "u_deactivate_trait" might.

#### Testing

1. Created a default world + Xedra Evolved, as well as a default character.
2. Gave myself Pooka trait and multiple pooka shapeshifting traits.
3. Activated different shapeshifting traits, confirming that using, for example, the Carapace (shapeshift) trait would also give you the Thick Fur (shapeshift) trait, even if I didn't have it originally. 
4. Tested "Spirit of the X" traits, confirming that running out of mana while transformed would give all other "Spirit of the X" traits, even if I didn't have them originally.
5. Applied fixes
6. Tried different shapeshifting traits, confirming that they wouldn't give you any other shapeshifting traits.
6. Tried different "Spirit of the X", confirming that they wouldn't give you any other "Spirit of the X" traits.

#### Additional context

Can't think of any.