### PR TITLE
Fix few issues in crafting

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1009,9 +1009,10 @@ void fire_step_complete_distraction( const std::string &interrupt_msg,
                                      const item_location &loc )
 {
     avatar &u = get_avatar();
-    if( ( u.activity.id() == ACT_CRAFT || u.activity.id() == ACT_CRAFT_WAIT )
-        && !u.activity.targets.empty()
-        && u.activity.targets.back() == loc ) {
+    const bool activity_is_crafting = u.activity.id() == ACT_CRAFT || u.activity.id() == ACT_CRAFT_WAIT;
+    const bool we_already_craft_it = !u.activity.targets.empty() && u.activity.targets.back() == loc;
+
+    if( activity_is_crafting && we_already_craft_it ) {
         return;
     }
     if( !u.has_watch() && !u.has_alarm_clock() ) {
@@ -1686,8 +1687,8 @@ static void craft_actualize_ready( item &craft, time_point now, const item_locat
     }
     if( !wakeups_rebuilt ) {
         get_item_wakeups().rebuild_for_item( loc );
+        fire_step_complete_distraction( completion_msg, flavor_msg, loc );
     }
-    fire_step_complete_distraction( completion_msg, flavor_msg, loc );
 }
 
 void craft_resolve_overdue_passive( item &craft, time_point now, item_location &loc )

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1315,8 +1315,9 @@ void crafting_ui_impl::draw_recipe_info_panel()
                 ImGui::TextColored( cataimgui::imvec4_from_color( c_white ), "%s",
                                     _( "Byproducts:" ) );
                 for( const auto &[bp_id, bp_count] : cached_byproducts ) {
+                    const int bp_c = bp_count * batch_size;
                     ImGui::BulletText( "%s", string_format( "%s x%d",
-                                                            item::nname( bp_id, bp_count ), bp_count ).c_str() );
+                                                            item::nname( bp_id, bp_c ), bp_c ).c_str() );
                 }
             }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Just fixing two issues i spotted while making changes elsewhere
#### Describe the solution
Byproducts of craft didn't increase with batch size, even if they should have - adjust function that prints byproducts accordingly
Having two consecutive unattended crafts properly advanced the crafting step, but always fired a distraction even if it were undersired - move fire_step_complete_distraction() behind wakeups_rebuilt
Also refactor check in fire_step_complete_distraction() to be more readable
#### Testing
Crafting now properly shows the byproducts
<img width="951" height="1282" alt="image" src="https://github.com/user-attachments/assets/65926005-b610-4976-93b2-d0d537ffac86" />

Crafting item with 2 unattended steps properly do not fire message when step 1 is finished, and fires only when last step is finished