### PR TITLE
Fix grammar in Advanced Game Design textbook description

### DIFF
--- a/data/json/items/book/computer.json
+++ b/data/json/items/book/computer.json
@@ -278,7 +278,7 @@
       {
         "id": "textbook_computer_3",
         "name": { "str": "Advanced Game Design: A Systems Approach", "str_pl": "copies of Advanced Game Design: A Systems Approach" },
-        "description": "Author research how computer game works, how they build, and how to make proper gameplay parts and prototypes, with examples of real code.",
+        "description": "Author researches how computer games work, how they are built, and how to make proper gameplay parts and prototypes, with examples of real code.",
         "//": "978-0134667607"
       },
       {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix grammar in the description of the Advanced Game Design textbook"

#### Purpose of change

Fixes #87874. The description of `textbook_computer_3` ("Advanced Game Design: A Systems Approach") had a subject-verb agreement issue and inconsistent singular/plural nouns: "Author research how computer game works, how they build...".

#### Describe the solution

Changed the description to "Author researches how computer games work, how they are built, and how to make proper gameplay parts and prototypes, with examples of real code.", matching the fix suggested in the issue.

#### Describe alternatives you've considered

None, this is a straightforward text fix.

#### Testing

Confirmed `data/json/items/book/computer.json` still parses as valid JSON after the change.

#### Additional context

N/A