### PR TITLE
Alien plushies

### DIFF
--- a/data/json/items/toy.json
+++ b/data/json/items/toy.json
@@ -320,6 +320,18 @@
         "name": { "str": "unicorn plushie" },
         "description": "This majestic unicorn plushie features a soft white body and horn, with tufts of white hair on its neck and tail.  Its black eyes are adorably large and round.",
         "weight": 1
+      },
+      {
+        "id": "toy_alien_green",
+        "name": { "str": "green alien plushie" },
+        "description": "A green alien plush with cute antennae and big shiny black eyes.  Considering current events, hopefully you won't encounter such aliens in your travels.",
+        "weight": 1
+      },
+      {
+        "id": "toy_alien_gray",
+        "name": { "str": "gray alien plushie" },
+        "description": "A gray alien plush with cute antennae and big shiny black eyes.  Considering current events, hopefully you won't encounter such aliens in your travels.",
+        "weight": 1
       }
     ]
   },


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Green and Gray alien plush because why not. also somewhat related to something i want to add to the Xedra Evolved side of things later.
#### Describe the solution

adds the two variants to the teddy bear item variants.
#### Describe alternatives you've considered

Nah.

#### Testing
<img width="474" height="524" alt="Screenshot_20260716_031752" src="https://github.com/user-attachments/assets/055e3b76-6e97-4cdd-a815-3e1a7a19723e" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
