### PR TITLE
Psi powers display "power radius" instead of "spell radius" in the powers UI

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -3080,7 +3080,8 @@ void spellcasting_callback::display_spell_info( size_t index )
                sp.effect() == "effect_on_condition" ) {
         std::string psi_aoe_string_temp = _( "Power Radius" );
         std::string aoe_string_temp = _( "Spell Radius" );
-        ImGui::Text( "%s: %d", is_psi ? psi_aoe_string_temp.c_str() : aoe_string_temp.c_str(), sp.aoe( pc ) );
+        ImGui::Text( "%s: %d", is_psi ? psi_aoe_string_temp.c_str() : aoe_string_temp.c_str(),
+                     sp.aoe( pc ) );
     } else if( sp.effect() == "ter_transform" ) {
         ImGui::Text( "%s: %s", _( "Spell Radius" ), sp.aoe_string( pc ).c_str() );
     } else if( sp.effect() == "banishment" ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -3060,6 +3060,7 @@ void spellcasting_callback::display_spell_info( size_t index )
     // if it's any type of attack spell, the stats are normal.
     if( sp.effect() == "attack" ) {
         if( sp.aoe( pc ) > 0 ) {
+            std::string psi_aoe_string_temp = _( "Power Radius" );
             std::string aoe_string_temp = _( "Spell Radius" );
             std::string degree_string;
             if( sp.shape() == spell_shape::cone ) {
@@ -3068,7 +3069,7 @@ void spellcasting_callback::display_spell_info( size_t index )
             } else if( sp.shape() == spell_shape::line ) {
                 aoe_string_temp = _( "Line Width" );
             }
-            ImGui::Text( "%s: %d %s", aoe_string_temp.c_str(), sp.aoe( pc ), degree_string.c_str() );
+            ImGui::Text( "%s: %d %s", is_psi ? psi_aoe_string_temp.c_str() : aoe_string_temp.c_str(), sp.aoe( pc ), degree_string.c_str() );
         }
     } else if( sp.effect() == "short_range_teleport" ) {
         if( sp.aoe( pc ) > 0 ) {
@@ -3076,7 +3077,9 @@ void spellcasting_callback::display_spell_info( size_t index )
         }
     } else if( sp.effect() == "summon" || sp.effect() == "fertilize_plant" ||
                sp.effect() == "effect_on_condition" ) {
-        ImGui::Text( "%s: %d", _( "Spell Radius" ), sp.aoe( pc ) );
+        std::string psi_aoe_string_temp = _( "Power Radius" );
+        std::string aoe_string_temp = _( "Spell Radius" );
+        ImGui::Text( "%s: %d", is_psi ? psi_aoe_string_temp.c_str() : aoe_string_temp.c_str(), sp.aoe( pc ) );
     } else if( sp.effect() == "ter_transform" ) {
         ImGui::Text( "%s: %s", _( "Spell Radius" ), sp.aoe_string( pc ).c_str() );
     } else if( sp.effect() == "banishment" ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -3069,7 +3069,8 @@ void spellcasting_callback::display_spell_info( size_t index )
             } else if( sp.shape() == spell_shape::line ) {
                 aoe_string_temp = _( "Line Width" );
             }
-            ImGui::Text( "%s: %d %s", is_psi ? psi_aoe_string_temp.c_str() : aoe_string_temp.c_str(), sp.aoe( pc ), degree_string.c_str() );
+            ImGui::Text( "%s: %d %s", is_psi ? psi_aoe_string_temp.c_str() : aoe_string_temp.c_str(),
+                         sp.aoe( pc ), degree_string.c_str() );
         }
     } else if( sp.effect() == "short_range_teleport" ) {
         if( sp.aoe( pc ) > 0 ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -3057,11 +3057,11 @@ void spellcasting_callback::display_spell_info( size_t index )
     std::string range = sp.range( pc ) <= 0 ? _( "self" ) : std::to_string( sp.range( pc ) );
     ImGui::Text( "%s: %s", _( "Range" ), range.c_str() );
 
+    std::string aoe_string_temp = is_psi ? _( "Power Radius" ) : _( "Spell Radius" );
+
     // if it's any type of attack spell, the stats are normal.
     if( sp.effect() == "attack" ) {
         if( sp.aoe( pc ) > 0 ) {
-            std::string psi_aoe_string_temp = _( "Power Radius" );
-            std::string aoe_string_temp = _( "Spell Radius" );
             std::string degree_string;
             if( sp.shape() == spell_shape::cone ) {
                 aoe_string_temp = _( "Cone Arc" );
@@ -3069,8 +3069,7 @@ void spellcasting_callback::display_spell_info( size_t index )
             } else if( sp.shape() == spell_shape::line ) {
                 aoe_string_temp = _( "Line Width" );
             }
-            ImGui::Text( "%s: %d %s", is_psi ? psi_aoe_string_temp.c_str() : aoe_string_temp.c_str(),
-                         sp.aoe( pc ), degree_string.c_str() );
+            ImGui::Text( "%s: %d %s", aoe_string_temp.c_str(), sp.aoe( pc ), degree_string.c_str() );
         }
     } else if( sp.effect() == "short_range_teleport" ) {
         if( sp.aoe( pc ) > 0 ) {
@@ -3078,15 +3077,12 @@ void spellcasting_callback::display_spell_info( size_t index )
         }
     } else if( sp.effect() == "summon" || sp.effect() == "fertilize_plant" ||
                sp.effect() == "effect_on_condition" ) {
-        std::string psi_aoe_string_temp = _( "Power Radius" );
-        std::string aoe_string_temp = _( "Spell Radius" );
-        ImGui::Text( "%s: %d", is_psi ? psi_aoe_string_temp.c_str() : aoe_string_temp.c_str(),
-                     sp.aoe( pc ) );
+        ImGui::Text( "%s: %d", aoe_string_temp.c_str(), sp.aoe( pc ) );
     } else if( sp.effect() == "ter_transform" ) {
-        ImGui::Text( "%s: %s", _( "Spell Radius" ), sp.aoe_string( pc ).c_str() );
+        ImGui::Text( "%s: %s", aoe_string_temp.c_str(), sp.aoe_string( pc ).c_str() );
     } else if( sp.effect() == "banishment" ) {
         if( sp.aoe( pc ) > 0 ) {
-            ImGui::Text( _( "Spell Radius: %d" ), sp.aoe( pc ) );
+            ImGui::Text( _( "%s: %d" ), aoe_string_temp.c_str(), sp.aoe( pc ) );
         }
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Psi powers display `power radius` instead of `spell radius` in the powers UI"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Terminology matters!

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Just set it up so that it says `Power Radius` if it's a psionic power and `spell radius` if it isn't.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<img width="549" height="358" alt="Untitled" src="https://github.com/user-attachments/assets/132a6c32-c666-45af-a196-53bdaa8f7703" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
