### PR TITLE
[Xedra Evolved] Update changeling Banquet of Dreams to allow a massive harvest at the cost of damage

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects_changeling_seasonal_magic.json
+++ b/data/mods/Xedra_Evolved/effects/effects_changeling_seasonal_magic.json
@@ -16,6 +16,20 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_changeling_active_banquet_of_dreams",
+    "//": "Hidden effect, used to determine if a mutation is active",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_changeling_banquet_of_dreams_damage",
+    "//": "Hidden effect, used if a target has had empowered Banquet of Dreams used on them",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_changeling_stop_nether_conditions",
     "name": [ "Dancer in the Endless Dark" ],
     "desc": [ "You are immune to several deleterious otherworldly conditions." ],

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -407,7 +407,7 @@
     "id": "CHANGELING_GAIN_DREAMDROSS_FROM_MORTAL_DREAMS",
     "name": { "str": "Banquet of Dreams" },
     "points": 2,
-    "description": "The Fair Folk rely on mortal dreams for power, and this glamour is one of the ways they harvest them.  When woven over a sleeping mortal, some of the power of their dreams coalesces as a shimmering metallic substance called dreamdross.",
+    "description": "The Fair Folk rely on mortal dreams for power, and this glamour is one of the ways they harvest them.  When woven over a sleeping mortal, some of the power of their dreams coalesces as a shimmering metallic substance called dreamdross.  Activate to increase the intensity, drawing out far more dreamdross but causing permanent damage to the target's dreams.",
     "category": [
       "FAIR_FOLK_NOBLE",
       "FAIR_FOLK_COMMONER_BROWNIE",
@@ -416,7 +416,15 @@
       "FAIR_FOLK_COMMONER_TROW"
     ],
     "purifiable": false,
-    "spells_learned": [ [ "changeling_gain_dreamdross_from_dreams", 1 ] ]
+    "active": true,
+    "activated_is_setup": true,
+    "spells_learned": [ [ "changeling_gain_dreamdross_from_dreams", 1 ] ],
+    "enchantments": [
+      {
+        "condition": "ACTIVE",
+        "ench_effects": [ { "effects": "effect_changeling_active_banquet_of_dreams", "intensity": 1 } ]
+      }
+    ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -418,11 +418,12 @@
     "purifiable": false,
     "active": true,
     "activated_is_setup": true,
+    "activation_msg": "You get ready to rip as much power from mortal dreams as you can.",
     "spells_learned": [ [ "changeling_gain_dreamdross_from_dreams", 1 ] ],
     "enchantments": [
       {
         "condition": "ACTIVE",
-        "ench_effects": [ { "effects": "effect_changeling_active_banquet_of_dreams", "intensity": 1 } ]
+        "ench_effects": [ { "effect": "effect_changeling_active_banquet_of_dreams", "intensity": 1 } ]
       }
     ]
   },

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -318,6 +318,7 @@
                 "u_add_effect": "effect_changeling_gain_dreamdross_from_dreams",
                 "duration": { "math": [ "518400 + rand(259200) - (n_skill('gramarye') * 28800) * rng(0.66666,1.333333)" ] }
               },
