### PR TITLE
Report version string for mods

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1963,8 +1963,8 @@ std::string game_info::mods_loaded()
     mod_names.reserve( mod_ids.size() );
     std::transform( mod_ids.begin(), mod_ids.end(),
     std::back_inserter( mod_names ), []( const mod_id & mod ) -> std::string {
-        // e.g. "Dark Days Ahead [dda]".
-        return string_format( "%s [%s]", mod->name(), mod->ident.str() );
+        // e.g. "Dark Days Ahead [dda] (95c4e03)".
+        return string_format( "%s [%s] (%s)", mod->name(), mod->ident.str(), mod->version );
     } );
 
     return string_join( mod_names, ",\n    " ); // note: 4 spaces for a slight offset.


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Just a little bit of help for any third-party mods out there that actually try to version properly.

I don't know of any that *do*, but this will make it a little easier for them.

#### Describe the solution
Include mod version string in the game report, present when trimming saves or specifically accessed through the debug menu.

#### Describe alternatives you've considered


#### Testing

```
- OS: Windows
    - OS Version: 10.0.19045.6466 (22H2)
- Game Version: cdda-experimental-2026-06-21-1514-dirty+SDL3 [64-bit]
- Graphics Version: Tiles
- Game Language: English [en]
- Mods loaded: [
    Dark Days Ahead [dda] (),
    Disable NPC Needs [no_npc_food] (),
    Portal Storms Ignore NPCs [personal_portal_storms] (test_version_string)
]
```

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
