### PR TITLE
Update broth recipes and various soups

### DIFF
--- a/data/json/items/comestibles/soup.json
+++ b/data/json/items/comestibles/soup.json
@@ -15,12 +15,13 @@
     "calories": 16,
     "description": "Vegetable stock.  Tasty and fairly nutritious.",
     "price": "3 USD 50 cent",
-    "price_postapoc": "25 cent",
+    "price_postapoc": "12 cent",
     "material": [ "veggy" ],
-    "volume": "500 ml",
-    "charges": 2,
+    "volume": "250 ml",
+    "charges": 1,
     "phase": "liquid",
     "flags": [ "EATEN_HOT" ],
+    "display_type": "BY_VOLUME",
     "fun": 1,
     "vitamins": [ [ "veggy_allergen", 1 ] ]
   },
@@ -44,12 +45,13 @@
     "calories": 17,
     "description": "Meat stock.  Tasty and fairly nutritious.",
     "price": "3 USD 50 cent",
-    "price_postapoc": "25 cent",
+    "price_postapoc": "12 cent",
     "material": [ "flesh" ],
-    "volume": "500 ml",
-    "charges": 2,
+    "volume": "250 ml",
+    "charges": 1,
     "phase": "liquid",
     "flags": [ "EATEN_HOT" ],
+    "display_type": "BY_VOLUME",
     "fun": 1,
     "vitamins": [ [ "vitC", "1 mg" ], [ "iron", "1 mg" ], [ "calcium", "19 mg" ], [ "meat_allergen", 1 ] ]
   },
@@ -71,14 +73,15 @@
     "symbol": "~",
     "quench": 30,
     "calories": 41,
-    "description": "A tasty and nutritious broth made from bones, with added vinegar to extract more calcium.",
+    "description": "A tasty and nutritious broth made from bones.",
     "price": "3 USD 50 cent",
-    "price_postapoc": "25 cent",
+    "price_postapoc": "12 cent",
     "material": [ { "type": "water", "portion": 10 }, { "type": "bone", "portion": 1 } ],
-    "volume": "500 ml",
-    "charges": 2,
+    "volume": "250 ml",
+    "charges": 1,
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE" ],
+    "display_type": "BY_VOLUME",
     "fun": 10,
     "vitamins": [ [ "calcium", 7 ], [ "iron", "200 μg" ], [ "meat_allergen", 1 ] ]
   },
@@ -104,6 +107,7 @@
     "charges": 2,
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
+    "display_type": "BY_VOLUME",
     "vitamins": [ [ "vitC", 4 ], [ "calcium", 1 ], [ "iron", 5 ], [ "veggy_allergen", 1 ] ],
     "fun": 1
   },
@@ -129,6 +133,7 @@
     "charges": 1,
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
+    "display_type": "BY_VOLUME",
     "vitamins": [ [ "vitC", 4 ], [ "calcium", 1 ], [ "iron", 5 ], [ "veggy_allergen", 1 ] ],
     "fun": 2
   },
@@ -159,6 +164,7 @@
     "charges": 2,
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
+    "display_type": "BY_VOLUME",
     "vitamins": [ [ "vitC", 36 ], [ "calcium", 3 ], [ "iron", 13 ], [ "meat_allergen", 1 ] ],
     "fun": 1
   },
@@ -184,6 +190,7 @@
     "charges": 2,
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
+    "display_type": "BY_VOLUME",
     "vitamins": [ [ "vitC", 28 ], [ "calcium", 4 ], [ "iron", 5 ], [ "meat_allergen", 1 ] ],
     "fun": 1
   },
@@ -261,6 +268,7 @@
     "charges": 2,
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
+    "display_type": "BY_VOLUME",
     "vitamins": [ [ "vitC", 9 ], [ "iron", 3 ], [ "meat_allergen", 1 ], [ "veggy_allergen", 1 ] ],
     "fun": 1
   },
@@ -287,6 +295,7 @@
     "charges": 2,
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
+    "display_type": "BY_VOLUME",
     "vitamins": [ [ "vitC", 9 ], [ "iron", 3 ], [ "veggy_allergen", 1 ], [ "egg_allergen", 1 ] ],
     "fun": 1
   },
