### PR TITLE
Made streams not drivethrough-able by the autodrive

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_stream.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_stream.json
@@ -6,6 +6,7 @@
     "name": "stream",
     "sym": ".",
     "color": "light_blue",
+    "travel_cost_type": "forest",
     "vision_levels": "blends_till_details",
     "flags": [ "REQUIRES_PREDECESSOR" ]
   }


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Got told that their autodrive kept driving through streams. considering the junk there that could damage car and the fact ya dont really just drive through water streams irl like that, i fixed it.

#### Describe the solution

`"travel_cost_type": "forest"`

#### Describe alternatives you've considered

None

#### Testing
Before
<img width="562" height="572" alt="Screenshot_20260716_152624" src="https://github.com/user-attachments/assets/73de8409-74b1-40b3-b82d-c711f0cecf2a" />

After
<img width="606" height="805" alt="Screenshot_20260716_153112" src="https://github.com/user-attachments/assets/352aa01e-3ed5-4c92-96dd-337d69ca3940" />

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
