### PR TITLE
Forbid reach attacks through autoattack if using Force Unarmed style

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -775,7 +775,12 @@ void avatar_action::autoattack( avatar &you, map &m )
         return;
     }
 
-    you.reach_attack( best.pos_bub() );
+    if( !you.used_weapon() && !weapon->is_gun() ) {
+        add_msg( m_info, _( "You can't use reach attacks while forcing yourself to fight unarmed." ) );
+        return;
+    } else {
+        you.reach_attack( best.pos_bub() );
+    }
 }
 
 // TODO: Move data/functions related to targeting out of game class

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -775,7 +775,7 @@ void avatar_action::autoattack( avatar &you, map &m )
         return;
     }
 
-    if( !you.used_weapon() && !weapon->is_gun() ) {
+    if( weapon && !you.used_weapon() && !weapon->is_gun() ) {
         add_msg( m_info, _( "You can't use reach attacks while forcing yourself to fight unarmed." ) );
         return;
     } else {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Addendum to #87939, fix autoattacks with Force Unarmed style still using reach attacks.

#### Describe the solution
Forbid reach attacks through autoattack if using Force Unarmed style.

#### Describe alternatives you've considered
None.

#### Testing
Got bronze pike. Set Force Unarmed martial style. While standing 2 tiles away from a debug monster, pressed `Tab` (default of autoattack), got a prohibitory notice. Walked right next to the monster, pressed `Tab` again. Got unarmed kicks and punches against the monster.
Set martial style to No Style, tested that autoattack correctly uses reach attacks when standing far from the monster, and regular attacks when standing next to the monster.

#### Additional context
None.