### PR TITLE
Fix Sky Island portal storm bug

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -1001,6 +1001,10 @@
       { "u_spawn_item": "item_portal_storm_dimension_returner", "suppress_message": true, "force_equip": true },
       { "u_add_effect": "effect_portal_storm_dungeon_time_tracker", "duration": "2 days" },
       { "u_message": { "global_val": "portal_storm_voice_mood", "default": "none" }, "snippet": true },
+      {
+        "u_message": "You can faintly feel the real world, somewhere in a direction you couldn't name, a fragment of reality in this unearthly place.  With enough effort, you could follow the trail back to the world you left behind.",
+        "type": "info"
+      },
       { "run_eocs": "EOC_PORTAL_STORM_DUNGEON_CRAWLING_TRACKER", "time_in_future": 60 }
     ]
   },
@@ -1157,11 +1161,31 @@
       { "u_add_effect": "effect_temporary_levitation", "duration": 0 },
       { "u_teleport": { "global_val": "portal_dungeon_original_loc" } },
       {
-        "u_travel_to_dimension": "",
-        "npc_travel_radius": 0,
-        "npc_travel_filter": "none",
-        "fail_message": "You feel a prickle at the edge of your senses.",
-        "success_message": "The shifting halls warp and fold on themselves and turn inside out, revealing the shape of the world you know."
+        "if": { "mod_is_loaded": "skyisland" },
+        "then": [
+          {
+            "if": { "u_has_trait": "awayfromhome" },
+            "then": {
+              "u_travel_to_dimension": "dimension_sky_island_mission",
+              "fail_message": "You feel a prickle at the edge of your senses.",
+              "success_message": "The shifting halls warp and fold on themselves and turn inside out, revealing the world below."
+            },
+            "else": {
+              "u_travel_to_dimension": "",
+              "npc_travel_radius": 0,
+              "npc_travel_filter": "none",
+              "fail_message": "You feel a prickle at the edge of your senses.",
+              "success_message": "The shifting halls warp and fold on themselves and turn inside out, revealing your island in the sky."
+            }
+          }
+        ],
+        "else": {
+          "u_travel_to_dimension": "",
+          "npc_travel_radius": 0,
+          "npc_travel_filter": "none",
+          "fail_message": "You feel a prickle at the edge of your senses.",
+          "success_message": "The shifting halls warp and fold on themselves and turn inside out, revealing the shape of the world you know."
+        }
       },
       { "clear_dimension": "portal_storm_dungeon_dimension" },
       { "run_eocs": "EOC_PORTAL_STORM_DUNGEON_DIMENSION_RETURN_REMOVE_ITEM" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix Sky Island portal storm bug"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #87977

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Check for `{ "mod_is_loaded": "skyisland" }`, send you back to the island if you start on the island, send you to the mission dimension if you started on a mission.

If `skyisland` isn't loaded that else portion is skipped, sending you back to the default dimension. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked on island, on mission, and without sky island loaded. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
