### PR TITLE
[XedraWood] Add giant serpents, add map extra giant serpent nest

### DIFF
--- a/data/mods/XedraWood/mapgen/map_extras/map_extras.json
+++ b/data/mods/XedraWood/mapgen/map_extras/map_extras.json
@@ -64,5 +64,17 @@
     "color": "green",
     "autonote_visibility": "none",
     "flags": [ "WILDERNESS" ]
+  },
+  {
+    "id": "mx_giant_snake_nest",
+    "type": "map_extra",
+    "name": { "str": "Giant snakes" },
+    "description": "This is the lair of a giant serpent.",
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_giant_snake_nest" },
+    "min_max_zlevel": [ -2, 0 ],
+    "sym": "s",
+    "color": "green",
+    "autonote_visibility": "none",
+    "flags": [ "WILDERNESS" ]
   }
 ]

--- a/data/mods/XedraWood/mapgen/map_extras/map_extras.json
+++ b/data/mods/XedraWood/mapgen/map_extras/map_extras.json
@@ -71,10 +71,10 @@
     "name": { "str": "Giant snakes" },
     "description": "This is the lair of a giant serpent.",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_giant_snake_nest" },
-    "min_max_zlevel": [ -2, 0 ],
+    "min_max_zlevel": [ 0, 0 ],
     "sym": "s",
     "color": "green",
-    "autonote_visibility": "none",
+    "autonote_visibility": "details",
     "flags": [ "WILDERNESS" ]
   }
 ]

--- a/data/mods/XedraWood/mapgen/map_extras/mx_giant_snake_nest.json
+++ b/data/mods/XedraWood/mapgen/map_extras/mx_giant_snake_nest.json
@@ -1,0 +1,41 @@
+[
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "mx_nest_claw_hunter",
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "            --          ",
+        "           ,,           ",
+        "           ,,           ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": { ".": [ "t_region_groundcover_swamp" ], ",": [ "t_pit_shallow" ], "-": [ "t_trunk" ] },
+      "place_corpses": [ { "group": "GROUP_SWAMP", "x": [ 9 ], "y": [ 10 ], "repeat": [ 1, 3 ] } ],
+      "place_monster": [
+        { "monster": "mon_rattlesnake_mega", "x": 9, "y": 11, "spawn_data": { "patrol": [ { "x": 4, "y": 11 } ] } },
+        { "monster": "mon_rattlesnake_big_s", "x": [ 6, 15 ], "y": [ 6, 15 ], "repeat": [ 2, 10 ], "chance": 50 }
+      ]
+    }
+  }
+]

--- a/data/mods/XedraWood/mapgen/map_extras/mx_giant_snake_nest.json
+++ b/data/mods/XedraWood/mapgen/map_extras/mx_giant_snake_nest.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "mapgen",
-    "update_mapgen_id": "mx_nest_claw_hunter",
+    "update_mapgen_id": "mx_giant_snake_nest",
     "object": {
       "rows": [
         "                        ",
@@ -10,12 +10,12 @@
         "                        ",
         "                        ",
         "                        ",
-        "                        ",
+        "             _          ",
         "                        ",
         "            --          ",
+        "       _   ,,           ",
         "           ,,           ",
-        "           ,,           ",
-        "                        ",
+        "         _    _         ",
         "                        ",
         "                        ",
         "                        ",
@@ -30,10 +30,13 @@
         "                        "
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "terrain": { ".": [ "t_region_groundcover_swamp" ], ",": [ "t_pit_shallow" ], "-": [ "t_trunk" ] },
+      "terrain": { ".": "t_region_groundcover_swamp", "_": "t_region_groundcover_swamp", ",": "t_pit_shallow", "-": "t_trunk" },
       "place_corpses": [ { "group": "GROUP_SWAMP", "x": [ 9 ], "y": [ 10 ], "repeat": [ 1, 3 ] } ],
+      "items": {
+        "_": [ { "item": "corpses", "chance": 10, "repeat": 1 }, { "item": "default_innawood_zombie_clothes", "chance": 20 } ]
+      },
       "place_monster": [
-        { "monster": "mon_rattlesnake_mega", "x": 9, "y": 11, "spawn_data": { "patrol": [ { "x": 4, "y": 11 } ] } },
+        { "monster": "mon_rattlesnake_mega", "x": 9, "y": 11, "spawn_data": { "patrol": [ { "x": 9, "y": 9 } ] } },
         { "monster": "mon_rattlesnake_big_s", "x": [ 6, 15 ], "y": [ 6, 15 ], "repeat": [ 2, 10 ], "chance": 50 }
       ]
     }

--- a/data/mods/XedraWood/monstergroups/default_additions.json
+++ b/data/mods/XedraWood/monstergroups/default_additions.json
@@ -94,6 +94,8 @@
         "starts": "360 days",
         "conditions": [ "WINTER" ]
       },
