### PR TITLE
[MoM] The Hounds can twist your Extended Stride and keep up

### DIFF
--- a/data/mods/MindOverMatter/effects/effects_monster.json
+++ b/data/mods/MindOverMatter/effects/effects_monster.json
@@ -434,6 +434,20 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_mom_tindalos_hounds_corrupted_stride",
+    "//": "Hidden affect, turns Extended Stride into a penalty",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_mom_tindalos_hounds_corrupted_stride_warning",
+    "name": [ "Corrupted Stride" ],
+    "desc": [ "Your Extended Stride is working the opposite of how it should, increasing relative distance around you." ],
+    "rating": "bad"
+  },
+  {
+    "type": "effect_type",
     "id": "effect_riftwalker_teleport",
     "name": [ "Dimensionally Unstable" ],
     "desc": [ "You feel like you're barely part of the world." ],

--- a/data/mods/MindOverMatter/effects/effects_monster.json
+++ b/data/mods/MindOverMatter/effects/effects_monster.json
@@ -435,7 +435,7 @@
   {
     "type": "effect_type",
     "id": "effect_mom_tindalos_hounds_corrupted_stride",
-    "//": "Hidden affect, turns Extended Stride into a penalty",
+    "//": "Hidden affect, reduces effects of extended stride",
     "name": [ "" ],
     "desc": [ "" ]
   },
@@ -443,8 +443,16 @@
     "type": "effect_type",
     "id": "effect_mom_tindalos_hounds_corrupted_stride_warning",
     "name": [ "Corrupted Stride" ],
-    "desc": [ "Your Extended Stride is working the opposite of how it should, increasing relative distance around you." ],
+    "desc": [ "Your Extended Stride isn't working nearly as well as it should." ],
     "rating": "bad"
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_hound_extended_speed_bonus",
+    "name": [ "Moving Oddly" ],
+    "desc": [ "The Hound flickers as it moves." ],
+    "show_in_info": true,
+    "base_mods": { "speed_mod": [ 35 ] }
   },
   {
     "type": "effect_type",

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -2474,12 +2474,7 @@
       },
       {
         "condition": { "u_has_effect": "effect_mom_tindalos_hounds_corrupted_stride" },
-        "values": [
-          {
-            "value": "MOVE_COST",
-            "multiply": { "math": [ "max( ( ( ( u_spell_level('teleport_stride') * 0.02 ) + 0.05 ) * psionic_power_modifiers() ), 0.6)" ] }
-          }
-        ],
+        "values": [ { "value": "MOVE_COST", "multiply": -0.05 } ],
         "ench_effects": [ { "effect": "effect_mom_tindalos_hounds_corrupted_stride_warning", "intensity": 1 } ]
       }
     ],

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -2461,7 +2461,8 @@
         "condition": {
           "and": [
             { "not": { "u_has_effect": "effect_clair_astral_projection" } },
-            { "not": { "u_has_effect": "effect_biokin_perfected_motion" } }
+            { "not": { "u_has_effect": "effect_biokin_perfected_motion" } },
+            { "not": { "u_has_effect": "effect_mom_tindalos_hounds_corrupted_stride" } }
           ]
         },
         "values": [
@@ -2470,6 +2471,16 @@
             "multiply": { "math": [ "max( ( ( ( u_spell_level('teleport_stride') * -0.02 ) - 0.05 ) * psionic_power_modifiers() ), -0.6)" ] }
           }
         ]
+      },
+      {
+        "condition": { "u_has_effect": "effect_mom_tindalos_hounds_corrupted_stride" },
+        "values": [
+          {
+            "value": "MOVE_COST",
+            "multiply": { "math": [ "max( ( ( ( u_spell_level('teleport_stride') * 0.02 ) + 0.05 ) * psionic_power_modifiers() ), 0.6)" ] }
+          }
+        ],
+        "ench_effects": [ { "effect": "effect_mom_tindalos_hounds_corrupted_stride_warning", "intensity": 1 } ]
       }
     ],
     "flags": [ "MUSCLE_VEH_BOOST" ]

