### PR TITLE
If we were caught in several bear traps at once, conduct a separate attempt to free for each one

### DIFF
--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -115,14 +115,19 @@ void Character::try_remove_bear_trap()
             }
         }
     } else {
-        if( can_escape_trap( 100 ) ) {
-            remove_effect( effect_beartrap );
-            here.spawn_item( pos_bub(), itype_beartrap );
-            add_msg_player_or_npc( m_good, _( "You free yourself from the bear trap!" ),
-                                   _( "<npcname> frees themselves from the bear trap!" ) );
-        } else {
-            add_msg_if_player( m_bad,
-                               _( "You try to free yourself from the bear trap, but can't get loose!" ) );
+        // If we were caught in several bear traps at once, conduct a separate attempt to free for each one
+        for( const bodypart_id &bp : get_all_body_parts() ) {
+            if( has_effect( effect_beartrap, bp ) ) {
+                if( can_escape_trap( 100 ) ) {
+                    remove_effect( effect_beartrap, bp );
+                    here.spawn_item( pos_bub(), itype_beartrap );
+                    add_msg_player_or_npc( m_good, _( "You free yourself from the bear trap!" ),
+                                           _( "<npcname> frees themselves from the bear trap!" ) );
+                } else {
+                    add_msg_if_player( m_bad,
+                                       _( "You try to free yourself from the bear trap, but can't get loose!" ) );
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #78760.

#### Describe the solution
If we were caught in several bear traps at once, conduct a separate attempt to free for each one and spawn that much bear traps on successful attempt as much as we have trapped legs.

#### Describe alternatives you've considered
None.

#### Testing
Spawned two bear traps, tried to disarm both of them, failed at both attempts. As such got two bear traps on both of my legs. Moved to try to break free from the traps. Got two bear traps at my feet on successful removal of both traps.

#### Additional context
None.