### PR TITLE
Inventory organization crashes/freezes fixes

### DIFF
--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2649,11 +2649,7 @@ std::vector<item_pocket *> outfit::grab_drop_pockets( const bodypart_id &bp )
     return pd;
 }
 
-void outfit::organize_items_menu()
+void outfit::organize_items_menu( Character &guy )
 {
-    std::vector<item *> to_organize;
-    for( item &i : worn ) {
-        to_organize.push_back( &i );
-    }
-    pocket_management_menu( _( "Inventory Organization" ), to_organize );
+    pocket_management_menu( _( "Inventory Organization" ), top_items_loc( guy ) );
 }

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -251,7 +251,7 @@ class outfit
         std::list<item> remove_items_with( Character &guy,
                                            const std::function<bool( const item & )> &filter, int &count );
 
-        void organize_items_menu();
+        void organize_items_menu( Character &guy );
 
         void serialize( JsonOut &json ) const;
         void deserialize( const JsonObject &jo );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2357,7 +2357,7 @@ int game::inventory_item_menu( item_location locThisItem,
                 case 'v':
                     if( oThisItem.is_container() ) {
                         ui_impl.reset();
-                        oThisItem.favorite_settings_menu();
+                        locThisItem.favorite_settings_menu();
                     }
                     break;
                 case 'V': {

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3919,7 +3919,7 @@ item_location inventory_pick_selector::execute()
                 on_input( input );
             }
         } else if( input.action == "ORGANIZE_MENU" ) {
-            u.worn.organize_items_menu();
+            u.worn.organize_items_menu( u );
             return item_location();
         } else if( input.action == "QUIT" ) {
             return item_location();

--- a/src/item.h
+++ b/src/item.h
@@ -3412,7 +3412,7 @@ class item : public visitable
         /**
          * Open a menu for the player to set pocket favorite settings for the pockets in this item_contents
          */
-        void favorite_settings_menu();
+        void favorite_settings_menu( item_location il );
 
         void combine( const item_contents &read_input, bool convert = false );
 

--- a/src/item_container.cpp
+++ b/src/item_container.cpp
@@ -1190,9 +1190,9 @@ const item &item::legacy_front() const
     return contents.legacy_front();
 }
 
-void item::favorite_settings_menu()
+void item::favorite_settings_menu( item_location il )
 {
-    contents.favorite_settings_menu( this );
+    contents.favorite_settings_menu( std::move( il ) );
 }
 
 void item::combine( const item_contents &read_input, bool convert )

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -252,6 +252,12 @@ void pocket_favorite_callback::move_item( uilist *menu, item_pocket *selected_po
                         }
                     }
                 }
+                // parent can contain
+                if( entry.enabled
+                    && !std::get<3>( *itt ).parents_can_contain_recursive( item_to_move.first ).success()
+                  ) {
+                    entry.enabled = false;
+                }
 
                 // move through the pockets as you process entries
                 ++itt;

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -198,6 +198,24 @@ void pocket_favorite_callback::refresh_columns( uilist *menu )
     menu->setup();
 }
 
