### PR TITLE
[Xedra Evolved] Add `The Withering`, another Nether Sorcery spell

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects_nether_sorcery.json
+++ b/data/mods/Xedra_Evolved/effects/effects_nether_sorcery.json
@@ -26,5 +26,14 @@
     "remove_message": "You can move again.",
     "show_in_info": true,
     "flags": [ "CANNOT_MOVE" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_xe_nether_sorcery_cause_withering_damage",
+    "name": [ "The Withering" ],
+    "desc": [ "You are slowed." ],
+    "remove_message": "Your strength returns.",
+    "show_in_info": true,
+    "base_mods": { "hit_mod": [ -2 ], "dodge_mod": [ -2 ], "speed_mod": [ -30 ] }
   }
 ]

--- a/data/mods/Xedra_Evolved/itemgroups/itemgroups.json
+++ b/data/mods/Xedra_Evolved/itemgroups/itemgroups.json
@@ -557,7 +557,7 @@
     "type": "item_group",
     "copy-from": "mansion_books",
     "subtype": "distribution",
-    "extend": { "entries": [ { "group": "hedge_magic_books", "prob": 5 }, { "group": "nether_sorcery_books", "prob": 3 } ] }
+    "extend": { "entries": [ { "group": "hedge_magic_books", "prob": 5 }, { "group": "nether_sorcery_books", "prob": 2 } ] }
   },
   {
     "id": "hedge_magic_books",
@@ -582,7 +582,8 @@
     "subtype": "distribution",
     "entries": [
       { "item": "nether_sorcery_grimoire_xe_nether_sorcery_cold_damage_over_time", "prob": 1 },
-      { "item": "nether_sorcery_grimoire_xe_nether_sorcery_summon_kreck_pack", "prob": 1 }
+      { "item": "nether_sorcery_grimoire_xe_nether_sorcery_summon_kreck_pack", "prob": 1 },
+      { "item": "nether_sorcery_grimoire_xe_nether_sorcery_cause_withering_damage", "prob": 1 }
     ]
   },
   {

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_nether_sorcery.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_nether_sorcery.json
@@ -26,5 +26,19 @@
     "symbol": "?",
     "color": "blue",
     "use_action": { "type": "learn_spell", "spells": [ "xe_nether_sorcery_summon_kreck_pack" ] }
+  },
+  {
+    "id": "nether_sorcery_grimoire_xe_nether_sorcery_cause_withering_damage",
+    "type": "ITEM",
+    "name": { "str": "Grimoire: The Withering", "str_pl": "Grimoires: The Withering" },
+    "description": "A hefty-looking tome, with an unadorned cover of dark leather.  The interior is filled with complicated instructions and some sort of formulae.",
+    "weight": "1200 g",
+    "volume": "2500 ml",
+    "price": "30 USD",
+    "material": [ "paper" ],
+    "looks_like": "cookbook",
+    "symbol": "?",
+    "color": "blue",
+    "use_action": { "type": "learn_spell", "spells": [ "xe_nether_sorcery_cause_withering_damage" ] }
   }
 ]

--- a/data/mods/Xedra_Evolved/spells/nether_sorcery.json
+++ b/data/mods/Xedra_Evolved/spells/nether_sorcery.json
@@ -41,6 +41,7 @@
     "type": "SPELL",
     "name": "Bound in Ebon Bands",
     "description": "Bind a single target in bands of shadow, holding them in place and causing cold damage over time.",
+    "message": "You intone the words of the spell.",
     "valid_targets": [ "hostile", "ground" ],
     "flags": [ "RANDOM_DAMAGE", "RANDOM_DURATION", "VERBAL", "SOMATIC", "NO_LEGS", "LOUD" ],
     "spell_class": "XE_NETHER_SORCERY",
@@ -67,6 +68,7 @@
     "type": "SPELL",
     "name": { "str": "The Baying of Hounds" },
     "description": "Using this spell will summon a pack of otherworldly hounds.  They are <color_yellow>somewhat difficult</color> to control.",
+    "message": "You intone the words of the spell.",
     "valid_targets": [ "self" ],
     "flags": [ "VERBAL", "SOMATIC", "NO_LEGS" ],
     "spell_class": "XE_NETHER_SORCERY",
@@ -121,5 +123,35 @@
         "else": [ { "u_message": "The things you called up resist your attempt to control them!", "type": "bad" } ]
       }
     ]
+  },
+  {
+    "type": "SPELL",
+    "id": "xe_nether_sorcery_cause_withering_damage",
+    "name": "The Withering",
+    "description": "Blast your targets with the raw energy of the grave, withering their flesh.",
+    "message": "You intone the words of the spell.",
+    "valid_targets": [ "ally", "hostile", "ground" ],
+    "flags": [ "RANDOM_DAMAGE", "RANDOM_DURATION", "SPLIT_DAMAGE", "VERBAL", "SILENT", "SOMATIC", "NO_LEGS" ],
+    "spell_class": "XE_NETHER_SORCERY",
+    "magic_type": "xe_nether_sorcery",
+    "skill": "deduction",
+    "difficulty": 90,
+    "max_level": 15,
+    "effect": "attack",
+    "effect_str": "effect_xe_nether_sorcery_cause_withering_damage",
+    "shape": "blast",
+    "damage_type": "withering_damage",
+    "min_damage": { "math": [ "(u_spell_level('xe_nether_sorcery_cause_withering_damage') * 3) + 25" ] },
+    "max_damage": { "math": [ "(u_spell_level('xe_nether_sorcery_cause_withering_damage') * 7.5) + 55" ] },
+    "min_duration": { "math": [ "(u_spell_level('xe_nether_sorcery_cause_withering_damage') * 350) + 1200" ] },
+    "max_duration": { "math": [ "(u_spell_level('xe_nether_sorcery_cause_withering_damage') * 1200) + 6000" ] },
+    "min_range": 6,
+    "range_increment": 0.5,
+    "max_range": 30,
+    "min_aoe": 1,
+    "max_aoe": 5,
+    "aoe_increment": 0.25,
+    "base_energy_cost": 4500,
+    "base_casting_time": 225
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Add `The Withering`, another Nether Sorcery spell"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Evil sorcerers rotting people away with magic. What's not to like?

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add `The Withering`, which uses the new withering damage for a spell. It's higher-difficulty and is pretty basic in effect--a bunch of damage and a weakening and slowing effect.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Cast the spell, it worked. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
