### PR TITLE
Forbid reach attacks when using force unarmed

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1814,6 +1814,10 @@ static void fire()
 
     const item_location weapon = you.get_wielded_item();
     // try reach weapon
+    if( !you.used_weapon() && !weapon->is_gun() ) {
+        add_msg( m_info, _( "You can't use reach attacks while forcing yourself to fight unarmed." ) );
+        return;
+    }
     if( weapon && !weapon->is_gun() && weapon->current_reach_range( you ).first > 1 ) {
         reach_attack( you );
         return;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1122,6 +1122,10 @@ void Character::reach_attack( const tripoint_bub_ms &p, int forced_movecost )
             // Communicate this with a different message?
         }
 
+        const int total_stamina = enchantment_cache->modify_value(
+                                      enchant_vals::mod::MELEE_STAMINA_CONSUMPTION, get_total_melee_stamina_cost() );
+        burn_energy_arms( std::min( -50, total_stamina ) );
+
         mod_moves( forced_movecost >= 0 ? -forced_movecost : -move_cost );
         return;
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Forbid reach attacks when using force unarmed"

#### Purpose of change
* Closes #77429.

#### Describe the solution
- Forbid reach attacks when using force unarmed.
- Also, while I'm here, I noticed that reach-attacking "air" (i.e. "You swing at the air") cost no stamina, so I decided to fix this too.

#### Describe alternatives you've considered
None.

#### Testing
- Got bronze pike. Set Force Unarmed martial style. Tried to `f`ire (= reach attack). Got a prohibitory notice. Set martial style to No Style. `f`ired again, successfully. Also, just in case, got M16 and tried to `f`ire with Force Unarmed, successfully.
- Checked my stamina before the hit, reach-attacked "air", checked that stamina was correctly burned.

#### Additional context
None.