+/**
+ * Return true, if item_pocket* needle is (eventually) in item* haystack.
+ */
+static bool is_pocket_in_item( const item *haystack, const item_pocket *needle )
+{
+    for( const item_pocket *pocket : haystack->get_standard_pockets() ) {
+        if( needle == pocket ) {
+            return true;
+        }
+        for( const item *itm : pocket->all_items_top() ) {
+            if( is_pocket_in_item( itm, needle ) ) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 void pocket_favorite_callback::move_item( uilist *menu, item_pocket *selected_pocket )
 {
     uilist selector_menu;
@@ -245,13 +263,10 @@ void pocket_favorite_callback::move_item( uilist *menu, item_pocket *selected_po
                 }
 
                 // make sure we dont try to put anything in itself
-                if( entry.enabled ) {
-                    for( item_pocket *pocket : item_to_move.first->get_standard_pockets() ) {
-                        if( std::get<0>( *itt ) == pocket ) {
-                            entry.enabled = false;
-                        }
-                    }
+                if( entry.enabled && is_pocket_in_item( item_to_move.first, std::get<0>( *itt ) ) ) {
+                    entry.enabled = false;
                 }
+
                 // parent can contain
                 if( entry.enabled
                     && !std::get<3>( *itt ).parents_can_contain_recursive( item_to_move.first ).success()

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -52,7 +52,7 @@ namespace
 class pocket_favorite_callback : public uilist_callback
 {
     private:
-        std::vector<std::tuple<item_pocket *, int, uilist_entry *>> saved_pockets;
+        std::vector<std::tuple<item_pocket *, int, uilist_entry *, item_location>> saved_pockets;
         // whitelist or blacklist, for interactions
         bool whitelist = true;
         std::pair<item *, item_pocket *> item_to_move = { nullptr, nullptr };
@@ -62,16 +62,16 @@ class pocket_favorite_callback : public uilist_callback
         std::string uilist_text;
 
         // items to create pockets for
-        std::vector<item *> to_organize;
+        std::vector<item_location> to_organize;
 
         void move_item( uilist *menu, item_pocket *selected_pocket );
 
         void refresh_columns( uilist *menu );
 
-        void add_pockets( item &i, uilist &pocket_selector, const std::string &depth );
+        void add_pockets( item_location il, uilist &pocket_selector, const std::string &depth );
     public:
         explicit pocket_favorite_callback( const std::string &uilist_text,
-                                           const std::vector<item *> &to_organize,
+                                           const std::vector<item_location> &to_organize,
                                            uilist &pocket_selector );
         void refresh( uilist *menu ) override;
         float desired_extra_space_right( ) override {
@@ -92,7 +92,7 @@ void pocket_favorite_callback::refresh( uilist *menu )
     item_pocket *selected_pocket = nullptr;
     int i = 0;
     int pocket_num = 0;
-    for( std::tuple<item_pocket *, int, uilist_entry *> &pocket_val : saved_pockets ) {
+    for( std::tuple<item_pocket *, int, uilist_entry *, item_location> &pocket_val : saved_pockets ) {
         item_pocket *pocket = std::get<0>( pocket_val );
         if( pocket == nullptr || ( pocket->get_pocket_data()  &&
                                    !pocket->is_type( pocket_type::CONTAINER ) ) ) {
@@ -136,17 +136,19 @@ void pocket_favorite_callback::refresh( uilist *menu )
 }
 
 pocket_favorite_callback::pocket_favorite_callback( const std::string &uilist_text,
-        const std::vector<item *> &to_organize, uilist &pocket_selector )
+        const std::vector<item_location> &to_organize, uilist &pocket_selector )
     : uilist_text( uilist_text ), to_organize( to_organize )
 {
-    for( item *i : to_organize ) {
-        add_pockets( *i, pocket_selector, "" );
+    for( const item_location &il : to_organize ) {
+        add_pockets( il, pocket_selector, "" );
     }
 }
 
-void pocket_favorite_callback::add_pockets( item &i, uilist &pocket_selector,
+void pocket_favorite_callback::add_pockets( item_location il,
+        uilist &pocket_selector,
         const std::string &depth )
 {
+    item &i = *il;
     if( i.get_container_pockets().empty() ) {
         // if it doesn't have pockets skip it
         return;
@@ -154,7 +156,7 @@ void pocket_favorite_callback::add_pockets( item &i, uilist &pocket_selector,
 
     pocket_selector.addentry( -1, false, '\0', string_format( "%s%s", depth, i.display_name() ) );
     // pad list with empty entries for the items themselves
-    saved_pockets.emplace_back( nullptr, 0, nullptr );
+    saved_pockets.emplace_back( nullptr, 0, nullptr, item_location() );
     if( ( i.is_collapsed() && to_organize.size() != 1 ) || i.all_pockets_sealed() ) {
         //is collapsed, or all pockets are sealed skip its nested pockets
         // only skip collapsed items if doing multi menu, for a single item this wouldn't make sense
@@ -172,13 +174,13 @@ void pocket_favorite_callback::add_pockets( item &i, uilist &pocket_selector,
                                   vol_to_info( "", "", it_pocket->contents_volume() ).sValue,
                                   vol_to_info( "", "", it_pocket->volume_capacity() ).sValue ) );
         // pocket number is displayed from 1 stored from 0
-        saved_pockets.emplace_back( it_pocket, pocket_num - 1, item_entry );
+        saved_pockets.emplace_back( it_pocket, pocket_num - 1, item_entry, il );
         pocket_num++;
 
         // display the items
         for( item *it : it_pocket->all_items_top() ) {
             // check for pockets in that pocket
-            add_pockets( *it, pocket_selector, depth + "  " );
+            add_pockets( item_location( il, it ), pocket_selector, depth + "  " );
         }
     }
 }
@@ -189,8 +191,8 @@ void pocket_favorite_callback::refresh_columns( uilist *menu )
     // clear all but one entry repopulate then delete that initial
     menu->entries.clear();
     saved_pockets.clear();
-    for( item *i : to_organize ) {
-        add_pockets( *i, *menu, "" );
+    for( const item_location &il : to_organize ) {
+        add_pockets( il, *menu, "" );
     }
     // there might be a better way to refresh this
     menu->setup();
@@ -288,7 +290,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
     item_pocket *selected_pocket = nullptr;
     int i = 0;
     int pocket_num = 0;
-    for( std::tuple<item_pocket *, int, uilist_entry *> &pocket_val : saved_pockets ) {
+    for( std::tuple<item_pocket *, int, uilist_entry *, item_location> &pocket_val : saved_pockets ) {
         item_pocket *pocket = std::get<0>( pocket_val );
         if( pocket == nullptr || ( pocket->get_pocket_data()  &&
                                    !pocket->is_type( pocket_type::CONTAINER ) ) ) {
@@ -2963,14 +2965,15 @@ void item_contents::info( std::vector<iteminfo> &info, const iteminfo_query *par
     }
 }
 
-void item_contents::favorite_settings_menu( item *i )
+void item_contents::favorite_settings_menu( item_location il )
 {
-    std::vector<item *> to_organize;
-    to_organize.push_back( i );
-    pocket_management_menu( remove_color_tags( i->display_name() ), to_organize );
+    std::vector<item_location> to_organize;
+    to_organize.push_back( il );
+    pocket_management_menu( remove_color_tags( il->display_name() ), to_organize );
 }
 
-void pocket_management_menu( const std::string &title, const std::vector<item *> &to_organize )
+void pocket_management_menu( const std::string &title,
+                             const std::vector<item_location> &to_organize )
 {
     static const std::string input_category = "INVENTORY";
     input_context ctxt( input_category );

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -353,7 +353,7 @@ class item_contents
         /**
          * Open a menu for the player to set pocket favorite settings for the pockets in this item_contents
          */
-        void favorite_settings_menu( item *i );
+        void favorite_settings_menu( item_location il );
 
         item_pocket *contained_where( const item &contained );
         void on_pickup( Character &guy, item *avoid = nullptr );
@@ -489,6 +489,7 @@ class item_contents
         friend struct item_contents_helper;
 };
 
-void pocket_management_menu( const std::string &title, const std::vector<item *> &to_organize );
+void pocket_management_menu( const std::string &title,
+                             const std::vector<item_location> &to_organize );
 
 #endif // CATA_SRC_ITEM_CONTENTS_H

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -1428,6 +1428,11 @@ int item_location::get_quality( const std::string &quality, bool strict_boiling 
     return tool->get_quality_nonrecursive( qualityid, strict_boiling );
 }
 
+void item_location::favorite_settings_menu()
+{
+    ( *this )->favorite_settings_menu( *this );
+}
+
 // Hint-driven uid resolution with bounded fallback.  No world-wide scan.
 // Returns invalid for items in monster stomachs, portals, or off-bubble.
 item_location find_item_by_uid( int64_t uid, const item_locator_hint &hint )

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -115,7 +115,7 @@ class item_location
         /** returns the character whose inventory contains this item, nullptr if none **/
         Character *carrier() const;
 
-        /** returns the character whose inventory contains this item, nullptr if none **/
+        /** returns the vehicle whose inventory contains this item, nullptr if none **/
         const vehicle_cursor *veh_cursor() const;
 
         /** returns true if the item is in the inventory of the given character **/
@@ -190,6 +190,11 @@ class item_location
         * @param strict_boiling True if containers must be empty to have BOIL quality
         */
         int get_quality( const std::string &quality, bool strict_boiling ) const;
+
+        /**
+         * Open a menu for the player to set pocket favorite settings for the pockets in the item's item_contents.
+         */
+        void favorite_settings_menu();
 
     private:
         class impl;


### PR DESCRIPTION
#### Summary
Bugfixes "Inventory organization crashes/freezes"

#### Purpose of change

 - Fixes #76505 (probably, it has no reproduction steps, but this addresses such crashes/freezes)
 - In general, this also forbids putting things in `pocket options` into a pocket if an ancestor's pocket forbids it.

#### Describe the solution
(1st, 2nd, 3rd commit)
1. Refactor to use `item_location` rather than `item`. With it, we will be able to call `parents_can_contain_recursive`.
2. Call `parents_can_contain_recursive`, which, with #82040, limits nesting to 12 to prevent save corruption. It does other checks as well; I haven't looked into them.
3. Fix putting containers into themselves: It checked only for parents (A>B), we now check for ancestors (A>...>X).

#### Describe alternatives you've considered

- Use `unique_ptr` instead of `shared_ptr`, I didn't get it working.
- Make method `all_item_locations_top`, to replace
```cpp
for( item *it : it_pocket->all_items_top() ) {
    add_pockets( std::make_shared<item_location>( *il, it ), pocket_selector, depth + "  " );
}
```
with something like
```cpp
for( item_location *il : it_pocket->all_item_locations_top() ) {
    add_pockets( il, pocket_selector, depth + "  " );
}
```

And maybe completely remove smart pointers from here.

#### Testing

 - Forbidding putting into a descendant's pocket:
<img width="2545" height="578" alt="image" src="https://github.com/user-attachments/assets/131177a9-28ca-4859-9a18-bfe0ce349009" />

 - With #82040 merged
<img width="1544" height="619" alt="image" src="https://github.com/user-attachments/assets/7bcd53ea-b428-4df3-8c04-38db477296bb" />


#### Additional context

Once this is merged, I have one more PR on this matter.