### PR TITLE
implement temperature modifier for weather

### DIFF
--- a/doc/JSON/WEATHER_TYPE.md
+++ b/doc/JSON/WEATHER_TYPE.md
@@ -14,6 +14,7 @@ Each weather type is a type of weather that occurs, and what causes it. The only
 | `ranged_penalty`     | Penalty to ranged attacks.                                                                       |
 | `sight_penalty`      | Penalty to per-square visibility, applied in transparency map.                                   |
 | `light_modifier`     | modification to ambient light.                                                                   |
+| `temperature_modifier` | additive modifier to ambient temperature above ground.                                         |
 | `sound_attn`         | Sound attenuation of a given weather type.                                                       |
 | `dangerous`          | If true, our activity gets interrupted.                                                          |
 | `precip`             | Amount of associated precipitation. Valid values are: none, very_light, light and heavy          |
@@ -47,6 +48,7 @@ Each weather type is a type of weather that occurs, and what causes it. The only
     "ranged_penalty": 4,
     "sight_penalty": 1.25,
     "light_modifier": -45,
+    "temperature_modifier": "-30 C",
     "sound_attn": 8,
     "dangerous": false,
     "precip": "heavy",

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -101,12 +101,7 @@ void temperature_delta::deserialize( const JsonValue &jv )
     if( jv.test_int() ) {
         *this = from_legacy_bodypart_temp_delta( jv.get_int() );
     } else {
-        // gross
-        std::optional<double> v = svtod( jv.get_string() );
-        if( !v.has_value() ) {
-            jv.throw_error( "Invalid double" );
-        }
-        *this = from_kelvin_delta( v.value() );
+        *this = read_from_json_string( jv, units::temperature_delta_units );
     }
 }
 

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -1213,6 +1213,7 @@ units::temperature weather_manager::get_temperature( const tripoint_bub_ms &loca
         temp_mod = get_heat_radiation( location );
         temp_mod += get_convection_temperature( location );
         temp_mod += get_map().get_temperature_mod( location );
+        temp_mod += weather_id->temperature_modifier;
 
         temp += temp_mod;
     }

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -108,6 +108,7 @@ void weather_type::load( const JsonObject &jo, std::string_view )
     mandatory( jo, was_loaded, "ranged_penalty", ranged_penalty );
     mandatory( jo, was_loaded, "sight_penalty", sight_penalty );
     mandatory( jo, was_loaded, "light_modifier", light_modifier );
+    optional( jo, was_loaded, "temperature_modifier", temperature_modifier, 0_K_delta );
     mandatory( jo, was_loaded, "priority", priority );
     optional( jo, was_loaded, "light_multiplier", light_multiplier, 1.f );
     optional( jo, was_loaded, "sun_multiplier", sun_multiplier, 1.f );

--- a/src/weather_type.h
+++ b/src/weather_type.h
@@ -95,6 +95,8 @@ struct weather_type {
         float sight_penalty = 0.0f;
         // Modification to ambient light.
         int light_modifier = 0;
+        // Increases or decreases average temperature when this weather is active
+        units::temperature_delta temperature_modifier = 0_K_delta;
         // Multiplier to ambient light.
         float light_multiplier = 1.f;
         // Multiplier to radiation from Sun.

--- a/src/weather_type.h
+++ b/src/weather_type.h
@@ -16,6 +16,7 @@
 #include "field_type.h"
 #include "translation.h"
 #include "type_id.h"
+#include "units.h"
 
 class JsonObject;
 struct const_dialogue;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Was requested by Balthazar, since there is no real way for temperature to be modified in any another way
#### Describe the solution
Implement `temperature_modifier` field for weather_type that does exactly that
#### Testing
Got instantly frozen when weather started
#### Additional context
Because of how weather works, the change in temperature is drastic and instantaneous, so i would recommend to whoever uses it to make it gradual via having multiple weather types shifting into each other (see the same issue with fog, for example); suggestions how it can be handled can be discussed, but i most probably will not implement it