### PR TITLE
Aftershock: Better power armor durability.

### DIFF
--- a/data/mods/aftershock_exoplanet/faults/armor_fault.json
+++ b/data/mods/aftershock_exoplanet/faults/armor_fault.json
@@ -36,5 +36,43 @@
       { "damage_id": "afs_laser", "multiply": 0.4 },
       { "damage_id": "afs_plasma", "multiply": 0.1 }
     ]
+  },
+  {
+    "type": "fault",
+    "id": "afs_fault_armor_steel",
+    "name": { "str": "damaged" },
+    "description": "Successive impacts have dented and weakened the steel panels of this armor piece, reducing its effectiveness.",
+    "fault_type": "mechanical_damage",
+    "item_prefix": "damaged",
+    "message": "%s was damaged!",
+    "degradation_mod": 100,
+    "price_modifier": 0.3,
+    "armor_mod": [
+      { "damage_id": "bash", "multiply": 0.6 },
+      { "damage_id": "cut", "multiply": 0.9 },
+      { "damage_id": "stab", "multiply": 0.9 },
+      { "damage_id": "bullet", "multiply": 0.6 },
+      { "damage_id": "afs_laser", "multiply": 0.6 }
+    ]
+  },
+  {
+    "type": "fault",
+    "id": "afs_fault_armor_steel_bad",
+    "name": { "str": "compromised" },
+    "affected_by_degradation": true,
+    "description": "Most of the steel panels of this armor piece have been torn away or completely destroyed.  It won't provide much protection at all, and could at best be recycled for scrap.",
+    "fault_type": "mechanical_damage",
+    "item_prefix": "compromised",
+    "message": "%s was heavily damaged!",
+    "degradation_mod": 100,
+    "price_modifier": 0.01,
+    "armor_mod": [
+      { "damage_id": "bash", "multiply": 0.3 },
+      { "damage_id": "cut", "multiply": 0.6 },
+      { "damage_id": "stab", "multiply": 0.3 },
+      { "damage_id": "bullet", "multiply": 0.3 },
+      { "damage_id": "afs_laser", "multiply": 0.4 },
+      { "damage_id": "afs_plasma", "multiply": 0.1 }
+    ]
   }
 ]

--- a/data/mods/aftershock_exoplanet/faults/fault_group_armor.json
+++ b/data/mods/aftershock_exoplanet/faults/fault_group_armor.json
@@ -3,5 +3,10 @@
     "type": "fault_group",
     "id": "carbide_armor",
     "group": [ { "fault": "fault_armor_carbide", "weight": 100 }, { "fault": "fault_armor_carbide_bad", "weight": 5 } ]
+  },
+  {
+    "type": "fault_group",
+    "id": "afs_steel_armor",
+    "group": [ { "fault": "afs_fault_armor_steel", "weight": 100 }, { "fault": "afs_fault_armor_steel_bad", "weight": 5 } ]
   }
 ]

--- a/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_plating_arms.json
+++ b/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_plating_arms.json
@@ -14,32 +14,7 @@
     "color": "light_gray",
     "warmth": 20,
     "flags": [ "CANT_WEAR", "ABLATIVE_LARGE", "EXO_ARM_PLATE" ],
