### PR TITLE
Exodii-Free Merchants trade, and a mission to negotiate it

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/ref_center_exodii_updater.json
+++ b/data/json/effects_on_condition/npc_eocs/ref_center_exodii_updater.json
@@ -1,0 +1,348 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EXODII_FM_UPDATES_RECURRANCE",
+    "//": "updates that occur automatically, without the player",
+    "recurrence": "24 hours",
+    "global": true,
+    "condition": {
+      "and": [
+        { "math": [ "exodii_FM_negotiation_failed != 1" ] },
+        {
+          "or": [
+            { "math": [ "FM_exodii_caravan_placed != 1" ] },
+            { "math": [ "FM_exodii_butte_building_placed != 1" ] },
+            { "math": [ "FM_exodii_autodoc_placed != 1" ] }
+          ]
+        }
+      ]
+    },
+    "deactivate_condition": {
+      "or": [
+        { "math": [ "exodii_FM_negotiation_failed == 1" ] },
+        {
+          "and": [
+            { "math": [ "FM_exodii_caravan_placed == 1" ] },
+            { "math": [ "FM_exodii_butte_building_placed == 1" ] },
+            { "math": [ "FM_exodii_autodoc_placed == 1" ] }
+          ]
+        }
+      ]
+    },
+    "effect": { "run_eocs": [ "EOC_EXODII_FM_UPDATES_RECURRANCE_EVENT_EXODII", "EOC_EXODII_FM_UPDATES_RECURRANCE_EVENT_FM" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EXODII_FM_UPDATES_RECURRANCE_EVENT_EXODII",
+    "global": true,
+    "condition": {
+      "and": [
+        { "u_near_om_location": "exodii_base_x0y3z0", "range": 180 },
+        { "not": { "u_near_om_location": "exodii_base_x0y3z0", "range": 2 } }
+      ]
+    },
+    "effect": [
+      {
+        "if": {
+          "and": [ { "math": [ "time_since('cataclysm', 'unit':'days') >= 60" ] }, { "math": [ "FM_exodii_caravan_placed != 1" ] } ]
+        },
+        "then": [
+          { "math": [ "FM_exodii_caravan_placed = 1" ] },
+          { "mapgen_update": "EXODII_FM_UPDATE_PLACE_TENTS", "om_terrain": "exodii_base_x0y3z0" }
+        ]
+      },
+      {
+        "if": {
+          "and": [
+            { "math": [ "time_since('cataclysm', 'unit':'days') >= 120" ] },
+            { "math": [ "FM_exodii_butte_building_placed != 1" ] }
+          ]
+        },
+        "then": [
+          { "math": [ "FM_exodii_butte_building_placed = 1" ] },
+          { "mapgen_update": "EXODII_FM_UPDATE_PLACE_WAREHOUSE", "om_terrain": "exo_base_safehouse_stone_0" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EXODII_FM_UPDATES_RECURRANCE_EVENT_FM",
+    "global": true,
+    "condition": {
+      "and": [
+        { "u_near_om_location": "evac_center_17", "range": 180 },
+        { "not": { "u_near_om_location": "evac_center_17", "range": 2 } }
+      ]
+    },
+    "effect": [
+      {
+        "if": {
+          "and": [ { "math": [ "time_since('cataclysm', 'unit':'days') >= 360" ] }, { "math": [ "FM_exodii_autodoc_placed != 1" ] } ]
+        },
+        "then": [
+          { "math": [ "FM_exodii_autodoc_placed = 1" ] },
+          { "mapgen_update": "EXODII_FM_UPDATE_PLACE_AUTODOC", "om_terrain": "evac_center_17" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "//": "updates if the player completes the negotiations between Exodii and Free Merchants.",
+    "id": "EOC_EXODII_FM_UPDATES",
+    "effect": { "run_eocs": [ "EOC_EXODII_FM_UPDATE_BUILD_BASE_AT_EXODII", "EOC_EXODII_FM_UPDATE_PLACE_AUTODOC" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EXODII_FM_UPDATE_BUILD_BASE_AT_EXODII",
+    "condition": {
+      "and": [
+        { "u_near_om_location": "exodii_base_x0y3z0", "range": 180 },
+        { "not": { "u_near_om_location": "exodii_base_x0y3z0", "range": 2 } }
+      ]
+    },
+    "effect": [
+      { "math": [ "FM_exodii_caravan_placed = 1" ] },
+      { "mapgen_update": "EXODII_FM_UPDATE_PLACE_TENTS", "om_terrain": "exodii_base_x0y3z0" },
+      {
+        "if": { "math": [ "exodii_FM_butte_building == 1" ] },
+        "then": [
+          { "math": [ "FM_exodii_butte_building_placed = 1" ] },
+          { "mapgen_update": "EXODII_FM_UPDATE_PLACE_WAREHOUSE", "om_terrain": "exo_base_safehouse_stone_0" }
+        ]
+      }
+    ],
+    "false_effect": { "run_eocs": "EOC_EXODII_FM_UPDATE_BUILD_BASE_AT_EXODII", "time_in_future": "12 hours" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EXODII_FM_UPDATE_PLACE_AUTODOC",
+    "condition": {
+      "and": [
+        { "u_near_om_location": "evac_center_17", "range": 180 },
+        { "not": { "u_near_om_location": "evac_center_17", "range": 2 } }
+      ]
+    },
+    "effect": [
+      {
+        "if": { "math": [ "exodii_FM_autodoc == 1" ] },
+        "then": [
+          { "math": [ "FM_exodii_autodoc_placed = 1" ] },
+          { "mapgen_update": "EXODII_FM_UPDATE_PLACE_AUTODOC", "om_terrain": "evac_center_17" }
+        ]
+      }
+    ],
+    "false_effect": { "run_eocs": "EOC_EXODII_FM_UPDATE_PLACE_AUTODOC", "time_in_future": "12 hours" }
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "EXODII_FM_UPDATE_PLACE_TENTS",
+    "object": { "place_nested": [ { "chunks": [ "EXODII_FM_UPDATE_PLACE_TENTS" ], "x": 0, "y": 8 } ] }
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "EXODII_FM_UPDATE_PLACE_WAREHOUSE",
+    "object": { "place_nested": [ { "chunks": [ "EXODII_FM_UPDATE_PLACE_WAREHOUSE" ], "x": 0, "y": 0 } ] }
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "EXODII_FM_UPDATE_PLACE_AUTODOC",
+    "object": {
+      "place_nested": [
+        { "chunks": [ "EXODII_FM_UPDATE_PLACE_AUTODOC_1" ], "x": 23, "y": 0 },
+        { "chunks": [ "EXODII_FM_UPDATE_PLACE_AUTODOC_2" ], "x": 23, "y": 1 }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "EXODII_FM_UPDATE_PLACE_AUTODOC_1",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rows": [ " " ],
+      "terrain": { " ": "t_floor" },
+      "furniture": { " ": "f_autodoc_couch" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "EXODII_FM_UPDATE_PLACE_AUTODOC_2",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rows": [ " " ],
+      "terrain": { " ": "t_floor" },
+      "furniture": { " ": "f_autodoc" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "EXODII_FM_UPDATE_PLACE_TENTS",
+    "object": {
+      "faction_owner": [ { "id": "free_merchants", "x": [ 0, 14 ], "y": [ 0, 14 ] } ],
+      "mapgensize": [ 15, 15 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "               ",
+        " ######..o hth ",
+        " #x.rrrr..     ",
+        " #t.rrrr..     ",
+        " #x.rrrr..  F  ",
+        " #+++##..o     ",
+        " #c.t#.... h   ",
+        " #####...   t  ",
+        "  o.....o   h  ",
+        " ...rrrr###    ",
+        "o..rrrr.+c#    ",
+        " .rrrr.o###    ",
+        "  ..#+#        ",
+        "   o#c#        ",
+        "    ###        "
+      ],
+      "terrain": {
+        ".": "t_dirt",
+        "r": "t_carpet_red_outdoor",
+        "#": "t_dirt",
+        "x": "t_dirt",
+        "c": "t_dirt",
+        "F": "t_pit_shallow",
+        "o": "t_wood_sunshade_pole"
+      },
+      "furniture": { "#": "f_skin_wall", "+": "f_skin_door", "x": "f_crate_o", "t": "f_table", "h": "f_chair", "F": "f_firering" },
+      "traps": { "c": "tr_fur_rollmat", "v": "tr_funnel" },
+      "place_npcs": [
+        { "class": "exodii_free_merchant", "x": 5, "y": 3 },
+        { "class": "guard", "x": 11, "y": 6 },
+        { "class": "guard", "x": 12, "y": 8 }
+      ],
+      "items": { "c": { "item": "bed", "chance": 100 } },
+      "item": { "F": { "item": "pot", "chance": 100 } },
+      "place_zones": [
+        { "type": "LOOT_UNSORTED", "faction": "free_merchants", "x": 2, "y": [ 2, 4 ] },
+        {
+          "type": "LOOT_ITEM_GROUP",
+          "filter": "NC_ROBOFAC_FREE_MERCHANT_misc",
+          "faction": "free_merchants",
+          "x": 2,
+          "y": 2
+        },
+        {
+          "type": "LOOT_ITEM_GROUP",
+          "filter": "NC_ROBOFAC_FREE_MERCHANT_misc",
+          "faction": "free_merchants",
+          "x": 2,
+          "y": 4
+        }
+      ],
+      "place_nested": [ { "chunks": [ "EXODII_FM_UPDATE_PLACE_TENTS_z1" ], "x": 0, "y": 0, "z": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "EXODII_FM_UPDATE_PLACE_TENTS_z1",
+    "object": {
+      "faction_owner": [ { "id": "free_merchants", "x": [ 0, 14 ], "y": [ 0, 14 ] } ],
+      "mapgensize": [ 15, 15 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "               ",
+        " ,,,,,,...     ",
+        " ,,,,,,...     ",
+        " ,,,,,,...     ",
+        " ,,,,,,...     ",
+        " ,,,,,,...     ",
+        " ,,,,,....     ",
+        " ,,,,,...      ",
+        "  .......      ",
+        " .......,,,    ",
+        "........,,,    ",
+        " .......,,,    ",
+        "  ..,,,        ",
+        "   .,,,        ",
+        "    ,,,        "
+      ],
+      "terrain": { ".": "t_canvas_roof", ",": "t_canvas_roof" }
+    }
+  },
+  {
+    "nested_mapgen_id": "EXODII_FM_UPDATE_PLACE_WAREHOUSE",
+    "type": "mapgen",
+    "object": {
+      "faction_owner": [ { "id": "free_merchants", "x": [ 0, 23 ], "y": [ 0, 23 ] } ],
+      "mapgensize": [ 24, 24 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "###                     ",
+        "#c#                     ",
+        "#+#                     ",
+        "                        ",
+        "                        ",
+        "   o   xxx   xxx   o    ",
+        "               x        ",
+        "                        ",
+        "                        ",
+        "       o       o        ",
+        "                        "
+      ],
+      "terrain": { ".": "t_dirt", "#": "t_dirt", "c": "t_dirt", "o": "t_wood_sunshade_pole" },
+      "furniture": { "#": "f_skin_wall", "+": "f_skin_door", "x": "f_crate_o" },
+      "traps": { "c": "tr_fur_rollmat", "v": "tr_funnel" },
+      "place_npcs": [ { "class": "guard", "x": 12, "y": 12 } ],
+      "items": { "c": { "item": "bed", "chance": 100 } },
+      "place_nested": [ { "chunks": [ "EXODII_FM_UPDATE_PLACE_WAREHOUSE_z1" ], "x": 0, "y": 0, "z": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "nested_mapgen_id": "EXODII_FM_UPDATE_PLACE_WAREHOUSE_z1",
+    "type": "mapgen",
+    "object": {
+      "faction_owner": [ { "id": "free_merchants", "x": [ 0, 23 ], "y": [ 0, 23 ] } ],
+      "mapgensize": [ 24, 24 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "...                     ",
+        "...                     ",
+        "...                     ",
+        "                        ",
+        "                        ",
+        "   ,,,,,,,,,,,,,,,,,    ",
+        "     ,,,,,,,,,,,,,      ",
+        "      ,,,,,,,,,,,       ",
+        "       ,,,,,,,,,        ",
+        "       ,,,,,,,,,        ",
+        "                        "
+      ],
+      "terrain": { ".": "t_canvas_roof", ",": "t_canvas_roof" }
+    }
+  }
+]

--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -1650,5 +1650,27 @@
       "ter_set": "t_dirt",
       "items": [ { "item": "glass_shard", "count": [ 21, 29 ] } ]
     }
+  },
+  {
+    "type": "terrain",
+    "id": "t_carpet_red_outdoor",
+    "copy-from": "t_carpet_base",
+    "looks_like": "t_carpet_red",
+    "name": "red carpet",
+    "description": "Soft red carpet laying directly on the dirt.",
+    "color": "red",
+    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG" ],
+    "bash": {
+      "sound": "SMASH!",
+      "ter_set": "t_dirt",
+      "str_min": 5,
+      "str_max": 15,
+      "str_min_supported": 100,
+      "items": [
+        { "item": "sheet_cotton", "count": [ 1, 2 ] },
+        { "item": "cotton_patchwork", "count": [ 2, 4 ] },
+        { "item": "nail", "charges": [ 1, 3 ] }
+      ]
+    }
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -2307,5 +2307,24 @@
     "roof": "t_foam_roof",
     "description": "A mass of expansive foam that has hardened like a rock, tough enough to stop most zombies from breaking through.  It's big enough to walk ontop of.",
     "bash": { "str_min": 38, "str_max": 120, "sound": "crunch!", "sound_fail": "whump!", "ter_set": "t_null" }
+  },
+  {
+    "type": "terrain",
+    "id": "t_wood_sunshade_pole",
+    "name": "wooden pole",
+    "description": "A wooden pole supporting a canvas sunshade.",
+    "color": "brown",
+    "symbol": "1",
+    "move_cost": 0,
+    "coverage": 80,
+    "flags": [ "WALL", "PERMEABLE" ],
+    "bash": {
+      "str_min": 20,
+      "str_max": 30,
+      "sound": "crash!",
+      "sound_fail": "whump!",
+      "ter_set": "t_dirt",
+      "items": [ { "item": "splinter", "count": [ 10, 22 ] } ]
+    }
   }
 ]

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -466,6 +466,24 @@
     "flags": [ "TRADER_AVOID" ]
   },
   {
+    "id": "exodii_portable_tv",
+    "//": "Based on Panasonic Ranger 505",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "Exodii TV-radio" },
+    "material": [ "plastic", "aluminum" ],
+    "to_hit": { "grip": "bad", "length": "hand", "surface": "any", "balance": "clumsy" },
+    "symbol": ",",
+    "color": "light_green",
+    "description": "This looks like a travel TV from the 1970s, styled to resemble military field equipment.  The bulbous CRT is encased in a drab plastic shell with an oversized carrying handle.  The switches and chunky tuning controls look like they were salvaged from an abandoned Cold War command center.  A single camera lens is visible above the screen, slightly off center.",
+    "price": "1 USD",
+    "price_postapoc": "1 cent",
+    "weight": "3600 g",
+    "volume": "15360 ml",
+    "longest_side": "32 cm",
+    "flags": [ "TRADER_AVOID" ]
+  },
+  {
     "id": "electrohack",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/data/json/mapgen/exodii/exodii_base_safehouse.json
+++ b/data/json/mapgen/exodii/exodii_base_safehouse.json
@@ -1,0 +1,119 @@
+[
+  {
+    "om_terrain": "exo_base_safehouse_stone_0",
+    "//": "A medieval stone barn from the Exodii's most recently visited world.  Turns into Free Merchants safehouse if negotiated.",
+    "type": "mapgen",
+    "object": {
+      "faction_owner": [ { "id": "exodii", "x": [ 5, 17 ], "y": [ 5, 18 ] } ],
+      "rows": [
+        "        .........       ",
+        "     ....,,,,,,,....    ",
+        "   ....,,,,,,,,,,,,,..  ",
+        "  ..,,,,,,;;;;;,,,,,..  ",
+        "  .,,,;;;;;;;;;;;;;,,.. ",
+        " ..,,;x;;;;;;;;;x;,,,.. ",
+        " .,,;x###########x;,,.. ",
+        "..,,;;#|ccc|ccc|#;;,,,..",
+        ".,,,;;#_3____{{g#;;;,,..",
+        ".,,;;;#_|__|{{||#;;;,,..",
+        ".,,;;;#<---I----#;;;,,..",
+        ".,,;;;#|------1|#;;;,,..",
+        ".,,;;;#C--------#;;;,,..",
+        ".,,;;;#C-----3--#;;;,,..",
+        ".,,;;;#C--------#;;;,,..",
+        "..,,;;#||-----||#;;;,,..",
+        "..,,;;#1-------1#;;,,,..",
+        " .,,;x####MMM####x;,,.. ",
+        " .,,;;x;;;;;;;;;x;,,,.. ",
+        " ..,,;x;;;;;;;;;x;,,,.. ",
+        "  ..,,xxxxx;;xxxx;,,..  ",
+        "  ...,,,,,,,,,,,,,,...  ",
+        "    ....,,,,,,,,....    ",
+        "       ..........       "
+      ],
+      "fill_ter": "t_dirtfloor",
+      "palettes": [ "exodii_stone_palette" ],
+      "place_monster": [
+        {
+          "monster": "mon_exodii_worker",
+          "x": 7,
+          "y": 8,
+          "spawn_data": { "patrol": [ { "x": 14, "y": 8 }, { "x": 7, "y": 8 } ] }
+        }
+      ],
+      "furniture": { "Y": "f_scrap_antenna", "I": "f_exodii_lamp" }
+    }
+  },
+  {
+    "om_terrain": "exo_base_safehouse_stone_1",
+    "type": "mapgen",
+    "object": {
+      "faction_owner": [ { "id": "exodii", "x": [ 5, 17 ], "y": [ 5, 18 ] } ],
+      "fill_ter": "t_junk_floor",
+      "rows": [
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvv###########vvvvvvv",
+        "vvvvvv#<{{{I{{{g#vvvvvvv",
+        "vvvvvv#'''''{'''#vvvvvvv",
+        "vvvvvv#'|1'|{1|C#vvvvvvv",
+        "vvvvvv#>vvvvvvvv#vvvvvvv",
+        "vvvvvv#vvvvvvvvv#vvvvvvv",
+        "vvvvvv#vvvvvvvvv#vvvvvvv",
+        "vvvvvv#vvvvvvvvv#vvvvvvv",
+        "vvvvvv#vvvvvvvvv#vvvvvvv",
+        "vvvvvv#vvvvvvvvv#vvvvvvv",
+        "vvvvvv#vvvvvvvvv#vvvvvvv",
+        "vvvvvv###########vvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv"
+      ],
+      "palettes": [ "exodii_stone_palette" ],
+      "furniture": { "I": "f_exodii_charger_cheap" }
+    }
+  },
+  {
+    "om_terrain": "exo_base_safehouse_stone_2",
+    "type": "mapgen",
+    "object": {
+      "faction_owner": [ { "id": "exodii", "x": [ 5, 17 ], "y": [ 5, 18 ] } ],
+      "fill_ter": "t_tile_flat_roof",
+      "rows": [
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvv^^^^^^^^^^^vvvvvvv",
+        "vvvvvv^>{Y^^^^^^^vvvvvvv",
+        "vvvvvv^^{^^^^^^^^vvvvvvv",
+        "vvvvvv^^{^^^^^^^^vvvvvvv",
+        "vvvvvv^^{^^^^^^^^vvvvvvv",
+        "vvvvvv^^{^^^^^^^^vvvvvvv",
+        "vvvvvv^^{^^^^^^^^vvvvvvv",
+        "vvvvvv^^{^^^^^^^^vvvvvvv",
+        "vvvvvv^^{^^^^^^^^vvvvvvv",
+        "vvvvvv^^{^^^^^^^^vvvvvvv",
+        "vvvvvv^^I^^^^^^^^vvvvvvv",
+        "vvvvvv^^^^^^^^^^^vvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv"
+      ],
+      "palettes": [ "exodii_stone_palette" ],
+      "furniture": { "Y": "f_exodii_portal_tower", "I": "f_exodii_scanner" }
+    }
+  }
+]

--- a/data/json/npcs/exodii/exodii_free_merchant.json
+++ b/data/json/npcs/exodii/exodii_free_merchant.json
@@ -1,0 +1,140 @@
+[
+  {
+    "type": "npc",
+    "id": "exodii_free_merchant",
+    "//": "A free merchant caravanner t",
+    "name_suffix": "Free Merchant",
+    "class": "NC_EXODII_FREE_MERCHANT",
+    "attitude": 0,
+    "mission": "SHOPKEEP",
+    "chat": "TALK_EXODII_FREE_MERCHANT",
+    "faction": "free_merchants"
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_EXODII_FREE_MERCHANT",
+    "name": { "str": "Caravaneer" },
+    "job_description": "I'm the owner of a trade caravan.",
+    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" }, { "trait": "RETURN_TO_START_POS" } ],
+    "//": "This is a unique NPC who doesn't get randomly selected background traits",
+    "common": false,
+    "bonus_int": { "one_in": 4 },
+    "bonus_per": { "one_in": 4 },
+    "shopkeeper_item_group": [ { "group": "NC_EXODII_FREE_MERCHANT_misc", "rigid": true } ],
+    "skills": [
+      {
+        "skill": "ALL",
+        "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "constant": -2 }, { "one_in": 4 } ] } ] }
+      },
+      { "skill": "mechanics", "bonus": { "one_in": 2 } },
+      { "skill": "computer", "bonus": { "one_in": 2 } },
+      { "skill": "electronics", "bonus": { "rng": [ 0, 2 ] } },
+      { "skill": "speech", "bonus": { "rng": [ 3, 5 ] } }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_EXODII_FREE_MERCHANT_storage",
+    "subtype": "distribution",
+    "entries": [ { "item": "duffelbag", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_EXODII_FREE_MERCHANT_coat",
+    "subtype": "distribution",
+    "entries": [ { "item": "trenchcoat", "prob": 80 }, { "item": "vest", "prob": 60 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "NC_EXODII_FREE_MERCHANT_misc",
+    "items": [
+      { "item": "jerky", "count": [ 10, 25 ], "prob": 100 },
+      { "item": "tallow", "prob": 100, "count": [ 20, 50 ] },
+      { "item": "pemmican", "count": [ 10, 25 ], "prob": 100 },
+      { "item": "dry_meat", "count": [ 10, 25 ], "prob": 100 },
+      { "item": "dry_fish", "count": [ 10, 25 ], "prob": 100 },
+      { "item": "dry_veggy", "prob": 100, "count": [ 20, 50 ] },
+      { "item": "dry_fruit", "count": [ 10, 25 ], "prob": 100 },
+      { "group": "solder_wire_spool", "count": [ 2, 5 ] },
+      { "item": "welding_rod_steel", "count": [ 750, 4000 ], "entry-wrapper": "tube_welding_rod" },
+      { "item": "welding_rod_alloy", "count": [ 750, 4000 ], "entry-wrapper": "tube_welding_rod" },
+      { "item": "welding_wire_steel", "count": [ 333, 2000 ], "entry-wrapper": "spool_welding" },
+      { "item": "welding_wire_alloy", "count": [ 500, 3000 ], "entry-wrapper": "spool_welding" },
+      { "item": "brazing_rod_bronze", "count": [ 250, 2000 ], "entry-wrapper": "tube_welding_rod" },
+      { "item": "brazing_rod_alloy", "count": [ 250, 2000 ], "entry-wrapper": "tube_welding_rod" },
+      { "item": "scrap", "count": [ 125, 250 ] },
+      { "item": "nuts_bolts", "count": [ 10, 25 ] },
+      { "item": "sheet_metal_small", "count": [ 50, 100 ] },
+      { "item": "lc_steel_chunk", "count": [ 100, 200 ] },
+      { "item": "lc_steel_lump", "count": [ 50, 100 ] },
+      { "item": "sheet_metal", "count": [ 25, 50 ] },
+      { "item": "lc_steel_lump", "count": [ 25, 50 ] },
+      { "item": "mc_steel_lump", "count": [ 25, 50 ] },
+      { "item": "hc_steel_lump", "count": [ 25, 50 ] }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_FREE_MERCHANT",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "u_is_wearing": "badge_marshal",
+      "yes": {
+        "u_has_trait": "EXODII_CYBERFRAME_GENERIC",
+        "yes": "Well, an Exodii… and a U.S marshal.  That's not something you see every day.",
+        "no": [
+          "Still plenty of outlaws in the roads, perhaps you should tend to your job, marshal…",
+          "You see anything you want, marshal?",
+          "Oh, a U.S. marshal."
+        ]
+      },
+      "no": {
+        "u_has_trait": "EXODII_CYBERFRAME_GENERIC",
+        "yes": [ "Ah, an Exodii?  Welcome…", "Any Exodii?  Here to trade, I hope?", "Safe travels, Exodii." ],
+        "no": [ "Welcome…", "Here to trade, I hope?", "Safe travels, scavenger." ]
+      }
+    },
+    "responses": [
+      { "text": "Let's trade.", "effect": "start_trade", "topic": "TALK_EXODII_FREE_MERCHANT" },
+      { "text": "When is the next shipment?", "topic": "TALK_EXODII_FREE_MERCHANT_INTERVAL" },
+      { "text": "What are you doing here?", "topic": "TALK_EXODII_FREE_MERCHANT_DOING" },
+      {
+        "text": "I'm not an Exodii, I'm just a cyborg.",
+        "condition": { "u_has_trait": "EXODII_CYBERFRAME_GENERIC" },
+        "topic": "TALK_EXODII_FREE_MERCHANT_EXODII"
+      },
+      { "text": "<end_talking_bye>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_FREE_MERCHANT_EXODII",
+    "type": "talk_topic",
+    "dynamic_line": "If you say so.  Can't say I can really tell the difference.  No offense.",
+    "responses": [ { "text": "Anyway…", "topic": "TALK_EXODII_FREE_MERCHANT" } ]
+  },
+  {
+    "id": "TALK_EXODII_FREE_MERCHANT_DOING",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "u_is_wearing": "badge_marshal",
+      "yes": "I keep to my own business, and you keep to yours, marshal.  Seems like a fair deal?",
+      "no": "Well, we're part of the caravan depot set up to keep regular trade with the Exodii, here.  I'm in charge of keeping things running and restocking the caravans, but also doing trade with scavs and the like.  Happy to trade food and supplies, if you're interested."
+    },
+    "responses": [
+      { "text": "Sounds good", "topic": "TALK_EXODII_FREE_MERCHANT" },
+      { "text": "So do you plan to stick around here permenantly?", "topic": "TALK_EXODII_FREE_MERCHANT_PERMENANT" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_FREE_MERCHANT_PERMENANT",
+    "type": "talk_topic",
+    "dynamic_line": "Who knows?  Lots of scavs come through.  The Exodii are quick to dispatch any <zombies>.  And the Exodii seem happy about it all.  Seems good a place as any to settle down.",
+    "responses": [ { "text": "Anyway…", "topic": "TALK_EXODII_FREE_MERCHANT" } ]
+  },
+  {
+    "id": "TALK_EXODII_FREE_MERCHANT_INTERVAL",
+    "type": "talk_topic",
+    "dynamic_line": "Around <restock_time_point>, if the caravan doesn't run into trouble.",
+    "responses": [ { "text": "Thanks for the info, bye.", "topic": "TALK_DONE" } ]
+  }
+]

--- a/data/json/npcs/exodii/exodii_free_merchant.json
+++ b/data/json/npcs/exodii/exodii_free_merchant.json
@@ -122,7 +122,7 @@
     },
     "responses": [
       { "text": "Sounds good", "topic": "TALK_EXODII_FREE_MERCHANT" },
-      { "text": "So do you plan to stick around here permenantly?", "topic": "TALK_EXODII_FREE_MERCHANT_PERMENANT" }
+      { "text": "So do you plan to stick around here permanently?", "topic": "TALK_EXODII_FREE_MERCHANT_PERMENANT" }
     ]
   },
   {

--- a/data/json/npcs/exodii/exodii_merchant_missions.json
+++ b/data/json/npcs/exodii/exodii_merchant_missions.json
@@ -1394,6 +1394,27 @@
     ]
   },
   {
+    "id": "TALK_EXODII_MERCHANT_mission_4_complete_partial",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//": "Indeed, they succeeded.  And yes, I know you rried.  That's how it goes, sometimes.  Have a look around the shop and choose a reward.",
+      "str": "Aye, they did indeed.  And aye, ye clearly tried.  That's the way'o'things.  Have a look about, tell me what ye like."
+    },
+    "responses": [
+      {
+        "text": "[$1000 in store credit] How about store credit instead?",
+        "effect": [ { "u_add_faction_trust": -4 }, { "u_spend_cash": -100000 }, "start_trade" ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "I don't need anything.  Just keep in mind that I'm always on your side, yeah?",
+        "effect": [ { "u_add_faction_trust": 4 } ],
+        "opinion": { "trust": 7, "value": 5 },
+        "topic": "TALK_DONE"
+      }
+    ]
+  },
+  {
     "id": "TALK_EXODII_MERCHANT_mission_4_complete_failed",
     "type": "talk_topic",
     "dynamic_line": {

--- a/data/json/npcs/exodii/exodii_merchant_missions.json
+++ b/data/json/npcs/exodii/exodii_merchant_missions.json
@@ -96,6 +96,33 @@
     }
   },
   {
+    "id": "EXODII_MISSION_MEET_FREE_MERCHANTS",
+    "name": {
+      "str": "Go to the Refugee Center and negotiate a trade deal between the Free Merchants and the Exodii.  Don't forget to take the Exodii \"talk-rad talk-vid\"."
+    },
+    "type": "mission_definition",
+    "goal": "MGOAL_NULL",
+    "destination": "evac_center_18",
+    "start": {
+      "assign_mission_target": { "om_terrain": "evac_center_18", "om_special": "evac_center", "reveal_radius": 4, "random": false }
+    },
+    "end": { "effect": [ { "u_add_var": "mission_completed_exodii_mission_meet_free_merchants", "value": "yes" } ] },
+    "difficulty": 5,
+    "value": 2,
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "dialogue": {
+      "describe": "",
+      "offer": "",
+      "accepted": "",
+      "rejected": "",
+      "advice": "",
+      "inquire": "",
+      "success": "",
+      "success_lie": "",
+      "failure": ""
+    }
+  },
+  {
     "id": "EXODII_MISSION_STRING_DIMENSION_EXODII",
     "name": { "str": "Download data from the other-dimension Exodii node" },
     "type": "mission_definition",
@@ -624,7 +651,7 @@
     ]
   },
   {
-    "id": "TALK_EXODII_MERCHANT_mission_2_complete_double_crossed_lie_truth",
+    "id": "TALK_EXODII_MERCHANT_mission_2_complete_double_crossed_truth",
     "type": "talk_topic",
     "dynamic_line": {
       "//~": "Alas.  You're a mercenary, so you'll act like a mercenary.  But you better remember that the Exodii also remember.",
@@ -1128,6 +1155,252 @@
         "topic": "TALK_DONE"
       }
     ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_4_intro",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "Well, as it were, things are going well.  In fact, we've started doing some good deals, and not just with you.  And we've become aware of a group that calls themselves the Free Merchants.  We need a human from this earth to talk to them, so that maybe we can set up some more organized trade, with the time we have left on this rock.  We're willing to pay you to make introductions.  Interested?",
+      "str": "&Rubik lets out a rather comfortable chuckle from their speakers, and slaps their robotic belly.  \"Well, well, things are goin' swell.  Us'n've started right an' proper jelly, and not wi' just you neither.  By the by we've come ken of some monicks themselves the \"Free Merchants,\" as it were.  Lots'o'scrap.  Stuff we like and need.  Need us a person'o'this'land t'parlay with'em, see if mayhap we can set up finer trade betwixt, for the good hours in the sun we've left here, 'least.  Us'nlll stand ye a mighty tidy reward for introductions.  What say, fruit gum?"
+    },
+    "responses": [
+      {
+        "text": "So you want me to introduce you to the Free Merchants?  Sure, why not.  I'll do it.",
+        "condition": {
+          "or": [
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Gavin" } ] },
+            { "compare_string": [ "yes", { "u_val": "exodii_told_u_about_free_merchants" } ] }
+          ]
+        },
+        "effect": { "assign_mission": "EXODII_MISSION_MEET_FREE_MERCHANTS" },
+        "topic": "TALK_EXODII_MERCHANT_mission_4_accepted"
+      },
+      {
+        "text": "Who are the Free Merchants?",
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Gavin" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "exodii_told_u_about_free_merchants" } ] } }
+          ]
+        },
+        "effect": { "u_add_var": "exodii_told_u_about_free_merchants", "value": "yes" },
+        "topic": "TALK_EXODII_MERCHANT_mission_4_who"
+      },
+      { "text": "So, why can't an Exodii do this?  Why me?", "topic": "TALK_EXODII_MERCHANT_mission_4_explain" },
+      {
+        "text": "Don't you think my new cyborg body might be a problem?",
+        "condition": { "u_has_trait": "EXODII_CYBERFRAME_GENERIC" },
+        "topic": "TALK_EXODII_MERCHANT_mission_4_explain_cyborg"
+      },
+      { "text": "Maybe some other time.  See you later, Rubik.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_4_who",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "Merchants held up in some sort of large building.  They're proper traders as far as I can tell.  To have caravans so soon after the end times speaks something to their ingenuity, but maybe should also inspire caution.  They're smart, but maybe conniving.  Either way, they're not secretive like that bunker, so that's good",
+      "str": "Mongers holed up in some great clunk of a buildin'.  Proper traders, far as ol' Rubik can tell.  To run a caravan so soon past the dyin'o'the'world, that speaks a mite to their grit an' know-how, but mayhaps it'd be wise to keep one eye sharp, too.  Keen as a tack, but maybe slippery ta'boot.  Either way, they be ain't secret.  Not hidin' behind crete n' iron like the bunker-folk.  So that's a fair mercy."
+    },
+    "responses": [
+      {
+        "text": "So you want me to introduce you to the Free Merchants?  Sure, why not.  I'll do it.",
+        "condition": {
+          "or": [
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Gavin" } ] },
+            { "compare_string": [ "yes", { "u_val": "exodii_told_u_about_free_merchants" } ] }
+          ]
+        },
+        "effect": { "assign_mission": "EXODII_MISSION_MEET_FREE_MERCHANTS" },
+        "topic": "TALK_EXODII_MERCHANT_mission_4_accepted"
+      },
+      {
+        "text": "Don't you think my new cyborg body might be a problem?",
+        "condition": { "u_has_trait": "EXODII_CYBERFRAME_GENERIC" },
+        "topic": "TALK_EXODII_MERCHANT_mission_4_explain_cyborg"
+      },
+      { "text": "Maybe some other time.  See you later, Rubik.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_4_explain",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "Well, I think it's obvious that someone people might be intimidated by our cybernetic enhancements. Rightfully so.  Might even think we're part of the Enemy.  You, though?  Normal, by their standards.  I think we stand a better chance.",
+      "str": "Well an' surely, some folk'll take a mightly long squint at the bright'n'steelies on me an' feel a MITE uneasy, aye?  And rightly so, an I'm ken.  Might even reckon us kin'o'the Enemy.  But you?  By their reckonin', yer ordinary.  Normal.  Regular clap.  Gives us a finer chance, I'd razz."
+    },
+    "responses": [
+      {
+        "text": "So you want me to introduce you to the Free Merchants?  Sure, why not.  I'll do it.",
+        "condition": {
+          "or": [
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Gavin" } ] },
+            { "compare_string": [ "yes", { "u_val": "exodii_told_u_about_free_merchants" } ] }
+          ]
+        },
+        "effect": { "assign_mission": "EXODII_MISSION_MEET_FREE_MERCHANTS" },
+        "topic": "TALK_EXODII_MERCHANT_mission_4_accepted"
+      },
+      {
+        "text": "Don't you think my new cyborg body might be a problem?",
+        "condition": { "u_has_trait": "EXODII_CYBERFRAME_GENERIC" },
+        "topic": "TALK_EXODII_MERCHANT_mission_4_explain_cyborg"
+      },
+      { "text": "Maybe some other time.  See you later, Rubik.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_4_explain_cyborg",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "Well, correct, these days we look a lot alike, being cyborgs and all.  But you speak normal English for this Earth, not Anglic like me.  Lower chance they mistake us for the Enemy, or something like that.",
+      "str": "Well an' surely, these days ye an' ol' Rubik look near alike, what with the whole cyborgin' an' all.  But ye parley THEIR, or rather YOUR Anglic, not mine.  Less chance they wrongly ken us for mates o' the Enemy or summit."
+    },
+    "responses": [
+      {
+        "text": "So you want me to introduce you to the Free Merchants?  Sure, why not.  I'll do it.",
+        "condition": {
+          "or": [
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Gavin" } ] },
+            { "compare_string": [ "yes", { "u_val": "exodii_told_u_about_free_merchants" } ] }
+          ]
+        },
+        "effect": { "assign_mission": "EXODII_MISSION_MEET_FREE_MERCHANTS" },
+        "topic": "TALK_EXODII_MERCHANT_mission_4_accepted"
+      },
+      { "text": "Maybe some other time.  See you later, Rubik.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_4_accepted",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "Excellent.  I'll give you a radio.  Take it to them, make introductions, and help me with translating, now that you've hopefully starting to understand me.",
+      "str": "Aye, alright.  Good.  I'll give ye a chitchat - a talk-rad talk-vid.  Take it t'them, make the introductions, and mayhaps lend a mite o' translating, now ye've hopefully started kennin' ol' Rubik's yark."
+    },
+    "responses": [
+      {
+        "text": "[Take the device] Will do, Rubik.",
+        "condition": { "math": [ "u_skill('social') < 3" ] },
+        "effect": { "u_spawn_item": "exodii_portable_tv" },
+        "topic": "TALK_EXODII_MERCHANT_mission_4_accepted_0-2"
+      },
+      {
+        "text": "[Take the device] Will do, Rubik.",
+        "condition": { "and": [ { "math": [ "u_skill('social') > 2" ] }, { "math": [ "u_skill('social') < 5" ] } ] },
+        "effect": { "u_spawn_item": "exodii_portable_tv" },
+        "topic": "TALK_EXODII_MERCHANT_mission_4_accepted_3-4"
+      },
+      {
+        "text": "[Take the device] Will do, Rubik.",
+        "condition": { "and": [ { "math": [ "u_skill('social') > 4" ] }, { "math": [ "u_skill('social') < 7" ] } ] },
+        "effect": { "u_spawn_item": "exodii_portable_tv" },
+        "topic": "TALK_EXODII_MERCHANT_mission_4_accepted_5-6"
+      },
+      {
+        "text": "[Take the device] Will do, Rubik.",
+        "condition": { "and": [ { "math": [ "u_skill('social') > 6" ] }, { "math": [ "u_skill('social') < 9" ] } ] },
+        "effect": { "u_spawn_item": "exodii_portable_tv" },
+        "topic": "TALK_EXODII_MERCHANT_mission_4_accepted_7-8"
+      },
+      {
+        "text": "[Take the device] Will do, Rubik.",
+        "condition": { "math": [ "u_skill('social') > 8" ] },
+        "effect": { "u_spawn_item": "exodii_portable_tv" },
+        "topic": "TALK_EXODII_MERCHANT_mission_4_accepted_9-10"
+      }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_4_accepted_0-2",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "Remember, we picked you because you speak this Earth's English.  But I know you're no negotiator.  Beyond that, well, our expectations are low.  No offense.  Take it slow.  Five minutes of polite conversation will exceed my expectations.  Try not to cause any sort of real problems, please?",
+      "str": "Keep keen.  We chose ye' cause ye' speak their Anglic.  But ol' Rubik knows yer' no parley barley.  Beyond that, well… let's call this an experiment in optimism.  Go easy, aye?  Five minutes'o polite conversation an ye'll exceed expectation.  Try not t'cause any real problems, aye?"
+    },
+    "responses": [ { "text": "Right.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_4_accepted_3-4",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "Remember, you're introducting traders, not making threats.  If they start backing away while taking, try smiling.  If that makes it work, stop smiling.  You've clearly got some sense.  Follow it.  Try not to cause any incidents.",
+      "str": "Remember yer a trader not a threater.  If folk back away, try smilin'.  If they don't like that, stop.  Ye' got a pinch of sense.  Follow it.  Try not t'cause any incidents, aye?"
+    },
+    "responses": [ { "text": "Right.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_4_accepted_5-6",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "You're good enough with people.  Better than most surivivors.  Keep it friendly, don't mention the Enemy, and don't make expensive promises, please.",
+      "str": "Ye've decent enough people-sense.  Better'an most scavvers.  Keep the yark friendly, don't menton the Enemy, an' try not t'promise anything too expensive, aye?"
+    },
+    "responses": [ { "text": "Right.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_4_accepted_7-8",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "I can tell you're good at this, and I trust you more than I should.  If you get us a good deal, I'll owe you.",
+      "str": "Got more faith'in'ye than Ol' Rubik mayhaps should.  If these Free Merchants leave thinkin' us'n are respectable traders instead'a vagabonds, ol' Rubik'll owe ye a favor.  And I don't say that lightly, aye?"
+    },
+    "responses": [ { "text": "Right.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_4_accepted_9-10",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "I know you're good at this.  Sometimes I forget you're just a survivor, and not some sort of diplomat.  Try not to do better than I would do, yeah?",
+      "str": "&\"Tell ye' true, I often forget ye're a scavver and not some sorta' treat-an'-sweety.  Do try not t'negotiate a bettter deal than ol' Rubik woul've got 'imself, aye?\"  Rubik chuckles."
+    },
+    "responses": [ { "text": "Right.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_4_complete",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//": "&Rubik chuckles and nods, leaning against the counter.  \"Aye, you did use a big favor.  What do you say about your reward?\"  Rubik reaches into the desk in front of them and pulls out a tiny, green-glowing CRT, scrolling rapidly down a list you cannot understand, they click on an option, and some complex robot schematics come on screen.\n\n\"How would you like to be attached to a suitcase like mine?\" Rubik taps their metal torso. \"This isn't like the CBMs I sell.  There's no going back.  And you better be able to produce enough power.  These need constant power.  Without it, you're as good as dead.  For a Cyberframe like mine, one power storage unit will last less than an hour of walking.  Less if you're fighting or running.  It's not an easy life.\"\n\n\"Think on it, and make a decision.\"",
+      "str": "&Rubik chuckles and nods, leaning against the counter.  \"Aye, ye did us'n a fine turn.  What say ye for reward?\"  Rubik reaches into the desk in front of them and pulls out a tiny, green-glowing CRT, scrolling rapidly down a list you cannot understand, they click on an option, and some complex robot schematics come on screen.\n\n\"How'd ye like ta'be cut inta' this sort'o crowded space?\"  Rubik taps their metal torso.  \"This isn't like the bright'n'steelies on offer.  No goin' back.  And ye best be happy with the amount'a power you can generate.  This'ere needs contant power.  Without power, yer good as dead.  The power storage units?  Fer a case this'n kind, one'a the power storage units buys you a little-less'an an hour of walkin'.  Less for scrappin' and scramblin'.  Nothin's easy about it.\"\n\n\"Think on it, decide on a last.\""
+    },
+    "responses": [
+      {
+        "text": "[Integrate your body into an Exodii Cyberframe] A robotic body I'll need to keep constantly powered?  Why not?  I'm ready.",
+        "effect": [
+          { "u_add_faction_trust": 5 },
+          {
+            "u_location_variable": { "u_val": "exodii_autodoc_couch_loc" },
+            "target_params": { "om_terrain": "exodii_base_x2y1z1", "om_special": "exodii_base" },
+            "furniture": "f_autodoc_couch",
+            "target_max_radius": 250
+          },
+          { "u_teleport": { "u_val": "exodii_autodoc_couch_loc" } }
+        ],
+        "opinion": { "trust": 7, "value": 5 },
+        "topic": "TALK_EXODII_MERCHANT_Exodize_Cyberframe"
+      },
+      {
+        "text": "[$2500 in store credit] How about store credit instead?",
+        "effect": [ { "u_spend_cash": -250000 }, "start_trade" ],
+        "opinion": { "trust": 4, "value": 3 },
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "I don't need anything.  Just keep in mind that I'm always on your side, yeah?",
+        "effect": [ { "u_add_faction_trust": 4 } ],
+        "opinion": { "trust": 7, "value": 5 },
+        "topic": "TALK_DONE"
+      }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_mission_4_complete_failed",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//": "Indeed, they failed.  That's how it goes, sometimes.  Maybe it's for the best.  Time will tell.",
+      "str": "Aye, failed they did.  That's the way'o'things.  Mayhaps for the best.  Time'll tell."
+    },
+    "responses": [ { "text": "Later, Rubik.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_EXODII_MERCHANT_String_Dimension_Exodii_Mission_Offer1",

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -686,6 +686,22 @@
         "topic": "TALK_EXODII_MERCHANT_mission_3_complete"
       },
       {
+        "text": "So, we seem to be done with the negotiations.  Let's talk payment.",
+        "condition": {
+          "and": [ { "math": [ "exodii_FM_negotiation_success == 1" ] }, { "u_has_mission": "EXODII_MISSION_MEET_FREE_MERCHANTS" } ]
+        },
+        "effect": { "finish_mission": "EXODII_MISSION_MEET_FREE_MERCHANTS", "success": true },
+        "topic": "TALK_EXODII_MERCHANT_mission_4_complete"
+      },
+      {
+        "text": "Those negotiations didn't go so well, did they?",
+        "condition": {
+          "and": [ { "math": [ "exodii_FM_negotiation_failed == 1" ] }, { "u_has_mission": "EXODII_MISSION_MEET_FREE_MERCHANTS" } ]
+        },
+        "effect": [ { "finish_mission": "EXODII_MISSION_MEET_FREE_MERCHANTS", "success": true }, { "u_add_faction_trust": -10 } ],
+        "topic": "TALK_EXODII_MERCHANT_mission_4_complete_failed"
+      },
+      {
         "text": "I managed to find a computer in that other-Exodii place we talked about.  Here's the data.",
         "condition": {
           "and": [
@@ -1412,6 +1428,24 @@
           ]
         },
         "topic": "TALK_EXODII_MERCHANT_mission_3_intro"
+      },
+      {
+        "text": "[Pop-an-Work: Free Merchants]",
+        "//": "Only available if the player didn't sell the warehouse to Hub 01, or if they did, as long as the Exodii didn't find out",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "EXODII_MISSION_MEET_FREE_MERCHANTS" } },
+            {
+              "not": { "compare_string": [ "yes", { "u_val": "mission_completed_exodii_mission_meet_free_merchants" } ] }
+            },
+            { "or": [ { "u_has_trait": "CBM_Interface" }, { "u_has_trait": "NL_CBM_Interface" } ] },
+            { "math": [ "warehouse_was_found == 1" ] },
+            { "math": [ "exodii_knows_u_double_crossed != 1" ] },
+            { "math": [ "time_since('cataclysm', 'unit':'days') >= 14" ] },
+            { "math": [ "FM_exodii_caravan_placed != 1" ] }
+          ]
+        },
+        "topic": "TALK_EXODII_MERCHANT_mission_4_intro"
       },
       { "text": "I'm not interested in anything right now.  <end_talking_bye>", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -688,10 +688,26 @@
       {
         "text": "So, we seem to be done with the negotiations.  Let's talk payment.",
         "condition": {
-          "and": [ { "math": [ "exodii_FM_negotiation_success == 1" ] }, { "u_has_mission": "EXODII_MISSION_MEET_FREE_MERCHANTS" } ]
+          "and": [
+            { "not": { "math": [ "exodii_FM_annoyed >= 3" ] } },
+            { "math": [ "exodii_FM_negotiation_success == 1" ] },
+            { "u_has_mission": "EXODII_MISSION_MEET_FREE_MERCHANTS" }
+          ]
         },
         "effect": { "finish_mission": "EXODII_MISSION_MEET_FREE_MERCHANTS", "success": true },
         "topic": "TALK_EXODII_MERCHANT_mission_4_complete"
+      },
+      {
+        "text": "Well, the deal went through.  I did my best, Rubik.",
+        "condition": {
+          "and": [
+            { "math": [ "exodii_FM_annoyed >= 3" ] },
+            { "math": [ "exodii_FM_negotiation_success == 1" ] },
+            { "u_has_mission": "EXODII_MISSION_MEET_FREE_MERCHANTS" }
+          ]
+        },
+        "effect": { "finish_mission": "EXODII_MISSION_MEET_FREE_MERCHANTS", "success": true },
+        "topic": "TALK_EXODII_MERCHANT_mission_4_complete_partial"
       },
       {
         "text": "Those negotiations didn't go so well, did they?",

--- a/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
@@ -44,6 +44,18 @@
       { "text": "Heard anything about the outside world?", "topic": "TALK_SCIENCE_REP_WORLD" },
       { "text": "Can I trade for supplies?", "topic": "TALK_SCIENCE_REP_ASK_TRADE" },
       { "text": "Can I do anything for you?", "topic": "TALK_MISSION_LIST" },
+      {
+        "text": "Can I you help me with bionic implants?",
+        "condition": {
+          "and": [
+            { "math": [ "FM_exodii_autodoc_placed == 1" ] },
+            {
+              "or": [ { "u_has_trait": "CBM_Interface" }, { "u_has_trait": "NL_CBM_Interface" }, { "u_has_trait": "Hub01_CBM_Interface" } ]
+            }
+          ]
+        },
+        "topic": "TALK_SCIENCE_REP_CBM"
+      },
       { "text": "<end_talking_bye>", "topic": "TALK_DONE" }
     ]
   },
@@ -85,6 +97,40 @@
     "type": "talk_topic",
     "dynamic_line": "We can't.  There's nothing we can spare to sell and I've got no budget to buy from you.  I don't suppose you want to donate?",
     "responses": [ { "text": "…", "topic": "TALK_SCIENCE_REP" } ]
+  },
+  {
+    "id": "TALK_SCIENCE_REP_CBM",
+    "type": "talk_topic",
+    "dynamic_line": "You've got one of those interfaces?  Sure.  Let me fire up the robot.",
+    "responses": [
+      {
+        "text": "Would you be able to help me install a bionic implant?",
+        "condition": {
+          "and": [
+            { "math": [ "FM_exodii_autodoc_placed == 1" ] },
+            {
+              "or": [ { "u_has_trait": "CBM_Interface" }, { "u_has_trait": "NL_CBM_Interface" }, { "u_has_trait": "Hub01_CBM_Interface" } ]
+            }
+          ]
+        },
+        "topic": "TALK_DONE",
+        "effect": "bionic_install"
+      },
+      {
+        "text": "Would you be able to take out one of my bionic implants?",
+        "condition": {
+          "and": [
+            { "math": [ "FM_exodii_autodoc_placed == 1" ] },
+            {
+              "or": [ { "u_has_trait": "CBM_Interface" }, { "u_has_trait": "NL_CBM_Interface" }, { "u_has_trait": "Hub01_CBM_Interface" } ]
+            }
+          ]
+        },
+        "topic": "TALK_DONE",
+        "effect": "bionic_remove"
+      },
+      { "text": "Never mind…", "topic": "TALK_SCIENCE_REP" }
+    ]
   },
   {
     "id": "MISSION_SCIENCE_REP_1",

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_exodii_negotiation.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_exodii_negotiation.json
@@ -1,0 +1,526 @@
+[
+  {
+    "id": [ "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations" ],
+    "type": "talk_topic",
+    "//": "exodii_FM_antagonized tracks the deal itself - at max value it fails totally.  exodii_FM_annoyed tracks reward - above 3, and you don't get a reward.  exodii_FM_balance tracks who gives the reward and its magnitude - negative favors exodii and positive favors FM.",
+    "dynamic_line": "&You boot up the strange TV-radio device.  There is a sharp squeel from the device as the screen, first covered in only static, blips into life.  After a moment, the image on the screen wobbles and Rubik appears, offering a stiff bow.  You hold the screen up so Smokes can see it.",
+    "speaker_effect": { "effect": { "math": [ "exodii_FM_balance = 0" ] } },
+    "responses": [
+      {
+        "text": "[Neutral] Introduce Rubik and Smokes to each other, then give them the floor.  Offer occassional help translating.",
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_2"
+      },
+      {
+        "text": "[Antagonize] Introduce Rubik as an alien and compare the Exodii to a few \"unfriendly\" robots from your Earth's popular culture.  \"So, they're sort of like the Borg, the Terminator, those machines from The Matrix, you know, that kind of thing…\"",
+        "trial": { "type": "PERSUADE", "difficulty": 15 },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_2",
+          "effect": [
+            { "u_message": "You succeed in antagonizing both parties.", "popup": true },
+            { "math": [ "exodii_FM_antagonized += 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [ { "u_message": "Your fail to antagonize them.", "popup": true }, { "math": [ "exodii_FM_annoyed += 1" ] } ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_2"
+        }
+      }
+    ]
+  },
+  {
+    "id": [ "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_2" ],
+    "type": "talk_topic",
+    "dynamic_line": "&Rubik explains they are primarily looking for plastics, metals, and media.  Rubik and Smokes start to talk about the nature of the trade.  Guaranteed shipments?  First right of refusal?  What about prices for bulk goods?",
+    "responses": [
+      {
+        "text": "[Neutral] Sit quietly and let them negotiate.  Offer occassional help translating.",
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_3"
+      },
+      {
+        "text": "[Favour Exodii] Point out that the Exodii's needs are predictable and simple.  \"They need a lot of things other survivors may not buy.\"",
+        "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_3",
+          "effect": [
+            { "u_message": "You feel that the deal favors the Exodii a bit more.", "popup": true },
+            { "math": [ "exodii_FM_balance -= 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [
+            { "u_message": "Your attempts at swaying the negotiation annoys both parties.", "popup": true },
+            { "if": { "one_in_chance": 2 }, "then": { "math": [ "exodii_FM_antagonized += 1" ] } },
+            { "math": [ "exodii_FM_annoyed += 1" ] }
+          ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_3"
+        }
+      },
+      {
+        "text": "[Favour Merchants] Remind Rubik that the Free Merchants are taking on the risk of the shipments, and need to stick around Earth even if the Exodii leave.  \"I think thats worth a small premium, no?\"",
+        "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_3",
+          "effect": [
+            { "u_message": "You feel that the deal favors the Free Merchants a bit more.", "popup": true },
+            { "math": [ "exodii_FM_balance += 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [
+            { "u_message": "Your attempts at swaying the negotiation annoys both parties.", "popup": true },
+            { "if": { "one_in_chance": 2 }, "then": { "math": [ "exodii_FM_antagonized += 1" ] } },
+            { "math": [ "exodii_FM_annoyed += 1" ] }
+          ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_3"
+        }
+      },
+      {
+        "text": "[Antagonize] Rush them.  \"Let's get to it!  A quick deal is a good deal.  Do you want to trade, or not?\"",
+        "trial": { "type": "PERSUADE", "difficulty": 15 },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_3",
+          "effect": [
+            { "u_message": "You succeed in antagonizing both parties.", "popup": true },
+            { "math": [ "exodii_FM_antagonized += 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [ { "u_message": "Your fail to antagonize them.", "popup": true }, { "math": [ "exodii_FM_annoyed += 1" ] } ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_3"
+        }
+      }
+    ]
+  },
+  {
+    "id": [ "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_3" ],
+    "type": "talk_topic",
+    "dynamic_line": "&Smokes and Rubik start to discuss what exactly the Exodii have to offer.  Rubik first offers up firearms, hefting one of their zombie hunting rifles into the frame…",
+    "responses": [
+      {
+        "text": "[Neutral] Sit quietly and let them negotiate.  Offer occassional help translating.",
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_4"
+      },
+      {
+        "text": "[Favour Exodii] Explain to Smokes the unique nature of the firearms you have seen.  \"They're really well tuned for taking down a <zombie>.\"",
+        "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_4",
+          "effect": [
+            { "u_message": "You feel that the deal favors the Exodii a bit more.", "popup": true },
+            { "math": [ "exodii_FM_balance -= 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [
+            { "u_message": "Your attempts at swaying the negotiation annoys both parties.", "popup": true },
+            { "if": { "one_in_chance": 2 }, "then": { "math": [ "exodii_FM_antagonized += 1" ] } },
+            { "math": [ "exodii_FM_annoyed += 1" ] }
+          ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_4"
+        }
+      },
+      {
+        "text": "[Favour Merchants] Remind Rubik & Smokes that these firearms use ammunition not from this world.  \"They're great guns, but be sure to work ammunition into the deal.\"",
+        "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_4",
+          "effect": [
+            { "u_message": "You feel that the deal favors the Free Merchants a bit more.", "popup": true },
+            { "math": [ "exodii_FM_balance += 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [
+            { "u_message": "Your attempts at swaying the negotiation annoys both parties.", "popup": true },
+            { "if": { "one_in_chance": 2 }, "then": { "math": [ "exodii_FM_antagonized += 1" ] } },
+            { "math": [ "exodii_FM_annoyed += 1" ] }
+          ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_4"
+        }
+      },
+      {
+        "text": "[Antagonize] Look knowingly at Smokes.  \"They have a LOT of guns.  And they know how to use them.\"",
+        "trial": { "type": "PERSUADE", "difficulty": 15 },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_4",
+          "effect": [
+            { "u_message": "You succeed in antagonizing both parties.", "popup": true },
+            { "math": [ "exodii_FM_antagonized += 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [ { "u_message": "Your fail to antagonize them.", "popup": true }, { "math": [ "exodii_FM_annoyed += 1" ] } ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_4"
+        }
+      }
+    ]
+  },
+  {
+    "id": [ "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_4" ],
+    "type": "talk_topic",
+    "dynamic_line": "&Rubik moves on to medical services and starts to explain the nature of their medical robots.  Smokes talks a bit about the Old Guard and a medical doctor stationed at the center…",
+    "responses": [
+      {
+        "text": "[Neutral] Sit quietly and let them negotiate.  Offer occassional help translating.",
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_5"
+      },
+      {
+        "text": "[Favour Exodii] Explain to Smokes the miraculous nature of their medical technology, and how it's definitely worth the price for access to it.",
+        "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_5",
+          "effect": [
+            { "u_message": "You feel that the deal favors the Exodii a bit more.", "popup": true },
+            { "math": [ "exodii_FM_balance -= 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [
+            { "u_message": "Your attempts at swaying the negotiation annoys both parties.", "popup": true },
+            { "if": { "one_in_chance": 2 }, "then": { "math": [ "exodii_FM_antagonized += 1" ] } },
+            { "math": [ "exodii_FM_annoyed += 1" ] }
+          ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_5"
+        }
+      },
+      {
+        "text": "[Favour Merchants] Encourage Smokes to negotiate a medical robot be installed at the Evacuee Center.",
+        "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_5",
+          "effect": [
+            {
+              "u_message": "Rubik agrees to selling the Free Merchants a medical robot.  You feel that the deal favors the Free Merchants a bit more.",
+              "popup": true
+            },
+            { "math": [ "exodii_FM_balance -= 1" ] },
+            { "math": [ "exodii_FM_autodoc = 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [
+            { "u_message": "Your attempts at swaying the negotiation annoys both parties.", "popup": true },
+            { "if": { "one_in_chance": 2 }, "then": { "math": [ "exodii_FM_antagonized += 1" ] } },
+            { "math": [ "exodii_FM_annoyed += 1" ] }
+          ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_5"
+        }
+      },
+      {
+        "text": "[Antagonize] Undermine the negotiation by bringing up Hub 01.  \"Actually, Smokes, those Hub 01 people you trade with have some pretty advanced tech, or at least it seems like they do.  Maybe this isn't worth being part of the deal.\"",
+        "condition": { "math": [ "free_merchants_hub_trade_route == 1" ] },
+        "trial": { "type": "PERSUADE", "difficulty": 15 },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_5",
+          "effect": [
+            { "u_message": "You succeed in antagonizing both parties.", "popup": true },
+            { "math": [ "exodii_FM_antagonized += 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [ { "u_message": "Your fail to antagonize them.", "popup": true }, { "math": [ "exodii_FM_annoyed += 1" ] } ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_5"
+        }
+      }
+    ]
+  },
+  {
+    "id": [ "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_5" ],
+    "type": "talk_topic",
+    "dynamic_line": "&There is a lull in the discussion as Smokes and Rubik quietly consider everything on the table.",
+    "responses": [
+      {
+        "text": "[Neutral] Let them move at their own pace.",
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_6"
+      },
+      {
+        "text": "[Favour Exodii] Whisper to Smokes: \"Listen, I know these guys.  Sweeten the deal as a gesture of good will, and things will go well for you.\"",
+        "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_6",
+          "effect": [
+            { "u_message": "You feel that the deal favors the Exodii a bit more.", "popup": true },
+            { "math": [ "exodii_FM_balance -= 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [
+            { "u_message": "Your attempts at swaying the negotiation annoys both parties.", "popup": true },
+            { "if": { "one_in_chance": 2 }, "then": { "math": [ "exodii_FM_antagonized += 1" ] } },
+            { "math": [ "exodii_FM_annoyed += 1" ] }
+          ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_6"
+        }
+      },
+      {
+        "text": "[Favour Merchants] Whisper to Smokes and encourage him to ask for a bit more.",
+        "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_6",
+          "effect": [
+            { "u_message": "You feel that the deal favors the Free Merchants a bit more.", "popup": true },
+            { "math": [ "exodii_FM_balance += 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [
+            { "u_message": "Your attempts at swaying the negotiation annoys both parties.", "popup": true },
+            { "if": { "one_in_chance": 2 }, "then": { "math": [ "exodii_FM_antagonized += 1" ] } },
+            { "math": [ "exodii_FM_annoyed += 1" ] }
+          ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_6"
+        }
+      },
+      {
+        "text": "[Antagonize] Rush them along - don't give them time to think.",
+        "trial": { "type": "PERSUADE", "difficulty": 15 },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_6",
+          "effect": [
+            { "u_message": "You succeed in antagonizing both parties.", "popup": true },
+            { "math": [ "exodii_FM_antagonized += 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [ { "u_message": "Your fail to antagonize them.", "popup": true }, { "math": [ "exodii_FM_annoyed += 1" ] } ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_6"
+        }
+      }
+    ]
+  },
+  {
+    "id": [ "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_6" ],
+    "type": "talk_topic",
+    "dynamic_line": "&After a quiet moment, the discussion moves on to the nature of the caravans.  The Free Merchants will want to set up an encampment near the Exodii's butte…",
+    "responses": [
+      {
+        "text": "[Neutral] Sit quietly and let them negotiate.  Offer occassional help translating.",
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_7"
+      },
+      {
+        "text": "[Favour Exodii] Suggest deliveries be managed through a nearby camp, rather than something more permenant.  Whisper to Smokes: \"Outside of the Exodii's protection, but also outside of their influence\".",
+        "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_7",
+          "effect": [
+            { "u_message": "You feel that the deal favors the Exodii a bit more.", "popup": true },
+            { "math": [ "exodii_FM_balance -= 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [
+            { "u_message": "Your attempts at swaying the negotiation annoys both parties.", "popup": true },
+            { "if": { "one_in_chance": 2 }, "then": { "math": [ "exodii_FM_antagonized += 1" ] } },
+            { "math": [ "exodii_FM_annoyed += 1" ] }
+          ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_7"
+        }
+      },
+      {
+        "text": "[Favour Merchants] Subtly hint to Smokes that they could probably negotiate protection, or a fortified structure for the Free Merchants.",
+        "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_7",
+          "effect": [
+            {
+              "u_message": "Rubik agrees that the Free Merchants can take over a nearby Exodii warehouse.  You feel that the deal favors the Free Merchants a bit more.",
+              "popup": true
+            },
+            { "math": [ "exodii_FM_balance += 1" ] },
+            { "math": [ "exodii_FM_butte_building = 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [
+            { "u_message": "Your attempts at swaying the negotiation annoys both parties.", "popup": true },
+            { "if": { "one_in_chance": 2 }, "then": { "math": [ "exodii_FM_antagonized += 1" ] } },
+            { "math": [ "exodii_FM_annoyed += 1" ] }
+          ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_7"
+        }
+      },
+      {
+        "text": "[Antagonize] Hype up how far away and dangerous it is to trade with the Exodii.  \"Think carefully on this.  It's really nasty over there.  Shame they couldn't set up somewhere else!\"",
+        "trial": { "type": "PERSUADE", "difficulty": 15 },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_7",
+          "effect": [
+            { "u_message": "You succeed in antagonizing both parties.", "popup": true },
+            { "math": [ "exodii_FM_antagonized += 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [ { "u_message": "Your fail to antagonize them.", "popup": true }, { "math": [ "exodii_FM_annoyed += 1" ] } ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_7"
+        }
+      }
+    ]
+  },
+  {
+    "id": [ "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_7" ],
+    "type": "talk_topic",
+    "dynamic_line": "&Rubik broaches the topic of recruitment & CBM interfaces…",
+    "responses": [
+      {
+        "text": "[Neutral] Sit quietly and let them negotiate.  Offer occassional help translating.",
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_8"
+      },
+      {
+        "text": "[Favour Exodii] Talk about the benefits of CBMs.",
+        "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_8",
+          "effect": [
+            { "u_message": "You feel that the deal favors the Exodii a bit more.", "popup": true },
+            { "math": [ "exodii_FM_balance -= 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [
+            { "u_message": "Your attempts at swaying the negotiation annoys both parties.", "popup": true },
+            { "if": { "one_in_chance": 2 }, "then": { "math": [ "exodii_FM_antagonized += 1" ] } },
+            { "math": [ "exodii_FM_annoyed += 1" ] }
+          ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_8"
+        }
+      },
+      {
+        "text": "[Favour Merchants] Point out that the Exodii are asking for access to people, which should be negotiated like anything else.  \"Rubik, maybe it's worth sweetening the deal some, if you're going to be courting some of their people.\"",
+        "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_8",
+          "effect": [
+            { "u_message": "You feel that the deal favors the Free Merchants a bit more.", "popup": true },
+            { "math": [ "exodii_FM_balance += 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [
+            { "u_message": "Your attempts at swaying the negotiation annoys both parties.", "popup": true },
+            { "if": { "one_in_chance": 2 }, "then": { "math": [ "exodii_FM_antagonized += 1" ] } },
+            { "math": [ "exodii_FM_annoyed += 1" ] }
+          ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_8"
+        }
+      },
+      {
+        "text": "[Antagonize] Make a mocking, robotic voice: \"Hahaha, we will add your biological and technological distinctiveness to our own!\"",
+        "trial": { "type": "PERSUADE", "difficulty": 15 },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_8",
+          "effect": [
+            { "u_message": "You succeed in antagonizing both parties.", "popup": true },
+            { "math": [ "exodii_FM_antagonized += 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [ { "u_message": "Your fail to antagonize them.", "popup": true }, { "math": [ "exodii_FM_annoyed += 1" ] } ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_8"
+        }
+      }
+    ]
+  },
+  {
+    "id": [ "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_8" ],
+    "type": "talk_topic",
+    "dynamic_line": "&The negotiation is coming to an end, and evething both parties are willing to offer is on the table…",
+    "responses": [
+      {
+        "text": "[Neutral] Let them finish, and offer occassional help translating.",
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_DONE"
+      },
+      {
+        "text": "[Antagonize] Well, that went way worse than I expected!  Smoke, Rubik, I don't think we have a deal here.",
+        "trial": { "type": "PERSUADE", "difficulty": 15 },
+        "success": {
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_DONE",
+          "effect": [
+            { "u_message": "You succeed in antagonizing both parties.", "popup": true },
+            { "math": [ "exodii_FM_antagonized += 1" ] }
+          ]
+        },
+        "failure": {
+          "effect": [ { "u_message": "Your fail to antagonize them.", "popup": true }, { "math": [ "exodii_FM_annoyed += 1" ] } ],
+          "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_DONE"
+        }
+      }
+    ]
+  },
+  {
+    "id": [ "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_DONE" ],
+    "type": "talk_topic",
+    "dynamic_line": {
+      "math": [ "exodii_FM_antagonized >= 5" ],
+      "yes": "&Rubik unceremoniously shuts off the the screen, leaving nothing but static.  Smokes leans back in his chair, wiping his brow.  \"Well, that didn't go well.  Something tells me it isn't gonna work out, and it's for the best.\"",
+      "no": {
+        "math": [ "exodii_FM_annoyed >= 3" ],
+        "yes": "&Rubik and Smokes finish their negotiation and agree to a complex set of terms.  Caravans will begin in about a week.  Rubik offers a stiff bow over the screen before it switches to static.  Smokes leans back, offering an easy smile.  \"Well, didn't expect that today, but that went well.  You were, uh, well, let's just say I think you should stick to scavenging, yeah?\"",
+        "no": "&Rubik and Smokes finish their negotiation and agree to a complex set of terms.  Caravans will begin in about a week.  Rubik offers a stiff bow over the screen before it switches to static.  Smokes leans back, offering an easy smile.  \"Well, didn't expect that today - negotiations with, well, whatever they are - but that went well.  I appreciate you.  Not sure we would've come to a deal without someone to do a bit of translating.\""
+      }
+    },
+    "responses": [
+      {
+        "text": "Yeah, it's definitely for the best.  See you around.  Maybe.",
+        "condition": { "math": [ "exodii_FM_antagonized >= 5" ] },
+        "effect": { "math": [ "exodii_FM_negotiation_failed = 1" ] },
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Hm.  See you around, I guess.",
+        "condition": { "and": [ { "not": { "math": [ "exodii_FM_antagonized >= 5" ] } }, { "math": [ "exodii_FM_annoyed >= 3" ] } ] },
+        "effect": [
+          { "math": [ "exodii_FM_negotiation_success = 1" ] },
+          { "run_eocs": "EOC_EXODII_FM_UPDATES", "time_in_future": "6 days" }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Glad to be of service.  I better get back to the Exodii.  See you around.",
+        "condition": {
+          "and": [
+            { "not": { "math": [ "exodii_FM_antagonized >= 5" ] } },
+            { "not": { "math": [ "exodii_FM_annoyed >= 3" ] } },
+            { "math": [ "exodii_FM_balance <= 0" ] }
+          ]
+        },
+        "effect": [
+          { "math": [ "exodii_FM_negotiation_success = 1" ] },
+          { "run_eocs": "EOC_EXODII_FM_UPDATES", "time_in_future": "6 days" }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Glad to be of service.  Seems the deal went pretty well for you, yeah?",
+        "condition": {
+          "and": [
+            { "not": { "math": [ "exodii_FM_antagonized >= 5" ] } },
+            { "not": { "math": [ "exodii_FM_annoyed >= 3" ] } },
+            { "math": [ "exodii_FM_balance > 0" ] }
+          ]
+        },
+        "effect": [
+          { "math": [ "exodii_FM_negotiation_success = 1" ] },
+          { "run_eocs": "EOC_EXODII_FM_UPDATES", "time_in_future": "6 days" }
+        ],
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_FAVORS_MERCHANTS"
+      }
+    ]
+  },
+  {
+    "id": [ "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_FAVORS_MERCHANTS" ],
+    "type": "talk_topic",
+    "dynamic_line": "&Smokes rubs his chin thoughtfully.  \"Yeah, it did, in no small part to you, I think.  How about I repay the favor?  You have anything in mind?\"",
+    "responses": [
+      {
+        "text": "[$100 credit] Some store credit would do nicely.",
+        "effect": [ { "u_spend_cash": -10000 }, "start_trade" ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Happy to help.  Just remember I'm a friend to the Center, yeah?",
+        "effect": [ { "u_add_faction_trust": 5 } ],
+        "topic": "TALK_DONE"
+      }
+    ]
+  }
+]

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_exodii_negotiation.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_exodii_negotiation.json
@@ -3,11 +3,11 @@
     "id": [ "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations" ],
     "type": "talk_topic",
     "//": "exodii_FM_antagonized tracks the deal itself - at max value it fails totally.  exodii_FM_annoyed tracks reward - above 3, and you don't get a reward.  exodii_FM_balance tracks who gives the reward and its magnitude - negative favors exodii and positive favors FM.",
-    "dynamic_line": "&You boot up the strange TV-radio device.  There is a sharp squeel from the device as the screen, first covered in only static, blips into life.  After a moment, the image on the screen wobbles and Rubik appears, offering a stiff bow.  You hold the screen up so Smokes can see it.",
+    "dynamic_line": "&You boot up the strange TV-radio device.  There is a sharp squeal from the device as the screen, first covered in only static, blips into life.  After a moment, the image on the screen wobbles and Rubik appears, offering a stiff bow.  You hold the screen up so Smokes can see it.",
     "speaker_effect": { "effect": { "math": [ "exodii_FM_balance = 0" ] } },
     "responses": [
       {
-        "text": "[Neutral] Introduce Rubik and Smokes to each other, then give them the floor.  Offer occassional help translating.",
+        "text": "[Neutral] Introduce Rubik and Smokes to each other, then give them the floor.  Offer occasional help translating.",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_2"
       },
       {
@@ -33,11 +33,11 @@
     "dynamic_line": "&Rubik explains they are primarily looking for plastics, metals, and media.  Rubik and Smokes start to talk about the nature of the trade.  Guaranteed shipments?  First right of refusal?  What about prices for bulk goods?",
     "responses": [
       {
-        "text": "[Neutral] Sit quietly and let them negotiate.  Offer occassional help translating.",
+        "text": "[Neutral] Sit quietly and let them negotiate.  Offer occasional help translating.",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_3"
       },
       {
-        "text": "[Favour Exodii] Point out that the Exodii's needs are predictable and simple.  \"They need a lot of things other survivors may not buy.\"",
+        "text": "[Favor Exodii] Point out that the Exodii's needs are predictable and simple.  \"They need a lot of things other survivors may not buy.\"",
         "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
         "success": {
           "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_3",
@@ -56,7 +56,7 @@
         }
       },
       {
-        "text": "[Favour Merchants] Remind Rubik that the Free Merchants are taking on the risk of the shipments, and need to stick around Earth even if the Exodii leave.  \"I think thats worth a small premium, no?\"",
+        "text": "[Favor Merchants] Remind Rubik that the Free Merchants are taking on the risk of the shipments, and need to stick around Earth even if the Exodii leave.  \"I think thats worth a small premium, no?\"",
         "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
         "success": {
           "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_3",
@@ -97,11 +97,11 @@
     "dynamic_line": "&Smokes and Rubik start to discuss what exactly the Exodii have to offer.  Rubik first offers up firearms, hefting one of their zombie hunting rifles into the frame…",
     "responses": [
       {
-        "text": "[Neutral] Sit quietly and let them negotiate.  Offer occassional help translating.",
+        "text": "[Neutral] Sit quietly and let them negotiate.  Offer occasional help translating.",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_4"
       },
       {
-        "text": "[Favour Exodii] Explain to Smokes the unique nature of the firearms you have seen.  \"They're really well tuned for taking down a <zombie>.\"",
+        "text": "[Favor Exodii] Explain to Smokes the unique nature of the firearms you have seen.  \"They're really well tuned for taking down a <zombie>.\"",
         "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
         "success": {
           "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_4",
@@ -120,7 +120,7 @@
         }
       },
       {
-        "text": "[Favour Merchants] Remind Rubik & Smokes that these firearms use ammunition not from this world.  \"They're great guns, but be sure to work ammunition into the deal.\"",
+        "text": "[Favor Merchants] Remind Rubik & Smokes that these firearms use ammunition not from this world.  \"They're great guns, but be sure to work ammunition into the deal.\"",
         "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
         "success": {
           "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_4",
@@ -161,11 +161,11 @@
     "dynamic_line": "&Rubik moves on to medical services and starts to explain the nature of their medical robots.  Smokes talks a bit about the Old Guard and a medical doctor stationed at the center…",
     "responses": [
       {
-        "text": "[Neutral] Sit quietly and let them negotiate.  Offer occassional help translating.",
+        "text": "[Neutral] Sit quietly and let them negotiate.  Offer occasional help translating.",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_5"
       },
       {
-        "text": "[Favour Exodii] Explain to Smokes the miraculous nature of their medical technology, and how it's definitely worth the price for access to it.",
+        "text": "[Favor Exodii] Explain to Smokes the miraculous nature of their medical technology, and how it's definitely worth the price for access to it.",
         "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
         "success": {
           "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_5",
@@ -184,7 +184,7 @@
         }
       },
       {
-        "text": "[Favour Merchants] Encourage Smokes to negotiate a medical robot be installed at the Evacuee Center.",
+        "text": "[Favor Merchants] Encourage Smokes to negotiate a medical robot be installed at the Evacuee Center.",
         "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
         "success": {
           "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_5",
@@ -234,7 +234,7 @@
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_6"
       },
       {
-        "text": "[Favour Exodii] Whisper to Smokes: \"Listen, I know these guys.  Sweeten the deal as a gesture of good will, and things will go well for you.\"",
+        "text": "[Favor Exodii] Whisper to Smokes: \"Listen, I know these guys.  Sweeten the deal as a gesture of good will, and things will go well for you.\"",
         "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
         "success": {
           "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_6",
@@ -253,7 +253,7 @@
         }
       },
       {
-        "text": "[Favour Merchants] Whisper to Smokes and encourage him to ask for a bit more.",
+        "text": "[Favor Merchants] Whisper to Smokes and encourage him to ask for a bit more.",
         "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
         "success": {
           "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_6",
@@ -294,11 +294,11 @@
     "dynamic_line": "&After a quiet moment, the discussion moves on to the nature of the caravans.  The Free Merchants will want to set up an encampment near the Exodii's butte…",
     "responses": [
       {
-        "text": "[Neutral] Sit quietly and let them negotiate.  Offer occassional help translating.",
+        "text": "[Neutral] Sit quietly and let them negotiate.  Offer occasional help translating.",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_7"
       },
       {
-        "text": "[Favour Exodii] Suggest deliveries be managed through a nearby camp, rather than something more permenant.  Whisper to Smokes: \"Outside of the Exodii's protection, but also outside of their influence\".",
+        "text": "[Favor Exodii] Suggest deliveries be managed through a nearby camp, rather than something more permenant.  Whisper to Smokes: \"Outside of the Exodii's protection, but also outside of their influence\".",
         "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
         "success": {
           "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_7",
@@ -317,7 +317,7 @@
         }
       },
       {
-        "text": "[Favour Merchants] Subtly hint to Smokes that they could probably negotiate protection, or a fortified structure for the Free Merchants.",
+        "text": "[Favor Merchants] Subtly hint to Smokes that they could probably negotiate protection, or a fortified structure for the Free Merchants.",
         "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
         "success": {
           "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_7",
@@ -362,11 +362,11 @@
     "dynamic_line": "&Rubik broaches the topic of recruitment & CBM interfaces…",
     "responses": [
       {
-        "text": "[Neutral] Sit quietly and let them negotiate.  Offer occassional help translating.",
+        "text": "[Neutral] Sit quietly and let them negotiate.  Offer occasional help translating.",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_8"
       },
       {
-        "text": "[Favour Exodii] Talk about the benefits of CBMs.",
+        "text": "[Favor Exodii] Talk about the benefits of CBMs.",
         "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
         "success": {
           "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_8",
@@ -385,7 +385,7 @@
         }
       },
       {
-        "text": "[Favour Merchants] Point out that the Exodii are asking for access to people, which should be negotiated like anything else.  \"Rubik, maybe it's worth sweetening the deal some, if you're going to be courting some of their people.\"",
+        "text": "[Favor Merchants] Point out that the Exodii are asking for access to people, which should be negotiated like anything else.  \"Rubik, maybe it's worth sweetening the deal some, if you're going to be courting some of their people.\"",
         "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
         "success": {
           "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_8",
@@ -423,10 +423,10 @@
   {
     "id": [ "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_8" ],
     "type": "talk_topic",
-    "dynamic_line": "&The negotiation is coming to an end, and evething both parties are willing to offer is on the table…",
+    "dynamic_line": "&The negotiation is coming to an end…",
     "responses": [
       {
-        "text": "[Neutral] Let them finish, and offer occassional help translating.",
+        "text": "[Neutral] Let them finish, and offer occasional help translating.",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_DONE"
       },
       {

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_exodii_negotiation.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_exodii_negotiation.json
@@ -298,7 +298,7 @@
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_7"
       },
       {
-        "text": "[Favor Exodii] Suggest deliveries be managed through a nearby camp, rather than something more permenant.  Whisper to Smokes: \"Outside of the Exodii's protection, but also outside of their influence\".",
+        "text": "[Favor Exodii] Suggest deliveries be managed through a nearby camp, rather than something more permanent.  Whisper to Smokes: \"Outside of the Exodii's protection, but also outside of their influence\".",
         "trial": { "type": "PERSUADE", "difficulty": 60, "mod": [ [ "TRUST", 3 ] ] },
         "success": {
           "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations_7",

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -129,6 +129,30 @@
     "dynamic_line": [ "What's on your mind?", "Lay it on me.", "Alright, shoot.", "Something on your mind?" ],
     "responses": [
       {
+        "text": "I'm here on behalf of a group called the Exodii.  They're interested in establishing trade.",
+        "condition": {
+          "and": [
+            { "u_has_mission": "EXODII_MISSION_MEET_FREE_MERCHANTS" },
+            { "u_has_item": "exodii_portable_tv" },
+            { "math": [ "exodii_FM_negotiation_failed != 1" ] },
+            { "math": [ "exodii_FM_negotiation_success != 1" ] }
+          ]
+        },
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants"
+      },
+      {
+        "text": "I'm here on behalf of a group called the Exodii.  They're interested in establishing trade.  Except I seem to have forgotten the radio I was supposed to bring.  I'll come back later.",
+        "condition": {
+          "and": [
+            { "u_has_mission": "EXODII_MISSION_MEET_FREE_MERCHANTS" },
+            { "not": { "u_has_item": "exodii_portable_tv" } },
+            { "math": [ "exodii_FM_negotiation_failed != 1" ] },
+            { "math": [ "exodii_FM_negotiation_success != 1" ] }
+          ]
+        },
+        "topic": "TALK_DONE"
+      },
+      {
         "text": "I'm trying to put a cleanup crew together to tidy up the back room.  Can you offer any help?",
         "condition": {
           "and": [
@@ -394,6 +418,66 @@
         "text": "Well, how about 300 merch for 10 liters of…",
         "effect": { "u_spawn_item": "trade_writ" },
         "topic": "TALK_DONE"
+      }
+    ]
+  },
+  {
+    "id": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "u_has_trait": "EXODII_CYBERFRAME_GENERIC",
+      "yes": "Well, from taking a look at you, I can only guess what these Exodii are all about.  But trade's trade, so tell me more.",
+      "no": "Exodii?  Tell me more."
+    },
+    "responses": [
+      {
+        "text": "[Boot up the Exodii TV-radio] Maybe it's best if their representative does the talking.  We'll call them on this screen.  They sort of speak English, and I can try and translate back and forth.",
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations"
+      },
+      {
+        "text": "I mean, just look at me!  They're cyborgs from another dimension.  They turn humans and maybe other beings into cyborgs, and jump from here to there, dodging cataclysms like ours.  And they're very interested in trade.",
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_2",
+        "condition": { "u_has_trait": "EXODII_CYBERFRAME_GENERIC" },
+        "effect": { "u_add_faction_trust": 1 }
+      },
+      {
+        "text": "They are a race of inter-dimensional beings.  These guys are more metal than man in my opinion and use automated machinery to do their fighting and heavy lifting.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_2",
+        "effect": { "u_add_faction_trust": 2 }
+      },
+      {
+        "text": "They are a race of inter-dimensional beings that use a mix of futuristic and ancient technology, the latter being mostly due to their last landing place being an ancient battlefield of some sort.  These guys are more metal than man in my opinion and use automated machinery to do their fighting and heavy lifting.  While their choice for personal defense was more along the lines of ancient gear like spears and swords.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
+        "condition": { "compare_string": [ "yes", { "u_val": "u_talk_exodii_about_medieval_stock" } ] },
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_2",
+        "effect": { "u_add_faction_trust": 3 }
+      },
+      {
+        "text": "They are a race of inter-dimensional beings.  These guys are more metal than man in my opinion - they use automated machinery to do their fighting and heavy lifting.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.  They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
+        "condition": { "compare_string": [ "yes", { "u_val": "u_know_exodii_purpose2" } ] },
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_2",
+        "effect": { "u_add_faction_trust": 4 }
+      },
+      {
+        "text": "They are a race of inter-dimensional beings that use a mix of futuristic and ancient technology, the latter being mostly due to their last landing place being an ancient battlefield of some sort.  These guys are more metal than man in my opinion and use automated machinery to do their fighting and heavy lifting.  However their choice for personal defense was more along the lines of ancient gear like spears and swords.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.  They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "u_know_exodii_purpose2" } ] },
+            { "compare_string": [ "yes", { "u_val": "u_talk_exodii_about_medieval_stock" } ] }
+          ]
+        },
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_2",
+        "effect": { "u_add_faction_trust": 5 }
+      }
+    ]
+  },
+  {
+    "id": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_2",
+    "type": "talk_topic",
+    "dynamic_line": "Well, that's a lot to take in.  What do they want?",
+    "responses": [
+      {
+        "text": "[Boot up the Exodii TV-radio] Maybe it's best if their representative does the talking.  We'll call them on this screen.  They sort of speak English, and I can try and translate back and forth.",
+        "topic": "TALK_FREE_MERCHANTS_MERCHANT_Exodii_mission_meet_free_merchants_negotiations"
       }
     ]
   },

--- a/data/json/overmap/overmap_special/alien.json
+++ b/data/json/overmap/overmap_special/alien.json
@@ -112,7 +112,10 @@
       { "point": [ 0, 3, 4 ], "overmap": "exodii_base_x0y3z4_north" },
       { "point": [ 1, 3, 4 ], "overmap": "exodii_base_x1y3z4_north" },
       { "point": [ 2, 3, 4 ], "overmap": "exodii_base_x2y3z4_north" },
-      { "point": [ 3, 3, 4 ], "overmap": "exodii_base_x3y3z4_north" }
+      { "point": [ 3, 3, 4 ], "overmap": "exodii_base_x3y3z4_north" },
+      { "point": [ -2, 2, 0 ], "overmap": "exo_base_safehouse_stone_0_north" },
+      { "point": [ -2, 2, 1 ], "overmap": "exo_base_safehouse_stone_1_north" },
+      { "point": [ -2, 2, 2 ], "overmap": "exo_base_safehouse_stone_2_north" }
     ],
     "locations": [ "land", "swamp", "forest" ],
     "city_distance": [ 2, 120 ],

--- a/data/json/overmap/overmap_terrain/overmap_terrain_alien.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_alien.json
@@ -183,6 +183,30 @@
   },
   {
     "type": "overmap_terrain",
+    "id": "exo_base_safehouse_stone_0",
+    "vision_levels": "isolated_building",
+    "name": "unusual stone barn",
+    "sym": "^",
+    "color": "brown",
+    "see_cost": "high",
+    "flags": [ "KNOWN_UP" ]
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "exo_base_safehouse_stone_1",
+    "copy-from": "exo_safehouse_stone_0",
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN" ]
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "exo_base_safehouse_stone_2",
+    "vision_levels": "roof_or_air",
+    "name": "unusual stone barn roof",
+    "copy-from": "exo_safehouse_stone_0",
+    "flags": [ "KNOWN_DOWN" ]
+  },
+  {
+    "type": "overmap_terrain",
     "abstract": "alien_meadow",
     "copy-from": "generic_open_land",
     "name": "alien meadow",

--- a/data/mods/translate-dialogue/exodii_merchant_missions.json
+++ b/data/mods/translate-dialogue/exodii_merchant_missions.json
@@ -211,7 +211,7 @@
     "dynamic_line": { "concatenate": [ "Aye?", "\"\n\n[TRANSLATE:] \"", "Aye?" ] }
   },
   {
-    "id": "TALK_EXODII_MERCHANT_mission_2_complete_double_crossed_lie_truth",
+    "id": "TALK_EXODII_MERCHANT_mission_2_complete_double_crossed_truth",
     "type": "talk_topic",
     "dynamic_line": {
       "concatenate": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "A mission to negotiate trade between the Exodii and Free Merchants"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Implement a version of #59911

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The Exodii will now naturally form a relationship with the Free Merchants.  Without intervention:
- +60 days post-catacylsm, a FM caravan will be set up outside the Exodii base, to trade materials to the exodii, and food to scavengers that come through.
- +120 days post-cataclysm, the Exodii will give the FM access to a nearby warehouse (that now always spawns with the Exodii base)
- +1 year post-cataclysm, the Exodii will install an AutoDoc at the Refugee Center.

The player can participate in this:
- +14 days post-cataclysm, the Exodii would have heard of the Free Merchants.  From this point, if the player finds the Exodii warehouse (and doesn't betray them to Hub 01), Rubik will ask them to help negotiate the deal.
- The mission is not available after the first caravan spawns at the Exodii base.
- The mission tasks the player with basically taking a TV-radio to Smokes, and facilitating the deal.  The mission itself is just a series of dialogue concerning the trade relationship between Exodii and FM.  Each step has a neutral option, an option to sway in favor of the FM, an option to sway in favor of the Exodii, and an option to sabotage the deal.
- Failing to sway the deal results in an increase to `exodii_FM_annoyed`;  >=3 results in the player getting a reduced reward.  There is also a 50% chance that it increases `exodii_FM_antagonized`;  >=5 results in the deal failing.
- Successful sabotage always increases `exodii_FM_antagonized`.  Failing to sabotage always increases `exodii_FM_annoyed`.
- If the player sways in favor of the FM, the Exodii don't care, and the FM will give the player a little reward.
- Two chances exist to (1) speed up the acquisition of the warehouse; and (2) speed up the acquisition of the AutoDoc.
- If the player fails, it now permanently sabotages the trade network.  The caravan will never spawn.
- If the player is successful, Rubik will offer them cyborgification, or a large amount of store credit.  If they annoyed everyone too much, they only get offered (less) store credit.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Did the dialogue in various configurations.

Watched it all spawn naturally without the mission.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

There's plenty of space for nuance and more features going forward.  Perhaps there should be alternative paths to salvage the deal after it fails, etc.

Screenshots:

Caravan:

<img width="565" height="477" alt="FM-exodii-camp" src="https://github.com/user-attachments/assets/973a3793-226c-4eaf-bca3-85de729f9b2d" />

Warehouse:

<img width="635" height="647" alt="FM-exodii-warehouse" src="https://github.com/user-attachments/assets/37626bfd-68d2-4188-9496-4113d2a37f4a" />

Autodoc:

<img width="451" height="582" alt="FM-exodii-autodoc" src="https://github.com/user-attachments/assets/ed815d90-5c31-4659-9b9b-db87391c98f7" />


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
