### PR TITLE
[Xedra Evolved] Add wraiths random encounter

### DIFF
--- a/data/mods/Xedra_Evolved/encounters/jotunn_encounters.json
+++ b/data/mods/Xedra_Evolved/encounters/jotunn_encounters.json
@@ -11,7 +11,7 @@
         "set_condition": "random_enc_condition",
         "condition": { "and": [ { "current_dimension": "" }, { "not": { "is_season": "winter" } } ] }
       },
-      { "u_message": "Jotunn/Zebra encounter has triggered!", "type": "debug" },
+      { "u_message": "Xedra Evolved Jotunn/Zebra encounter has triggered!", "type": "debug" },
       {
         "set_string_var": "You hear a sustained burst of gunfire somewhere in the distance.",
         "target_var": { "global_val": "XE_RandEnc_Trigger_Message" },

--- a/data/mods/Xedra_Evolved/encounters/march_lord_hunt_encounters.json
+++ b/data/mods/Xedra_Evolved/encounters/march_lord_hunt_encounters.json
@@ -11,7 +11,7 @@
         "set_condition": "random_enc_condition",
         "condition": { "and": [ "is_day", { "current_dimension": "" }, { "is_weather": "fog" } ] }
       },
-      { "u_message": "March Lord hunt encounter has triggered!", "type": "debug" },
+      { "u_message": "Xedra Evolved March Lord hunt encounter has triggered!", "type": "debug" },
       {
         "set_string_var": "You hear a low horn-call somewhere out in the fog.",
         "target_var": { "global_val": "XE_RandEnc_Trigger_Message" },

--- a/data/mods/Xedra_Evolved/encounters/wraiths_encounters.json
+++ b/data/mods/Xedra_Evolved/encounters/wraiths_encounters.json
@@ -1,0 +1,113 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_RandEnc_XE_Wraiths_On_Dark_Nights",
+    "recurrence": 69480,
+    "global": true,
+    "run_for_npcs": false,
+    "condition": { "math": [ "XE_RandEnc == 0" ] },
+    "effect": [
+      {
+        "set_condition": "random_enc_condition",
+        "condition": {
+          "and": [
+            { "not": "is_day" },
+            {
+              "or": [ { "math": [ "moon_phase() == 0" ] }, { "math": [ "moon_phase() == 1" ] }, { "math": [ "moon_phase() == 7" ] } ]
+            },
+            { "not": { "is_weather": "weather_light_drizzle" } },
+            { "not": { "is_weather": "weather_drizzle" } },
+            { "not": { "is_weather": "weather_rain" } },
+            { "not": { "is_weather": "weather_rainstorm" } },
+            { "not": { "is_weather": "weather_thunder" } },
+            { "not": { "is_weather": "weather_lightning" } },
+            { "not": { "is_weather": "magic_weather_light_drizzle" } },
+            { "not": { "is_weather": "magic_weather_drizzle" } },
+            { "not": { "is_weather": "magic_weather_rain" } },
+            { "not": { "is_weather": "magic_weather_rainstorm" } },
+            { "not": { "is_weather": "magic_weather_thunder" } },
+            { "not": { "is_weather": "magic_weather_lightning" } }
+          ]
+        }
+      },
+      { "u_message": "Xedra Evolved wraiths encounter has triggered!", "type": "debug" },
+      {
+        "set_string_var": "A shadow seems to pass over the waning moon.",
+        "target_var": { "global_val": "XE_RandEnc_Trigger_Message" },
+        "i18n": true
+      },
+      {
+        "set_condition": "XE_random_enc_trigger_message_condition",
+        "condition": {
+          "and": [
+            "u_is_outside",
+            { "or": [ { "math": [ "moon_phase() == 1" ] }, { "math": [ "moon_phase() == 7" ] } ] },
+            { "or": [ { "is_weather": "sunny" }, { "is_weather": "clear" } ] }
+          ]
+        }
+      },
+      {
+        "switch": { "math": [ "rand(2)" ] },
+        "cases": [
+          {
+            "case": 0,
+            "effect": [
+              {
+                "run_eocs": "EOC_XE_RandEnc",
+                "variables": {
+                  "omt": "field",
+                  "map_update": "nest_RandEnc_XE_Wraiths_On_Dark_Nights",
+                  "map_removal": "nest_RandEnc_XE_Wraiths_On_Dark_Nights_remove",
+                  "chance": 15,
+                  "days_till_spawn": 0
+                }
+              }
+            ]
+          },
+          {
+            "case": 1,
+            "effect": [
+              {
+                "run_eocs": "EOC_XE_RandEnc",
+                "variables": {
+                  "omt": "forest",
+                  "map_update": "nest_RandEnc_XE_Wraiths_On_Dark_Nights",
+                  "map_removal": "nest_RandEnc_XE_Wraiths_On_Dark_Nights_remove",
+                  "chance": 20,
+                  "days_till_spawn": 0
+                }
+              }
+            ]
+          },
+          {
+            "case": 2,
+            "effect": [
+              {
+                "run_eocs": "EOC_XE_RandEnc",
+                "variables": {
+                  "omt": "forest_water",
+                  "map_update": "nest_RandEnc_XE_Wraiths_On_Dark_Nights",
+                  "map_removal": "nest_RandEnc_XE_Wraiths_On_Dark_Nights_remove",
+                  "chance": 20,
+                  "days_till_spawn": 0
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "nest_RandEnc_XE_Wraiths_On_Dark_Nights",
+    "//": "Adds a random encounter at this field",
+    "object": { "place_monster": [ { "monster": "mon_darkman", "x": [ 6, 14 ], "y": [ 6, 14 ], "repeat": [ 2, 3 ] } ] }
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "nest_RandEnc_XE_Wraiths_On_Dark_Nights_remove",
+    "//": "removes a random encounter at the field",
+    "object": { "set": [ { "square": "creature_remove", "x": 0, "y": 0, "x2": 23, "y2": 23 } ] }
+  }
+]

--- a/data/mods/Xedra_Evolved/encounters/wraiths_encounters.json
+++ b/data/mods/Xedra_Evolved/encounters/wraiths_encounters.json
@@ -32,7 +32,7 @@
       },
       { "u_message": "Xedra Evolved wraiths encounter has triggered!", "type": "debug" },
       {
-        "set_string_var": "A shadow seems to pass over the waning moon.",
+        "set_string_var": "A shadow seems to pass over the remnants of the moon.",
         "target_var": { "global_val": "XE_RandEnc_Trigger_Message" },
         "i18n": true
       },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Add wraiths random encounter"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

There's more than one `a shadow?` out there.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a Xedra Evolved random encounter with 3 wraiths. Prepare to die.

...that said, this happens rarely. The check is once every ~18 hours, and it only happens at night, during a crescent or new moon, when there's no precipitation. If there is a moon and it's clear and you're outside, you get the message

> A shadow seems to pass over the remnants of the moon

And of course, there's no guarantee you'll actually stumble on them--they're out there in 30 OMT radius, somewhere.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Triggered the encounter, wraiths spawned. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I think it's generally better to have a lot of encounters that all happen pretty rarely--DDA is meant to be replayed, you don't want the same ones to keep popping up.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
