### PR TITLE
Allow basecamp NPCs to milk local livestock

### DIFF
--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -259,6 +259,7 @@ class basecamp
         /// Takes all the food from the camp_food zone and increases the faction
         /// food_supply
         bool distribute_food( bool player_command = true );
+        bool milk_animals();
         std::string name_display_of( const mission_id &miss_id );
         void handle_hide_mission( const point_rel_omt &dir );
         void handle_reveal_mission( const point_rel_omt &dir );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -103,10 +103,6 @@
 #include "visitable.h"
 #include "vpart_position.h"
 #include "weather.h"
-#include "creature_tracker.h"
-#include "monster.h"
-#include "mtype.h"
-#include "game.h"
 
 static const addiction_id addiction_alcohol( "alcohol" );
 
@@ -1334,17 +1330,17 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
         }
         {
             const mission_id miss_id = { Camp_Milk_Animals, "", {}, base_dir };
-            entry = _("Notes:\n"
-                "Assign an idle camp companion to harvest milk from "
-                "any tamed, milkable livestock stationed nearby.\n"
-                "Requirements:\n"
-                "> Empty liquid containers must be located in your "
-                "camp food or storage zones.\n"
-                "Effects:\n"
-                "> Automatically fills empty bottles/bags with raw milk "
-                "and returns them to the camp zones.");
+            entry = _( "Notes:\n"
+                       "Assign an idle camp companion to harvest milk from "
+                       "any tamed, milkable livestock stationed nearby.\n"
+                       "Requirements:\n"
+                       "> Empty liquid containers must be located in your "
+                       "camp food or storage zones.\n"
+                       "Effects:\n"
+                       "> Automatically fills empty bottles/bags with raw milk "
+                       "and returns them to the camp zones." );
 
-            mission_key.add({ miss_id, false }, _("Milk Local Livestock"), entry);
+            mission_key.add( { miss_id, false }, _( "Milk Local Livestock" ), entry );
         }
         {
             const mission_id miss_id = { Camp_Determine_Leadership, "", {}, base_dir };
@@ -6232,85 +6228,87 @@ bool survive_random_encounter( npc &comp, std::string &situation, int favor, int
     return true;
 }
 
-bool basecamp::milk_animals() {
+bool basecamp::milk_animals()
+{
     // 1. Zone Validation (Copying distribute_food pattern)
-    if (!validate_sort_points()) {
-        popup(_("You do not have a valid camp storage zone. Aborting…"));
+    if( !validate_sort_points() ) {
+        popup( _( "You do not have a valid camp storage zone. Aborting…" ) );
         return false;
     }
 
-    map& here = get_map();
-    zone_manager& mgr = zone_manager::get_manager();
-    const tripoint_abs_ms& abspos = get_dumping_spot();
+    map &here = get_map();
+    zone_manager &mgr = zone_manager::get_manager();
+    const tripoint_abs_ms &abspos = get_dumping_spot();
 
     // 2. Gather all food/storage zones near the camp's center
-    const std::unordered_set<tripoint_abs_ms>& z_food = mgr.get_near(zone_type_CAMP_FOOD, abspos, MAX_VIEW_DISTANCE, nullptr, get_owner());
+    const std::unordered_set<tripoint_abs_ms> &z_food = mgr.get_near( zone_type_CAMP_FOOD, abspos,
+            MAX_VIEW_DISTANCE, nullptr, get_owner() );
 
-    std::vector<item*> empty_containers;
+    std::vector<item *> empty_containers;
 
     // 3. Loop through every map tile inside those designated zones to find bottles/bags
-    for (const tripoint_abs_ms& p_food_stock_abs : z_food) {
-        const tripoint_bub_ms p_food_stock = here.get_bub(p_food_stock_abs);
-        map_stack items = here.i_at(p_food_stock);
+    for( const tripoint_abs_ms &p_food_stock_abs : z_food ) {
+        const tripoint_bub_ms p_food_stock = here.get_bub( p_food_stock_abs );
+        map_stack items = here.i_at( p_food_stock );
 
-        for (item& it : items) {
+        for( item &it : items ) {
             // Check if the item is an empty glass bottle or zipper bag
-            if (it.typeId() == itype_id("bottle_glass") || it.typeId() == itype_id("zipper_bag")) {
-                if (it.is_container() && it.is_container_empty()) {
-                    empty_containers.push_back(&it);
+            if( it.typeId() == itype_id( "bottle_glass" ) || it.typeId() == itype_id( "zipper_bag" ) ) {
+                if( it.is_container() && it.is_container_empty() ) {
+                    empty_containers.push_back( &it );
                 }
             }
         }
     }
 
     // 4. Verification check for empty containers
-    if (empty_containers.empty()) {
-        popup(_("Your companions couldn't find any empty glass bottles or zipper bags in the camp food zone!"));
+    if( empty_containers.empty() ) {
+        popup( _( "Your companions couldn't find any empty glass bottles or zipper bags in the camp food zone!" ) );
         return false;
     }
 
     // 5. Query the game manager instance for nearby tamed cows
-    std::vector<monster*> milkable_cows;
+    std::vector<monster *> milkable_cows;
 
-    for (Creature& critter : g->all_creatures()) {
-        monster* mon = dynamic_cast<monster*>(&critter);
-        if (mon) {
-            if (mon->type->id == mtype_id("mon_cow") && mon->friendly != 0) {
-                milkable_cows.push_back(mon);
+    for( Creature &critter : g->all_creatures() ) {
+        monster *mon = dynamic_cast<monster *>( &critter );
+        if( mon ) {
+            if( mon->type->id == mtype_id( "mon_cow" ) && mon->friendly != 0 ) {
+                milkable_cows.push_back( mon );
             }
         }
     }
 
     // 6. Verification check for located livestock
-    if (milkable_cows.empty()) {
-        popup(_("Your companions scouted the camp but couldn't find any tamed cows nearby!"));
+    if( milkable_cows.empty() ) {
+        popup( _( "Your companions scouted the camp but couldn't find any tamed cows nearby!" ) );
         return false;
     }
 
     int milk_bottles_filled = 0;
 
     // 7. Loop through every empty container we found on the floor
-    for (item* target_bottle : empty_containers) {
+    for( item *target_bottle : empty_containers ) {
         bool container_processed = false;
 
         // Try to fill this specific bottle using any available nearby cow
-        for (monster* cow : milkable_cows) {
-            if (container_processed) {
+        for( monster *cow : milkable_cows ) {
+            if( container_processed ) {
                 break;
             }
 
-            if (!cow->type->starting_ammo.empty()) {
+            if( !cow->type->starting_ammo.empty() ) {
                 itype_id milked_item = cow->type->starting_ammo.begin()->first;
 
                 // Find the cow's ammo mapping reference
-                auto milkable_ammo = cow->ammo.find(milked_item);
-                if (milkable_ammo != cow->ammo.end() && milkable_ammo->second > 0) {
+                auto milkable_ammo = cow->ammo.find( milked_item );
+                if( milkable_ammo != cow->ammo.end() && milkable_ammo->second > 0 ) {
 
                     // Build the fresh milk fluid item
-                    item milk_fluid(milked_item, calendar::turn);
+                    item milk_fluid( milked_item, calendar::turn );
 
                     // Inject the milk into the bottle pocket (Fixed standalone pocket_type syntax)
-                    target_bottle->put_in(milk_fluid, pocket_type::CONTAINER);
+                    target_bottle->put_in( milk_fluid, pocket_type::CONTAINER );
 
                     // Consume 1 charge of milk from the cow's 39 rounds pool
                     milkable_ammo->second--;
@@ -6323,21 +6321,22 @@ bool basecamp::milk_animals() {
         }
 
         // If we processed all cows and they are completely empty of milk, stop the outer loop
-        if (!container_processed) {
+        if( !container_processed ) {
             break;
         }
     }
 
     // 8. Output final summary results to the player screen
-    if (milk_bottles_filled > 0) {
-        popup(string_format(_("Task Complete! Your camp companions successfully milked the livestock and placed %d bottles of raw milk in your food storage larders."), milk_bottles_filled));
+    if( milk_bottles_filled > 0 ) {
+        popup( string_format(
+                   _( "Task Complete! Your camp companions successfully milked the livestock and placed %d bottles of raw milk in your food storage larders." ),
+                   milk_bottles_filled ) );
 
         // Force the local map viewport to redraw so the newly filled bottles visually appear on the floor
-        here.invalidate_map_cache(here.get_abs_sub().z());
+        here.invalidate_map_cache( here.get_abs_sub().z() );
         return true;
-    }
-    else {
-        popup(_("The livestock didn't have any milk ready to be harvested today."));
+    } else {
+        popup( _( "The livestock didn't have any milk ready to be harvested today." ) );
         return false;
     }
 }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -103,6 +103,10 @@
 #include "visitable.h"
 #include "vpart_position.h"
 #include "weather.h"
+#include "creature_tracker.h"
+#include "monster.h"
+#include "mtype.h"
+#include "game.h"
 
 static const addiction_id addiction_alcohol( "alcohol" );
 
@@ -1329,6 +1333,20 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
                              entry );
         }
         {
+            const mission_id miss_id = { Camp_Milk_Animals, "", {}, base_dir };
+            entry = _("Notes:\n"
+                "Assign an idle camp companion to harvest milk from "
+                "any tamed, milkable livestock stationed nearby.\n"
+                "Requirements:\n"
+                "> Empty liquid containers must be located in your "
+                "camp food or storage zones.\n"
+                "Effects:\n"
+                "> Automatically fills empty bottles/bags with raw milk "
+                "and returns them to the camp zones.");
+
+            mission_key.add({ miss_id, false }, _("Milk Local Livestock"), entry);
+        }
+        {
             const mission_id miss_id = { Camp_Determine_Leadership, "", {}, base_dir };
             entry = string_format( _( "Notes:\n"
                                       "Choose a new leader for your faction.\n"
@@ -1546,6 +1564,10 @@ bool basecamp::handle_mission( const ui_mission_id &miss_id )
     switch( miss_id.id.id ) {
         case Camp_Distribute_Food:
             distribute_food();
+            break;
+
+        case Camp_Milk_Animals:
+            milk_animals();
             break;
 
         case Camp_Determine_Leadership:
@@ -6208,4 +6230,114 @@ bool survive_random_encounter( npc &comp, std::string &situation, int favor, int
         }
     }
     return true;
+}
+
+bool basecamp::milk_animals() {
+    // 1. Zone Validation (Copying distribute_food pattern)
+    if (!validate_sort_points()) {
+        popup(_("You do not have a valid camp storage zone. Aborting…"));
+        return false;
+    }
+
+    map& here = get_map();
+    zone_manager& mgr = zone_manager::get_manager();
+    const tripoint_abs_ms& abspos = get_dumping_spot();
+
+    // 2. Gather all food/storage zones near the camp's center
+    const std::unordered_set<tripoint_abs_ms>& z_food = mgr.get_near(zone_type_CAMP_FOOD, abspos, MAX_VIEW_DISTANCE, nullptr, get_owner());
+
+    std::vector<item*> empty_containers;
+
+    // 3. Loop through every map tile inside those designated zones to find bottles/bags
+    for (const tripoint_abs_ms& p_food_stock_abs : z_food) {
+        const tripoint_bub_ms p_food_stock = here.get_bub(p_food_stock_abs);
+        map_stack items = here.i_at(p_food_stock);
+
+        for (item& it : items) {
+            // Check if the item is an empty glass bottle or zipper bag
+            if (it.typeId() == itype_id("bottle_glass") || it.typeId() == itype_id("zipper_bag")) {
+                if (it.is_container() && it.is_container_empty()) {
+                    empty_containers.push_back(&it);
+                }
+            }
+        }
+    }
+
+    // 4. Verification check for empty containers
+    if (empty_containers.empty()) {
+        popup(_("Your companions couldn't find any empty glass bottles or zipper bags in the camp food zone!"));
+        return false;
+    }
+
+    // 5. Query the game manager instance for nearby tamed cows
+    std::vector<monster*> milkable_cows;
+
+    for (Creature& critter : g->all_creatures()) {
+        monster* mon = dynamic_cast<monster*>(&critter);
+        if (mon) {
+            if (mon->type->id == mtype_id("mon_cow") && mon->friendly != 0) {
+                milkable_cows.push_back(mon);
+            }
+        }
+    }
+
+    // 6. Verification check for located livestock
+    if (milkable_cows.empty()) {
+        popup(_("Your companions scouted the camp but couldn't find any tamed cows nearby!"));
+        return false;
+    }
+
+    int milk_bottles_filled = 0;
+
+    // 7. Loop through every empty container we found on the floor
+    for (item* target_bottle : empty_containers) {
+        bool container_processed = false;
+
+        // Try to fill this specific bottle using any available nearby cow
+        for (monster* cow : milkable_cows) {
+            if (container_processed) {
+                break;
+            }
+
+            if (!cow->type->starting_ammo.empty()) {
+                itype_id milked_item = cow->type->starting_ammo.begin()->first;
+
+                // Find the cow's ammo mapping reference
+                auto milkable_ammo = cow->ammo.find(milked_item);
+                if (milkable_ammo != cow->ammo.end() && milkable_ammo->second > 0) {
+
+                    // Build the fresh milk fluid item
+                    item milk_fluid(milked_item, calendar::turn);
+
+                    // Inject the milk into the bottle pocket (Fixed standalone pocket_type syntax)
+                    target_bottle->put_in(milk_fluid, pocket_type::CONTAINER);
+
+                    // Consume 1 charge of milk from the cow's 39 rounds pool
+                    milkable_ammo->second--;
+                    milk_bottles_filled++;
+
+                    // Flag that this bottle is successfully taken care of
+                    container_processed = true;
+                }
+            }
+        }
+
+        // If we processed all cows and they are completely empty of milk, stop the outer loop
+        if (!container_processed) {
+            break;
+        }
+    }
+
+    // 8. Output final summary results to the player screen
+    if (milk_bottles_filled > 0) {
+        popup(string_format(_("Task Complete! Your camp companions successfully milked the livestock and placed %d bottles of raw milk in your food storage larders."), milk_bottles_filled));
+
+        // Force the local map viewport to redraw so the newly filled bottles visually appear on the floor
+        here.invalidate_map_cache(here.get_abs_sub().z());
+        return true;
+    }
+    else {
+        popup(_("The livestock didn't have any milk ready to be harvested today."));
+        return false;
+    }
 }

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -200,6 +200,7 @@ std::string enum_to_string<mission_kind>( mission_kind data )
         case mission_kind::Forage_Job: return "Forage_Job";
         case mission_kind::Caravan_Commune_Center_Job: return "Caravan_Commune_Center_Job";
         case mission_kind::Camp_Distribute_Food: return "Camp_Distribute_Food";
+        case mission_kind::Camp_Milk_Animals: return "Camp_Milk_Animals";
 		case mission_kind::Camp_Determine_Leadership: return "Camp_Determine_Leadership";
 		case mission_kind::Camp_Have_Meal: return "Camp_Have_Meal";
         case mission_kind::Camp_Hide_Mission: return "Camp_Hide_Mission";
@@ -275,6 +276,10 @@ static const std::array < miss_data, Camp_Harvest + 1 > miss_info = { {
         //  Faction camp missions
         {
             "Camp_Distribute_Food",
+            no_translation( "" )
+        },
+        {
+            "Camp_Milk_Animals",
             no_translation( "" )
         },
         {
@@ -1257,6 +1262,7 @@ bool talk_function::handle_outpost_mission( const mission_entry &cur_key, npc &p
             return false;
 
         case Camp_Distribute_Food:
+        case Camp_Milk_Animals:
         case Camp_Determine_Leadership:
         case Camp_Have_Meal:
         case Camp_Hide_Mission:

--- a/src/mission_companion.h
+++ b/src/mission_companion.h
@@ -49,6 +49,7 @@ enum mission_kind : int {
 
     //  Faction camp tasks
     Camp_Distribute_Food,        //  Direct action, not serialized
+    Camp_Milk_Animals,
     Camp_Determine_Leadership,   //  Direct action, not serialized
     Camp_Have_Meal,              //  Direct action, not serialized
     Camp_Hide_Mission,           //  Direct action, not serialized


### PR DESCRIPTION
#### Summary
Interface "Add a basecamp mission option allowing NPCs to milk tamed livestock using camp zones."

#### Purpose of change
This resolves feature request #86410. This change allows players to delegate this daily chore to idle camp companions.

#### Describe the solution
- Added `Camp_Milk_Animals` to the `mission_kind` enumeration registry and mapped it to string identifiers.
- Added a "Milk local livestock" entry to the basecamp mission selection UI panel under `src/faction_camp.cpp`.
- Implemented `basecamp::milk_animals()`, which validates camp sort zones, searches `zone_type_CAMP_FOOD` for empty containers (`bottle_glass` or `zipper_bag`), tracks nearby tamed cows using the global creature tracker, consumes their accumulated milk resource (`ammo`), and places the filled raw milk containers back into the food zone.

#### Describe alternatives you've considered
I considered integrating this into the automated "Setting Work Priorities" background tasks, but a direct-action macro command under Base Missions mirrors the existing `distribute_food` mechanic much cleaner and handles instantaneous inventory transformations safely.

#### Testing
- Created a camp using a custom follower NPC.
- Set up a valid `CAMP_FOOD` zone.
- Spawned a cow, force-tamed it using cattle fodder, and verified its milk ammo pool via the debug menu.
- Placed 5 empty glass bottles on the ground in the food zone.
- Triggered "Milk local livestock" from the camp interface. The game successfully completed the task, subtracted charges from the cow, and filled the empty bottles on the ground with Fresh Raw Milk.

#### Additional context
None.