### PR TITLE
Fix random zeds/ferals having no loot

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4938,7 +4938,6 @@ bool game::revive_corpse( const tripoint_bub_ms &p, item &it, int radius )
         return false;
     }
 
-    critter.death_drops = false;
     critter.add_effect( effect_downed, 5_turns, true );
 
     if( it.get_var( "no_ammo" ) == "no_ammo" ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2627,7 +2627,11 @@ void monster::load( const JsonObject &data )
     }
     data.read( "mission_fused", mission_fused );
     // for migration, remove in 0.K
-    data.read( "no_extra_death_drops", death_drops );
+    if( data.has_object( "no_extra_death_drops" ) ) {
+        bool no_extra_death_drops;
+        data.read( "no_extra_death_drops", no_extra_death_drops );
+        death_drops = !no_extra_death_drops;
+    }
     data.read( "death_drops", death_drops );
     data.read( "spawn_corpse", spawn_corpse );
     data.read( "death_message", death_message );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #87802
#### Describe the solution
The root of the issue is that for some mysterious reasons revive_corpse() function previously set no_extra_death_drops to true; similarly mysteriously it didn't affect the game before, but when replaced with death_drops, it started to remove loot from revived bodies. Removing death drop modification at revival seems to fix the issue
separately, instead of reading `no_extra_death_drops` as is, read it if it's present, and then invert, since it's default value is opposite to new `death_drops`
#### Testing
Dormant and revived zombies now drop loot properly
Cannot test feral issue, tho, for i cannot reproduce it