-    "non_functional": "damaged_exo_arm_steel",
-    "armor": [
-      {
-        "material": [ { "type": "afs_steel", "covered_by_mat": 100, "thickness": 2 } ],
-        "covers": [ "arm_l", "arm_r" ],
-        "coverage": 100,
-        "encumbrance": 5,
-        "layers": [ "OUTER" ]
-      },
-      {
-        "material": [ { "type": "afs_steel", "covered_by_mat": 100, "thickness": 2 } ],
-        "covers": [ "hand_l", "hand_r" ],
-        "coverage": 100,
-        "encumbrance": 5
-      }
-    ]
-  },
-  {
-    "id": "damaged_exo_arm_steel",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "copy-from": "exo_arm_steel",
-    "name": { "str": "damaged steel arm plate (exosuit)", "str_pl": "damaged steel arm plates (exosuit)" },
-    "description": "The remains of a steel arm plate after taking a strong impact.  Can be restored to full effectiveness via reforging.",
-    "looks_like": "exo_arm_steel",
-    "non_functional": "destroyed_exo_arm_steel",
+    "faults": [ { "fault_group": "afs_steel_armor" } ],
     "armor": [
       {
         "material": [ { "type": "afs_steel", "covered_by_mat": 100, "thickness": 1 } ],
@@ -55,16 +30,6 @@
         "encumbrance": 5
       }
     ]
-  },
-  {
-    "id": "destroyed_exo_arm_steel",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "copy-from": "exo_arm_steel",
-    "name": { "str": "destroyed steel arm plate (exosuit)", "str_pl": "destroyed steel arm plates (exosuit)" },
-    "description": "The remains of a steel arm plate after taking a strong impact.  Can be recycled at a nanofabricator.",
-    "looks_like": "exo_arm_steel",
-    "extend": { "flags": [ "NO_REPAIR" ] }
   },
   {
     "id": "exo_arm_plastic",
@@ -138,7 +103,6 @@
     "weight": "20250 g",
     "material": [ "vacuum_carbide_hard" ],
     "faults": [ { "fault_group": "carbide_armor" } ],
-    "non_functional": "damaged_exo_arm_vcc",
     "armor": [
       {
         "material": [ { "type": "vacuum_carbide_hard", "covered_by_mat": 100, "thickness": 1 } ],
@@ -154,39 +118,5 @@
         "encumbrance": 5
       }
     ]
-  },
-  {
-    "id": "damaged_exo_arm_vcc",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "copy-from": "exo_arm_vcc",
-    "name": { "str": "damaged carbide arm plate (exosuit)", "str_pl": "damaged carbide arm plates (exosuit)" },
-    "description": "The remains of a carbide arm plate after taking a strong impact.",
-    "looks_like": "exo_arm_vcc",
-    "non_functional": "destroyed_exo_arm_vcc",
-    "armor": [
-      {
-        "material": [ { "type": "vacuum_carbide", "covered_by_mat": 100, "thickness": 1 } ],
-        "covers": [ "arm_l", "arm_r" ],
-        "coverage": 100,
-        "encumbrance": 5,
-        "layers": [ "OUTER" ]
-      },
-      {
-        "material": [ { "type": "vacuum_carbide", "covered_by_mat": 100, "thickness": 1 } ],
-        "covers": [ "hand_l", "hand_r" ],
-        "coverage": 100,
-        "encumbrance": 5
-      }
-    ]
-  },
-  {
-    "id": "destroyed_exo_arm_vcc",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "copy-from": "exo_arm_vcc",
-    "name": { "str": "shattered carbide arm plate (exosuit)", "str_pl": "shattered carbide arm plates (exosuit)" },
-    "description": "The remains of a vacuum-cast carbide arm plate after taking a strong impact.  No longer provides functional protection, just weight.",
-    "looks_like": "exo_arm_vcc"
   }
 ]

--- a/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_plating_head.json
+++ b/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_plating_head.json
@@ -12,8 +12,8 @@
     "symbol": "[",
     "looks_like": "power_armor_helmet_basic",
     "color": "light_gray",
-    "flags": [ "CANT_WEAR", "ABLATIVE_LARGE", "EXO_HELMET_PLATE" ],
-    "non_functional": "damaged_exo_helmet_steel",
+    "flags": [ "CANT_WEAR", "ABLATIVE_LARGE", "EXO_HELMET_PLATE", "FRAGILE" ],
+    "faults": [ { "fault_group": "afs_steel_armor" } ],
     "armor": [
       {
         "material": [ { "type": "afs_steel", "covered_by_mat": 100, "thickness": 2 } ],
@@ -22,34 +22,6 @@
         "encumbrance": 5
       }
     ]
