### PR TITLE
Hotwire if has immobilizer, not if has security

### DIFF
--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2362,7 +2362,14 @@ void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub
         .on_submit( [this] { display_effects(); } );
     }
 
-    if( ( is_locked || has_security_working( *here ) ) && controls_here ) {
+    bool has_immobilizer = false;
+    for( const vehicle_part *vp : vp_parts ) {
+        if( vp->has_fault_flag( "IMMOBILIZER" ) ) {
+            has_immobilizer = true;
+        }
+    }
+
+    if( ( is_locked || has_immobilizer ) && controls_here ) {
         if( player_inside ) {
             ///\EFFECT_MECHANICS speeds up vehicle hotwiring
             const float skill = std::max( 1.0f, get_player_character().get_skill_level( skill_mechanics ) );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Whoever made #84457 is a moron, for it checks the fact the security installed, not the fact the immobilizer is installed
That result in working, open car still shows you a suggestion to immobilize it
#### Describe the solution
Check if vehicle has immobilizer installed instead
#### Testing
No line to hotwire if you already open the car and sit in it