### PR TITLE
Fix potassium hydroxide powder spawning in units of 1

### DIFF
--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -297,7 +297,7 @@
       { "item": "chem_nitric_acid", "prob": 15, "charges": [ 1, -1 ] },
       { "item": "chem_muriatic_acid", "prob": 20, "charges": [ 1, -1 ] },
       { "group": "potassiumchloride_small_bottle_part", "prob": 5 },
-      { "item": "chem_potassium_hydroxide", "prob": 10, "count": [ 100, -1 ] },
+      { "group": "potassiumhydroxide_small_bottle_part", "prob": 10 },
       { "item": "chem_zinc_oxide", "prob": 10, "count": [ 100, -1 ] },
       { "group": "chromiumoxide_small_bottle_part", "prob": 10 },
       { "group": "zincpowder_small_bottle_part", "prob": 10 },

--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -297,7 +297,7 @@
       { "item": "chem_nitric_acid", "prob": 15, "charges": [ 1, -1 ] },
       { "item": "chem_muriatic_acid", "prob": 20, "charges": [ 1, -1 ] },
       { "group": "potassiumchloride_small_bottle_part", "prob": 5 },
-      { "group": "potassiumhydroxide_small_bottle_part", "prob": 10 },
+      { "group": "potassiumhydroxide_small_bag_part", "prob": 10 },
       { "item": "chem_zinc_oxide", "prob": 10, "count": [ 100, -1 ] },
       { "group": "chromiumoxide_small_bottle_part", "prob": 10 },
       { "group": "zincpowder_small_bottle_part", "prob": 10 },

--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -297,7 +297,7 @@
       { "item": "chem_nitric_acid", "prob": 15, "charges": [ 1, -1 ] },
       { "item": "chem_muriatic_acid", "prob": 20, "charges": [ 1, -1 ] },
       { "group": "potassiumchloride_small_bottle_part", "prob": 5 },
-      { "group": "potassiumhydroxide_small_bag_part", "prob": 10 },
+      { "group": "potassiumhydroxide_small_bottle_part", "prob": 10 },
       { "item": "chem_zinc_oxide", "prob": 10, "count": [ 100, -1 ] },
       { "group": "chromiumoxide_small_bottle_part", "prob": 10 },
       { "group": "zincpowder_small_bottle_part", "prob": 10 },

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -114,16 +114,16 @@
     "items": [ { "item": "chem_potassium_chloride", "count": [ 2, 355 ] } ]
   },
   {
-    "id": "potassiumhydroxide_small_bag",
+    "id": "potassiumhydroxide_small_bottle",
     "type": "item_group",
     "container-item": "bag_plastic_small",
-    "items": [ { "item": "chem_potassium_hydroxide", "count": 355 } ]
+    "items": [ { "item": "chem_potassium_hydroxide", "count": 350 } ]
   },
   {
-    "id": "potassiumhydroxide_small_bag_part",
+    "id": "potassiumhydroxide_small_bottle_part",
     "type": "item_group",
     "container-item": "bag_plastic_small",
-    "items": [ { "item": "chem_potassium_hydroxide", "count": [ 2, 355 ] } ]
+    "items": [ { "item": "chem_potassium_hydroxide", "count": [ 2, 350 ] } ]
   },
   {
     "id": "redphosphorus_small_bottle",

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -117,13 +117,13 @@
     "id": "potassiumhydroxide_small_bottle",
     "type": "item_group",
     "container-item": "bottle_plastic_355ml",
-    "items": [ { "item": "chem_potassium_hydroxide", "count": 350 } ]
+    "items": [ { "item": "chem_potassium_hydroxide", "count": 250 } ]
   },
   {
     "id": "potassiumhydroxide_small_bottle_part",
     "type": "item_group",
     "container-item": "bottle_plastic_355ml",
-    "items": [ { "item": "chem_potassium_hydroxide", "count": [ 2, 350 ] } ]
+    "items": [ { "item": "chem_potassium_hydroxide", "count": [ 2, 250 ] } ]
   },
   {
     "id": "redphosphorus_small_bottle",

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -114,16 +114,16 @@
     "items": [ { "item": "chem_potassium_chloride", "count": [ 2, 355 ] } ]
   },
   {
-    "id": "potassiumhydroxide_small_bottle",
+    "id": "potassiumhydroxide_small_bag",
     "type": "item_group",
-    "container-item": "bottle_plastic_355ml",
-    "items": [ { "item": "chem_potassium_hydroxide", "count": 250 } ]
+    "container-item": "bag_plastic_small",
+    "items": [ { "item": "chem_potassium_hydroxide", "count": 355 } ]
   },
   {
-    "id": "potassiumhydroxide_small_bottle_part",
+    "id": "potassiumhydroxide_small_bag_part",
     "type": "item_group",
-    "container-item": "bottle_plastic_355ml",
-    "items": [ { "item": "chem_potassium_hydroxide", "count": [ 2, 250 ] } ]
+    "container-item": "bag_plastic_small",
+    "items": [ { "item": "chem_potassium_hydroxide", "count": [ 2, 355 ] } ]
   },
   {
     "id": "redphosphorus_small_bottle",

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -113,6 +113,20 @@
     "//": "8 oz bottle, opened with a variable amount",
     "items": [ { "item": "chem_potassium_chloride", "count": [ 2, 355 ] } ]
   },
