### PR TITLE
removed edible tag documentation from materials

### DIFF
--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -1757,7 +1757,6 @@ The list of possible faults, their weight and actual chances can be checked in i
 | `specific_heat_solid`  | Specific heat of a material when frozen (J/(g K)). Default 2.108 - water.
 | `latent_heat`          | Latent heat of fusion for a material (J/g). Default 334.
 | `freezing_point`       | Freezing point of this material (C). Default 0 C ( 32 F ).
-| `edible`               | Optional boolean. Default is false.
 | `rotting`              | Optional boolean. Default is false.
 | `breathability`        | What breathability the clothes, made out of this material, would have; can be `IMPERMEABLE` (0%), `POOR` (30%), `AVERAGE` (50%), `GOOD` (80%), `MOISTURE_WICKING` (110%), `SECOND_SKIN` (140%)
 | `burn_products`        | Burning this material drop this items; array, first in array is the id of an item, and another is the number, respond for effeciency of burning - the bigger the burnable item is (by weight), and the more items there is, the bigger output; Multiple items could be returned simultaneously, like `[ [ "corpse_ash", 0.035 ], [ "glass_shard", 0.5 ] ]`,


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

"edible" tag got removed from material definitions, which wasn't reflected in docs

#### Describe the solution

Removed edible explanation from materials explanation

#### Describe alternatives you've considered

wait for someone else to do it

#### Testing

confirmed that issue #80097 was a thing (thanks MrDraMaster on Discord)


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
