### PR TITLE
Update Jorts to have the same pockets as Jeans

### DIFF
--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -1885,6 +1885,20 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
+        "max_contains_volume": "1250 ml",
+        "max_contains_weight": "4 kg",
+        "max_item_length": "19 cm",
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "1250 ml",
+        "max_contains_weight": "4 kg",
+        "max_item_length": "19 cm",
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
         "max_contains_volume": "1080 ml",
         "max_contains_weight": "4 kg",
         "max_item_length": "165 mm",
@@ -1913,7 +1927,7 @@
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
-        "volume_encumber_modifier": 0.7
+        "volume_encumber_modifier": 0.5
       },
       {
         "coverage": 90,


### PR DESCRIPTION
#### Summary

Balance "Update Jorts to have the same pockets as Jeans."

#### Purpose of change

The issue with Jorts is that if you craft them by cutting up Jeans, they somehow lose 2 pockets.

#### Describe the solution

I updated Jorts to use the same pockets as Jeans. I modified the encumbrance so when the pockets are full they are nearly as encumbering as jeans.

#### Describe alternatives you've considered

Not doing it. Or modifying the encumbrance to be more similar to Jeans

#### Testing

I started a game and look at the jorts. They have the same pockets as jeans and should have similar encumbrance when the pockets are full

#### Additional context