### PR TITLE
[MoM] Increase channeling time for extremely fast powers

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -1033,7 +1033,7 @@ Powers causing telekinetic damage have a 40% chance to stagger the target for 2 
 *Target*: The items in a space up to 3 squares away plus 0.9 squares per power level<br />
 *Duration*: Instant<br />
 *Stamina Cost*: 1250, minus 80 per level to a minimum of 500<br />
-*Channeling Time*: 50 moves, minus 4 moves per level to a minimum of 10<br />
+*Channeling Time*: 150 moves, minus 4 moves per level to a minimum of 65<br />
 *Effects*: The psion reaches out and pulls a set of items toward or away from them, moving it 1 to 4 squares plus 0.4 to 0.9 squares per power level.<br />
 *Prerequisites*: Starting power<br />
 </details>
@@ -1044,7 +1044,7 @@ Powers causing telekinetic damage have a 40% chance to stagger the target for 2 
 *Target*: One enemy, ally, or the items in a space up to 2 squares away plus 0.9 squares per power level<br />
 *Duration*: Instant<br />
 *Stamina Cost*: 1750, minus 80 per level to a minimum of 750<br />
-*Channeling Time*: 50 moves, minus 4 moves per level to a minimum of 10<br />
+*Channeling Time*: 150 moves, minus 4 moves per level to a minimum of 65<br />
 *Effects*: The psion attempts to shove a single target either to them or in a chosen direction. The distance is based on the ratio of the target's weight to the psion's power level (modified by Intelligence and Nether Attunement as usual).  By default, the formula is (power level * 25 kg) * Intelligence modifier * Nether Attunement modifier, divided by the target's weight in kg. If this is 1 or higher, the target is hurled 1 square for every 0.5 above 1 the ratio is. If it is below one, there is still a chance to knock the target over (chance is weight ratio * 100 in percentage; a weight ratio of 0.678 has a 67.8% chance of causing knockdown).<br />
 *Prerequisites*: Starting power<br />
 </details>
@@ -1198,7 +1198,7 @@ Powers causing telekinetic damage have a 40% chance to stagger the target for 2 
 *Target*: One target in a space up to 2 squares away plus 0.9 squares per power level<br />
 *Duration*: Instant<br />
 *Stamina Cost*: 9500, minus 175 per level to a minimum of 5000<br />
-*Channeling Time*: 80 moves, minus 5 moves per level to a minimum of 25<br />/>
+*Channeling Time*: 150 moves, minus 5 moves per level to a minimum of 65<br />/>
 *Effects*: Like Force Shove, but on a much greater scale, the psion hurls a single target either to them or in a chosen direction. The distance is based on the ratio of the target's weight to the psion's power level (modified by Intelligence and Nether Attunement as usual).  By default, the formula is (power level * 150 kg) * Intelligence modifier * Nether Attunement modifier, plus 100 kg, divided by the target's weight in kg. If this is 1 or higher, the target is hurled 1 square for every 0.5 above 1 the ratio is. If it is below one, there is still a chance to knock the target over (chance is weight ratio * 1000 in percentage; a weight ratio of 0.952 has a 95.2% chance of causing knockdown).<br />
 *Prerequisites*: Force Shove 15 *or* Far Hand 15, Momentum Alteration 10, Lift Vehicle 6<br />
 </details>
@@ -1260,7 +1260,7 @@ Powers causing telepathic damage have a 5% chance to down the target, a 33% chan
 *Target*: Self<br />
 *Duration*: 3 minutes to 12 minutes, plus 15 to 36 seconds per power level<br />
 *Stamina Cost*: 2500, minus 125 per level to a minimum of 500<br />
-*Channeling Time*: 100 moves, minus 6.5 moves per level to a minimum of 10<br />
+*Channeling Time*: 200 moves, minus 6.5 moves per level to a minimum of 45<br />
 *Effects*: Place a shield over the psion's mind, preventing telepathic assault and also rendering the psion immune to the attacks of flaming eyes and the personal effects of portal storms. The psion is immune to telepathic damage and most telepathy-related effects while this power is active.<br />
 *Prerequisites*: Concentration Trance 5<br />
 </details>

--- a/data/mods/MindOverMatter/README.md
+++ b/data/mods/MindOverMatter/README.md
@@ -19,7 +19,7 @@ The goal is for each path to be upgraded through usage, since sitting and studyi
 
 ADVANTAGES
 
-1) Psionic powers are fast. Many powers take less than 100 moves to use, with high-level powers sometimes taking much less (a level 10 Telekinetic Hand takes only 10 moves!), reflecting that they are as fast as thought.
+1) Psionic powers are fast. Many powers take less than 100 moves to use, with high-level powers sometimes taking much less (a fully-levlled Far Hand takes only 65 moves!), reflecting that they are as fast as thought.
 2) Powers use Stamina as their power source, meaning that a fully-charged psychic is only a five-minute breather away. 
 3) Powers are generally very quiet (generally. Pyrokinesis is very loud)
 

--- a/data/mods/MindOverMatter/powers/telekinesis.json
+++ b/data/mods/MindOverMatter/powers/telekinesis.json
@@ -20,8 +20,8 @@
     "base_energy_cost": 1250,
     "final_energy_cost": 500,
     "energy_increment": -80,
-    "base_casting_time": 50,
-    "final_casting_time": 10,
+    "base_casting_time": 150,
+    "final_casting_time": 65,
     "casting_time_increment": -4,
     "ignored_monster_species": [ "PSI_NULL", "TELEKIN_PUSHPULL_NULL" ]
   },
@@ -132,8 +132,8 @@
     "base_energy_cost": 1750,
     "final_energy_cost": 750,
     "energy_increment": -80,
-    "base_casting_time": 50,
-    "final_casting_time": 10,
+    "base_casting_time": 150,
+    "final_casting_time": 65,
     "casting_time_increment": -4,
     "ignored_monster_species": [ "PSI_NULL", "TELEKIN_PUSHPULL_NULL" ]
   },
@@ -596,9 +596,9 @@
     "base_energy_cost": 9500,
     "final_energy_cost": 5000,
     "energy_increment": -175,
-    "base_casting_time": 80,
-    "final_casting_time": 25,
-    "casting_time_increment": -5
+    "base_casting_time": 150,
+    "final_casting_time": 65,
+    "casting_time_increment": -4
   },
   {
     "id": "telekinetic_aegis",

--- a/data/mods/MindOverMatter/powers/telepathy.json
+++ b/data/mods/MindOverMatter/powers/telepathy.json
@@ -63,7 +63,7 @@
     },
     "base_casting_time": {
       "math": [
-        "u_effect_intensity('effect_telepathic_psi_armor') > -1 ? 10 : max( (100 - ( (u_spell_level('telepathic_shield') + u_spell_level('telepathic_shield_knack') ) * 6.5)), 10)"
+        "u_effect_intensity('effect_telepathic_psi_armor') > -1 ? 10 : max( (200 - ( (u_spell_level('telepathic_shield') + u_spell_level('telepathic_shield_knack') ) * 6.5)), 45)"
       ]
     }
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Increase channeling time for extremely fast powers"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Force Shove taking only 10 moves at max level is a neat idea conceptually, but where it really falls down is that it lets you do it 10 times a second so nothing can get anywhere near you until you run out of stamina. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Increase minimum channeling time to 65 moves. This is still extremely fast, but no longer so fast that multiple fast enemies can never even get close to you.

Similarly increase the minimum time for Megakinesis and Telepathic Shield. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
