### PR TITLE
[MoM] Teleporting in the portal storm dungeon is...ill-advised

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_location_specific.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_location_specific.json
@@ -1,0 +1,61 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MOM_TELEPORTING_IN_PORTAL_STORM_DUNGEON",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": {
+      "and": [
+        { "u_has_trait": "TELEPORTER" },
+        { "compare_string": [ "TELEPORTER", { "context_val": "school" } ] },
+        { "current_dimension": "portal_storm_dungeon_dimension" },
+        { "not": { "compare_string": [ "teleport_slow", { "context_val": "spell" } ] } },
+        { "not": { "compare_string": [ "teleport_stride", { "context_val": "spell" } ] } },
+        { "not": { "compare_string": [ "teleport_collapse", { "context_val": "spell" } ] } }
+      ]
+    },
+    "effect": [
+      { "if": { "u_has_effect": "psi_nether_attention" }, "then": { "u_add_effect": "tindrift", "duration": "10 minutes" } },
+      {
+        "if": { "not": { "u_has_effect": "psi_nether_attention" } },
+        "then": [
+          {
+            "if": { "x_in_y_chance": { "x": { "math": [ "15 - u_skill('metaphysics')" ] }, "y": 15 } },
+            "then": [
+              { "u_add_effect": "psi_nether_attention", "duration": { "math": [ "43200 + rand(43200)" ] } },
+              {
+                "u_message": "As you come out of a cold and the dark of the teleport the hair rises on the back of your neck.  You don't think that was such a good idea.",
+                "type": "bad"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MOM_TELEPORTING_PHASING_IN_PORTAL_STORM_DUNGEON",
+    "eoc_type": "EVENT",
+    "required_event": "phase_move",
+    "condition": { "current_dimension": "portal_storm_dungeon_dimension" },
+    "effect": [
+      { "if": { "u_has_effect": "psi_nether_attention" }, "then": { "u_add_effect": "tindrift", "duration": "10 minutes" } },
+      {
+        "if": { "not": { "u_has_effect": "psi_nether_attention" } },
+        "then": [
+          {
+            "if": { "x_in_y_chance": { "x": { "math": [ "15 - u_skill('metaphysics')" ] }, "y": 15 } },
+            "then": [
+              { "u_add_effect": "psi_nether_attention", "duration": { "math": [ "43200 + rand(43200)" ] } },
+              {
+                "u_message": "As you appear on the other side of the barrier the hair rises on the back of your neck.  You don't think that was such a good idea.",
+                "type": "bad"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_portal_storm_effects.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_portal_storm_effects.json
@@ -1,29 +1,6 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_PORTAL_DUNGEON_REWARD_ITEM",
-    "effect": [
-      { "u_message": "A strange item comes back with you.", "popup": true },
-      {
-        "set_string_var": [
-          "unstable_rift",
-          "unstable_rift",
-          "calming_stone",
-          "escape_stone",
-          "escape_stone",
-          "chaos_stone",
-          "translation_stone",
-          "abjuration_stone",
-          "cascade_stone",
-          "matrix_crystal_coruscating"
-        ],
-        "target_var": { "global_val": "item_type" }
-      },
-      { "u_spawn_item": { "global_val": "item_type" } }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "EOC_PORTAL_EFFECTS_ACTIVE",
     "//2": "Overwrite of data/json/effects_on_condition/nether_eocs/portal_storm_effects_on_condition.json",
     "//": "More dangerous portal effects, should cost IRE to do.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Teleporting in the portal storm dungeon is...ill-advised"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I admit that this is partially about balance, but I think it's reasonable that if you're teleporting _in_ the Nether you're more likely to attract attention. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

If you teleport in the portal storm dungeon, there's a chance (based on Metaphysics skill) that you gain the `Observed` effect.

If you have the `Observed` effect and teleport, the ~~teleportation cops~~Hound show up.

If you have high skill you can get away with 1-2 teleports, but don't rely on it.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Farstepped at Metaphysics 7. On the third Farstep, got the warning. Then I teleported again and Foul Fog appeared. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
