### PR TITLE
[Xedra Evolved] Some random encounter tweaking

### DIFF
--- a/data/mods/Xedra_Evolved/encounters/base_eoc.json
+++ b/data/mods/Xedra_Evolved/encounters/base_eoc.json
@@ -25,7 +25,7 @@
       { "u_message": "Xedra Evolved random encounter has met its conditions.", "type": "debug" },
       {
         "u_location_variable": { "global_val": "XE_randenc_loc" },
-        "target_params": { "om_terrain": { "context_val": "omt" }, "random": true, "search_range": 30, "min_distance": 3 }
+        "target_params": { "om_terrain": { "context_val": "omt" }, "random": true, "z": 0, "search_range": 30, "min_distance": 3 }
       },
       {
         "mapgen_update": [ { "context_val": "map_update" } ],

--- a/data/mods/Xedra_Evolved/encounters/jotunn_encounters.json
+++ b/data/mods/Xedra_Evolved/encounters/jotunn_encounters.json
@@ -2,12 +2,15 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_RandEnc_Roadstop_Jotunn",
-    "recurrence": 3000,
+    "recurrence": 43400,
     "global": true,
     "run_for_npcs": false,
     "condition": { "math": [ "XE_RandEnc == 0" ] },
     "effect": [
-      { "set_condition": "random_enc_condition", "condition": { "not": { "is_season": "winter" } } },
+      {
+        "set_condition": "random_enc_condition",
+        "condition": { "and": [ { "current_dimension": "" }, { "not": { "is_season": "winter" } } ] }
+      },
       { "u_message": "Jotunn/Zebra encounter has triggered!", "type": "debug" },
       {
         "set_string_var": "You hear a sustained burst of gunfire somewhere in the distance.",

--- a/data/mods/Xedra_Evolved/encounters/march_lord_hunt_encounters.json
+++ b/data/mods/Xedra_Evolved/encounters/march_lord_hunt_encounters.json
@@ -7,7 +7,10 @@
     "run_for_npcs": false,
     "condition": { "math": [ "XE_RandEnc == 0" ] },
     "effect": [
-      { "set_condition": "random_enc_condition", "condition": { "and": [ "u_is_outside", { "is_weather": "fog" } ] } },
+      {
+        "set_condition": "random_enc_condition",
+        "condition": { "and": [ "is_day", { "current_dimension": "" }, { "is_weather": "fog" } ] }
+      },
       { "u_message": "March Lord hunt encounter has triggered!", "type": "debug" },
       {
         "set_string_var": "You hear a low horn-call somewhere out in the fog.",

--- a/data/mods/Xedra_Evolved/encounters/march_lord_hunt_encounters.json
+++ b/data/mods/Xedra_Evolved/encounters/march_lord_hunt_encounters.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_RandEnc_March_Lord_Hunting_Party",
-    "recurrence": 21600,
+    "recurrence": 27600,
     "global": true,
     "run_for_npcs": false,
     "condition": { "math": [ "XE_RandEnc == 0" ] },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Some random encounter tweaking"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Realized that as we get more random encounters, we don't want to them all running very often because then the map will be filled with something happening too often (in addition to everything already happening). Also, we need to make sure the current encounters are set to `{ "current_dimension": "" }` so you don't e.g. run into the Wild Hunt in the Highlands.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Make sure the random encounter main EoC does a terrain search for z-level 0
- Increase the recurrence on the Jotunn/Zebra encounter by a lot.
- Remove the requirement that you be outside for the Wild Hunt encounter but require that it takes place during the day.
- Set both current encounters to look for `{ "current_dimension": "" }` so they don't fire elsewhere. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

now that I've got this set up more encounters are coming. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