+      { "monster": "mon_rattlesnake_big", "weight": 15 },
+      { "monster": "mon_rattlesnake_giant", "weight": 7, "cost_multiplier": 2 },
       { "monster": "mon_claw_runner", "weight": 9, "cost_multiplier": 4 },
       { "monster": "mon_claw_runner", "weight": 3, "cost_multiplier": 4, "pack_size": [ 2, 5 ] },
       { "monster": "mon_claw_hunter", "weight": 3, "cost_multiplier": 30 },
@@ -120,6 +122,8 @@
         "starts": "360 days",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
+      { "monster": "mon_rattlesnake_big", "weight": 30 },
+      { "monster": "mon_rattlesnake_giant", "weight": 25, "cost_multiplier": 2 },
       { "monster": "mon_claw_runner", "weight": 15, "cost_multiplier": 4 },
       { "monster": "mon_claw_runner", "weight": 5, "cost_multiplier": 4, "pack_size": [ 2, 5 ] },
       { "monster": "mon_claw_hunter", "weight": 6, "cost_multiplier": 30 },

--- a/data/mods/XedraWood/monsters/factions.json
+++ b/data/mods/XedraWood/monsters/factions.json
@@ -79,6 +79,14 @@
   },
   {
     "type": "MONSTER_FACTION",
+    "name": "snakes",
+    "base_faction": "animal",
+    "neutral": [ "snakes" ],
+    "by_mood": [ "animal", "zombie_aquatic" ],
+    "hate": [ "herbivore" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
     "name": "utahraptor",
     "base_faction": "predator_dino",
     "friendly": [ "utahraptor_juvenile", "utahraptor_hatchling" ]

--- a/data/mods/XedraWood/monsters/reptiles.json
+++ b/data/mods/XedraWood/monsters/reptiles.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "mon_rattlesnake_mega",
+    "type": "MONSTER",
+    "copy-from": "mon_rattlesnake_mega",
+    "name": { "str": "deathrattle elder serpent" },
+    "description": "An enormous serpent of the deep swamps, bigger around than a man and at least four times as long.  Vicious fangs dripping with venom gleam in its mouth and its eyes are alive with malign intent.  Its rattle is large enough to be worked into a mace.  This one definitely hunts humans.",
+    "harvest": "animal_large_noskin",
+    "regenerates": 0,
+    "reproduction": { "baby_type": { "baby_monster": "mon_rattlesnake_big_s" }, "baby_count": 20, "baby_timer": 90 }
+  },
+  {
+    "id": "mon_rattlesnake_big_s",
+    "type": "MONSTER",
+    "copy-from": "mon_rattlesnake_big_s",
+    "name": { "str_sp": "deathrattle snakelet" },
+    "description": "A baby deathrattle, not dangerous now but with time it will eventually become a monster.  It will eventually grow a rattle and learn how to hunt.",
+    "harvest": "mammal_tiny",
+    "regenerates": 0,
+    "upgrades": { "age_grow": 260, "into": "mon_rattlesnake_big" }
+  },
+  {
+    "id": "mon_rattlesnake_big",
+    "type": "MONSTER",
+    "copy-from": "mon_rattlesnake_big",
+    "name": { "str": "deathrattle youth" },
+    "description": "A young deathrattle serpent, having learned to hunt and seeking prey.  It won't hunt humans yet, but it's only a matter of time.",
+    "harvest": "animal_large_noskin",
+    "regenerates": 0,
+    "upgrades": { "age_grow": 260, "into": "mon_rattlesnake_giant" }
+  },
+  {
+    "id": "mon_rattlesnake_giant",
+    "type": "MONSTER",
+    "copy-from": "mon_rattlesnake_giant",
+    "name": { "str": "deathrattle serpent" },
+    "description": "A large deathrattle serpent, about the same size and weight as a human.  They only rarely hunt humans, but will attack opportunistically or if threatened.",
+    "harvest": "animal_large_noskin",
+    "regenerates": 0,
+    "anger_triggers": [ "HURT", "PLAYER_CLOSE", "PLAYER_WEAK" ],
+    "placate_triggers": [  ],
+    "upgrades": false
+  }
+]

