### PR TITLE
Fix COLDBLOOD4/Ectothermic speed bonus not applying in hot weather

### DIFF
--- a/data/json/mutations/mutation_jmath.json
+++ b/data/json/mutations/mutation_jmath.json
@@ -18,5 +18,15 @@
     "//example3": "temperature_speed_mod(65, 0.2), but character has mutation, that gives CLIMATE_CONTROL_HEAT 5; it would make you lose 0.2 speed, if temperature around is lower than 60 F; temperature of 55 F would result in `(65-5-55)*0.2 = 5*0.2 = 1` 1 move speed decrease",
     "num_args": 2,
     "return": "min((fahrenheit(weather('temperature')) - _0 + u_climate_control_str_heat()) * _1, 0)"
+  },
+  {
+    "type": "jmath_function",
+    "id": "temperature_speed_mod_bipolar",
+    "//": "Changes your speed based on temperature in both directions: penalty below the threshold, bonus above it",
+    "//_0": "Temperature threshold in fahrenheit",
+    "//_1": "Speed change per degree",
+    "//example": "temperature_speed_mod_bipolar(65, 0.5) would give -10 speed at 45 F and +12 speed at 89 F",
+    "num_args": 2,
+    "return": "(fahrenheit(weather('temperature')) - _0 + u_climate_control_str_heat()) * _1"
   }
 ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3045,7 +3045,7 @@
       {
         "values": [
           { "value": "METABOLISM", "multiply": -0.5 },
-          { "value": "SPEED", "add": { "math": [ "temperature_speed_mod(65, 0.5)" ] } }
+          { "value": "SPEED", "add": { "math": [ "temperature_speed_mod_bipolar(65, 0.5)" ] } }
         ]
       }
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Restores Ectothermic speed bonus in hot weather"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
In #72328 COLDBLOOD4's speed modifier was migrated to `temperature_speed_mod(65, 0.5)` along with COLDBLOOD1–3. That function locked its result to `min(..., 0)`, so a heat bonus was impossible. Before migration, COLDBLOOD4 applied modifier unconditionally with the `ECTOTHERM` flag short-circuit, giving a speed bonus above 65°F and penalty below it, which matched its description. It has been functionally identical to COLDBLOOD3 since March 2024.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added `temperature_speed_mod_bipolar`, identical to `temperature_speed_mod` but without the `min(..., 0)` restriction, and applied it to COLDBLOOD4's SPEED enchantment. COLDBLOOD1–3 are unchanged.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Fixing the description instead of the math. Rejected because both the pre-migration code and the description confirm the heat bonus was intended.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Set season to mid-summer (1), mid-day (14:00), stood outdoors, applied COLDBLOOD1-3, then THRESH_LIZARD, then COLDBLOOD4. Character sheet speed line shows a positive Ectothermic bonus in hot weather.

Note that "Force temperature" debug option will not work for testing as `weather('temperature')` reads `weather_precise->temperature` directly, not the forced value, so use weather.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