-  },
-  {
-    "id": "damaged_exo_helmet_steel",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "copy-from": "exo_helmet_steel",
-    "name": { "str": "damaged steel helmet plate (exosuit)", "str_pl": "damaged steel helmet plates (exosuit)" },
-    "description": "The remains of a steel helmet plate after taking a strong impact.  Can be restored to full effectiveness via reforging.",
-    "looks_like": "exo_helmet_steel",
-    "non_functional": "destroyed_exo_helmet_steel",
-    "armor": [
-      {
-        "material": [ { "type": "afs_steel", "covered_by_mat": 100, "thickness": 1 } ],
-        "covers": [ "head", "eyes", "mouth" ],
-        "coverage": 85,
-        "encumbrance": 5
-      }
-    ]
-  },
-  {
-    "id": "destroyed_exo_helmet_steel",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "copy-from": "exo_helmet_steel",
-    "name": { "str": "destroyed steel helmet plate (exosuit)", "str_pl": "destroyed steel helmet plates (exosuit)" },
-    "description": "The remains of a steel helmet plate after taking a strong impact.  Can be recycled at a nanofabricator.",
-    "looks_like": "exo_helmet_steel",
-    "extend": { "flags": [ "NO_REPAIR" ] }
   },
   {
     "id": "exo_helmet_plastic",
@@ -112,7 +84,6 @@
     "material": [ "vacuum_carbide_hard" ],
     "faults": [ { "fault_group": "carbide_armor" } ],
     "looks_like": "power_armor_helmet_basic",
-    "non_functional": "damaged_exo_helmet_vcc",
     "extend": { "flags": [ "NO_REPAIR" ] },
     "armor": [
       {
@@ -122,36 +93,5 @@
         "encumbrance": 5
       }
     ]
-  },
-  {
-    "id": "damaged_exo_helmet_vcc",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "category": "exosuit",
-    "copy-from": "exo_helmet_vcc",
-    "name": { "str": "damaged carbide helmet plate (exosuit)", "str_pl": "damaged carbide helmet plates (exosuit)" },
-    "description": "The remains of a carbide helmet plate after taking a strong impact.",
-    "material": [ "vacuum_carbide" ],
-    "looks_like": "power_armor_helmet_basic",
-    "non_functional": "destroyed_exo_helmet_vcc",
-    "extend": { "flags": [ "NO_REPAIR" ] },
-    "armor": [
-      {
-        "material": [ { "type": "vacuum_carbide", "covered_by_mat": 100, "thickness": 1 } ],
-        "covers": [ "head", "eyes", "mouth" ],
-        "coverage": 85,
-        "encumbrance": 5
-      }
-    ]
-  },
-  {
-    "id": "destroyed_exo_helmet_vcc",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "copy-from": "exo_helmet_vcc",
-    "name": { "str": "shattered carbide helmet plate (exosuit)", "str_pl": "shattered carbide helmet plates (exosuit)" },
-    "description": "The remains of a vacuum-cast carbide helmet plate after taking a strong impact.  No longer provides functional protection, just weight.",
-    "looks_like": "exo_helmet_vcc",
-    "extend": { "flags": [ "NO_REPAIR" ] }
   }
 ]

--- a/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_plating_legs.json
+++ b/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_plating_legs.json
@@ -13,7 +13,7 @@
     "looks_like": "armor_lc_leg_guard",
     "color": "light_gray",
     "flags": [ "CANT_WEAR", "ABLATIVE_LARGE", "EXO_LEG_PLATE" ],
-    "non_functional": "damaged_exo_leg_steel",
+    "faults": [ { "fault_group": "afs_steel_armor" } ],
     "armor": [
       {
         "material": [ { "type": "afs_steel", "covered_by_mat": 100, "thickness": 2 } ],
@@ -22,33 +22,6 @@
         "encumbrance": 5
       }
     ]