+              { "u_add_effect": "effect_changeling_banquet_of_dreams_damage", "duration": "PERMANENT" },
               {
                 "run_eocs": [
                   {
@@ -334,7 +335,8 @@
                           "ADDICTIVE",
                           "NARCOLEPTIC",
                           "JITTERY",
-                          "INSOMNIA"
+                          "INSOMNIA",
+                          "HEAVYSLEEPER2"
                         ],
                         "type": "mutation"
                       }

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -302,10 +302,66 @@
     "condition": { "not": { "u_has_effect": "effect_changeling_gain_dreamdross_from_dreams" } },
     "effect": [
       {
-        "u_add_effect": "effect_changeling_gain_dreamdross_from_dreams",
-        "duration": { "math": [ "518400 + rand(259200) - (n_skill('gramarye') * 28800) * rng(0.66666,1.333333)" ] }
-      },
-      { "run_eocs": [ "EOC_CHANGELING_GAIN_DREAMDROSS_FROM_DREAMS_SPAWN" ], "alpha_talker": "npc" }
+        "if": { "not": { "u_has_effect": "effect_changeling_banquet_of_dreams_damage" } },
+        "then": [
+          {
+            "if": {
+              "or": [
+                { "npc_has_effect": "effect_changeling_active_banquet_of_dreams" },
+                {
+                  "and": [ { "npc_has_effect": "effect_changeling_temporary_psychopath" }, { "x_in_y_chance": { "x": 1, "y": 5 } } ]
+                }
+              ]
+            },
+            "then": [
+              {
+                "u_add_effect": "effect_changeling_gain_dreamdross_from_dreams",
+                "duration": { "math": [ "518400 + rand(259200) - (n_skill('gramarye') * 28800) * rng(0.66666,1.333333)" ] }
+              },
+              {
+                "run_eocs": [
+                  {
+                    "id": "EOC_CHANGELING_GAIN_DREAMDROSS_FROM_DREAMS_TARGET_PSYCHOLOGICAL_DAMAGE",
+                    "effect": [
+                      {
+                        "u_roll_remainder": [
+                          "NUMB",
+                          "BADTEMPER",
+                          "SHOUT2",
+                          "CHEMIMBALANCE",
+                          "MOODSWINGS",
+                          "FORGETFUL",
+                          "ADDICTIVE",
+                          "NARCOLEPTIC",
+                          "JITTERY",
+                          "INSOMNIA"
+                        ],
+                        "type": "mutation"
+                      }
+                    ]
+                  }
+                ],
+                "iterations": 3
+              },
+              { "run_eocs": [ "EOC_CHANGELING_GAIN_DREAMDROSS_FROM_DREAMS_SPAWN_FEAST" ], "alpha_talker": "npc" }
+            ],
+            "else": [
+              {
+                "u_add_effect": "effect_changeling_gain_dreamdross_from_dreams",
+                "duration": { "math": [ "518400 + rand(259200) - (n_skill('gramarye') * 28800) * rng(0.66666,1.333333)" ] }
+              },
+              { "run_eocs": [ "EOC_CHANGELING_GAIN_DREAMDROSS_FROM_DREAMS_SPAWN" ], "alpha_talker": "npc" }
+            ]
+          }
+        ],
+        "else": [
+          {
+            "u_add_effect": "effect_changeling_gain_dreamdross_from_dreams",
+            "duration": { "math": [ "518400 + rand(259200) - (n_skill('gramarye') * 28800) * rng(0.66666,1.333333)" ] }
+          },
+          { "run_eocs": [ "EOC_CHANGELING_GAIN_DREAMDROSS_FROM_DREAMS_SPAWN_LOW" ], "alpha_talker": "npc" }
+        ]
+      }
     ],
     "false_effect": [
       { "npc_message": "The mortal's dreams are fragile, evanescent things, not suitable for the harvest.", "type": "bad" }
@@ -328,6 +384,34 @@
         "else": { "u_spawn_item": "scrap_dreamdross", "count": { "math": [ "(rand(4) + 1)" ] }, "suppress_message": true }
       },
       { "u_message": "You reach into the mortal's dreams and coalesce them into shining dreamdross.", "type": "good" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CHANGELING_GAIN_DREAMDROSS_FROM_DREAMS_SPAWN_LOW",
+    "//": "We need this hack because there is no npc_spawn_item",
+    "effect": [
+      { "u_spawn_item": "scrap_dreamdross", "count": { "math": [ "rand(2)" ] }, "suppress_message": true },
+      {
+        "u_message": "You reach into the mortal's feeble dreams and pull what few scraps of dreamdross out as you can.",
+        "type": "good"
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CHANGELING_GAIN_DREAMDROSS_FROM_DREAMS_SPAWN_FEAST",
+    "//": "We need this hack because there is no npc_spawn_item",
+    "effect": [
+      {
+        "u_spawn_item": "scrap_dreamdross",
+        "count": { "math": [ "(rand(4) + 4) + (rand(4) + 4) + (rand(4) + 4) + (rand(4) + 4) + (rand(4) + 4) + 12" ] },
+        "suppress_message": true
+      },
+      {
+        "u_message": "You reach into the mortal's and rip them out whole, filling both hands with a cascade of shining dreamdross.",
+        "type": "good"
+      }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Update changeling Banquet of Dreams to allow a massive harvest at the cost of damage"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Add some moral conflict for changelings around using humans as a dream battery.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Update Banquet of Dreams--you can now activate it. While active, if you use the Banquet of Dreams glamour it greatly empowers it. You'll get dozens of dreamdross from a single mortal's dreams, but it causes permanent psychological damage (3 negative traits) and damages their dreams so they can never produce more than 0-2 dreamdross again. 

This can also happen if you have `Empty Your Heart of its Mortal Dream` active, at a 20% chance, when your lack of care for mortals means you just decide to rip out as many dreams as you can. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Used various iterations of `Banquet of Dreams` and made sure the appropriate amount of dreamdross was produced. Target NPC gained several negative traits.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
