### PR TITLE
wish.cpp: fix hint, desc width; add scroll; keep ?success msg

### DIFF
--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -1193,7 +1193,7 @@ void debug_menu::wishitem( Character *you, const tripoint_bub_ms &pos )
         { "SCROLL_DESC_UP", translation() },
         { "SCROLL_DESC_DOWN", translation() },
     };
-    wmenu.desired_bounds = { -0.9, -0.9, 0.9, 0.9 };
+    wmenu.desired_bounds = { -1.0, -1.0, 1.0, 1.0 };
     wmenu.selected = uistate.wishitem_selected;
     wish_item_callback cb( itypes, ivariants, snipped_id_str );
     wmenu.callback = &cb;

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -9,6 +9,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -67,6 +68,14 @@
 static const efftype_id effect_pet( "pet" );
 
 static const mongroup_id GROUP_ZOMBIE( "GROUP_ZOMBIE" );
+
+static float lines_for_msg( std::string_view msg )
+{
+    if( msg.empty() ) {
+        return 0.0;
+    }
+    return 1.0 + static_cast<float>( std::count( msg.begin(), msg.end(), '\n' ) );
+}
 
 namespace
 {
@@ -193,7 +202,12 @@ class wish_mutate_callback: public uilist_callback
 
             ImGui::TableSetColumnIndex( 2 );
 
-            if( menu->previewing >= 0 && static_cast<size_t>( menu->previewing ) < vTraits.size() ) {
+            ImVec2 info_size = ImGui::GetContentRegionAvail( );
+            // 1 line for ctxt + 0 to 1 line for msg
+            info_size.y -= ( 1.0 + lines_for_msg( msg ) ) * ImGui::GetTextLineHeightWithSpacing();
+            if( ImGui::BeginChild( "mutation info", info_size )
+                && menu->previewing >= 0 && static_cast<size_t>( menu->previewing ) < vTraits.size()
+              ) {
                 const mutation_branch &mdata = vTraits[menu->previewing].obj();
 
                 ImGui::TextUnformatted( mdata.valid ? _( "Valid" ) : _( "Nonvalid" ) );
@@ -237,13 +251,10 @@ class wish_mutate_callback: public uilist_callback
                 ImGui::NewLine();
                 ImGui::TextWrapped( "%s", you->mutation_desc( mdata.id ).c_str() );
             }
-
-            float y = ImGui::GetContentRegionMax().y - 3 * ImGui::GetTextLineHeightWithSpacing();
-            if( ImGui::GetCursorPosY() < y ) {
-                ImGui::SetCursorPosY( y );
+            ImGui::EndChild();
+            if( !msg.empty() ) {
+                ImGui::TextColored( c_green, "%s", msg.c_str() );
             }
-            ImGui::TextColored( c_green, "%s", msg.c_str() );
-            msg.clear();
             input_context ctxt( menu->input_category, keyboard_mode::keycode );
 
             cataimgui::TextKeybinding( ctxt, "UILIST.FILTER", _( "Find" ),
@@ -698,60 +709,54 @@ class wish_monster_callback: public uilist_callback
         }
 
         void refresh( uilist *menu ) override {
-            ImVec2 info_size = ImGui::GetContentRegionAvail( );
-            info_size.x = desired_extra_space_right( );
-            ImGui::TableSetColumnIndex( 2 );
-            if( ImGui::BeginChild( "monster info", info_size ) ) {
-                const int entnum = menu->previewing;
-                const bool valid_entnum = entnum >= 0 && static_cast<size_t>( entnum ) < mtypes.size();
-                if( entnum != lastent ) {
-                    lastent = entnum;
-                    if( valid_entnum ) {
-                        tmp = monster( mtypes[ entnum ]->id );
-                        if( friendly ) {
-                            tmp.friendly = -1;
-                        }
-                    } else {
-                        tmp = monster();
-                    }
-                }
-
+            const int entnum = menu->previewing;
+            const bool valid_entnum = entnum >= 0 && static_cast<size_t>( entnum ) < mtypes.size();
+            if( entnum != lastent ) {
+                lastent = entnum;
                 if( valid_entnum ) {
-                    std::string header = string_format( "#%d: %s (%d)%s", entnum, tmp.type->id.c_str(), group,
-                                                        hallucination ? _( " (hallucination)" ) : "" );
-                    ImGui::SetCursorPosX( ( ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(
-                                                header.c_str() ).x ) * 0.5 );
-                    ImGui::TextColored( c_cyan, "%s", header.c_str() );
-
-                    // show debug info
-                    restore_on_out_of_scope<bool> restore_debugmode( debug_mode );
-                    debug_mode = true;
-                    tmp.print_info_imgui();
+                    tmp = monster( mtypes[ entnum ]->id );
+                    if( friendly ) {
+                        tmp.friendly = -1;
+                    }
+                } else {
+                    tmp = monster();
                 }
+            }
 
-                float y = ImGui::GetContentRegionMax().y - 3 * ImGui::GetTextLineHeightWithSpacing();
-                if( ImGui::GetCursorPosY() < y ) {
-                    ImGui::SetCursorPosY( y );
-                }
-                ImGui::TextColored( c_green, "%s", msg.c_str() );
-                msg.clear();
-                input_context ctxt( menu->input_category, keyboard_mode::keycode );
+            ImGui::TableSetColumnIndex( 2 );
+            ImVec2 info_size = ImGui::GetContentRegionAvail( );
+            // 1 line for ctxt + 0 to 2 lines for msg
+            info_size.y -= ( 1.0 + lines_for_msg( msg ) ) * ImGui::GetTextLineHeightWithSpacing();
+            if( ImGui::BeginChild( "monster info", info_size ) && valid_entnum ) {
+                std::string header = string_format( "#%d: %s (%d)%s", entnum, tmp.type->id.c_str(), group,
+                                                    hallucination ? _( " (hallucination)" ) : "" );
+                ImGui::SetCursorPosX( ( ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(
+                                            header.c_str() ).x ) * 0.5 );
+                ImGui::TextColored( c_cyan, "%s", header.c_str() );
 
-                cataimgui::TextKeybinding( ctxt, "UILIST.FILTER", _( "Find" ),
-                                           menu->filtering && ( !menu->filter.empty() ) );
-                cataimgui::TextListSeparator();
-                cataimgui::TextKeybinding( ctxt, "f",      _( "Friendly" ),       friendly );
-                cataimgui::TextListSeparator();
-                cataimgui::TextKeybinding( ctxt, "h",      _( "Hallucination" ),  hallucination );
-                cataimgui::TextListSeparator();
-                cataimgui::TextKeybinding( ctxt, "i",      _( "Increase Group" ), false );
-                cataimgui::TextListSeparator();
-                cataimgui::TextKeybinding( ctxt, "d",      _( "Decrease Group" ), false );
-                cataimgui::TextListSeparator();
-                cataimgui::TextKeybinding( ctxt, "UILIST.QUIT", _( "Quit" ),      false );
-
+                // show debug info
+                restore_on_out_of_scope<bool> restore_debugmode( debug_mode );
+                debug_mode = true;
+                tmp.print_info_imgui();
             }
             ImGui::EndChild();
+            if( !msg.empty() ) {
+                ImGui::TextColored( c_green, "%s", msg.c_str() );
+            }
+            input_context ctxt( menu->input_category, keyboard_mode::keycode );
+
+            cataimgui::TextKeybinding( ctxt, "UILIST.FILTER", _( "Find" ),
+                                       menu->filtering && ( !menu->filter.empty() ) );
+            cataimgui::TextListSeparator();
+            cataimgui::TextKeybinding( ctxt, "f",      _( "Friendly" ),       friendly );
+            cataimgui::TextListSeparator();
+            cataimgui::TextKeybinding( ctxt, "h",      _( "Hallucination" ),  hallucination );
+            cataimgui::TextListSeparator();
+            cataimgui::TextKeybinding( ctxt, "i",      _( "Increase Group" ), false );
+            cataimgui::TextListSeparator();
+            cataimgui::TextKeybinding( ctxt, "d",      _( "Decrease Group" ), false );
+            cataimgui::TextListSeparator();
+            cataimgui::TextKeybinding( ctxt, "UILIST.QUIT", _( "Quit" ),      false );
         }
 
         ~wish_monster_callback() override = default;
@@ -1072,19 +1077,21 @@ class wish_item_callback: public uilist_callback
                 info = tmp.get_info( true );
             }
 
-            ImVec2 info_size = ImGui::GetContentRegionAvail();
-            info_size.x = desired_extra_space_right( );
-            info_size.y -= ( 3.0 * ImGui::GetTextLineHeightWithSpacing() ) - ImGui::GetFrameHeightWithSpacing();
-
             ImGui::TableSetColumnIndex( 2 );
+            ImVec2 info_size = ImGui::GetContentRegionAvail();
+            // 1 line for ctxt + 0 to 1 line for msg
+            info_size.y -= ( 1.0 + lines_for_msg( msg ) ) * ImGui::GetTextLineHeightWithSpacing();
+
             if( ImGui::BeginChild( "wish item", info_size ) ) {
+                cataimgui::set_scroll( desc_scroll );
                 ImGui::SetCursorPosX( ( info_size.x - ImGui::CalcTextSize( header.c_str() ).x ) * 0.5 );
                 ImGui::TextColored( c_cyan, "%s", header.c_str() );
                 display_item_info( info, {} );
             }
             ImGui::EndChild();
-
-            ImGui::TextColored( c_green, "%s", msg.c_str() );
+            if( !msg.empty() ) {
+                ImGui::TextColored( c_green, "%s", msg.c_str() );
+            }
             input_context ctxt( menu->input_category, keyboard_mode::keycode );
 
             cataimgui::TextKeybinding( ctxt, "UILIST.FILTER", _( "Find" ),

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -246,14 +246,14 @@ class wish_mutate_callback: public uilist_callback
             msg.clear();
             input_context ctxt( menu->input_category, keyboard_mode::keycode );
 
-            cataimgui::TextKeybinding( ctxt, "FILTER", _( "Find" ),
+            cataimgui::TextKeybinding( ctxt, "UILIST.FILTER", _( "Find" ),
                                        menu->filtering && ( !menu->filter.empty() ) );
             cataimgui::TextListSeparator();
             cataimgui::TextKeybinding( ctxt, "t",      _( "Toggle base trait" ),  false );
             cataimgui::TextListSeparator();
             cataimgui::TextKeybinding( ctxt, "a",      _( "Show active traits" ), only_active );
             cataimgui::TextListSeparator();
-            cataimgui::TextKeybinding( ctxt, "QUIT",   _( "Quit" ),               false );
+            cataimgui::TextKeybinding( ctxt, "UILIST.QUIT", _( "Quit" ),          false );
         }
 
         ~wish_mutate_callback() override = default;
@@ -737,7 +737,7 @@ class wish_monster_callback: public uilist_callback
                 msg.clear();
                 input_context ctxt( menu->input_category, keyboard_mode::keycode );
 
-                cataimgui::TextKeybinding( ctxt, "FILTER", _( "Find" ),
+                cataimgui::TextKeybinding( ctxt, "UILIST.FILTER", _( "Find" ),
                                            menu->filtering && ( !menu->filter.empty() ) );
                 cataimgui::TextListSeparator();
                 cataimgui::TextKeybinding( ctxt, "f",      _( "Friendly" ),       friendly );
@@ -748,7 +748,7 @@ class wish_monster_callback: public uilist_callback
                 cataimgui::TextListSeparator();
                 cataimgui::TextKeybinding( ctxt, "d",      _( "Decrease Group" ), false );
                 cataimgui::TextListSeparator();
-                cataimgui::TextKeybinding( ctxt, "QUIT",   _( "Quit" ),           false );
+                cataimgui::TextKeybinding( ctxt, "UILIST.QUIT", _( "Quit" ),      false );
 
             }
             ImGui::EndChild();
@@ -872,7 +872,7 @@ void debug_menu::wishmonster( const std::optional<tripoint_bub_ms> &p )
                 }
                 input_context ctxt( wmenu.input_category, keyboard_mode::keycode );
                 cb.msg = string_format( _( "Spawned %d monsters, choose another or [%s] to quit." ),
-                                        num_spawned, ctxt.get_desc( "QUIT" ) );
+                                        num_spawned, ctxt.get_desc( "UILIST.QUIT" ) );
                 if( num_spawned == 0 ) {
                     cb.msg += _( "\nTarget location is not suitable for placing this kind of monster.  Choose a different target or [i]ncrease the groups size." );
                 }
@@ -1087,7 +1087,7 @@ class wish_item_callback: public uilist_callback
             ImGui::TextColored( c_green, "%s", msg.c_str() );
             input_context ctxt( menu->input_category, keyboard_mode::keycode );
 
-            cataimgui::TextKeybinding( ctxt, "FILTER",     _( "Find" ),
+            cataimgui::TextKeybinding( ctxt, "UILIST.FILTER", _( "Find" ),
                                        menu->filtering && ( !menu->filter.empty() ) );
             cataimgui::TextListSeparator();
             cataimgui::TextKeybinding( ctxt, "CONTAINER",  _( "Container" ),  incontainer );
@@ -1098,7 +1098,7 @@ class wish_item_callback: public uilist_callback
             cataimgui::TextListSeparator();
             cataimgui::TextKeybinding( ctxt, "SNIPPET",    _( "Snippet" ),    chosen_snippet_id.first != -1 );
             cataimgui::TextListSeparator();
-            cataimgui::TextKeybinding( ctxt, "QUIT",       _( "Quit" ),       false );
+            cataimgui::TextKeybinding( ctxt, "UILIST.QUIT", _( "Quit" ),      false );
         }
 };
 } // namespace
