### PR TITLE
Update suits_protection.json

### DIFF
--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -1242,7 +1242,7 @@
         "encumbrance": 22,
         "material": [
           { "type": "leather", "covered_by_mat": 100, "thickness": 4.5 },
-          { "type": "budget_steel", "covered_by_mat": 85, "thickness": 1.75 }
+          { "type": "budget_steel", "covered_by_mat": 90, "thickness": 1.75 }
         ]
       },
       {
@@ -1251,7 +1251,7 @@
         "encumbrance": 22,
         "material": [
           { "type": "leather", "covered_by_mat": 100, "thickness": 4 },
-          { "type": "budget_steel", "covered_by_mat": 75, "thickness": 1.25 }
+          { "type": "budget_steel", "covered_by_mat": 85, "thickness": 1.25 }
         ],
         "specifically_covers": [ "arm_lower_l", "arm_lower_r", "arm_upper_r", "arm_upper_l" ]
       },
@@ -1268,7 +1268,7 @@
         "encumbrance": 22,
         "material": [
           { "type": "leather", "covered_by_mat": 100, "thickness": 4 },
-          { "type": "budget_steel", "covered_by_mat": 70, "thickness": 1.25 }
+          { "type": "budget_steel", "covered_by_mat": 85, "thickness": 1.25 }
         ],
         "specifically_covers": [ "leg_lower_l", "leg_lower_r", "leg_upper_l", "leg_upper_r" ]
       },


### PR DESCRIPTION
If an armored leather vest has 90% torso coverage for its steel, then the torso coverage for plated leather armor shouldn't go down to 85%.  If the armored leather vest torso coverage for its steel is 90%, and the armored jean and armored motorcycle jackets torso coverage for its steel is 80%, then it follows that plated leather armors metal arm and leg coverage should be higher than an armored jackets (75% arms) and armored jeans (80% legs) as well.

The Hitchhikers guide plated armor entry is borked. It has arm and leg leather coverage at over 100% and arm and leg metal coverage at ~ 50%, it doesn't match the Json files.  https://cdda-guide.nornagon.net/item/armor_plarmor

Currently there is no way to armor leather leg guards and arm guards, assemble them into plated leather armor using the armored leather vest.   This pull corrects the metal coverage on the plated leather armor legs and arms to be more in line with the armored motorcycle jacket armored jean jacket, and armored jeans, increasing them both to 85%, and increases the metal torso coverage on plated leather armor to 90% to match the armored leather vest.  I would like to make recipes for armored leather arm and leg guards and stitching them into plated armor in the future, but will likely need some help.