### PR TITLE
examine_action supports array notation

### DIFF
--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -86,7 +86,7 @@
     "flags": [ "TRANSPARENT", "PERMEABLE", "LOCKED", "PICKABLE", "THIN_OBSTACLE", "BURROWABLE" ],
     "connect_groups": "CHAINFENCE",
     "connects_to": "CHAINFENCE",
-    "examine_action": "locked_object_pickable",
+    "examine_action": [ "locked_object_pickable", "chainfence" ],
     "oxytorch": {
       "result": "t_dirt",
       "duration": "9 seconds",

--- a/doc/JSON/EXAMINE.md
+++ b/doc/JSON/EXAMINE.md
@@ -45,6 +45,7 @@
 These are actions that will be performed when a terrain/furniture is examined.
 The hardcoded examine actions specified as a `"examine_action": "ACTION"`, where `ACTION` is replaced with one of the strings from the list below.
 The examine actors are specified as JSON objects with a `type` corresponding to a certain type of action, and other members filling in the data for how the action functions.
+Examine actions and examine actors can be mixed within single key, like `"examine_action": [ "locked_object_pickable", "chainfence", { "type": "effect_on_conditions", ... } ]`
 
 ## Hardcoded Examine Actions
 
@@ -83,6 +84,16 @@ The examine actors are specified as JSON objects with a `type` corresponding to 
 - ```mortar``` Shoot a projectile.
 
 ## Examine Actors
+
+All examine actions share the keys `"type"` and `"name"`
+
+```jsonc
+  {
+    "type": "appliance_convert",
+    "name": "Take down"
+    ...
+  }
+```
 
 ### `appliance_convert`
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -7513,86 +7513,91 @@ void iexamine::invalid( Character &/*you*/, const tripoint_bub_ms &examp )
  */
 iexamine_functions iexamine_functions_from_string( const std::string &function_name )
 {
-    static const std::map<std::string, iexamine_examine_function> function_map = {{
-            { "none", &iexamine::none },
-            { "deployed_furniture", &iexamine::deployed_furniture },
-            { "change_appearance", &iexamine::change_appearance },
-            { "genemill", &iexamine::genemill },
-            { "nanofab", &iexamine::nanofab },
-            { "gaspump", &iexamine::gaspump },
-            { "atm", &iexamine::atm },
-            { "vending", &iexamine::vending },
-            { "elevator", &iexamine::elevator },
-            { "controls_gate", &iexamine::controls_gate },
-            { "cardreader_robofac", &iexamine::cardreader_robofac },
-            { "cardreader_fp", &iexamine::cardreader_foodplace },
-            { "intercom", &iexamine::intercom },
-            { "intercom_balthazar", &iexamine::intercom_balthazar },
-            { "rubble", &iexamine::rubble },
-            { "chainfence", &iexamine::chainfence },
-            { "bars", &iexamine::bars },
-            { "portable_structure", &iexamine::portable_structure },
-            { "pit", &iexamine::pit },
-            { "pit_covered", &iexamine::pit_covered },
-            { "thin_ice", &iexamine::thin_ice },
-            { "safe", &iexamine::safe },
-            { "bulletin_board", &iexamine::bulletin_board },
-            { "pedestal_wyrm", &iexamine::pedestal_wyrm },
-            { "pedestal_temple", &iexamine::pedestal_temple },
-            { "door_peephole", &iexamine::door_peephole },
-            { "fswitch", &iexamine::fswitch },
-            { "flower_poppy", &iexamine::flower_poppy },
-            { "flower_cactus", &iexamine::flower_cactus },
-            { "fungus", &iexamine::fungus },
-            { "flower_dahlia", &iexamine::flower_dahlia },
-            { "flower_marloss", &iexamine::flower_marloss },
-            { "dirtmound", &iexamine::dirtmound },
-            { "aggie_plant", &iexamine::aggie_plant },
-            { "fvat_empty", &iexamine::fvat_empty },
-            { "fvat_full", &iexamine::fvat_full },
-            { "compost_empty", &iexamine::compost_empty },
-            { "compost_full", &iexamine::compost_full },
-            { "keg", &iexamine::keg },
-            { "harvest_furn_nectar", &iexamine::harvest_furn_nectar },
-            { "harvest_furn", &iexamine::harvest_furn },
-            { "harvest_ter_nectar", &iexamine::harvest_ter_nectar },
-            { "harvest_ter", &iexamine::harvest_ter },
-            { "clear_overgrown", &iexamine::clear_overgrown },
-            { "harvest_plant_ex", &iexamine::harvest_plant_ex },
-            { "harvested_plant", &iexamine::harvested_plant },
-            { "shrub_marloss", &iexamine::shrub_marloss },
-            { "translocator", &iexamine::translocator },
-            { "tree_marloss", &iexamine::tree_marloss },
-            { "tree_hickory", &iexamine::tree_hickory },
-            { "tree_maple", &iexamine::tree_maple },
-            { "tree_maple_tapped", &iexamine::tree_maple_tapped },
-            { "shrub_wildveggies", &iexamine::shrub_wildveggies },
-            { "water_source", &iexamine::water_source },
-            { "finite_water_source", &iexamine::finite_water_source },
-            { "reload_furniture", &iexamine::reload_furniture },
-            { "curtains", &iexamine::curtains },
-            { "sign", &iexamine::sign },
-            { "pay_gas", &iexamine::pay_gas },
-            { "gunsafe_el", &iexamine::gunsafe_el },
-            { "locked_object", &iexamine::locked_object },
-            { "locked_object_pickable", &iexamine::locked_object_pickable },
-            { "kiln_empty", &iexamine::kiln_empty },
-            { "kiln_full", &iexamine::kiln_full },
-            { "stook_empty", &iexamine::stook_empty },
-            { "stook_full", &iexamine::stook_full },
-            { "arcfurnace_empty", &iexamine::arcfurnace_empty },
-            { "arcfurnace_full", &iexamine::arcfurnace_full },
-            { "autoclave_empty", &iexamine::autoclave_empty },
-            { "autoclave_full", &iexamine::autoclave_full },
-            { "fireplace", &iexamine::fireplace },
-            { "ledge", &iexamine::ledge },
-            { "autodoc", &iexamine::autodoc },
-            { "quern_examine", &iexamine::quern_examine },
-            { "smoker_options", &iexamine::smoker_options },
-            { "open_safe", &iexamine::open_safe },
-            { "workbench", &iexamine::workbench },
-            { "workout", &iexamine::workout },
-            { "invalid", &iexamine::invalid },
+    struct function_data {
+        translation name;
+        iexamine_examine_function function;
+    };
+
+    static const std::map<std::string, function_data> function_map = {{
+            { "none", { no_translation( "none" ), &iexamine::none } },
+            { "deployed_furniture", { to_translation( "Take down or deploy furniture" ), &iexamine::deployed_furniture } },
+            { "change_appearance", { to_translation( "Change your appearance" ), &iexamine::change_appearance } },
+            { "genemill", { to_translation( "Use genemill" ), &iexamine::genemill } },
+            { "nanofab", { to_translation( "Use nanofab" ), &iexamine::nanofab } },
+            { "gaspump", { to_translation( "Use gas pump" ), &iexamine::gaspump } },
+            { "atm", { to_translation( "Use ATM" ), &iexamine::atm } },
+            { "vending", { to_translation( "Use vending machine" ), &iexamine::vending } },
+            { "elevator", { to_translation( "Use elevator" ), &iexamine::elevator } },
+            { "controls_gate", { to_translation( "Use control gate" ), &iexamine::controls_gate } },
+            { "cardreader_robofac", { to_translation( "Use card reader" ), &iexamine::cardreader_robofac } },
+            { "cardreader_fp", { to_translation( "Use card reader" ), &iexamine::cardreader_foodplace } },
+            { "intercom", { to_translation( "Use intercom" ), &iexamine::intercom } },
+            { "intercom_balthazar", { to_translation( "Use intercom" ), &iexamine::intercom_balthazar } },
+            { "rubble", { to_translation( "Clear rubble" ), &iexamine::rubble } },
+            { "chainfence", { to_translation( "Hop over" ), &iexamine::chainfence } },
+            { "bars", { to_translation( "Try to slip through the bars" ), &iexamine::bars } },
+            { "portable_structure", { to_translation( "Take down" ), &iexamine::portable_structure } },
+            { "pit", { to_translation( "Cover the pit" ), &iexamine::pit } },
+            { "pit_covered", { to_translation( "Uncover the pit" ), &iexamine::pit_covered } },
+            { "thin_ice", { to_translation( "Check the thickness of ice" ), &iexamine::thin_ice } },
+            { "safe", { to_translation( "Attempt to crack a safe" ), &iexamine::safe } },
+            { "bulletin_board", { to_translation( "Arrange tasks of faction camp" ), &iexamine::bulletin_board } },
+            { "pedestal_wyrm", { to_translation( "Interact with pedestal" ), &iexamine::pedestal_wyrm } },
+            { "pedestal_temple", { to_translation( "Interact with pedestal" ), &iexamine::pedestal_temple } },
+            { "door_peephole", { to_translation( "Use a peephole" ), &iexamine::door_peephole } },
+            { "fswitch", { to_translation( "Flip the switch" ), &iexamine::fswitch } },
+            { "flower_poppy", { to_translation( "Pick the poppy" ), &iexamine::flower_poppy } },
+            { "flower_cactus", { to_translation( "Pick the cactus" ), &iexamine::flower_cactus } },
+            { "fungus", { to_translation( "Touch the fungus" ), &iexamine::fungus } },
+            { "flower_dahlia", { to_translation( "Check the dahlia" ), &iexamine::flower_dahlia } },
+            { "flower_marloss", { to_translation( "Pick the marloss flower" ), &iexamine::flower_marloss } },
+            { "dirtmound", { to_translation( "Plant seeds" ), &iexamine::dirtmound } },
+            { "aggie_plant", { to_translation( "Harvest plants" ), &iexamine::aggie_plant } },
+            { "fvat_empty", { to_translation( "Use fermenting vat (empty)" ), &iexamine::fvat_empty } },
+            { "fvat_full", { to_translation( "Use fermenting vat (full)" ), &iexamine::fvat_full } },
+            { "compost_empty", { to_translation( "Use composter (empty)" ), &iexamine::compost_empty } },
+            { "compost_full", { to_translation( "Use composter (full)" ), &iexamine::compost_full } },
+            { "keg", { to_translation( "Use keg" ), &iexamine::keg } },
+            { "harvest_furn_nectar", { to_translation( "Harvest nectar" ), &iexamine::harvest_furn_nectar } },
+            { "harvest_furn", { to_translation( "Harvest" ), &iexamine::harvest_furn } },
+            { "harvest_ter_nectar", { to_translation( "Harvest nectar" ), &iexamine::harvest_ter_nectar } },
+            { "harvest_ter", { to_translation( "Harvest" ), &iexamine::harvest_ter } },
+            { "clear_overgrown", { to_translation( "Clear overgrown plants" ), &iexamine::clear_overgrown } },
+            { "harvest_plant_ex", { to_translation( "Harvest" ), &iexamine::harvest_plant_ex } },
+            { "harvested_plant", { to_translation( "Harvest" ), &iexamine::harvested_plant } },
+            { "shrub_marloss", { to_translation( "Pick marloss bush" ), &iexamine::shrub_marloss } },
+            { "translocator", { to_translation( "Use translocator" ), &iexamine::translocator } },
+            { "tree_marloss", { to_translation( "Pick marloss tree" ), &iexamine::tree_marloss } },
+            { "tree_hickory", { to_translation( "Pick hickory tree" ), &iexamine::tree_hickory } },
+            { "tree_maple", { to_translation( "Tap the maple tree" ), &iexamine::tree_maple } },
+            { "tree_maple_tapped", { to_translation( "Harvest maple sap" ), &iexamine::tree_maple_tapped } },
+            { "shrub_wildveggies", { to_translation( "Harvest wild veggies" ), &iexamine::shrub_wildveggies } },
+            { "water_source", { to_translation( "Use provided liquid" ), &iexamine::water_source } },
+            { "finite_water_source", { to_translation( "Use provided liquid" ), &iexamine::finite_water_source } },
+            { "reload_furniture", { to_translation( "Reload" ), &iexamine::reload_furniture } },
+            { "curtains", { to_translation( "Use curtains" ), &iexamine::curtains } },
+            { "sign", { to_translation( "Read sign" ), &iexamine::sign } },
+            { "pay_gas", { to_translation( "Pay for fuel" ), &iexamine::pay_gas } },
+            { "gunsafe_el", { to_translation( "Try to hack e-safe" ), &iexamine::gunsafe_el } },
+            { "locked_object", { to_translation( "Try to open" ), &iexamine::locked_object } },
+            { "locked_object_pickable", { to_translation( "Try to lockpick" ), &iexamine::locked_object_pickable } },
+            { "kiln_empty", { to_translation( "Use kiln (empty)" ), &iexamine::kiln_empty } },
+            { "kiln_full", { to_translation( "Use kiln (full)" ), &iexamine::kiln_full } },
+            { "stook_empty", { to_translation( "Use stook" ), &iexamine::stook_empty } },
+            { "stook_full", { to_translation( "Use stook" ), &iexamine::stook_full } },
+            { "arcfurnace_empty", { to_translation( "Use arc furnace (empty)" ), &iexamine::arcfurnace_empty } },
+            { "arcfurnace_full", { to_translation( "Use arc furnace (full)" ), &iexamine::arcfurnace_full } },
+            { "autoclave_empty", { to_translation( "Use autoclave (empty)" ), &iexamine::autoclave_empty } },
+            { "autoclave_full", { to_translation( "Use autoclave (full)" ), &iexamine::autoclave_full } },
+            { "fireplace", { to_translation( "Set some fire" ), &iexamine::fireplace } },
+            { "ledge", { to_translation( "Check the ledge" ), &iexamine::ledge } },
+            { "autodoc", { to_translation( "Use autodoc" ), &iexamine::autodoc } },
+            { "quern_examine", { to_translation( "Use quern" ), &iexamine::quern_examine } },
+            { "smoker_options", { to_translation( "Use smoker" ), &iexamine::smoker_options } },
+            { "open_safe", { to_translation( "Open the safe" ), &iexamine::open_safe } },
+            { "workbench", { to_translation( "Craft something" ), &iexamine::workbench } },
+            { "workout", { to_translation( "Workout" ), &iexamine::workout } },
+            { "invalid", { no_translation( "invalid" ), &iexamine::invalid } },
         }
     };
 
@@ -7606,21 +7611,21 @@ iexamine_functions iexamine_functions_from_string( const std::string &function_n
 
     auto iter = function_map.find( function_name );
     if( iter != function_map.end() ) {
-        iexamine_examine_function func = iter->second;
+        function_data func = iter->second;
         if( function_name == "none" ) {
-            return iexamine_functions{&iexamine::always_false, func};
+            return iexamine_functions{&iexamine::always_false, func.function, func.name};
         } else if( function_name == "invalid" ) {
-            return iexamine_functions{&iexamine::false_and_debugmsg, func};
+            return iexamine_functions{&iexamine::false_and_debugmsg, func.function, func.name};
         } else if( harvestable_functions.find( function_name ) != harvestable_functions.end() ) {
-            return iexamine_functions{&iexamine::harvestable_now, func};
+            return iexamine_functions{&iexamine::harvestable_now, func.function, func.name};
         } else {
-            return iexamine_functions{&iexamine::always_true, func};
+            return iexamine_functions{&iexamine::always_true, func.function, func.name};
         }
     }
 
     //No match found
     debugmsg( "Could not find an iexamine function matching '%s'!", function_name );
-    return iexamine_functions{&iexamine::always_false, &iexamine::none};
+    return iexamine_functions{&iexamine::always_false, &iexamine::none, no_translation( "invalid" ) };
 }
 
 void iexamine::practice_survival_while_foraging( Character &who )

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -12,6 +12,7 @@
 
 #include "coords_fwd.h"
 #include "ret_val.h"
+#include "translation.h"
 #include "type_id.h"
 
 class Character;
@@ -28,6 +29,7 @@ using seed_tuple = std::tuple<itype_id, std::string, int>;
 
 struct iexamine_actor {
     const std::string type;
+    translation name;
 
     explicit iexamine_actor( const std::string &type ) : type( type ) {}
 
@@ -38,6 +40,10 @@ struct iexamine_actor {
     virtual std::unique_ptr<iexamine_actor> clone() const = 0;
 
     virtual ~iexamine_actor() = default;
+
+    std::string get_name() const {
+        return name.translated();
+    }
 };
 
 enum fuel_station_fuel_type {
@@ -193,6 +199,11 @@ using iexamine_can_examine_function = bool ( * )( const tripoint_bub_ms & );
 struct iexamine_functions {
     iexamine_can_examine_function can_examine = nullptr;
     iexamine_examine_function examine = nullptr;
+    translation examine_name;
+
+    std::string get_name() const {
+        return examine_name.translated();
+    };
 };
 
 iexamine_functions iexamine_functions_from_string( const std::string &function_name );

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -31,6 +31,7 @@
 #include "translations.h"
 #include "trap.h"
 #include "type_id.h"
+#include "uilist.h"
 
 
 static furn_id f_null;
@@ -597,7 +598,7 @@ furn_t null_furniture_t()
     new_furniture.move_str_req = -1;
     new_furniture.transparent = true;
     new_furniture.set_flag( ter_furn_flag::TFLAG_TRANSPARENT );
-    new_furniture.examine_func = iexamine_functions_from_string( "none" );
+    new_furniture.examine_func.emplace_back( iexamine_functions_from_string( "none" ) );
     new_furniture.max_volume = DEFAULT_TILE_VOLUME;
     return new_furniture;
 }
@@ -619,7 +620,7 @@ ter_t null_terrain_t()
     new_terrain.transparent = true;
     new_terrain.set_flag( ter_furn_flag::TFLAG_TRANSPARENT );
     new_terrain.set_flag( ter_furn_flag::TFLAG_DIGGABLE );
-    new_terrain.examine_func = iexamine_functions_from_string( "none" );
+    new_terrain.examine_func.emplace_back( iexamine_functions_from_string( "none" ) );
     new_terrain.max_volume = DEFAULT_TILE_VOLUME;
     return new_terrain;
 }
@@ -668,31 +669,95 @@ std::string map_data_common_t::name() const
 
 bool map_data_common_t::can_examine( const tripoint_bub_ms &examp ) const
 {
-    return examine_actor || examine_func.can_examine( examp );
+    if( !examine_actor.empty() ) {
+        return true;
+    }
+
+    for( const iexamine_functions &func : examine_func ) {
+        if( func.can_examine( examp ) ) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool map_data_common_t::has_examine( iexamine_examine_function func ) const
 {
-    return examine_func.examine == func;
+    return std::find_if( examine_func.begin(),
+    examine_func.end(), [func]( const iexamine_functions & f ) {
+        return f.examine == func;
+    } ) != examine_func.end();
 }
 
 bool map_data_common_t::has_examine( const std::string &action ) const
 {
-    return examine_actor && examine_actor->type == action;
+    return !examine_actor.empty() && std::find_if( examine_actor.begin(),
+    examine_actor.end(), [action]( const cata::clone_ptr<iexamine_actor> &a ) {
+        return a->type == action;
+    } ) != examine_actor.end();
 }
 
-void map_data_common_t::set_examine( iexamine_functions func )
+void map_data_common_t::set_examine( const iexamine_functions &func )
 {
-    examine_func = func;
+    examine_func.clear();
+    examine_func.emplace_back( func );
 }
 
 void map_data_common_t::examine( Character &you, const tripoint_bub_ms &examp ) const
 {
-    if( !examine_actor ) {
-        examine_func.examine( you, examp );
+
+    if( examine_actor.empty() && examine_func.empty() ) {
         return;
     }
-    examine_actor->call( you, examp );
+
+    // skip uilist query if only 1 option
+    if( examine_actor.size() + examine_func.size() == 1 ) {
+        if( examine_actor.size() == 1 ) {
+            examine_actor.front()->call( you, examp );
+        } else {
+            examine_func.front().examine( you, examp );
+        }
+        return;
+    }
+
+    // if NPC, pick the very first option
+    // TODO, but i have no idea how to approach it for generic use cases
+    if( you.is_npc() ) {
+        if( examine_actor.size() > 0 ) {
+            examine_actor.front()->call( you, examp );
+        } else {
+            examine_func.front().examine( you, examp );
+        }
+        return;
+    }
+
+    uilist selector;
+    selector.text = string_format( _( "What to do with the %s?" ), name() );
+
+    for( const iexamine_functions &func : examine_func ) {
+        uilist_entry e( func.get_name() );
+        e.enabled = func.can_examine( examp );
+        selector.addentry( e );
+    }
+
+    for( const cata::clone_ptr<iexamine_actor> &act : examine_actor ) {
+        uilist_entry e( act->get_name() );
+        selector.addentry( e );
+    }
+
+    selector.query();
+
+    if( selector.ret < 0 ) {
+        return;
+    }
+
+    if( selector.ret < static_cast<int>( examine_func.size() ) ) {
+        const int i = selector.ret;
+        examine_func[i].examine( you, examp );
+    } else {
+        const int i = selector.ret - examine_func.size();
+        examine_actor[i]->call( you, examp );
+    }
 }
 
 void map_data_common_t::load_symbol_color( const JsonObject &jo, const std::string &context )
@@ -1164,21 +1229,30 @@ void map_data_common_t::load( const JsonObject &jo, const std::string &src )
     } else if( was_loaded && has_any_harvest( harvest_by_season ) ) {
         // Explicitly don't inherit harvest_by_season so _harvested versions don't need to override it
         harvest_by_season.fill( harvest_id::NULL_ID() );
-        examine_actor = nullptr;
-        examine_func = iexamine_functions_from_string( "none" );
     }
 
+    // this certainly need some cleanup, leverage it to generic factory or something
     if( jo.has_string( "examine_action" ) ) {
-        examine_actor = nullptr;
-        examine_func = iexamine_functions_from_string( jo.get_string( "examine_action" ) );
+        examine_func.emplace_back( iexamine_functions_from_string( jo.get_string( "examine_action" ) ) );
     } else if( jo.has_object( "examine_action" ) ) {
         JsonObject data = jo.get_object( "examine_action" );
-        examine_actor = iexamine_actor_from_jsobj( data );
-        examine_actor->load( data, src );
-        examine_func = iexamine_functions_from_string( "invalid" );
-    } else if( !was_loaded ) {
-        examine_actor = nullptr;
-        examine_func = iexamine_functions_from_string( "none" );
+        cata::clone_ptr<iexamine_actor> a = iexamine_actor_from_jsobj( data );
+        optional( data, was_loaded, "name", a->name );
+        a->load( data, src );
+        examine_actor.emplace_back( a );
+    } else if( jo.has_array( "examine_action" ) ) {
+        for( JsonValue jov : jo.get_array( "examine_action" ) ) {
+            // if string, examine_func
+            if( jov.test_string() ) {
+                examine_func.emplace_back( iexamine_functions_from_string( jov.get_string() ) );
+            } else { // object, examine_actor
+                JsonObject data = jov.get_object();
+                cata::clone_ptr<iexamine_actor> a = iexamine_actor_from_jsobj( data );
+                optional( data, was_loaded, "name", a->name );
+                a->load( data, src );
+                examine_actor.emplace_back( a );
+            }
+        }
     }
 
     if( was_loaded && jo.has_member( "flags" ) ) {

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -524,10 +524,10 @@ struct map_data_common_t {
         translation name_;
 
         // Hardcoded examination function; what happens when the terrain/furniture is examined
-        iexamine_functions examine_func;
+        std::vector<iexamine_functions> examine_func;
 
         // Data-driven examine actor
-        cata::clone_ptr<iexamine_actor> examine_actor;
+        std::vector<cata::clone_ptr<iexamine_actor>> examine_actor;
 
     private:
         std::set<std::string> flags; // string flags which possibly refer to what's documented above.
@@ -553,9 +553,11 @@ struct map_data_common_t {
         std::array<int, NUM_SEASONS> symbol_;
 
         bool can_examine( const tripoint_bub_ms &examp ) const;
+        // checks if it has corresponding examine_func
         bool has_examine( iexamine_examine_function func ) const;
+        // checks if it has corresponding examine_actor
         bool has_examine( const std::string &action ) const;
-        void set_examine( iexamine_functions func );
+        void set_examine( const iexamine_functions &func );
         void examine( Character &, const tripoint_bub_ms & ) const;
 
         int light_emitted = 0;

--- a/tests/iexamine_test.cpp
+++ b/tests/iexamine_test.cpp
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "calendar.h"
 #include "cata_catch.h"
 #include "coordinates.h"
@@ -6,12 +8,13 @@
 #include "map_helpers.h"
 #include "mapdata.h"
 #include "point.h"
+#include "translation.h"
 #include "type_id.h"
 
 TEST_CASE( "mapdata_examine" )
 {
     ter_t data;
-    data.set_examine( iexamine_functions{iexamine::always_true, iexamine::water_source} );
+    data.set_examine( iexamine_functions{iexamine::always_true, iexamine::water_source, no_translation( "test water source" ) } );
 
     CHECK( data.has_examine( iexamine::water_source ) );
     CHECK_FALSE( data.has_examine( iexamine::fungus ) );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
For a long time, you could only climb chain link fence, but not chain link gates. Why? Because they can be lockpicked, and therefore cannot have `chainfence` examine action anymore. Why? Because each terrain could support only one examine action. No more
#### Describe the solution
Make both examine_actor and examine_func support array notation, adjust the code accordingly
If ter/furn has more than 1 examine action, uilist is shown where player can select which options they can use
#### Testing
<img width="930" height="879" alt="image" src="https://github.com/user-attachments/assets/22933817-5f57-4f7d-8ce7-5bc0d4dfb51e" />

#### Additional context
It is terrifying that at least a dozen of examine actions are different types of harvests