### PR TITLE
fix broken mod dimensions

### DIFF
--- a/data/json/debug/teleportation.json
+++ b/data/json/debug/teleportation.json
@@ -11,7 +11,6 @@
       },
       {
         "u_travel_to_dimension": { "u_val": "destination_dimension" },
-        "region_type": { "u_val": "test" },
         "take_vehicle": true,
         "fail_message": "The Perambulator shivers but does not move.",
         "success_message": "In a flash of light the surroundings outside the Perambulator are changed!."

--- a/data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json
@@ -191,7 +191,7 @@
     "effect": [
       { "u_message": "Zworunk.", "popup": true },
       {
-        "u_travel_to_dimension": "",
+        "u_travel_to_dimension": "default",
         "npc_travel_radius": 0,
         "npc_travel_filter": "none",
         "fail_message": "You feel a prickle at the edge of your senses.",
@@ -1346,7 +1346,7 @@
     "effect": [
       { "u_message": "Zworunk.", "popup": true },
       {
-        "u_travel_to_dimension": "",
+        "u_travel_to_dimension": "default",
         "npc_travel_radius": 0,
         "npc_travel_filter": "none",
         "fail_message": "You feel a prickle at the edge of your senses.",

--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -1170,7 +1170,7 @@
           {
             "if": { "u_has_trait": "awayfromhome" },
             "then": {
-              "u_travel_to_dimension": "dimension_sky_island_mission",
+              "u_travel_to_dimension": { "global_val": "sky_island_target_region_settings" },
               "fail_message": "You feel a prickle at the edge of your senses.",
               "success_message": "The shifting halls warp and fold on themselves and turn inside out, revealing the world below."
             },

--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -688,7 +688,7 @@
     "id": "EOC_PORTAL_HIGHLANDS_RETURN",
     "effect": [
       {
-        "u_travel_to_dimension": "",
+        "u_travel_to_dimension": "default",
         "npc_travel_radius": 0,
         "npc_travel_filter": "none",
         "fail_message": "Nothing seems to change.",
@@ -974,7 +974,6 @@
       { "u_add_effect": "effect_temporary_levitation", "duration": 0 },
       {
         "u_travel_to_dimension": "portal_storm_dungeon_dimension",
-        "region_type": "default_portal_storm_dungeon",
         "npc_travel_radius": 0,
         "npc_travel_filter": "none",
         "fail_message": "Nothing seems to change.",
@@ -1176,7 +1175,7 @@
               "success_message": "The shifting halls warp and fold on themselves and turn inside out, revealing the world below."
             },
             "else": {
-              "u_travel_to_dimension": "",
+              "u_travel_to_dimension": "default",
               "npc_travel_radius": 0,
               "npc_travel_filter": "none",
               "fail_message": "You feel a prickle at the edge of your senses.",
@@ -1185,7 +1184,7 @@
           }
         ],
         "else": {
-          "u_travel_to_dimension": "",
+          "u_travel_to_dimension": "default",
           "npc_travel_radius": 0,
           "npc_travel_filter": "none",
           "fail_message": "You feel a prickle at the edge of your senses.",

--- a/data/json/effects_on_condition/nether_eocs/reverberations.json
+++ b/data/json/effects_on_condition/nether_eocs/reverberations.json
@@ -52,7 +52,7 @@
     "effect": [
       { "u_add_effect": "blind", "duration": 0 },
       {
-        "u_travel_to_dimension": "",
+        "u_travel_to_dimension": "default",
         "npc_travel_radius": 0,
         "npc_travel_filter": "none",
         "fail_message": "Nothing seems to change.",
@@ -121,7 +121,7 @@
     "effect": [
       { "u_add_effect": "blind", "duration": 0 },
       {
-        "u_travel_to_dimension": "",
+        "u_travel_to_dimension": "default",
         "npc_travel_radius": 0,
         "npc_travel_filter": "none",
         "fail_message": "Nothing seems to change.",

--- a/data/json/effects_on_condition/nether_eocs/string_dimension.json
+++ b/data/json/effects_on_condition/nether_eocs/string_dimension.json
@@ -88,7 +88,7 @@
     },
     "effect": [
       {
-        "u_travel_to_dimension": "",
+        "u_travel_to_dimension": "default",
         "npc_travel_radius": 0,
         "npc_travel_filter": "none",
         "fail_message": "You feel a prickle at the edge of your senses.",

--- a/data/json/monster_special_attacks/void_spider_mechanics.json
+++ b/data/json/monster_special_attacks/void_spider_mechanics.json
@@ -41,7 +41,6 @@
       {
         "u_travel_to_dimension": "spider_dimension",
         "npc_travel_radius": 0,
-        "region_type": "spider_dimension",
         "npc_travel_filter": "none",
         "fail_message": "Nothing happens.",
         "success_message": "The abyss opens up around you."
@@ -423,7 +422,7 @@
     "effect": [
       { "u_message": "The cavern folds itself beyond perception.", "popup": true },
       {
-        "u_travel_to_dimension": "",
+        "u_travel_to_dimension": "default",
         "npc_travel_radius": 0,
         "npc_travel_filter": "none",
         "fail_message": "Nothing seems to change.",

--- a/data/json/region_settings/region_settings/dimensions/portal_storm_dungeon.json
+++ b/data/json/region_settings/region_settings/dimensions/portal_storm_dungeon.json
@@ -22,7 +22,7 @@
   },
   {
     "type": "dimension",
-    "id": "default_portal_storm_dungeon",
+    "id": "portal_storm_dungeon_dimension",
     "region_layout": "default_portal_storm_dungeon"
   },
   {

--- a/data/json/region_settings/region_settings/dimensions/portal_storm_dungeon.json
+++ b/data/json/region_settings/region_settings/dimensions/portal_storm_dungeon.json
@@ -21,6 +21,17 @@
     "ravine_depth": -9
   },
   {
+    "type": "dimension",
+    "id": "default_portal_storm_dungeon",
+    "region_layout": "default_portal_storm_dungeon"
+  },
+  {
+    "type": "dimension_region_layout",
+    "id": "default_portal_storm_dungeon",
+    "generation_mode": "UNIFORM",
+    "uniform_region": "default_portal_storm_dungeon"
+  },
+  {
     "type": "region_settings",
     "id": "default_portal_storm_dungeon",
     "copy-from": "default",

--- a/data/mods/BombasticPerks/perkdata/closetland.json
+++ b/data/mods/BombasticPerks/perkdata/closetland.json
@@ -112,11 +112,7 @@
               { "u_location_variable": { "u_val": "closetland_departure_point" }, "min_radius": 0, "max_radius": 0 },
               { "u_add_effect": "blind", "duration": 0 },
               { "u_add_effect": "effect_perk_closetland_temp_levitation", "duration": 0 },
-              {
-                "u_travel_to_dimension": "dimension_perk_closetland",
-                "npc_travel_radius": 0,
-                "region_type": "dimension_perk_closetland_settings"
-              },
+              { "u_travel_to_dimension": "dimension_perk_closetland", "npc_travel_radius": 0 },
               { "u_add_effect": "effect_perk_closetland_sleepiness", "duration": "PERMANENT" },
               {
                 "if": { "not": { "math": [ "has_var(u_closetland_arrival_point)" ] } },

--- a/data/mods/BombasticPerks/perkdata/perk_regions_and_mapgen/Closetland.json
+++ b/data/mods/BombasticPerks/perkdata/perk_regions_and_mapgen/Closetland.json
@@ -1,5 +1,16 @@
 [
   {
+    "type": "dimension",
+    "id": "dimension_perk_closetland",
+    "region_layout": "dimension_perk_closetland"
+  },
+  {
+    "type": "dimension_region_layout",
+    "id": "dimension_perk_closetland",
+    "generation_mode": "UNIFORM",
+    "uniform_region": "dimension_perk_closetland_settings"
+  },
+  {
     "type": "region_settings",
     "//": "We only need one Overmap, if in the future that's possible",
     "id": "dimension_perk_closetland_settings",

--- a/data/mods/MindOverMatter/dimensions/innawood_mom.json
+++ b/data/mods/MindOverMatter/dimensions/innawood_mom.json
@@ -1,5 +1,16 @@
 [
   {
+    "type": "dimension",
+    "id": "mom_innawood",
+    "region_layout": "mom_innawood"
+  },
+  {
+    "type": "dimension_region_layout",
+    "id": "mom_innawood",
+    "generation_mode": "UNIFORM",
+    "uniform_region": "mom_innawood"
+  },
+  {
     "type": "region_settings",
     "id": "mom_innawood",
     "copy-from": "default",

--- a/data/mods/MindOverMatter/dimensions/innawood_rainy_mom.json
+++ b/data/mods/MindOverMatter/dimensions/innawood_rainy_mom.json
@@ -1,5 +1,16 @@
 [
   {
+    "type": "dimension",
+    "id": "mom_innawood_rainy",
+    "region_layout": "mom_innawood_rainy"
+  },
+  {
+    "type": "dimension_region_layout",
+    "id": "mom_innawood_rainy",
+    "generation_mode": "UNIFORM",
+    "uniform_region": "mom_innawood_rainy"
+  },
+  {
     "type": "region_settings",
     "id": "mom_innawood_rainy",
     "copy-from": "default",

--- a/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
@@ -1,5 +1,16 @@
 [
   {
+    "type": "dimension",
+    "id": "mom_mycus_world",
+    "region_layout": "mom_mycus_world"
+  },
+  {
+    "type": "dimension_region_layout",
+    "id": "mom_mycus_world",
+    "generation_mode": "UNIFORM",
+    "uniform_region": "mom_mycus_world"
+  },
+  {
     "type": "region_settings",
     "id": "mom_mycus_world",
     "copy-from": "default",

--- a/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
+++ b/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
@@ -598,7 +598,6 @@
               {
                 "u_travel_to_dimension": "mom_innawood",
                 "npc_travel_radius": 0,
-                "region_type": "mom_innawood",
                 "npc_travel_filter": "none",
                 "fail_message": "You experience brief vertigo, but nothing dangerous seems to happen.",
                 "success_message": "Your surroundings warp and fold before reforming into a strange landscape."
@@ -612,7 +611,6 @@
               {
                 "u_travel_to_dimension": "mom_innawood_rainy",
                 "npc_travel_radius": 0,
-                "region_type": "mom_innawood_rainy",
                 "npc_travel_filter": "none",
                 "fail_message": "You experience brief vertigo, but nothing dangerous seems to happen.",
                 "success_message": "Your surroundings warp and fold before reforming into a strange landscape."
@@ -626,7 +624,6 @@
               {
                 "u_travel_to_dimension": "highlands",
                 "npc_travel_radius": 0,
-                "region_type": "highlands",
                 "npc_travel_filter": "none",
                 "fail_message": "You experience brief vertigo, but nothing dangerous seems to happen.",
                 "success_message": "Your surroundings warp and fold before reforming into a strange landscape."
@@ -638,9 +635,8 @@
             "case": 6,
             "effect": [
               {
-                "u_travel_to_dimension": "mycus_world",
+                "u_travel_to_dimension": "mom_mycus_world",
                 "npc_travel_radius": 0,
-                "region_type": "mom_mycus_world",
                 "npc_travel_filter": "none",
                 "fail_message": "You experience brief vertigo, but nothing dangerous seems to happen.",
                 "success_message": "Your surroundings warp and fold before reforming into a strange landscape."
@@ -657,7 +653,7 @@
     "id": "EOC_PORTAL_OUBLIETTE_RETURN",
     "effect": [
       {
-        "u_travel_to_dimension": "",
+        "u_travel_to_dimension": "default",
         "npc_travel_radius": 0,
         "npc_travel_filter": "none",
         "fail_message": "Nothing seems to change.",

--- a/data/mods/Sky_Island/effectoncondition/teleport.json
+++ b/data/mods/Sky_Island/effectoncondition/teleport.json
@@ -44,15 +44,8 @@
       { "u_teleport": { "global_val": "OM_temp" }, "force_safe": true },
       {
         "if": { "math": [ "si_npcs_will_join_raid == 1" ] },
-        "then": {
-          "u_travel_to_dimension": "dimension_sky_island_mission",
-          "npc_travel_radius": 10,
-          "region_type": { "global_val": "sky_island_target_region_settings" }
-        },
-        "else": {
-          "u_travel_to_dimension": "dimension_sky_island_mission",
-          "region_type": { "global_val": "sky_island_target_region_settings" }
-        }
+        "then": { "u_travel_to_dimension": { "global_val": "sky_island_target_region_settings" }, "npc_travel_radius": 10 },
+        "else": { "u_travel_to_dimension": { "global_val": "sky_island_target_region_settings" } }
       }
     ]
   },
@@ -213,12 +206,7 @@
         "fail_message": "It seems the portal couldn't find a valid location.",
         "force_safe": true
       },
-      {
-        "u_travel_to_dimension": "default",
-        "npc_travel_radius": 10,
-        "item_travel_radius": 10,
-        "region_type": "default"
-      },
+      { "u_travel_to_dimension": "default", "npc_travel_radius": 10, "item_travel_radius": 10 },
       { "u_remove_item_with": "warphome" },
       { "u_remove_item_with": "warp_healing_salve" },
       { "u_remove_item_with": "warpextender" },

--- a/data/mods/Sky_Island/region_settings.json
+++ b/data/mods/Sky_Island/region_settings.json
@@ -7,10 +7,32 @@
     "//1": "Can be used in the future for other islands to find in the home dimension?"
   },
   {
+    "type": "dimension",
+    "id": "dimension_sky_island_region",
+    "region_layout": "dimension_sky_island_region"
+  },
+  {
+    "type": "dimension_region_layout",
+    "id": "dimension_sky_island_region",
+    "generation_mode": "UNIFORM",
+    "uniform_region": "dimension_sky_island_region"
+  },
+  {
     "type": "region_settings",
     "id": "dimension_sky_island_region",
     "copy-from": "default",
     "feature_flag_settings": { "extend": { "blacklist": [ "SKY_ISLAND", "SKY_ISLAND_NO_RAID_SPAWN" ] } }
+  },
+  {
+    "type": "dimension",
+    "id": "default",
+    "region_layout": "default_skyisland"
+  },
+  {
+    "type": "dimension_region_layout",
+    "id": "default_skyisland",
+    "generation_mode": "UNIFORM",
+    "uniform_region": "default_skyisland"
   },
   {
     "type": "weather_generator",
@@ -72,6 +94,17 @@
     }
   },
   {
+    "type": "dimension",
+    "id": "sky_island_raid_region_hot",
+    "region_layout": "sky_island_raid_region_hot"
+  },
+  {
+    "type": "dimension_region_layout",
+    "id": "sky_island_raid_region_hot",
+    "generation_mode": "UNIFORM",
+    "uniform_region": "sky_island_raid_region_hot"
+  },
+  {
     "type": "weather_generator",
     "id": "sky_island_raid_weather_hot",
     "copy-from": "default",
@@ -86,6 +119,17 @@
     "id": "sky_island_raid_region_hot",
     "copy-from": "dimension_sky_island_region",
     "weather": "sky_island_raid_weather_hot"
+  },
+  {
+    "type": "dimension",
+    "id": "sky_island_raid_region_cold",
+    "region_layout": "sky_island_raid_region_cold"
+  },
+  {
+    "type": "dimension_region_layout",
+    "id": "sky_island_raid_region_cold",
+    "generation_mode": "UNIFORM",
+    "uniform_region": "sky_island_raid_region_cold"
   },
   {
     "type": "weather_generator",
@@ -107,6 +151,17 @@
     "id": "MEGACITY_FLAG",
     "type": "json_flag",
     "name": ""
+  },
+  {
+    "type": "dimension",
+    "id": "sky_island_raid_region_mega_city",
+    "region_layout": "sky_island_raid_region_mega_city"
+  },
+  {
+    "type": "dimension_region_layout",
+    "id": "sky_island_raid_region_mega_city",
+    "generation_mode": "UNIFORM",
+    "uniform_region": "sky_island_raid_region_mega_city"
   },
   {
     "type": "region_settings",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "fix broken mod dimensions"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
they were broken
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
add "dimension" objects for every dimension that was missing one. fixed up eocs in cases where the usage of "dimension" objects caused issues. hopefully.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
most of my testing involved directly warping into said dimensions, which worked fine. Portal Storm Dungeon was "properly" entered and it worked. Sky Island works, but i haven't tested the challenge dimension EOCs, the dimensions themselves work.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
closes #88021
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
