### PR TITLE
[Innawood] Adds autolearn to poppy drug recipes

### DIFF
--- a/data/mods/innawood/recipes/medsandchemicals.json
+++ b/data/mods/innawood/recipes/medsandchemicals.json
@@ -258,7 +258,7 @@
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "electrolysis_kit", 250 ] ] ],
     "components": [ [ [ "salt_water", 2 ], [ "saline", 10 ] ] ]
-   },
+  },
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/mods/innawood/recipes/medsandchemicals.json
+++ b/data/mods/innawood/recipes/medsandchemicals.json
@@ -258,5 +258,64 @@
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "electrolysis_kit", 250 ] ] ],
     "components": [ [ [ "salt_water", 2 ], [ "saline", 10 ] ] ]
-  }
+   },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "poppy_sleep",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_DRUGS",
+    "skill_used": "chemistry",
+    "skills_required": [ "survival", 1 ],
+    "difficulty": 2,
+    "time": "5 m",
+    "autolearn": true,
+    "proficiencies": [
+      { "proficiency": "prof_intro_chemistry" },
+      { "proficiency": "prof_organic_chemistry" },
+      { "proficiency": "prof_pharmaceutical" }
+    ],
+    "qualities": [ { "id": "CHEM", "level": 2 } ],
+    "tools": [ [ [ "surface_heat", 2, "LIST" ] ] ],
+    "components": [ [ [ "poppy_bud", 2 ] ] ],
+    "charges": 10
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "poppy_pain",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_DRUGS",
+    "skill_used": "chemistry",
+    "skills_required": [ "survival", 1 ],
+    "difficulty": 2,
+    "time": "5 m",
+    "autolearn": true,
+    "proficiencies": [
+      { "proficiency": "prof_intro_chemistry" },
+      { "proficiency": "prof_organic_chemistry" },
+      { "proficiency": "prof_pharmaceutical" }
+    ],
+    "qualities": [ { "id": "CHEM", "level": 2 } ],
+    "tools": [ [ [ "surface_heat", 2, "LIST" ] ] ],
+    "components": [ [ [ "poppy_bud", 2 ] ] ],
+    "charges": 10
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "poppysyrup",
+    "charges": 5,
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_DRUGS",
+    "skill_used": "chemistry",
+    "skills_required": [ "survival", 1 ],
+    "difficulty": 3,
+    "time": "5 m",
+    "autolearn": true,
+    "proficiencies": [ { "proficiency": "prof_intro_chemistry" }, { "proficiency": "prof_pharmaceutical" } ],
+    "qualities": [ { "id": "CHEM", "level": 1 } ],
+    "tools": [ [ [ "surface_heat", 2, "LIST" ] ] ],
+    "components": [ [ [ "poppy_bud", 2 ] ] ]
+  } 
 ]

--- a/data/mods/innawood/recipes/medsandchemicals.json
+++ b/data/mods/innawood/recipes/medsandchemicals.json
@@ -317,5 +317,5 @@
     "qualities": [ { "id": "CHEM", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 2, "LIST" ] ] ],
     "components": [ [ [ "poppy_bud", 2 ] ] ]
-  } 
+  }
 ]


### PR DESCRIPTION


#### Summary
Mods "Poppy-bud drug recipes are autolearned in Innawoods"


#### Purpose of change

More herbal/natural recipes are always good, and poppy buds have a use now! Not sure why this wasn't already the case.

#### Describe the solution

Adds the recipes for poppy sleep, cough, and pain drugs to innawoods with autolearn enabled, following the precedent set by other recipes in the same file of copying over the entire recipe and making the required adjustments.

#### Describe alternatives you've considered

Not doing this, or a complete rework of the recipes and drugs to add in opium. 

#### Testing

Ran the game, loaded the world,, incremented the applied science stat until recipes appeared. Confirmed that this carries over to xedrawood as well.

<img width="1539" height="551" alt="Screenshot 2026-07-08 131932" src="https://github.com/user-attachments/assets/6d57ab01-12dd-4a14-bb9c-e067a21cd5b7" />
<img width="708" height="460" alt="Screenshot 2026-07-08 132522" src="https://github.com/user-attachments/assets/991b4965-a74d-4899-81ef-354ee9f2bd29" />


#### Additional context




<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