@@ -336,6 +345,7 @@
     "charges": 2,
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
+    "display_type": "BY_VOLUME",
     "vitamins": [ [ "calcium", 1 ], [ "iron", 9 ], [ "meat_allergen", 1 ], [ "wheat_allergen", 1 ] ],
     "fun": 2
   },
@@ -361,6 +371,7 @@
     "phase": "liquid",
     "charges": 2,
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
+    "display_type": "BY_VOLUME",
     "fun": 1,
     "vitamins": [ [ "calcium", 2 ], [ "iron", 2 ], [ "veggy_allergen", 1 ] ]
   },
@@ -386,6 +397,7 @@
     "phase": "liquid",
     "charges": 2,
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
+    "display_type": "BY_VOLUME",
     "fun": 1,
     "vitamins": [ [ "meat_allergen", 1 ], [ "wheat_allergen", 1 ] ]
   },
@@ -412,6 +424,7 @@
     "charges": 1,
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
+    "display_type": "BY_VOLUME",
     "vitamins": [ [ "vitC", "31200 μg" ], [ "iron", "1400 μg" ], [ "calcium", "31500 μg" ], [ "veggy_allergen", 1 ] ],
     "fun": 2
   },
@@ -437,6 +450,7 @@
     "charges": 2,
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
+    "display_type": "BY_VOLUME",
     "vitamins": [ [ "vitC", 7 ], [ "calcium", 9 ], [ "iron", 13 ], [ "meat_allergen", 1 ], [ "wheat_allergen", 1 ] ],
     "fun": 3
   },
@@ -462,6 +476,7 @@
     "charges": 2,
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
+    "display_type": "BY_VOLUME",
     "vitamins": [ [ "vitC", 8 ], [ "calcium", 7 ], [ "iron", 7 ], [ "meat_allergen", 1 ], [ "milk_allergen", 1 ] ],
     "fun": 3
   },
@@ -487,6 +502,7 @@
     "charges": 2,
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
+    "display_type": "BY_VOLUME",
     "vitamins": [ [ "vitC", 8 ], [ "calcium", 7 ], [ "iron", 7 ], [ "meat_allergen", 1 ], [ "milk_allergen", 1 ] ],
     "fun": 10
   },
@@ -512,6 +528,7 @@
     "charges": 1,
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
+    "display_type": "BY_VOLUME",
     "vitamins": [ [ "iron", 2 ], [ "meat_allergen", 1 ], [ "wheat_allergen", 1 ] ],
     "fun": 1
   },
@@ -560,6 +577,7 @@
     "charges": 1,
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
+    "display_type": "BY_VOLUME",
     "vitamins": [ [ "iron", 2 ], [ "veggy_allergen", 1 ], [ "wheat_allergen", 1 ] ],
     "fun": 1
   },

