### PR TITLE
Guard NPC loading nonexistent faction

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2163,7 +2163,7 @@ void npc::load( const JsonObject &data )
 
     int misstmp = 0;
     int atttmp = 0;
-    std::string facID;
+    faction_id facID;
     std::string comp_miss_role;
     tripoint_abs_omt comp_miss_pt;
     std::string companion_mission_role;
@@ -2217,7 +2217,11 @@ void npc::load( const JsonObject &data )
     }
 
     if( data.read( "my_fac", facID ) ) {
-        fac_id = faction_id( facID );
+        if( facID.is_valid() ) {
+            fac_id = facID;
+        } else {
+            fac_id = faction_id::NULL_ID();
+        }
     }
     int temp_fac_api_ver = 0;
     if( data.read( "faction_api_ver", temp_fac_api_ver ) ) {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #87862
#### Describe the solution
Put a guard against loading invalid faction
#### Testing
Save file loads properly, without errors