### PR TITLE
Berserk:  A status in which the PC can no longer flee.

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3215,6 +3215,13 @@
   },
   {
     "type": "effect_type",
+    "id": "berserk",
+    "//COMMENT": "Hardcoded effect to track a pc as berserk. Applied and checked in C++ only.",
+    "name": [ "RAGE" ],
+    "desc": [ "Uncontrollably raging.  You cannot flee from hostiles." ]
+  },
+  {
+    "type": "effect_type",
     "id": "slimed",
     "name": [ "Slimed" ],
     "desc": [ "You're covered in thick goo!" ],

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -246,34 +246,34 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
 
     // Berserk creatures cannot voluntarily move farther away from visible hostiles.
     if( you.has_effect( effect_berserk ) ) {
-    bool retreating = false;
+        bool retreating = false;
 
-    get_creature_tracker().for_each_reachable( you, [&]( Creature *critter ) {
-    if( retreating || critter == &you ) {
-        return;
+        get_creature_tracker().for_each_reachable( you, [&]( Creature * critter ) {
+            if( retreating || critter == &you ) {
+                return;
+            }
+
+            if( !you.sees( here, *critter ) ) {
+                return;
+            }
+
+            if( critter->attitude_to( you ) != Creature::Attitude::HOSTILE ) {
+                return;
+            }
+
+            const int current_dist = rl_dist( you_pos, critter->pos_bub() );
+            const int new_dist = rl_dist( dest_loc, critter->pos_bub() );
+
+            if( new_dist > current_dist ) {
+                retreating = true;
+            }
+        } );
+
+        if( retreating ) {
+            add_msg( m_info, _( "You are too enraged to retreat!" ) );
+            return false;
+        }
     }
-
-    if( !you.sees( here, *critter ) ) {
-        return;
-    }
-
-    if( critter->attitude_to( you ) != Creature::Attitude::HOSTILE ) {
-        return;
-    }
-
-    const int current_dist = rl_dist( you_pos, critter->pos_bub() );
-    const int new_dist = rl_dist( dest_loc, critter->pos_bub() );
-
-    if( new_dist > current_dist ) {
-        retreating = true;
-    }
-} );
-
-    if( retreating ) {
-        add_msg( m_info, _( "You are too enraged to retreat!" ) );
-        return false;
-    }
-}
 
     item_location weapon = you.get_wielded_item();
     if( m.has_flag( ter_furn_flag::TFLAG_MINEABLE, dest_loc ) && g->mostseen == 0 &&

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -64,6 +64,7 @@
 #include "vpart_position.h"
 
 static const efftype_id effect_amigara( "amigara" );
+static const efftype_id effect_berserk( "berserk" );
 static const efftype_id effect_bile_irritant( "bile_irritant" );
 static const efftype_id effect_glowing( "glowing" );
 static const efftype_id effect_harnessed( "harnessed" );
@@ -242,6 +243,37 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
         dest_loc.z() -= 1;
         via_ramp = true;
     }
+
+    // Berserk creatures cannot voluntarily move farther away from visible hostiles.
+    if( you.has_effect( effect_berserk ) ) {
+    bool retreating = false;
+
+    get_creature_tracker().for_each_reachable( you, [&]( Creature *critter ) {
+    if( retreating || critter == &you ) {
+        return;
+    }
+
+    if( !you.sees( here, *critter ) ) {
+        return;
+    }
+
+    if( critter->attitude_to( you ) != Creature::Attitude::HOSTILE ) {
+        return;
+    }
+
+    const int current_dist = rl_dist( you_pos, critter->pos_bub() );
+    const int new_dist = rl_dist( dest_loc, critter->pos_bub() );
+
+    if( new_dist > current_dist ) {
+        retreating = true;
+    }
+} );
+
+    if( retreating ) {
+        add_msg( m_info, _( "You are too enraged to retreat!" ) );
+        return false;
+    }
+}
 
     item_location weapon = you.get_wielded_item();
     if( m.has_flag( ter_furn_flag::TFLAG_MINEABLE, dest_loc ) && g->mostseen == 0 &&

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -246,10 +246,10 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
 
     // Berserk creatures cannot voluntarily move farther away from visible hostiles.
     if( you.has_effect( effect_berserk ) ) {
-        bool chasing = false;
+        bool retreating = false;
 
-        get_creature_tracker().for_each_reachable( you, [ &chasing ]( Creature * critter ) {
-            if( chasing || critter == &you ) {
+        get_creature_tracker().for_each_reachable( you, [&]( Creature * critter ) {
+            if( retreating || critter == &you ) {
                 return;
             }
 
@@ -264,13 +264,12 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
             const int current_dist = rl_dist( you_pos, critter->pos_bub() );
             const int new_dist = rl_dist( dest_loc, critter->pos_bub() );
 
-            if( new_dist < current_dist ) {
-                chasing = true;
-                break;
+            if( new_dist > current_dist ) {
+                retreating = true;
             }
         } );
 
-        if( !chasing ) {
+        if( retreating ) {
             add_msg( m_info, _( "You are too enraged to retreat!" ) );
             return false;
         }

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -246,10 +246,10 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
 
     // Berserk creatures cannot voluntarily move farther away from visible hostiles.
     if( you.has_effect( effect_berserk ) ) {
-        bool retreating = false;
+        bool chasing = false;
 
-        get_creature_tracker().for_each_reachable( you, [&]( Creature * critter ) {
-            if( retreating || critter == &you ) {
+        get_creature_tracker().for_each_reachable( you, [ &chasing ]( Creature * critter ) {
+            if( chasing || critter == &you ) {
                 return;
             }
 
@@ -264,12 +264,13 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
             const int current_dist = rl_dist( you_pos, critter->pos_bub() );
             const int new_dist = rl_dist( dest_loc, critter->pos_bub() );
 
-            if( new_dist > current_dist ) {
-                retreating = true;
+            if( new_dist < current_dist ) {
+                chasing = true;
+                break;
             }
         } );
 
-        if( retreating ) {
+        if( !chasing ) {
             add_msg( m_info, _( "You are too enraged to retreat!" ) );
             return false;
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Berserk Rage Prevents fleeing hostile enemies"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adds Berserk rage in movement code and a json effect.  I've added it in base game as there may be other mods than XE that need this like XedraWood or Isolation Protocol.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds additional code to bool avatar_action::move in order add this limitation.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
m_warning instead of m_info
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<img width="925" height="358" alt="Enraged" src="https://github.com/user-attachments/assets/09231259-79a1-487f-9939-d60c18cba9f3" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