--- a/data/mods/XedraWood/monsters/reptiles.json
+++ b/data/mods/XedraWood/monsters/reptiles.json
@@ -5,6 +5,7 @@
     "copy-from": "mon_rattlesnake_mega",
     "name": { "str": "deathrattle elder serpent" },
     "description": "An enormous serpent of the deep swamps, bigger around than a man and at least four times as long.  Vicious fangs dripping with venom gleam in its mouth and its eyes are alive with malign intent.  Its rattle is large enough to be worked into a mace.  This one definitely hunts humans.",
+    "default_faction": "snakes",
     "harvest": "animal_large_noskin",
     "regenerates": 0,
     "reproduction": { "baby_type": { "baby_monster": "mon_rattlesnake_big_s" }, "baby_count": 20, "baby_timer": 90 }
@@ -15,6 +16,7 @@
     "copy-from": "mon_rattlesnake_big_s",
     "name": { "str_sp": "deathrattle snakelet" },
     "description": "A baby deathrattle, not dangerous now but with time it will eventually become a monster.  It will eventually grow a rattle and learn how to hunt.",
+    "default_faction": "snakes",
     "harvest": "mammal_tiny",
     "regenerates": 0,
     "upgrades": { "age_grow": 260, "into": "mon_rattlesnake_big" }
@@ -25,6 +27,7 @@
     "copy-from": "mon_rattlesnake_big",
     "name": { "str": "deathrattle youth" },
     "description": "A young deathrattle serpent, having learned to hunt and seeking prey.  It won't hunt humans yet, but it's only a matter of time.",
+    "default_faction": "snakes",
     "harvest": "animal_large_noskin",
     "regenerates": 0,
     "upgrades": { "age_grow": 260, "into": "mon_rattlesnake_giant" }
@@ -35,6 +38,7 @@
     "copy-from": "mon_rattlesnake_giant",
     "name": { "str": "deathrattle serpent" },
     "description": "A large deathrattle serpent, about the same size and weight as a human.  They only rarely hunt humans, but will attack opportunistically or if threatened.",
+    "default_faction": "snakes",
     "harvest": "animal_large_noskin",
     "regenerates": 0,
     "anger_triggers": [ "HURT", "PLAYER_CLOSE", "PLAYER_WEAK" ],

--- a/data/mods/XedraWood/regional_overlay.json
+++ b/data/mods/XedraWood/regional_overlay.json
@@ -48,7 +48,7 @@
     "type": "map_extra_collection",
     "id": "forest_water",
     "copy-from": "forest_water",
-    "extend": { "extras": [ [ "mx_nest_claw_hunter", 1 ], [ "mx_nest_claw_runner", 4 ] ] }
+    "extend": { "extras": [ [ "mx_giant_snake_nest", 1 ], [ "mx_nest_claw_hunter", 1 ], [ "mx_nest_claw_runner", 4 ] ] }
   },
   {
     "type": "map_extra_collection",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[XedraWood] Add giant serpents, add map extra giant serpent nest"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It's not sword and sorcery without giant snakes

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add giant snakes to the swamps (and rarely the forest). The largest snakes, those big enough to swallow a human, only spawn near their lairs, but other snakes can be found here and there through the swamps. Remnants of their meals occasionally spawn in snake lairs. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned a lair, it looked proper.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
