### PR TITLE
Vehicle wheels don't crush items in deep water

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1228,7 +1228,8 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
             veh.handle_trap( this, wheel_p, vp_wheel );
             // dont use vp_wheel or vp_wheel_idx below this - handle_trap might've removed it from parts
 
-            if( has_items( wheel_p ) && !has_flag( ter_furn_flag::TFLAG_SEALED, wheel_p ) ) {
+            if( has_items( wheel_p ) && !has_flag( ter_furn_flag::TFLAG_SEALED, wheel_p ) &&
+                !has_flag( ter_furn_flag::TFLAG_DEEP_WATER, wheel_p ) ) {
                 // Damage is calculated based on the weight of the vehicle,
                 // The area of it's wheels, and the area of the wheel running over the items.
                 // This number is multiplied by weight_to_damage_factor to get reasonable results, damage-wise.


### PR DESCRIPTION
#### Summary
Bugfixes "Vehicle wheels don't crush items in deep water"

#### Purpose of change
* Closes #81961.

#### Describe the solution
Added check for wheel being on a deep water tile in `move_vehicle`.

#### Describe alternatives you've considered
None.

#### Testing
Threw some stuff to a deep water tile. Got myself DUKW truck. Rolled over the stuff with wheels of the truck. Items were not damaged.

#### Additional context
None.