### PR TITLE
Fix Random NPCs not getting spells from professions or hobbies

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2174,8 +2174,7 @@ void Character::empty_skills()
 
 void Character::add_traits()
 {
-    //TODO: NPCs already get profession stuff assigned at least twice elsewhere causing issues and it all wants unifying (if not here this should be made an avatar::add_traits()
-    if( !is_npc() ) {
+    {
         for( const trait_and_var &tr : prof->get_locked_traits() ) {
             if( !has_trait( tr.trait ) ) {
                 toggle_trait_deps( tr.trait );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -964,6 +964,13 @@ void Character::initialize( bool learn_recipes )
         learn_recipe( &r );
     }
 
+    prof->learn_spells( *this );
+
+    // Also learn spells from hobbies
+    for( const profession *profession : hobbies ) {
+        profession->learn_spells( *this );
+    }
+
     // Add hobby proficiencies
     set_proficiencies_from_hobbies();
 
@@ -1057,13 +1064,6 @@ void avatar::initialize( character_type type )
     const point_rel_om &offset = scen->get_origin_offset();
     if( offset != point_rel_om::zero ) {
         world_origin = world_origin.value_or( point_abs_om() ) + offset;
-    }
-
-    prof->learn_spells( *this );
-
-    // Also learn spells from hobbies
-    for( const profession *profession : hobbies ) {
-        profession->learn_spells( *this );
     }
 
 }

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -823,12 +823,12 @@ std::map<spell_id, int> profession::spells() const
     return _starting_spells;
 }
 
-void profession::learn_spells( avatar &you ) const
+void profession::learn_spells( Character &you ) const
 {
-    for( const std::pair<const spell_id, int> &spell_pair : spells() ) {
-        you.magic->learn_spell( spell_pair.first, you, true );
-        spell &sp = you.magic->get_spell( spell_pair.first );
-        while( sp.get_level() < spell_pair.second && !sp.is_max_level( you ) ) {
+    for( const auto &[spell_id, level] : spells() ) {
+        you.magic->learn_spell( spell_id, you, true );
+        spell &sp = you.magic->get_spell( spell_id );
+        while( sp.get_level() < level && !sp.is_max_level( you ) ) {
             sp.gain_level( you );
         }
     }

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -10,7 +10,6 @@
 
 #include "achievement.h"
 #include "addiction.h"
-#include "avatar.h"
 #include "calendar.h"
 #include "character.h"
 #include "color.h"

--- a/src/profession.h
+++ b/src/profession.h
@@ -19,7 +19,6 @@
 
 class Character;
 class JsonObject;
-class avatar;
 class item;
 template<typename T>
 class generic_factory;

--- a/src/profession.h
+++ b/src/profession.h
@@ -146,7 +146,7 @@ class profession
         std::vector<achievement_id> get_requirements() const;
 
         std::map<spell_id, int> spells() const;
-        void learn_spells( avatar &you ) const;
+        void learn_spells( Character &you ) const;
         std::vector<effect_on_condition_id> get_eocs() const;
         //returns the profession id
         profession_id get_profession_id() const;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "NPCs will now get their spells from professions and hobbies during random NPC creation"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Followup to https://github.com/CleverRaven/Cataclysm-DDA/pull/76935 and [#85906](https://github.com/CleverRaven/Cataclysm-DDA/pull/85906)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Push spell learning from Avatar to character so that it applies across all character types.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Begging for help
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Testing with Magiclysm was a success for both profession spells and hobby spells.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<img width="923" height="290" alt="Got it  Excitement" src="https://github.com/user-attachments/assets/498899c0-a0b4-4f2f-b6a4-eaffa96b4a5a" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