+   {
+    "id": "potassiumhydroxide_small_bottle",
+    "type": "item_group",
+    "container-item": "bottle_plastic_355ml",
+    "//": "8 oz bottle, filled 80% as new",
+    "items": [ { "item": "chem_potassium_hydroxide", "count": 355 } ]
+  },
+  {
+    "id": "potassiumhydroxide_small_bottle_part",
+    "type": "item_group",
+    "container-item": "bottle_plastic_355ml",
+    "//": "8 oz bottle, opened with a variable amount",
+    "items": [ { "item": "chem_potassium_hydroxide", "count": [ 2, 355 ] } ]
+  },
   {
     "id": "redphosphorus_small_bottle",
     "type": "item_group",

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -113,18 +113,16 @@
     "//": "8 oz bottle, opened with a variable amount",
     "items": [ { "item": "chem_potassium_chloride", "count": [ 2, 355 ] } ]
   },
-   {
+  {
     "id": "potassiumhydroxide_small_bottle",
     "type": "item_group",
     "container-item": "bottle_plastic_355ml",
-    "//": "8 oz bottle, filled 80% as new",
     "items": [ { "item": "chem_potassium_hydroxide", "count": 350 } ]
   },
   {
     "id": "potassiumhydroxide_small_bottle_part",
     "type": "item_group",
     "container-item": "bottle_plastic_355ml",
-    "//": "8 oz bottle, opened with a variable amount",
     "items": [ { "item": "chem_potassium_hydroxide", "count": [ 2, 350 ] } ]
   },
   {

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -118,14 +118,14 @@
     "type": "item_group",
     "container-item": "bottle_plastic_355ml",
     "//": "8 oz bottle, filled 80% as new",
-    "items": [ { "item": "chem_potassium_hydroxide", "count": 355 } ]
+    "items": [ { "item": "chem_potassium_hydroxide", "count": 350 } ]
   },
   {
     "id": "potassiumhydroxide_small_bottle_part",
     "type": "item_group",
     "container-item": "bottle_plastic_355ml",
     "//": "8 oz bottle, opened with a variable amount",
-    "items": [ { "item": "chem_potassium_hydroxide", "count": [ 2, 355 ] } ]
+    "items": [ { "item": "chem_potassium_hydroxide", "count": [ 2, 350 ] } ]
   },
   {
     "id": "redphosphorus_small_bottle",

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -757,7 +757,6 @@
     "volume": "1 ml",
     "weight": "2120 mg",
     "//": "density: 2.12 g/cm3 (25 °C)",
-    "container": "bottle_plastic_small"
   },
   {
     "type": "ITEM",

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -756,7 +756,7 @@
     "material": [ "dense_powder" ],
     "volume": "1 ml",
     "weight": "2120 mg",
-    "//": "density: 2.12 g/cm3 (25 °C)",
+    "//": "density: 2.12 g/cm3 (25 °C)"
   },
   {
     "type": "ITEM",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Correct Potassium Hydroxide Spawning"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Another ChemLab loottable fix, similar to previous PR's. 
De-Charging has caused several spawns to create multiple containers containing 1 unit of the chemical. This PR now makes it so it spawns a single container, containing a variable amount from near empty to full.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

We used the exact same fix as in #87635 
Created item group, ensured the MAX fill fell within the max weight and volume for the container (both chloride and hydroxide have the same volume, slightly different weight)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Leaving it as is. 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

~~Since we are simply copying the changes in PR #87635 and renaming the item ID to chem_potassium_hydroxide, no testing is required since it is a proven fix, just modified for the specific item ID~~

Because I am dumb dumb, I forgot to remove default container from the chemical json. Testing by Spawning Chem_Lab Item Group to force Json error to determine problem, corrected it and now bottles spawn properly. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
