### PR TITLE
[Xedra Evolved] Add Follower dialogue topic to ask them to cast spells

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects_changeling_seasonal_magic.json
+++ b/data/mods/Xedra_Evolved/effects/effects_changeling_seasonal_magic.json
@@ -214,7 +214,7 @@
         "values": [
           {
             "value": "CLIMATE_CONTROL_CHILL",
-            "add": { "math": [ "10 + (u_summer_spell_count * 2) + (u_deduction_for_spells * 4)" ] }
+            "add": { "math": [ "10 + (u_summer_spell_count * 2) + (u_gramarye_for_spells * 4)" ] }
           }
         ]
       }

--- a/data/mods/Xedra_Evolved/npc/dialogue/follower_dialogue.json
+++ b/data/mods/Xedra_Evolved/npc/dialogue/follower_dialogue.json
@@ -17,9 +17,164 @@
     "dynamic_line": "Which spell did you want?",
     "responses": [
       {
-        "text": "Could you cast a spell for me?",
+        "text": "Could you summon some dreamdross?",
         "topic": "TALK_FRIEND_FOLLOWER_CAST_SPELL_DREAMER_CREATE_DREAMDROSS",
-        "condition": { "and": [ { "npc_has_trait": "DREAMER" }, { "math": [ "(u_spell_level('create_dream_dross')  >= 1" ] }, { "math": [ "u_val('mana_max') >= 1000" ] } ] }
+        "condition": {
+          "and": [
+            { "npc_has_trait": "DREAMER" },
+            { "math": [ "n_spell_level('create_dream_dross') >= 1" ] },
+            { "math": [ "n_val('mana_max') >= 1000" ] }
+          ]
+        }
+      },
+      {
+        "text": "Could you cure my illnesses?",
+        "topic": "TALK_FRIEND_FOLLOWER_CAST_SPELL_FAIR_FOLK_SPRING_CLEANSING",
+        "condition": {
+          "and": [
+            { "npc_has_trait": "CHANGELING_SEASONAL_MAGIC_SPRING" },
+            { "math": [ "n_spell_level('changeling_spring_prevent_bad_conditions_spell') >= 1" ] },
+            {
+              "math": [
+                "n_val('mana_max') >= max( ( 500 - (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 4) - (n_skill('gramarye') * 8)), 350)"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "text": "Could you heal my wounds?",
+        "topic": "TALK_FRIEND_FOLLOWER_CAST_SPELL_FAIR_FOLK_NEW_GROWTH",
+        "condition": {
+          "and": [
+            { "npc_has_trait": "CHANGELING_SEASONAL_MAGIC_SPRING" },
+            "u_is_outside",
+            "npc_is_outside",
+            { "math": [ "n_spell_level('changeling_spring_healing_increase_while_outside_spell') >= 1" ] },
+            {
+              "math": [
+                "n_val('mana_max') >= max( ( 800 - (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 8) - (n_skill('gramarye') * 15)), 450)"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "text": "Could you help me deal with these hot temperatures?",
+        "topic": "TALK_FRIEND_FOLLOWER_CAST_SPELL_FAIR_FOLK_GIFT_OF_WARM_BLOOD",
+        "condition": {
+          "and": [
+            { "npc_has_trait": "CHANGELING_SEASONAL_MAGIC_SUMMER" },
+            { "math": [ "n_spell_level('changeling_summer_protect_from_hot_weather_spell') >= 1" ] },
+            {
+              "math": [
+                "n_val('mana_max') >= max( ( 250 - (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2) - (n_skill('gramarye') * 4.5) ), 100)"
+              ]
+            }
+          ]
+        }
+      },
+      { "text": "Never mind", "topic": "TALK_FRIEND" }
+    ]
+  },
+  {
+    "id": [ "TALK_FRIEND_FOLLOWER_CAST_SPELL_DREAMER_CREATE_DREAMDROSS" ],
+    "type": "talk_topic",
+    "dynamic_line": "*<npc_name> cups <mypronoun> hands and closes <mypronoun> eyes, and over a few seconds, several fragments of shining metal slowly appear in a soft shimmering light.  <mypronoun> hands them to you.",
+    "responses": [
+      {
+        "text": "Thank you.",
+        "topic": "TALK_FRIEND",
+        "effect": [
+          { "math": [ "n_val('mana') -= 1000" ] },
+          {
+            "u_spawn_item": "scrap_dreamdross",
+            "count": { "math": [ "(n_spell_level('create_dream_dross') / 2) + 1" ] }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": [ "TALK_FRIEND_FOLLOWER_CAST_SPELL_FAIR_FOLK_SPRING_CLEANSING" ],
+    "type": "talk_topic",
+    "dynamic_line": "*<npc_name> mutters something under <mypronoun> breath and a green glow surrounds you.",
+    "responses": [
+      {
+        "text": "Much better, thank you.",
+        "topic": "TALK_FRIEND",
+        "effect": [
+          {
+            "math": [
+              "_duration_lower_bound = ( ( 908.54 + (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 186.25) + (n_skill('gramarye') * 385.43) ) ) * (global_what_is_the_season == 3 ? 0.3 : 1)"
+            ]
+          },
+          {
+            "math": [
+              "_duration_upper_bound = ( ( 2448.00 + (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 418.35) + (n_skill('gramarye') * 985.15) ) )  * (global_what_is_the_season == 3 ? 0.2 : 1)"
+            ]
+          },
+          {
+            "math": [
+              "n_val('mana') -= max( ( 500 - (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 4) - (n_skill('gramarye') * 8)), 350)"
+            ]
+          },
+          {
+            "u_add_effect": "effect_changeling_spring_prevent_bad_conditions",
+            "duration": { "math": [ "rng(_duration_lower_bound, _duration_upper_bound)" ] }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": [ "TALK_FRIEND_FOLLOWER_CAST_SPELL_FAIR_FOLK_NEW_GROWTH" ],
+    "type": "talk_topic",
+    "dynamic_line": "*<npc_name> puts a hand on you and you feel a warmth spread across your entire body.  \"But remember, stay outside or the glamour won't work.\"",
+    "responses": [
+      {
+        "text": "Much better, thank you.",
+        "topic": "TALK_FRIEND",
+        "effect": [
+          {
+            "math": [
+              "_duration_lower_bound = ( ( 846.12 + (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 129.52) + (n_skill('gramarye') * 385.42) ) )"
+            ]
+          },
+          {
+            "math": [
+              "_duration_upper_bound = ( ( 1685.24 + (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 348.15) + (n_skill('gramarye') * 898.51) ) )"
+            ]
+          },
+          {
+            "math": [
+              "n_val('mana') -= max( ( 800 - (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 8) - (n_skill('gramarye') * 15)), 450)"
+            ]
+          },
+          {
+            "u_add_effect": "effect_changeling_spring_healing_increase_while_outside",
+            "duration": { "math": [ "rng(_duration_lower_bound, _duration_upper_bound)" ] }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": [ "TALK_FRIEND_FOLLOWER_CAST_SPELL_FAIR_FOLK_GIFT_OF_WARM_BLOOD" ],
+    "type": "talk_topic",
+    "dynamic_line": "*<npc_name> sings a few scraps of a half-familiar melody and a cool breeze blows past you.",
+    "responses": [
+      {
+        "text": "Much better, thank you.",
+        "topic": "TALK_FRIEND",
+        "effect": [
+          { "run_eocs": "EOC_CHANGELING_SUMMER_PROTECT_FROM_HOT_WEATHER", "alpha_talker": "u" },
+          {
+            "math": [
+              "n_val('mana') -= max( ( 250 - (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2) - (n_skill('gramarye') * 4.5) ), 100)"
+            ]
+          }
+        ]
       }
     ]
   }

--- a/data/mods/Xedra_Evolved/npc/dialogue/follower_dialogue.json
+++ b/data/mods/Xedra_Evolved/npc/dialogue/follower_dialogue.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": [ "TALK_FRIEND" ],
+    "type": "talk_topic",
+    "insert_before_standard_exits": true,
+    "responses": [
+      {
+        "text": "Could you cast a spell for me?",
+        "topic": "TALK_FRIEND_FOLLOWER_CAST_SPELL",
+        "condition": { "npc_has_any_trait": [ "DREAMER", "EATER", "HEDGE_MAGIC", "CHANGELING_MAGIC", "XE_NETHER_SORCERY" ] }
+      }
+    ]
+  },
+  {
+    "id": [ "TALK_FRIEND_FOLLOWER_CAST_SPELL" ],
+    "type": "talk_topic",
+    "dynamic_line": "Which spell did you want?",
+    "responses": [
+      {
+        "text": "Could you cast a spell for me?",
+        "topic": "TALK_FRIEND_FOLLOWER_CAST_SPELL_DREAMER_CREATE_DREAMDROSS",
+        "condition": { "and": [ { "npc_has_trait": "DREAMER" }, { "math": [ "(u_spell_level('create_dream_dross')  >= 1" ] }, { "math": [ "u_val('mana_max') >= 1000" ] } ] }
+      }
+    ]
+  }
+]

--- a/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_spring.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_spring.json
@@ -143,7 +143,7 @@
     "type": "SPELL",
     "name": "Spring Cleansing",
     "description": "Like a house after a long winter, this glamour removes impurities in the target's body, curing them of poison or disease and preventing them from reoccurring while it lasts.  The glamour's duration is <color_yellow>greatly reduced</color> in the autumn.",
-    "message": "",
+    "message": "You mutter a few words backwards and as you gesture, a soft green glow surrounds your target.",
     "flags": [ "VERBAL", "SOMATIC", "RANDOM_DURATION", "NO_LEGS" ],
     "magic_type": "xe_fey_seasonal_magick_spring",
     "spell_class": "CHANGELING_SEASONAL_MAGIC_SPRING",
@@ -455,6 +455,8 @@
     "flags": [ "VERBAL", "SOMATIC", "RANDOM_DURATION", "NO_LEGS" ],
     "magic_type": "xe_fey_seasonal_magick_spring",
     "spell_class": "CHANGELING_SEASONAL_MAGIC_SPRING",
+    "caster_condition": "u_is_outside",
+    "caster_condition_fail_message": "You must be outside to weave this glamour.",
     "valid_targets": [ "self", "ally" ],
     "teachable": false,
     "skill": "gramarye",
@@ -467,12 +469,12 @@
     "min_range": 10,
     "min_duration": {
       "math": [
-        "( ( 84612 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 12952) + (u_skill('gramarye') * 18542) ) )"
+        "( ( 84612 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 12952) + (u_skill('gramarye') * 38542) ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 168524 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 34815) + (u_skill('gramarye') * 49851) ) )"
+        "( ( 168524 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 34815) + (u_skill('gramarye') * 89851) ) )"
       ]
     },
     "base_energy_cost": {

--- a/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_summer.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_summer.json
@@ -111,7 +111,7 @@
     "max_level": 1,
     "shape": "blast",
     "difficulty": 3,
-    "effect": "effect_on_condition",
+    "effect": "attack",
     "effect_str": "EOC_CHANGELING_SUMMER_PROTECT_FROM_HOT_WEATHER",
     "min_range": 10,
     "min_duration": {
@@ -121,7 +121,9 @@
       "math": [ "169485 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 45508) + (u_skill('gramarye') * 116805)" ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 250 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2) - (u_skill('gramarye') * 2)), 100)" ]
+      "math": [
+        "max( ( 250 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2) - (u_skill('gramarye') * 4.5) ), 100)"
+      ]
     },
     "base_casting_time": 50
   },

--- a/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_summer_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_summer_eocs.json
@@ -71,17 +71,19 @@
     "effect": [
       {
         "math": [
-          "u_spell_low_duration = (766.28 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 144.96) + (u_skill('gramarye') * 295.21) )"
+          "_spell_low_duration = (766.28 + (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 144.96) + (n_skill('gramarye') * 295.21) )"
         ]
       },
       {
         "math": [
-          "u_spell_high_duration = ( 1694.85 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 455.08) + (u_skill('gramarye') * 1168.05) )"
+          "_spell_high_duration = ( 1694.85 + (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 455.08) + (n_skill('gramarye') * 1168.05) )"
         ]
       },
+      { "math": [ "u_summer_spell_count = n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER')" ] },
+      { "math": [ "u_gramarye_for_spells = n_skill('gramarye')" ] },
       {
         "u_add_effect": "effect_changeling_summer_protect_from_hot_weather",
-        "duration": { "math": [ "rng(u_spell_low_duration, u_spell_high_duration)" ] }
+        "duration": { "math": [ "rng(_spell_low_duration, _spell_high_duration)" ] }
       }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Add Follower dialogue topic to ask them to cast spells"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Thought about this for dreamdross but the framework is useful for others.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a follower dialogue option to have them cast spells. This is set up for utility spells or spells they wouldn't otherwise cast, it's not for giving them orders during combat.

Spells:

- Bring Forth Dreamdross (Dreamer)
- Spring Cleansing (Fair Folk)
- New Growth (Fair Folk)
- Gift of Warm Blood (Fair Folk)

Not actually a lot of spells Dreamers or Eaters could cast for your benefit.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked each dialogue choice and made sure they worked properly.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
