### PR TITLE
Spell menu as wide as the screen

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -3334,7 +3334,7 @@ spell &known_magic::select_spell( Character &guy )
     spell_menu.desired_bounds = {
         -1.0,
             -1.0,
-            std::clamp( float( EVEN_MINIMUM_TERM_WIDTH * ImGui::CalcTextSize( "X" ).x ), ImGui::GetMainViewport()->Size.x * 3 / 8, ImGui::GetMainViewport()->Size.x ),
+            ImGui::GetMainViewport()->Size.x,
             spell_menu_height
         };
 


### PR DESCRIPTION
#### Summary
Interface "Spell menu as wide as the screen"

#### Purpose of change

Resolve these on a big enough monitor:
 - #77116
 - #84796

#### Describe the solution

Make the spell menu as wide as the screen.

#### Describe alternatives you've considered

#### Testing

1. Launch game.
2. Learn all spells.
3. Open spell menu.

#### Additional context
