### PR TITLE
Fix segfault while trying to fire a bare hands

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1814,7 +1814,8 @@ static void fire()
 
     const item_location weapon = you.get_wielded_item();
     // try reach weapon
-    if( !you.used_weapon() && !weapon->is_gun() ) {
+    // used_weapon() returns null location if force unarmed is selected
+    if( weapon && !you.used_weapon() && !weapon->is_gun() ) {
         add_msg( m_info, _( "You can't use reach attacks while forcing yourself to fight unarmed." ) );
         return;
     }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #87949
#### Describe the solution
Before checking `!weapon->is_gun()`, check the `weapon` is presented
#### Testing
Pressing `f` while unarmed do not segfault; still can fight when unarmed, armed, can shoot guns, but cannot `f` with spear anymore