### PR TITLE
Boxer shorts are now 0.1mm thick

### DIFF
--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -472,7 +472,7 @@
     "color": "light_gray",
     "faults": [ { "fault_group": "fabric_cotton" } ],
     "warmth": 5,
-    "material_thickness": 0.01,
+    "material_thickness": 0.1,
     "flags": [ "VARSIZE", "SKINTIGHT" ],
     "armor": [
       { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #82712.

#### Describe the solution
Changed boxer shorts material thickness from 0.01 to 0.1.

#### Describe alternatives you've considered
None.

#### Testing
None, obvious json change.

#### Additional context
None.