### PR TITLE
Print fungus bristle attack message only if playes sees the attacker

### DIFF
--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1758,8 +1758,8 @@ bool mattack::fungus_bristle( monster *z )
 
     game_message_type msg_type = target->is_avatar() ? m_warning : m_neutral;
 
-    add_msg( msg_type, _( "The %1$s swipes at %2$s with a barbed tendril!" ), z->name(),
-             target->disp_name() );
+    add_msg_if_player_sees( *z, msg_type, _( "The %1$s swipes at %2$s with a barbed tendril!" ),
+                            z->name(), target->disp_name() );
     z->mod_moves( -to_moves<int>( 1_seconds ) * 1.5 );
 
     bodypart_id hit = target->get_random_body_part();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Closes #76399.

#### Describe the solution
Replaced simple `add_msg` with `add_msg_if_player_sees`.

#### Describe alternatives you've considered
None.

#### Testing
Debug-spawned fungal tower location. Debug-spawned dissoluted devourer on that location near the fungal hedgerow. Made sure that my character doesn't see the hedgerow. Waited some time to check that no fungus bristle attack message is shown in the log.

#### Additional context
None.