### PR TITLE
Changed accepted battery type for hologram cloak from light to medium

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -684,7 +684,7 @@
     "material": [ "superalloy" ],
     "symbol": "[",
     "color": "light_gray",
-    "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "rigid": true, "item_restriction": [ "light_battery_cell" ] } ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "rigid": true, "item_restriction": [ "medium_battery_cell" ] } ],
     "charges_per_use": 25,
     "warmth": 10,
     "material_thickness": 0.5,


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #83039.

#### Describe the solution
Changed accepted battery type for hologram cloak from light to medium. This allows for creating 2 holograms from one fully charged battery.

#### Describe alternatives you've considered
- Change battery type to heavy (this would allow creating 10+ holograms from a fully charged battery);
- Reduce power use from 25 to like 16 or even less.

#### Testing
Got hologram cloak, got fully-charged medium battery. Reloaded the cloak. Activated it two times to create two holograms.

#### Additional context
None.