### PR TITLE
[Xedra Evolved] Moons tears repair updates

### DIFF
--- a/data/mods/Xedra_Evolved/itemgroups/monster_drops.json
+++ b/data/mods/Xedra_Evolved/itemgroups/monster_drops.json
@@ -75,6 +75,7 @@
       { "group": "bannerman_armor", "prob": 100, "damage": [ 2, 5 ] },
       { "group": "pendant_necklaces_silver", "prob": 5 },
       { "group": "clothing_watch", "prob": 5 },
+      { "item": "hammer_fey_smith", "prob": 2 },
       { "group": "bannerman_weapons", "prob": 100, "damage": [ 2, 5 ] },
       { "item": "baldric", "prob": 100 },
       { "item": "scrap_dreamdross", "prob": 75, "count": [ 1, 4 ] }
@@ -221,6 +222,7 @@
       },
       { "group": "bannerman_armor", "prob": 100, "damage": [ 0, 4 ] },
       { "group": "pendant_necklaces_silver", "prob": 5 },
+      { "item": "hammer_fey_smith", "prob": 2 },
       { "item": "baldric", "prob": 100 },
       { "item": "purity_crackers", "prob": 10 },
       { "item": "golden_bridle", "prob": 5 },

--- a/data/mods/Xedra_Evolved/itemgroups/spell_artifacts/main.json
+++ b/data/mods/Xedra_Evolved/itemgroups/spell_artifacts/main.json
@@ -82,7 +82,7 @@
       { "group": "dreamer_artifact", "prob": 50 },
       { "group": "dreamsmith_artifact", "prob": 50 },
       { "group": "inventor_creations", "prob": 50 },
-      { "item": "nether_sorcery_books", "chance": 25 },
+      { "group": "nether_sorcery_books", "prob": 25 },
       { "group": "xe_nether_cult_artifact", "prob": 25 },
       { "item": "hammer_fey_smith", "prob": 15 }
     ]

--- a/data/mods/Xedra_Evolved/itemgroups/spell_artifacts/main.json
+++ b/data/mods/Xedra_Evolved/itemgroups/spell_artifacts/main.json
@@ -82,7 +82,9 @@
       { "group": "dreamer_artifact", "prob": 50 },
       { "group": "dreamsmith_artifact", "prob": 50 },
       { "group": "inventor_creations", "prob": 50 },
-      { "group": "xe_nether_cult_artifact", "prob": 25 }
+      { "item": "nether_sorcery_books", "chance": 25 },
+      { "group": "xe_nether_cult_artifact", "prob": 25 },
+      { "item": "hammer_fey_smith", "prob": 15 }
     ]
   }
 ]

--- a/data/mods/Xedra_Evolved/items/tools.json
+++ b/data/mods/Xedra_Evolved/items/tools.json
@@ -263,5 +263,44 @@
     "weight": "91500 g",
     "symbol": "%",
     "description": "A macabre effigy made of meat and bone, with a heart filled with glass and faewild dust.  When the full moon will shine upon it, you will be able to use it to summon the Luna-attuned revenant."
