### PR TITLE
In roll_melee_damage_internal(), fix an armor penetration bug and an inaccurate comment.

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1362,7 +1362,7 @@ static void roll_melee_damage_internal( const Character &u, const damage_type_id
     } else if( dt == damage_bash ) {
         float melee_bonus = u.get_skill_level( skill_melee );
 
-        /** @EFFECT_UNARMED caps bash damage with unarmed weapons */
+        /** Martial arts can increase bash cap by melee skill. */
         if( u.is_melee_bash_damage_cap_bonus() ) {
             bash_cap += melee_bonus;
         }
@@ -1421,7 +1421,7 @@ static void roll_melee_damage_internal( const Character &u, const damage_type_id
         } else if( dt == damage_bash ) {
             dmg_mul *= 1.f + 0.5f * crit_mod;
             // 50% armor penetration
-            armor_mult = 0.5f * crit_mod;
+            armor_mult = 1.f - 0.5f * crit_mod;
         }
     }
 


### PR DESCRIPTION
#### Summary
None

In roll_melee_damage_internal(), fix (1) crit_mod decreasing armor penetration for bash damage, (2) inaccurate comment for is_melee_bash_damage_cap_bonus.

1. For stab and cut damage, an increase in crit_mod causes a decrease in armor_mult, which causes increased armor penetration. For bash damage, an increase in crit_mod causes an increase in armor_mult, which seems to be a bug.
2. The comment before is_melee_bash_damage_cap_bonus() is irrelevant and seems to be describing an old version of the code. IIUC, is_melee_bash_damage_cap_bonus() is a martial arts buff (only currently enabled by Bojutsu), which causes melee skill to increase the bash damage cap.