### PR TITLE
Kelvar is now fireproof

### DIFF
--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -1332,7 +1332,8 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
-    "resist": { "bash": 1, "cut": 3, "acid": 5, "heat": 2, "bullet": 2, "stab": 5 },
+    "burn_data": [ { "immune": true }, { "immune": true }, { "immune": true } ],
+    "resist": { "bash": 1, "cut": 3, "acid": 5, "heat": 40, "bullet": 2, "stab": 5 },
     "repair_difficulty": 4
   },
   {


### PR DESCRIPTION
#### Summary
Balance "Kelvar is now fireproof"

#### Purpose of change
* Kevlar has thermal conductivity of around 0.04 W/(m·K) (for example, https://www.matweb.com/search/datasheet.aspx?matguid=77b5205f0dcc43bb8cbe6fee7d36cbb5&n=1&ckck=1), which is more than two times lower than that of a nomex, which has thermal conductivity ranging between 0.08 and 0.14 W/(m·K) (for example, https://www.matweb.com/search/DataSheet.aspx?MatGUID=389ac8bf734e4aa1980022397e6b5016). Nomex ingame has `"resist": { "heat": 20 }`, so I guess it's safe to assume that kevlar could be two times more heat-resistant than nomex.

* Also kevlar is highly flame-resistant, starting to char only at 430–450°C.

* Closes #82419.

#### Describe the solution
- Added immunity to burning to kevlar material.
- Set its heat resistance to 40.

#### Describe alternatives you've considered
None.

#### Testing
Checked stats of tactical gloves ingame.

#### Additional context
<img width="772" height="551" alt="изображение" src="https://github.com/user-attachments/assets/1c3def29-c542-452a-b354-3cd2d172e69b" />