+  },
+  {
+    "id": "hammer_bronze",
+    "copy-from": "hammer_bronze",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "qualities": [ [ "FEY_HAMMER", 3 ], [ "HAMMER", 3 ], [ "HAMMER_FINE", 1 ] ],
+    "use_action": [
+      {
+        "type": "repair_item",
+        "item_action_type": "repair_metal",
+        "materials": [ "moon_tears", "moon_tears_fine_chain" ],
+        "skill": "fabrication",
+        "tool_quality": -3,
+        "cost_scaling": 0.1,
+        "move_cost": 100
+      }
+    ]
+  },
+  {
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "copy-from": "hammer_peen",
+    "id": "hammer_fey_smith",
+    "name": { "str": "fey smith's hammer" },
+    "description": "This blacksmith's hammer is so full of delicate carvings and filigree it seems like it would snap at the first blow against heated metal.  Despite that, it doesn't have a single scratch or mark on it.",
+    "material": [ { "type": "wood", "portion": 5 }, { "type": "moon_tears" } ],
+    "qualities": [ { "id": "FEY_HAMMER", "level": 3, "speed": 0.75 }, [ "HAMMER", 3 ], [ "HAMMER_FINE", 1 ] ],
+    "use_action": [
+      {
+        "type": "repair_item",
+        "item_action_type": "repair_metal",
+        "materials": [ "moon_tears", "moon_tears_fine_chain" ],
+        "skill": "fabrication",
+        "tool_quality": 1,
+        "cost_scaling": 0.1,
+        "move_cost": 100
+      }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/recipes/blacksmithing.json
+++ b/data/mods/Xedra_Evolved/recipes/blacksmithing.json
@@ -66,7 +66,7 @@
     "time": "1 h 30 m",
     "result_mult": 6,
     "autolearn": true,
-    "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 } ],
+    "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "FEY_HAMMER", "level": 3 } ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -90,7 +90,7 @@
     "difficulty": 2,
     "time": "30 m",
     "book_learn": [ [ "book_moons_tears_ingot", 2 ] ],
-    "using": [ [ "forging_standard", 1 ], [ "bronzesmithing_tools", 1 ] ],
+    "using": [ [ "forging_standard", 1 ], [ "fey_smithing_tools", 1 ] ],
     "tools": [ [ [ "casting_mold", -1 ] ] ],
     "components": [ [ [ "scrap_moon_tears", 140 ] ] ]
   },
@@ -112,7 +112,7 @@
       { "proficiency": "prof_bladesmith" },
       { "proficiency": "prof_leatherworking_basic", "skill_penalty": 0 }
     ],
-    "using": [ [ "blacksmithing_standard", 4 ], [ "bronzesmithing_tools", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 4 ], [ "fey_smithing_tools", 1 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "casting_mold", -1 ] ] ],
     "components": [
@@ -138,7 +138,7 @@
       { "proficiency": "prof_moonstearssmithing" },
       { "proficiency": "prof_bladesmith" }
     ],
-    "using": [ [ "blacksmithing_standard", 12 ], [ "bronzesmithing_tools", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 12 ], [ "fey_smithing_tools", 1 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ], [ [ "casting_mold", -1 ] ] ],
     "components": [ [ [ "leather", 1 ], [ "hc_wire", 2 ] ], [ [ "moon_tear_ingot", 2 ] ] ]
@@ -160,7 +160,7 @@
       { "proficiency": "prof_moonstearssmithing" },
       { "proficiency": "prof_leatherworking_basic", "skill_penalty": 0.15 }
     ],
-    "using": [ [ "blacksmithing_standard", 12 ], [ "bronzesmithing_tools", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 12 ], [ "fey_smithing_tools", 1 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ], [ [ "casting_mold", -1 ] ] ],
     "components": [ [ [ "leather", 2 ] ], [ [ "moon_tear_ingot", 2 ] ] ]
@@ -175,7 +175,7 @@
     "difficulty": 5,
     "time": "15 h",
     "flags": [ "SECRET" ],