-  },
-  {
-    "id": "damaged_exo_leg_steel",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "copy-from": "exo_leg_steel",
-    "name": { "str": "damaged steel leg plate (exosuit)", "str_pl": "damaged steel leg plates (exosuit)" },
-    "description": "The remains of a steel leg plate after taking a strong impact.  Can be restored to full effectiveness via reforging.",
-    "looks_like": "exo_leg_steel",
-    "non_functional": "destroyed_exo_leg_steel",
-    "armor": [
-      {
-        "material": [ { "type": "afs_steel", "covered_by_mat": 100, "thickness": 1 } ],
-        "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ],
-        "coverage": 85,
-        "encumbrance": 5
-      }
-    ]
-  },
-  {
-    "id": "destroyed_exo_leg_steel",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "copy-from": "exo_leg_steel",
-    "name": { "str": "shattered steel leg plate (exosuit)", "str_pl": "shattered steel leg plates (exosuit)" },
-    "description": "The remains of a steel leg plate after taking a strong impact.  No longer provides functional protection, just weight.",
-    "looks_like": "exo_leg_steel"
   },
   {
     "id": "exo_leg_plastic",
@@ -108,7 +81,6 @@
     "weight": "20250 g",
     "material": [ "vacuum_carbide_hard" ],
     "faults": [ { "fault_group": "carbide_armor" } ],
-    "non_functional": "damaged_exo_leg_vcc",
     "armor": [
       {
         "material": [ { "type": "vacuum_carbide", "covered_by_mat": 100, "thickness": 1 } ],
@@ -117,32 +89,5 @@
         "encumbrance": 20
       }
     ]
-  },
-  {
-    "id": "damaged_exo_leg_vcc",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "copy-from": "exo_leg_vcc",
-    "name": { "str": "damaged carbide leg plate (exosuit)", "str_pl": "damaged carbide leg plates (exosuit)" },
-    "description": "The remains of a carbide leg plate after taking a strong impact.",
-    "looks_like": "exo_leg_vcc",
-    "non_functional": "destroyed_exo_leg_vcc",
-    "armor": [
-      {
-        "material": [ { "type": "vacuum_carbide", "covered_by_mat": 100, "thickness": 1 } ],
-        "covers": [ "leg_l", "leg_r", "foot_l", "foot_r" ],
-        "coverage": 85,
-        "encumbrance": 5
-      }
-    ]
-  },
-  {
-    "id": "destroyed_exo_leg_vcc",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "copy-from": "exo_leg_vcc",
-    "name": { "str": "shattered carbide leg plate (exosuit)", "str_pl": "shattered carbide leg plates (exosuit)" },
-    "description": "The remains of a vacuum-cast carbide leg plate after taking a strong impact.  No longer provides functional protection, just weight.",
-    "looks_like": "exo_leg_vcc"
   }
 ]

--- a/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_plating_torso.json
+++ b/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_plating_torso.json
@@ -14,10 +14,10 @@
     "color": "light_gray",
     "warmth": 25,
     "flags": [ "CANT_WEAR", "ABLATIVE_LARGE", "EXO_TORSO_PLATE" ],
-    "non_functional": "damaged_exo_torso_steel",
+    "faults": [ { "fault_group": "afs_steel_armor" } ],
     "armor": [
       {
-        "material": [ { "type": "afs_steel", "covered_by_mat": 100, "thickness": 2 } ],
+        "material": [ { "type": "afs_steel", "covered_by_mat": 100, "thickness": 1 } ],
         "covers": [ "torso" ],
         "coverage": 100,
         "encumbrance": 5
@@ -30,41 +30,6 @@
         "encumbrance": 5
       }
     ]
-  },
-  {
-    "id": "damaged_exo_torso_steel",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "copy-from": "exo_torso_steel",
-    "name": { "str": "damaged steel helmet plate (exosuit)", "str_pl": "damaged steel helmet plates (exosuit)" },
-    "description": "The remains of a steel torso plate after taking a strong impact.  Can be restored to full effectiveness via reforging.",
-    "looks_like": "exo_torso_steel",
-    "non_functional": "destroyed_exo_helmet_steel",
-    "armor": [
-      {
-        "material": [ { "type": "afs_steel", "covered_by_mat": 100, "thickness": 1 } ],
-        "covers": [ "torso" ],
-        "coverage": 85,
-        "encumbrance": 5
-      },
-      {
-        "material": [ { "type": "afs_steel", "covered_by_mat": 100, "thickness": 1 } ],
-        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r" ],
-        "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l", "leg_hip_l", "leg_hip_r" ],
-        "coverage": 85,
-        "encumbrance": 5
-      }
-    ]
-  },
-  {
-    "id": "destroyed_exo_torso_steel",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "copy-from": "exo_torso_steel",
-    "name": { "str": "shattered steel torso plate (exosuit)", "str_pl": "shattered steel torso plates (exosuit)" },
-    "description": "The remains of a steel torso plate after taking a strong impact.  No longer provides functional protection, just weight.",
-    "looks_like": "exo_torso_steel",
-    "extend": { "flags": [ "NO_REPAIR" ] }
   },
   {
     "id": "exo_torso_plastic",
@@ -139,7 +104,6 @@
     "weight": "50 kg",
     "material": [ "vacuum_carbide_hard" ],
     "faults": [ { "fault_group": "carbide_armor" } ],
-    "non_functional": "damaged_exo_torso_vcc",
     "armor": [
       {
         "material": [ { "type": "vacuum_carbide", "covered_by_mat": 100, "thickness": 1 } ],
@@ -155,41 +119,5 @@
         "encumbrance": 5
       }
     ]
-  },
-  {
-    "id": "damaged_exo_torso_vcc",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "category": "exosuit",
-    "copy-from": "exo_torso_vcc",
-    "name": { "str": "damaged carbide torso plate (exosuit)", "str_pl": "damaged carbide torso plates (exosuit)" },
-    "description": "The remains of a carbide torso plate after taking a strong impact.",
-    "weight": "44000 g",
-    "material": [ "vacuum_carbide" ],
-    "non_functional": "destroyed_exo_torso_vcc",
-    "armor": [
-      {
-        "material": [ { "type": "vacuum_carbide", "covered_by_mat": 100, "thickness": 1 } ],
-        "covers": [ "torso" ],
-        "coverage": 85,
-        "encumbrance": 5
-      },
-      {
-        "material": [ { "type": "vacuum_carbide", "covered_by_mat": 100, "thickness": 1 } ],
-        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r" ],
-        "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l", "leg_hip_l", "leg_hip_r" ],
-        "coverage": 85,
-        "encumbrance": 5
-      }
-    ]
-  },
-  {
-    "id": "destroyed_exo_torso_vcc",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "copy-from": "exo_torso_vcc",
-    "name": { "str": "shattered carbide torso plate (exosuit)", "str_pl": "shattered carbide torso plates (exosuit)" },
-    "description": "The remains of a vacuum-cast carbide torso plate after taking a strong impact.  No longer provides functional protection, just weight.",
-    "looks_like": "exo_torso_vcc"
   }
 ]