--- a/data/mods/MindOverMatter/monsters/monster_overrides.json
+++ b/data/mods/MindOverMatter/monsters/monster_overrides.json
@@ -291,21 +291,175 @@
     "id": "mon_hound_tindalos",
     "copy-from": "mon_hound_tindalos",
     "type": "MONSTER",
-    "extend": { "flags": [ "TEEP_IMMUNE", "TELEPORT_IMMUNE" ], "armor": { "psi_telekinetic_damage": 50 } },
+    "extend": {
+      "flags": [ "TEEP_IMMUNE", "TELEPORT_IMMUNE" ],
+      "armor": { "psi_telekinetic_damage": 50 },
+      "special_attacks": [
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "hound_tindalos_maintain_speed",
+          "cooldown": 1,
+          "move_cost": 1,
+          "range": 60,
+          "damage_max_instance": [ { "damage_type": "biological", "amount": 0 } ],
+          "dodgeable": false,
+          "blockable": false,
+          "condition": {
+            "and": [ { "npc_has_effect": "effect_teleport_stride" }, { "not": { "u_has_effect": "effect_hound_extended_speed_bonus" } } ]
+          },
+          "eoc": [ "EOC_MOM_HOUND_SPEED_ADJUSTMENT" ],
+          "hit_dmg_u": "",
+          "hit_dmg_npc": "",
+          "miss_msg_u": "",
+          "miss_msg_npc": "",
+          "no_dmg_msg_u": "",
+          "no_dmg_msg_npc": ""
+        },
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "hound_tindalos_lose_speed",
+          "cooldown": 1,
+          "move_cost": 1,
+          "range": 60,
+          "damage_max_instance": [ { "damage_type": "biological", "amount": 0 } ],
+          "dodgeable": false,
+          "blockable": false,
+          "condition": {
+            "and": [ { "not": { "npc_has_effect": "effect_teleport_stride" } }, { "u_has_effect": "effect_hound_extended_speed_bonus" } ]
+          },
+          "eoc": [ "EOC_MOM_HOUND_SPEED_ADJUSTMENT" ],
+          "hit_dmg_u": "",
+          "hit_dmg_npc": "",
+          "miss_msg_u": "",
+          "miss_msg_npc": "",
+          "no_dmg_msg_u": "",
+          "no_dmg_msg_npc": ""
+        }
+      ]
+    },
     "attack_effs": [ { "id": "effect_teleporting_lock", "duration": [ 5, 60 ], "chance": 50 } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MOM_HOUND_SPEED_ADJUSTMENT",
+    "condition": { "not": { "u_has_effect": "effect_hound_extended_speed_bonus" } },
+    "effect": [
+      { "u_add_effect": "effect_hound_extended_speed_bonus", "duration": "5 minutes" },
+      { "npc_add_effect": "effect_mom_tindalos_hounds_corrupted_stride", "duration": "5 minutes" }
+    ],
+    "false_effect": [
+      { "u_lose_effect": "effect_hound_extended_speed_bonus" },
+      { "npc_lose_effect": "effect_mom_tindalos_hounds_corrupted_stride" }
+    ]
   },
   {
     "id": "mon_hound_tindalos_afterimage",
     "copy-from": "mon_hound_tindalos_afterimage",
     "type": "MONSTER",
-    "extend": { "flags": [ "TEEP_IMMUNE", "TELEPORT_IMMUNE" ], "armor": { "psi_telekinetic_damage": 50 } },
+    "extend": {
+      "flags": [ "TEEP_IMMUNE", "TELEPORT_IMMUNE" ],
+      "armor": { "psi_telekinetic_damage": 50 },
+      "special_attacks": [
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "hound_tindalos_maintain_speed",
+          "cooldown": 1,
+          "move_cost": 1,
+          "range": 60,
+          "damage_max_instance": [ { "damage_type": "biological", "amount": 0 } ],
+          "dodgeable": false,
+          "blockable": false,
+          "condition": {
+            "and": [ { "npc_has_effect": "effect_teleport_stride" }, { "not": { "u_has_effect": "effect_hound_extended_speed_bonus" } } ]
+          },
+          "eoc": [ "EOC_MOM_HOUND_SPEED_ADJUSTMENT" ],
+          "hit_dmg_u": "",
+          "hit_dmg_npc": "",
+          "miss_msg_u": "",
+          "miss_msg_npc": "",
+          "no_dmg_msg_u": "",
+          "no_dmg_msg_npc": ""
+        },
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "hound_tindalos_lose_speed",
+          "cooldown": 1,
+          "move_cost": 1,
+          "range": 60,
+          "damage_max_instance": [ { "damage_type": "biological", "amount": 0 } ],
+          "dodgeable": false,
+          "blockable": false,
+          "condition": {
+            "and": [ { "not": { "npc_has_effect": "effect_teleport_stride" } }, { "u_has_effect": "effect_hound_extended_speed_bonus" } ]
+          },
+          "eoc": [ "EOC_MOM_HOUND_SPEED_ADJUSTMENT" ],
+          "hit_dmg_u": "",
+          "hit_dmg_npc": "",
+          "miss_msg_u": "",
+          "miss_msg_npc": "",
+          "no_dmg_msg_u": "",
+          "no_dmg_msg_npc": ""
+        }
+      ]
+    },
     "attack_effs": [ { "id": "effect_teleporting_lock", "duration": [ 5, 60 ], "chance": 50 } ]
   },
   {
     "id": "mon_tindalos",
     "copy-from": "mon_tindalos",
     "type": "MONSTER",
-    "extend": { "flags": [ "TEEP_IMMUNE", "TELEPORT_IMMUNE" ], "armor": { "psi_telekinetic_damage": 50 } },
+    "extend": {
+      "flags": [ "TEEP_IMMUNE", "TELEPORT_IMMUNE" ],
+      "armor": { "psi_telekinetic_damage": 50 },
+      "special_attacks": [
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "hound_tindalos_maintain_speed",
+          "cooldown": 1,
+          "move_cost": 1,
+          "range": 60,
+          "damage_max_instance": [ { "damage_type": "biological", "amount": 0 } ],
+          "dodgeable": false,
+          "blockable": false,
+          "condition": {
+            "and": [ { "npc_has_effect": "effect_teleport_stride" }, { "not": { "u_has_effect": "effect_hound_extended_speed_bonus" } } ]
+          },
+          "eoc": [ "EOC_MOM_HOUND_SPEED_ADJUSTMENT" ],
+          "hit_dmg_u": "",
+          "hit_dmg_npc": "",
+          "miss_msg_u": "",
+          "miss_msg_npc": "",
+          "no_dmg_msg_u": "",
+          "no_dmg_msg_npc": ""
+        },
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "hound_tindalos_lose_speed",
+          "cooldown": 1,
+          "move_cost": 1,
+          "range": 60,
+          "damage_max_instance": [ { "damage_type": "biological", "amount": 0 } ],
+          "dodgeable": false,
+          "blockable": false,
+          "condition": {
+            "and": [ { "not": { "npc_has_effect": "effect_teleport_stride" } }, { "u_has_effect": "effect_hound_extended_speed_bonus" } ]
+          },
+          "eoc": [ "EOC_MOM_HOUND_SPEED_ADJUSTMENT" ],
+          "hit_dmg_u": "",
+          "hit_dmg_npc": "",
+          "miss_msg_u": "",
+          "miss_msg_npc": "",
+          "no_dmg_msg_u": "",
+          "no_dmg_msg_npc": ""
+        }
+      ]
+    },
     "attack_effs": [ { "id": "effect_teleporting_lock", "duration": [ 5, 60 ], "chance": 50 } ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] The Hounds can twist your Extended Stride and keep up"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The Hounds are better at teleporting than you.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

If you have Extended Stride on, the Hounds will "corrupt" it, limiting it to a small move cost reduction. At the same time, they'll get a speed boost to match your speed. If you deactivate Extended Stride, both of these effects go away.

You get an effect in your @ sheet that tells you something is wrong.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested it, it worked. Effect applied when you have Extended Stride, removed when you don't. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
