### PR TITLE
[XEDRA Evolved] Summer March Lord's bright light

### DIFF
--- a/data/mods/Xedra_Evolved/monsters/changeling.json
+++ b/data/mods/Xedra_Evolved/monsters/changeling.json
@@ -515,7 +515,8 @@
         "monster_message": "%1$s gestures and heat-haze shimmers around them for a moment."
       }
     ],
-    "death_drops": "changeling_lord_summer_death_drops"
+    "death_drops": "changeling_lord_summer_death_drops",
+    "luminance": 5000
   },
   {
     "type": "MONSTER",


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Summer usually have longer days so why not represent it with the summer March Lord by making them bringing the day around them. Mostly made this because spriting reasons.

#### Describe the solution
`"luminance": 5000`

#### Describe alternatives you've considered
More ~~cowbells~~ daylights.

#### Testing
<img width="816" height="1023" alt="Screenshot_20260705_193123" src="https://github.com/user-attachments/assets/968d2b9d-4282-4995-ada0-5af39c88340c" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