--- a/data/json/recipes/food/canned.json
+++ b/data/json/recipes/food/canned.json
@@ -416,7 +416,7 @@
     "//": "this was using 20 bones (2.3kg), so it was lowered.  Bone broth uses 1:2-1:4 bone:water per weight.",
     "using": [ [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
-    "components": [ [ [ "jar_glass_sealed", 1 ] ], [ [ "water_clean", 2 ] ], [ [ "bone_edible", 2, "LIST" ] ], [ [ "vinegar", 2 ] ] ]
+    "components": [ [ [ "jar_glass_sealed", 1 ] ], [ [ "water_clean", 2 ] ], [ [ "bone_edible", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -743,12 +743,7 @@
     "//": "this was using 120 bones (13.8kg), so it was lowered.  Bone broth uses 1:2-1:4 bone:water per weight.",
     "using": [ [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
-    "components": [
-      [ [ "jar_3l_glass_sealed", 1 ] ],
-      [ [ "water_clean", 12 ] ],
-      [ [ "bone_edible", 12, "LIST" ] ],
-      [ [ "vinegar", 12 ] ]
-    ]
+    "components": [ [ [ "jar_3l_glass_sealed", 1 ] ], [ [ "water_clean", 12 ] ], [ [ "bone_edible", 12, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -2821,7 +2816,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
-    "components": [ [ [ "bone_edible", 2, "LIST" ] ], [ [ "water_clean", 3 ] ], [ [ "vinegar", 2 ] ] ],
+    "components": [ [ [ "bone_edible", 2, "LIST" ] ], [ [ "water_clean", 3 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ]
   },
@@ -2842,7 +2837,7 @@
     "container": "can_food",
     "charges": 1,
     "batch_time_factors": [ 83, 5 ],
-    "components": [ [ [ "bone_edible", 2, "LIST" ] ], [ [ "water_clean", 2 ] ], [ [ "vinegar", 2 ] ] ],
+    "components": [ [ [ "bone_edible", 2, "LIST" ] ], [ [ "water_clean", 2 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
     "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ]
   },
@@ -2863,7 +2858,7 @@
     "container": "can_food_big",
     "charges": 12,
     "batch_time_factors": [ 83, 5 ],
-    "components": [ [ [ "bone_edible", 12, "LIST" ] ], [ [ "water_clean", 16 ] ], [ [ "vinegar", 12 ] ] ],
+    "components": [ [ [ "bone_edible", 12, "LIST" ] ], [ [ "water_clean", 16 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ]
   },

--- a/data/json/recipes/food/soup.json
+++ b/data/json/recipes/food/soup.json
@@ -56,45 +56,80 @@
   },
   {
     "type": "recipe",
-    "activity_level": "NO_EXERCISE",
     "result": "broth",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_VEGGI",
     "skill_used": "cooking",
     "difficulty": 2,
-    "time": "20 m",
-    "charges": 1,
+    "charges": 2,
     "autolearn": true,
-    "batch_time_factors": [ 80, 4 ],
-    "qualities": [ { "id": "COOK", "level": 3 } ],
-    "proficiencies": [ { "proficiency": "prof_food_prep" } ],
-    "tools": [ [ [ "water_boiling_heat", 3, "LIST" ] ] ],
+    "steps": [
+      {
+        "name": "Boiling",
+        "time": "5 m",
+        "//": "Copied from water boiling recipe step.",
+        "activity_level": "NO_EXERCISE",
+        "qualities": [ { "id": "BOIL", "level": 1 } ],
+        "//2": "2u for 2 units of water to boil",
+        "tools": [ [ [ "water_boiling_heat", 2, "LIST" ] ] ],
+        "batch_time_factors": [ 20, 1 ],
+        "attention": "unattended"
+      },
+      {
+        "name": "Cooking",
+        "time": "30 m",
+        "batch_time_factors": { "mode": "linear", "setup": "30 m" },
+        "activity_level": "NO_EXERCISE",
+        "//": "4u for 30 min of boiling of 2 units of water, but since it is simmering, not boiling, half as much, so 2u.",
+        "tools": [ [ [ "water_boiling_heat", 2, "LIST" ] ] ],
+        "qualities": [ { "id": "COOK", "level": 3 } ],
+        "proficiencies": [ { "proficiency": "prof_food_prep" } ],
+        "attention": "unattended",
+        "max_time": "90 m"
+      }
+    ],
     "using": [ [ "broth_ingredients", 1 ] ],
-    "//": "power usage here is 1u for the base water boiling and 2u between the ingredients and the boil time",
-    "components": [ [ [ "water", 1 ], [ "water_clean", 1 ] ] ]
+    "components": [ [ [ "water", 2 ], [ "water_clean", 2 ] ] ]
   },
   {
     "type": "recipe",
-    "activity_level": "NO_EXERCISE",
     "result": "broth_meat",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
     "difficulty": 2,
-    "time": "20 m",
-    "charges": 1,
+    "charges": 2,
     "autolearn": true,
-    "batch_time_factors": [ 80, 4 ],
-    "qualities": [ { "id": "COOK", "level": 3 } ],
-    "proficiencies": [ { "proficiency": "prof_food_prep" } ],
-    "tools": [ [ [ "water_boiling_heat", 3, "LIST" ] ] ],
+    "steps": [
+      {
+        "name": "Boiling",
+        "time": "5 m",
+        "//": "Copied from water boiling recipe step.",
+        "activity_level": "NO_EXERCISE",
+        "qualities": [ { "id": "BOIL", "level": 1 } ],
+        "//2": "2u for 2 units of water to boil",
+        "tools": [ [ [ "water_boiling_heat", 2, "LIST" ] ] ],
+        "batch_time_factors": [ 20, 1 ],
+        "attention": "unattended"
+      },
+      {
+        "name": "Cooking",
+        "time": "1 h",
+        "batch_time_factors": { "mode": "linear", "setup": "1 h" },
+        "activity_level": "NO_EXERCISE",
+        "//": "8u for 1 hour of boiling of 2 units of water, but since it is simmering, not boiling, half as much, so 4u.",
+        "tools": [ [ [ "water_boiling_heat", 4, "LIST" ] ] ],
+        "qualities": [ { "id": "COOK", "level": 3 } ],
+        "proficiencies": [ { "proficiency": "prof_food_prep" } ],
+        "attention": "unattended",
+        "max_time": "4 h"
+      }
+    ],
     "using": [ [ "broth_meat_ingredients", 1 ] ],
-    "//": "power usage here is 1u for the base water boiling and 2u between the ingredients and the boil time",
-    "components": [ [ [ "water", 1 ], [ "water_clean", 1 ] ] ]
+    "components": [ [ [ "water", 2 ], [ "water_clean", 2 ] ] ]
   },
   {
     "type": "recipe",
-    "activity_level": "NO_EXERCISE",
     "result": "broth_bone",
     "byproducts": [ [ "gelatin_fresh", 2 ] ],
     "charges": 2,
@@ -102,14 +137,34 @@
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
     "difficulty": 1,
-    "time": "1 h",
     "autolearn": true,
-    "batch_time_factors": [ 95, 2 ],
-    "qualities": [ { "id": "COOK", "level": 3 } ],
-    "proficiencies": [ { "proficiency": "prof_food_prep" } ],
-    "tools": [ [ [ "water_boiling_heat", 11, "LIST" ] ] ],
-    "//": "this was using 10 bones (2.3kg), so it was lowered.  Bone broth uses minimum 1:2-1:4 bone:water per weight.  2u for the water + 10u for the 60min boiling + 1u for the bone.",
-    "components": [ [ [ "bone_edible", 2, "LIST" ] ], [ [ "water", 2 ], [ "water_clean", 2 ] ], [ [ "vinegar", 2 ] ] ]
+    "//": "Bone broth uses minimum 1:2-1:4 bone:water per weight.",
+    "steps": [
+      {
+        "name": "Boiling",
+        "time": "5 m",
+        "//": "Copied from water boiling recipe step.",
+        "activity_level": "NO_EXERCISE",
+        "qualities": [ { "id": "BOIL", "level": 1 } ],
+        "//2": "2u for 2 units of water to boil",
+        "tools": [ [ [ "water_boiling_heat", 2, "LIST" ] ] ],
+        "batch_time_factors": [ 20, 1 ],
+        "attention": "unattended"
+      },
+      {
+        "name": "Cooking",
+        "time": "4 h",
+        "batch_time_factors": { "mode": "linear", "setup": "4 h" },
+        "activity_level": "NO_EXERCISE",
+        "//": "32u for 4 of boiling of 2 units of water, but since it is simmering, not boiling, half as much, so 16u.",
+        "tools": [ [ [ "water_boiling_heat", 16, "LIST" ] ] ],
+        "qualities": [ { "id": "COOK", "level": 3 } ],
+        "proficiencies": [ { "proficiency": "prof_food_prep" } ],
+        "attention": "unattended",
+        "max_time": "16 h"
+      }
+    ],
+    "components": [ [ [ "bone_edible", 1, "LIST" ] ], [ [ "water", 2 ], [ "water_clean", 2 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Unattended recipe power
Also wanted to update the recipes for a while
#### Describe the solution
- Remove the use of vinegar from bone broth recipe, there is no evidence it meaningfully helps with extraction of anything from bones, and i never myself used any vinegar in making stock, yet had quite good stock nontheless
- Update broth item stats a bit, mainly setting charges to 1, for ease of work
- Add display_type to all soups
- Modify the recipe for all broth to be in line with how they are actually cooked - bone broth is cooked for 4 hours, meat broth cooks for 1 hour, and vegetable broth cooks for 30 minutes. Recipes for canning were left untouched
#### Testing

<img width="1282" height="1374" alt="image" src="https://github.com/user-attachments/assets/579876fb-7737-4424-bdd1-e0db6f6fe368" />

<img width="1287" height="1380" alt="image" src="https://github.com/user-attachments/assets/9cd39245-2969-4792-8513-ee420e743bfa" />

<img width="1282" height="1377" alt="image" src="https://github.com/user-attachments/assets/b0dcc377-983c-4c0a-9526-d4226c47b81d" />