-    "using": [ [ "blacksmithing_standard", 12 ], [ "bronzesmithing_tools", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 12 ], [ "fey_smithing_tools", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -203,7 +203,7 @@
       { "proficiency": "prof_moonstearssmithing" },
       { "proficiency": "prof_bladesmith" }
     ],
-    "using": [ [ "blacksmithing_standard", 16 ], [ "bronzesmithing_tools", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 16 ], [ "fey_smithing_tools", 1 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "components": [ [ [ "leather", 2 ] ], [ [ "moon_tear_ingot", 2 ] ] ]
@@ -224,7 +224,7 @@
       { "proficiency": "prof_bladesmith" },
       { "proficiency": "prof_moonstearssmithing" }
     ],
-    "using": [ [ "blacksmithing_standard", 12 ], [ "bronzesmithing_tools", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 12 ], [ "fey_smithing_tools", 1 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "components": [ [ [ "leather", 4 ] ], [ [ "moon_tear_ingot", 2 ] ] ]
@@ -246,7 +246,7 @@
       { "proficiency": "prof_moonstearssmithing" },
       { "proficiency": "prof_carving", "time_multiplier": 1.5, "skill_penalty": 0 }
     ],
-    "using": [ [ "blacksmithing_standard", 4 ], [ "bronzesmithing_tools", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 4 ], [ "fey_smithing_tools", 1 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "components": [ [ [ "spear_shaft", 1 ] ], [ [ "moon_tear_ingot", 1 ] ] ]
@@ -268,7 +268,7 @@
       { "proficiency": "prof_moonstearssmithing" },
       { "proficiency": "prof_carving", "time_multiplier": 1.2, "learning_time_multiplier": 0.2, "skill_penalty": 0 }
     ],
-    "using": [ [ "blacksmithing_standard", 12 ], [ "bronzesmithing_tools", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 12 ], [ "fey_smithing_tools", 1 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ], [ "drift", -1 ] ] ],
     "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "fur", 2 ], [ "leather", 2 ] ], [ [ "moon_tear_ingot", 2 ] ] ]
@@ -289,7 +289,7 @@
       { "proficiency": "prof_bladesmith" },
       { "proficiency": "prof_moonstearssmithing" }
     ],
-    "using": [ [ "blacksmithing_standard", 8 ], [ "bronzesmithing_tools", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 8 ], [ "fey_smithing_tools", 1 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "components": [ [ [ "fur", 2 ], [ "leather", 2 ] ], [ [ "moon_tear_ingot", 2 ] ] ]

--- a/data/mods/Xedra_Evolved/recipes/requirements.json
+++ b/data/mods/Xedra_Evolved/recipes/requirements.json
@@ -22,5 +22,12 @@
     "id": "data_core_install",
     "type": "requirement",
     "tools": [ [ "data_core_slots" ] ]
+  },
+  {
+    "id": "fey_smithing_tools",
+    "type": "requirement",
+    "//": "Copy of bronzesmithing_tools but requires non-iron hammering instead of hammering",
+    "qualities": [ { "id": "FEY_HAMMER", "level": 2 }, { "id": "ANVIL", "level": 2 } ],
+    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
   }
 ]

--- a/data/mods/Xedra_Evolved/tool_qualities.json
+++ b/data/mods/Xedra_Evolved/tool_qualities.json
@@ -15,5 +15,11 @@
     "id": "SACRIFICE",
     "//": "a place to convert one type of magic to another via sacrificing it to elder powers",
     "name": { "str": "sacrificial altar" }
+  },
+  {
+    "type": "tool_quality",
+    "id": "FEY_HAMMER",
+    "name": { "str": "non-iron hammering" },
+    "//": "For when you're one of the Fair Folk and what kind of hammer you use on your gear matters"
   }
 ]

--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -1349,6 +1349,15 @@ The contents of `use_action` fields can either be a string indicating a built-in
   "not_ready_msg": "The yeast has not been done The yeast isn't done culturing yet." // A message, shown when the item is not old enough
 },
 "use_action": {
+  "type": "repair_item",                            // Place NPC of specific class on the map
+  "item_action_type": "repair_fabric",              // Possible options are "repair_fabric" and "repair_metal"
+  "materials": [ "iron", "cotton", "candyfloss" ],  // Array of material types that the item can repair
+  "skill": "swimming",                              // The skill used for repairing
+  "tool_quality": 0,                                // Integer, used in the formula "( 10 + 2 * skill - 2 * difficulty + tool_quality / 5.0f ) / 100.0f" to determine success
+  "cost_scaling": 0.1,                              // Unknown
+  "move_cost": 100                                  // How many move points the action takes
+},
+"use_action": {
   "type": "firestarter",  // Start a fire, like with a lighter.
   "moves": 15,            // Number of moves it takes to start the fire. This is reduced by survival skill
   "moves_slow": 1500,     // Number of moves it takes to start a fire on something that is difficult to ignite. This is reduced by survival skill


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Moons tears repair updates"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

You could only repair moon's tears with an oneiric hammer, which seems a little odd. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the `fey smith's hammer`

> This blacksmith's hammer is so full of delicate carvings and filigree it seems like it would snap at the first blow against heated metal.  Despite that, it doesn't have a single scratch or mark on it.

which you can use to repair moon's tears. Also make it so you can use a bronze hammer too, though a fey smith's hammer is better--it's faster and much more likely to succeed. 

I also added the `FEY_HAMMER` quality, so you can no longer use iron or steel hammers to forge fey weaponry, and gave it to fey smith's hammers and bronze hammers. I then edited moon's tears recipes to need them. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded game, checked out moon's tears chainmail, it had the appropriate list of possible items to repair it. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Faults will be a better solution to this, but not allowing iron to make fey gear is important too. 

To do: add trow aspirants that have a higher chance of having fey smith's hammers. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
