### PR TITLE
Updated Magiclysm's Improved Knock with more types of doors

### DIFF
--- a/data/mods/Magiclysm/ter_fur_transform/ter_fur_transform.json
+++ b/data/mods/Magiclysm/ter_fur_transform/ter_fur_transform.json
@@ -218,8 +218,15 @@
       },
       {
         "result": "t_door_metal_o",
-        "valid_terrain": [ "t_door_metal_locked", "t_door_metal_pickable", "t_door_bar_locked" ],
+        "valid_terrain": [ "t_door_metal_locked", "t_door_metal_pickable", "t_door_bar_locked", "t_door_metal_interior_locked" ],
         "message": "The door opens forcefully!"
+      },
+      { "result": "t_door_bar_o", "valid_terrain": [ "t_door_bar_locked" ], "message": "The door opens forcefully!" },
+      { "result": "t_chaingate_o", "valid_terrain": [ "t_chaingate_l" ], "message": "The gate opens forcefully!" },
+      {
+        "result": "t_retractable_gate_o",
+        "valid_terrain": [ "t_retractable_gate_l" ],
+        "message": "The gate opens forcefully!"
       }
     ]
   },


### PR DESCRIPTION
#### Summary
Mods " Magiclysm's Improved Knock now opens more types of doors"

#### Purpose of change
* Closes #64031.

#### Describe the solution
Added `t_door_metal_interior_locked` to the list of metal doors to open. Also added `t_door_bar_locked`, `t_chaingate_l`, and `t_retractable_gate_l` to the list.

There are also doors with electronic locks. I'm not sure if this spell could open such locks. If it does, I'll add these doors to the list.

#### Describe alternatives you've considered
None.

#### Testing
None needed, obvious json change.

#### Additional context
None.