@@ -1222,7 +1222,7 @@ void debug_menu::wishitem( Character *you, const tripoint_bub_ms &pos )
                 if( amount > 0 ) {
                     input_context ctxt( wmenu.input_category, keyboard_mode::keycode );
                     cb.msg = string_format( _( "Wish granted.  Wish for more or hit [%s] to quit." ),
-                                            ctxt.get_desc( "QUIT" ) );
+                                            ctxt.get_desc( "UILIST.QUIT" ) );
                 }
             }
             uistate.wishitem_selected = wmenu.selected;

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -82,6 +82,7 @@ namespace
 class wish_mutate_callback: public uilist_callback
 {
     public:
+        cataimgui::scroll desc_scroll = cataimgui::scroll::none;
         // Last menu entry
         int lastlen = 0;
         // Feedback message
@@ -159,7 +160,16 @@ class wish_mutate_callback: public uilist_callback
         }
 
         wish_mutate_callback() = default;
-        bool key( const input_context &, const input_event &event, int entnum, uilist *menu ) override {
+        bool key( const input_context &ctxt, const input_event &event, int entnum, uilist *menu ) override {
+            const std::string &action = ctxt.input_to_action( event );
+            if( action == "SCROLL_DESC_UP" ) {
+                desc_scroll = cataimgui::scroll::page_up;
+                return true;
+            }
+            if( action == "SCROLL_DESC_DOWN" ) {
+                desc_scroll = cataimgui::scroll::page_down;
+                return true;
+            }
             if( event.get_first_input() == 't' && you->has_trait( vTraits[ entnum ] ) ) {
                 if( !you->has_base_trait( vTraits[ entnum ] ) ) {
                     you->unset_mutation( vTraits[ entnum ] );
@@ -208,6 +218,7 @@ class wish_mutate_callback: public uilist_callback
             if( ImGui::BeginChild( "mutation info", info_size )
                 && menu->previewing >= 0 && static_cast<size_t>( menu->previewing ) < vTraits.size()
               ) {
+                cataimgui::set_scroll( desc_scroll );
                 const mutation_branch &mdata = vTraits[menu->previewing].obj();
 
                 ImGui::TextUnformatted( mdata.valid ? _( "Valid" ) : _( "Nonvalid" ) );
@@ -274,6 +285,11 @@ class wish_mutate_callback: public uilist_callback
 void debug_menu::wishmutate( Character *you )
 {
     uilist wmenu;
+    wmenu.input_category = "WISH_ITEM";
+    wmenu.additional_actions = {
+        { "SCROLL_DESC_UP", translation() },
+        { "SCROLL_DESC_DOWN", translation() },
+    };
     int c = 0;
 
     for( const mutation_branch &traits_iter : mutation_branch::get_all() ) {
@@ -661,6 +677,7 @@ namespace
 class wish_monster_callback: public uilist_callback
 {
     public:
+        cataimgui::scroll desc_scroll = cataimgui::scroll::none;
         // last menu entry
         int lastent;
         // feedback message
@@ -682,8 +699,17 @@ class wish_monster_callback: public uilist_callback
             lastent = -2;
         }
 
-        bool key( const input_context &, const input_event &event, int /*entnum*/,
+        bool key( const input_context &ctxt, const input_event &event, int /*entnum*/,
                   uilist * /*menu*/ ) override {
+            const std::string &action = ctxt.input_to_action( event );
+            if( action == "SCROLL_DESC_UP" ) {
+                desc_scroll = cataimgui::scroll::page_up;
+                return true;
+            }
+            if( action == "SCROLL_DESC_DOWN" ) {
+                desc_scroll = cataimgui::scroll::page_down;
+                return true;
+            }
             if( event.get_first_input() == 'f' ) {
                 friendly = !friendly;
                 // Force tmp monster regen
@@ -728,6 +754,7 @@ class wish_monster_callback: public uilist_callback
             // 1 line for ctxt + 0 to 2 lines for msg
             info_size.y -= ( 1.0 + lines_for_msg( msg ) ) * ImGui::GetTextLineHeightWithSpacing();
             if( ImGui::BeginChild( "monster info", info_size ) && valid_entnum ) {
+                cataimgui::set_scroll( desc_scroll );
                 std::string header = string_format( "#%d: %s (%d)%s", entnum, tmp.type->id.c_str(), group,
                                                     hallucination ? _( " (hallucination)" ) : "" );
                 ImGui::SetCursorPosX( ( ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(
@@ -851,6 +878,11 @@ void debug_menu::wishmonster( const std::optional<tripoint_bub_ms> &p )
     std::vector<const mtype *> mtypes;
 
     uilist wmenu;
+    wmenu.input_category = "WISH_ITEM";
+    wmenu.additional_actions = {
+        { "SCROLL_DESC_UP", translation() },
+        { "SCROLL_DESC_DOWN", translation() },
+    };
     setup_wishmonster( wmenu, mtypes );
     wish_monster_callback cb( mtypes );
     wmenu.callback = &cb;
@@ -915,7 +947,7 @@ namespace
 class wish_item_callback: public uilist_callback
 {
     public:
-        int examine_pos;
+        cataimgui::scroll desc_scroll = cataimgui::scroll::none;
         bool incontainer;
         bool spawn_everything;
         bool renew_snippet;
@@ -943,7 +975,7 @@ class wish_item_callback: public uilist_callback
             if( menu->selected < 0 ) {
                 return;
             }
-            examine_pos = 0;
+            desc_scroll = cataimgui::scroll::begin;
             chosen_snippet_id = { -1, "" };
             renew_snippet = true;
             const itype &selected_itype = *standard_itype_ids[menu->selected];
@@ -1025,10 +1057,10 @@ class wish_item_callback: public uilist_callback
                 return true;
             }
             if( action == "SCROLL_DESC_UP" ) {
-                examine_pos = std::max( examine_pos - 1, 0 );
+                desc_scroll = cataimgui::scroll::page_up;
             }
             if( action == "SCROLL_DESC_DOWN" ) {
-                examine_pos += 1;
+                desc_scroll = cataimgui::scroll::page_down;
             }
             if( cur_key == KEY_LEFT || cur_key == KEY_RIGHT ) {
                 // For Renew snippet_id.


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

 - Fixes #73640

Fix the incorrect width of the second window leading to a clipped-out description.

 - Fixes #82436

?success msg always disappeared after one tick. Keep it.

Implement scrolling for wish menus.

#### Describe the solution

_outdated keybindings_
 - There was `FILTER` instead of `UILIST.FILTER`, same for `QUIT`.

_debug wish: fix desc width; normalize & always show hint and ?success msg_

 - move ImGui::TableSetColumnIndex( 2 ) before ImGui::GetContentRegionAvail( )
   - this fixes width, as we get width of second panel, not first
   - no need to call for desired_extra_space_right( )
 - calculate space (newlines) for hint and ?success msg, use that space
   - this still doesn't wrap the hint and success msg
   - if msg.empty(), yield space to description
 - remove clearing of ?success msg, so that it survives

_scrolling_
 - fix scroll by replacing broken (dead) int examine_pos
 - copied what crafting_gui.cpp uses
 - It uses WISH_ITEM SCROLL_DESC_UP/DOWN, so the description is about item. It doesn't matter. It's a debug menu.

#### Describe alternatives you've considered

Clear ?success msg at some point.

#### Testing

_outdated keybindings_

Check these menus:
 - Debug functions > Spawning... > Spawn an item
 - Debug functions > Spawning... > Spawn monster
 - Debug functions > Player... > Mutate

Find (filter) can be added with `?`, check the keybindings.

For Quit, open uilist, such as `Debug functions`, but not `Spawn an item`; here edit keybindings with `?`. Then open the menus and check all keybindings do it.

_debug wish: fix desc width; normalize & always show hint and ?success msg_

The hint & keybindings are always on the bottom, the description gets scrollable text.

Show hint: Spawn an item / monster / mutate. Observe: The message stays doesn't disappear after one tick.

_all_
<img width="691" height="385" alt="image" src="https://github.com/user-attachments/assets/af4b6147-bfbc-4d2e-a608-e1bd464ccc0d" />

#### Additional context

uilist doesn't support resizing

<img width="876" height="108" alt="image" src="https://github.com/user-attachments/assets/fb3e0e37-a4e1-4a5c-b231-d54b5d51361d" />

<img width="1124" height="122" alt="image" src="https://github.com/user-attachments/assets/8749bc09-c703-4aa5-b56c-2afc0f0aaf1a" />



Spawn monster and mutate are simple uilists that cannot even have the keybindings changed.
 - `WISH_ITEM` Debug functions > Spawning... > Spawn an item
 - `UILIST` Debug functions > Spawning... > Spawn monster
 - `UILIST` Debug functions > Player... > Mutate

We could also merge `cataimgui::TextKeybinding` used in `wish.cpp` with `input_context::get_desc` used in `crafting_gui.cpp`.