--- a/data/mods/aftershock_exoplanet/items/obsolete.json
+++ b/data/mods/aftershock_exoplanet/items/obsolete.json
@@ -58,5 +58,101 @@
     "//": "remove after 0.J",
     "id": "xllegpouch_large",
     "replace": "legpouch_large"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.K",
+    "id": "destroyed_exo_torso_steel",
+    "replace": "exo_torso_steel"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.K",
+    "id": "damaged_exo_torso_steel",
+    "replace": "exo_torso_steel"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.K",
+    "id": "destroyed_exo_torso_vcc",
+    "replace": "exo_torso_vcc"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.K",
+    "id": "damaged_exo_torso_vcc",
+    "replace": "exo_torso_vcc"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.K",
+    "id": "destroyed_exo_leg_steel",
+    "replace": "exo_leg_steel"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.K",
+    "id": "damaged_exo_leg_steel",
+    "replace": "exo_leg_steel"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.K",
+    "id": "destroyed_exo_leg_vcc",
+    "replace": "exo_leg_vcc"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.K",
+    "id": "damaged_exo_leg_vcc",
+    "replace": "exo_leg_vcc"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.K",
+    "id": "destroyed_exo_helmet_steel",
+    "replace": "exo_helmet_steel"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.K",
+    "id": "damaged_exo_helmet_steel",
+    "replace": "exo_helmet_steel"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.K",
+    "id": "destroyed_exo_helmet_vcc",
+    "replace": "exo_helmet_vcc"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.K",
+    "id": "damaged_exo_helmet_vcc",
+    "replace": "exo_helmet_vcc"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.K",
+    "id": "destroyed_exo_arm_steel",
+    "replace": "exo_arm_steel"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.K",
+    "id": "damaged_exo_arm_steel",
+    "replace": "exo_arm_steel"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.K",
+    "id": "destroyed_exo_arm_vcc",
+    "replace": "exo_arm_vcc"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.K",
+    "id": "damaged_exo_arm_vcc",
+    "replace": "exo_arm_vcc"
   }
 ]


### PR DESCRIPTION


#### Summary
Mods "Aftershock: Better power armor durability."

#### Purpose of change
Fix #87922

#### Describe the solution
Power armor pieces now degrade like normal armor, not like ballistic plates.

Also noticed that steel plates were heavy instead of medium armor. That was an oversight, only Carbide VC is meant to be heavy.

#### Testing
Fought for a while. It was a long while, the mod lacks PA worthy foes.

#### Additional context
Maybe too durable now, I need to figure out a way to make AP affect the armor degradation calculation.