### PR TITLE
Fix bronze lamellar armor

### DIFF
--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -1469,7 +1469,7 @@
     ],
     "using": [ [ "forging_standard", 2 ], [ "bronzesmithing_tools", 1 ] ],
     "tools": [ [ [ "casting_mold", -1 ] ] ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fur", 2 ], [ "leather", 2 ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fur", 2 ], [ "leather", 2 ] ], [ [ "scrap_bronze", 10 ] ]  ]
   },
   {
     "result": "bronze_brush_pole",

--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -1469,7 +1469,7 @@
     ],
     "using": [ [ "forging_standard", 2 ], [ "bronzesmithing_tools", 1 ] ],
     "tools": [ [ [ "casting_mold", -1 ] ] ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fur", 2 ], [ "leather", 2 ] ], [ [ "scrap_bronze", 10 ] ]  ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fur", 2 ], [ "leather", 2 ] ], [ [ "scrap_bronze", 10 ] ] ]
   },
   {
     "result": "bronze_brush_pole",

--- a/data/mods/XedraWood/recipes/armor/body.json
+++ b/data/mods/XedraWood/recipes/armor/body.json
@@ -21,5 +21,20 @@
         "skill_penalty": 0.15
       }
     ]
+  },
+  {
+    "result": "armor_lamellar_bronze",
+    "type": "recipe",
+    "id_suffix": "repair",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "difficulty": 4,
+    "time": "30 m",
+    "autolearn": true,
+    "using": [ [ "cordage", 6 ] ],
+    "components": [ [ [ "lamellae_bronze", 18 ] ], [ [ "armor_lamellar_bronze", 1 ] ] ],
+    "proficiencies": [ { "proficiency": "prof_closures" } ]
   }
 ]

--- a/data/mods/XedraWood/recipes/materials.json
+++ b/data/mods/XedraWood/recipes/materials.json
@@ -7,7 +7,8 @@
     "skill_used": "fabrication",
     "difficulty": 2,
     "autolearn": true,
-    "using": [ [ "smelting_standard", 47100 ] ],
+    "using": [ [ "smelting_standard", 180 ] ],
+    "components": [ [ [ "scrap_bronze", 1 ] ] ],
     "steps": [
       { "name": "Gather resources and start the process", "time": "1 m", "activity_level": "LIGHT_EXERCISE" },
       {
@@ -34,6 +35,7 @@
     "subcategory": "CSC_OTHER_MATERIALS",
     "skill_used": "fabrication",
     "difficulty": 3,
+    "autolearn": true,	    
     "components": [ [ [ "sheet_metal_bronze", 1 ] ] ],
     "result_mult": 20,
     "steps": [

--- a/data/mods/XedraWood/recipes/materials.json
+++ b/data/mods/XedraWood/recipes/materials.json
@@ -35,7 +35,7 @@
     "subcategory": "CSC_OTHER_MATERIALS",
     "skill_used": "fabrication",
     "difficulty": 3,
-    "autolearn": true,	    
+    "autolearn": true,
     "components": [ [ [ "sheet_metal_bronze", 1 ] ] ],
     "result_mult": 20,
     "steps": [


### PR DESCRIPTION

#### Summary
Bugfixes "Corrects multiple issues with xedrawood bronze lamellar armor"

#### Purpose of change

There were multiple issues with #87664:
The recipe for small bronze sheets had the overly large requirement for smelting charges of 47,100, which for reference is 107 pounds of charcoal and perhaps not coincidentally is exactly the amount required to melt a 10 pound ingot worth of bronze. Also, the recipe lacked any requirement for bronze at all.

The recipe for bronze lamellae lacked the autolearn tag, which prevented players from accessing the recipe.

#### Describe the solution
I divided the smelting requirement for the 10 L bronze ingot by the number of bronze chunks used in the recipe to give the smelting charges needed to melt one bronze chunk- 180. I could have gone with a much lower number consistent for other bronze recipes that used sandcasting molds and much larger amounts of bronze, but I believe the ingot recipes were calculated more recently and realistically. 
The 'small bronze sheet" item has the same mass as a chunk of bronze, so the crafting requirement was set to that.

Added    "autolearn": true   to the recipe for bronze lamella.

Also noticed that the recipe for the bronze bill axe lacked any requirements for bronze chunks either, so I added 10 to the recipe as consistent with the other bronze bill recipes.

I also added in a recipe to repair the armor with spare lamella as the steel counterparts are, as it could not otherwise be repaired.

#### Describe alternatives you've considered

Moving the items and recipes to the Innawoods mod, or to the base game.
Reworking the recipe for bronze lamella or adding an alternative that used metalworking tools to cut out the lamella and punch the holes while the bronze was still softened by heat.
Adding in custom faults for the armor that would be repaired through the mending interface instead of repairing the armor through a crafting recipe.


#### Testing
Ran the game, created a character, raised the fabrication and tailoring skills, confirmed that the recipes were visible.
<img width="668" height="421" alt="Screenshot 2026-07-14 110853" src="https://github.com/user-attachments/assets/54a97a46-6001-4faf-864a-68e57f7291a8" />
<img width="693" height="468" alt="Screenshot 2026-07-14 102925" src="https://github.com/user-attachments/assets/695ee86f-209d-4b24-828c-b0e0ee406df6" />
<img width="698" height="464" alt="Screenshot 2026-07-14 102938" src="https://github.com/user-attachments/assets/4cc4ec57-2b1b-44ce-974a-4ba888d8ad85" />
<img width="708" height="449" alt="Screenshot 2026-07-14 102911" src="https://github.com/user-attachments/assets/ccfb6c02-6f1d-4189-9399-1537bd57b3c4" />

#### Additional context

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
