### PR TITLE
[Xedra Evolved ] Ozma's Emerald Poppies

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -1,11 +1,16 @@
 [
   {
     "type": "effect_type",
-    "id": "docile",
-    "name": [ { "str": "Docile Monster", "//~": "NO_I18N" } ],
-    "desc": [ { "str": "AI tag for when monsters are tamed.  This is a bug if you have it.", "//~": "NO_I18N" } ],
-    "base_mods": { "hit_mod": [ -10 ], "bash_mod": [ -10 ] },
-    "miss_messages": [ [ "Peace be upon thee, whether you want it or not.", 1 ] ],
+    "id": "ozmas_peace",
+    "name": [ { "str": "A desolation called Peace" } ],
+    "desc": [ { "str": "Ubi solitudinem faciunt, pacem appelant", "//~": "NO_I18N" } ],
+    "apply_message": "A deep and abiding calm settles upon you.",
+    "remove_message": "The Pax is no more.",
+    "base_mods": { "hit_mod": [ -20 ], "bash_mod": [ -20 ] },
+    "max_duration": "30 m",
+    "max_intensity": 5,
+    "int_dur_factor": "5 s",
+    "miss_messages": [ [ "Peace be upon thee, whether you want it or not.", 1 ] ]
   },
   {
     "type": "effect_type",

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -1,6 +1,14 @@
 [
   {
     "type": "effect_type",
+    "id": "docile",
+    "name": [ { "str": "Docile Monster", "//~": "NO_I18N" } ],
+    "desc": [ { "str": "AI tag for when monsters are tamed.  This is a bug if you have it.", "//~": "NO_I18N" } ],
+    "base_mods": { "hit_mod": [ -10 ], "bash_mod": [ -10 ] },
+    "miss_messages": [ [ "Peace be upon thee, whether you want it or not.", 1 ] ],
+  },
+  {
+    "type": "effect_type",
     "id": "curevamp",
     "removes_effects": [ "vampire_virus" ],
     "max_duration": "72 h"

--- a/data/mods/Xedra_Evolved/emit.json
+++ b/data/mods/Xedra_Evolved/emit.json
@@ -28,8 +28,9 @@
     "type": "emit",
     "field": "fd_emerald_poppy_pollen",
     "intensity": 3,
-    "chance": 10
-  }
+    "chance": 80,
+    "qty": 7
+  },
   {
     "id": "emit_blood_karma",
     "type": "emit",

--- a/data/mods/Xedra_Evolved/emit.json
+++ b/data/mods/Xedra_Evolved/emit.json
@@ -24,6 +24,13 @@
     "chance": 15
   },
   {
+    "id": "emit_emerald_poppy_pollen",
+    "type": "emit",
+    "field": "fd_emerald_poppy_pollen",
+    "intensity": 3,
+    "chance": 10
+  }
+  {
     "id": "emit_blood_karma",
     "type": "emit",
     "field": "fd_blood_karma",

--- a/data/mods/Xedra_Evolved/field_type.json
+++ b/data/mods/Xedra_Evolved/field_type.json
@@ -506,7 +506,7 @@
         "concentration": 1,
         "effects": [
           {
-            "effect_id": "effect_docile",
+            "effect_id": "ozmas_peace",
             "body_part": "mouth",
             "intensity": 2,
             "min_duration": "2 minutes",
@@ -525,7 +525,7 @@
         "concentration": 2,
         "effects": [
           {
-            "effect_id": "effect_docile",
+            "effect_id": "ozmas_peace",
             "body_part": "mouth",
             "intensity": 5,
             "min_duration": "3 minutes",
@@ -539,16 +539,16 @@
     ],
     "decay_amount_factor": 5,
     "gas_absorption_factor": "80m",
-    "percent_spread": 30,
+    "percent_spread": 60,
     "outdoor_age_speedup": "3 minutes",
     "dirty_transparency_cache": true,
     "has_fume": true,
     "immunity_data": { "flags": [ "INHALED_TOXIN_IMMUNE" ], "body_part_env_resistance": [ [ "mouth", 15 ] ] },
     "priority": 8,
-    "half_life": "10 minutes",
+    "half_life": "30 minutes",
     "phase": "gas",
     "display_items": false,
     "display_field": true,
     "looks_like": "fd_pollen_arvore_weaken"
-  },
+  }
 ]

--- a/data/mods/Xedra_Evolved/field_type.json
+++ b/data/mods/Xedra_Evolved/field_type.json
@@ -493,5 +493,62 @@
     "display_items": true,
     "display_field": true,
     "looks_like": "fd_dust"
-  }
+  },
+  {
+    "id": "fd_emerald_poppy_pollen",
+    "type": "field_type",
+    "intensity_levels": [
+      {
+        "name": "pollen cloud",
+        "sym": "8",
+        "dangerous": true,
+        "translucency": 1,
+        "concentration": 1,
+        "effects": [
+          {
+            "effect_id": "effect_docile",
+            "body_part": "mouth",
+            "intensity": 2,
+            "min_duration": "2 minutes",
+            "max_duration": "2 minutes",
+            "immune_inside_vehicle": true,
+            "message": "You feel peace from inhaling the pollen cloud.",
+            "message_type": "bad"
+          }
+        ]
+      },
+      {
+        "name": "pollen cloud",
+        "color": "light_green",
+        "transparent": false,
+        "translucency": 10,
+        "concentration": 2,
+        "effects": [
+          {
+            "effect_id": "effect_docile",
+            "body_part": "mouth",
+            "intensity": 5,
+            "min_duration": "3 minutes",
+            "max_duration": "3 minutes",
+            "immune_inside_vehicle": true,
+            "message": "You feel peace from inhaling the pollen cloud.",
+            "message_type": "bad"
+          }
+        ]
+      }
+    ],
+    "decay_amount_factor": 5,
+    "gas_absorption_factor": "80m",
+    "percent_spread": 30,
+    "outdoor_age_speedup": "3 minutes",
+    "dirty_transparency_cache": true,
+    "has_fume": true,
+    "immunity_data": { "flags": [ "INHALED_TOXIN_IMMUNE" ], "body_part_env_resistance": [ [ "mouth", 15 ] ] },
+    "priority": 8,
+    "half_life": "10 minutes",
+    "phase": "gas",
+    "display_items": false,
+    "display_field": true,
+    "looks_like": "fd_pollen_arvore_weaken"
+  },
 ]

--- a/data/mods/Xedra_Evolved/field_type.json
+++ b/data/mods/Xedra_Evolved/field_type.json
@@ -502,6 +502,9 @@
         "name": "pollen cloud",
         "sym": "8",
         "dangerous": true,
+        "color": "light_green",
+        "light_emitted": 60,
+        "light_color": [ 80, 240, 150 ],
         "translucency": 1,
         "concentration": 1,
         "effects": [
@@ -520,6 +523,8 @@
       {
         "name": "pollen cloud",
         "color": "light_green",
+        "light_emitted": 60,
+        "light_color": [ 80, 240, 150 ],
         "transparent": false,
         "translucency": 10,
         "concentration": 2,

--- a/data/mods/Xedra_Evolved/furniture_and_terrain/furniture-plants.json
+++ b/data/mods/Xedra_Evolved/furniture_and_terrain/furniture-plants.json
@@ -68,5 +68,20 @@
       "ter_set": "t_dirt",
       "items": [ { "item": "withered", "count": [ 40, 70 ] } ]
     }
+  },
+  {
+    "type": "furniture",
+    "id": "f_ozma_poppy",
+    "name": "Ozma's emerald poppy",
+    "description": "These strange flowers have appeared in the wake of the Cataclysm, and their buds can be used for medicinal purposes, like the buds of the mundane poppy they're named after.  The dirt around it gently churns as its roots writhe beneath the soil, and it's surrounded by an overwhelming floral smell that makes you feel sleepy.",
+    "symbol": "f",
+    "color": "green",
+    "looks_like": "f_mutpoppy",
+    "move_cost_mod": 0,
+    "required_str": -1,
+    "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER", "GRAZER_INEDIBLE" ],
+    "examine_action": "flower_poppy",
+    "emissions": [ "emit_emerald_poppy_pollen" ],
+    "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
   }
 ]

--- a/data/mods/Xedra_Evolved/furniture_and_terrain/furniture.json
+++ b/data/mods/Xedra_Evolved/furniture_and_terrain/furniture.json
@@ -1,6 +1,25 @@
 [
   {
     "type": "furniture",
+    "id": "t_statue_fae_ozymandius",
+    "name": "broken statue",
+    "description": "All that remains of this previously grand statue are a pair of feet and a set of broken wings.",
+    "looks_like": "f_statue",
+    "copy-from": "f_statue",
+    "bash": {
+      "str_min": 16,
+      "str_max": 40,
+      "sound": "smash!",
+      "sound_fail": "thump.",
+      "items": [
+        { "item": "rock", "count": [ 10, 14 ] },
+        { "item": "rock_large", "count": 2 },
+        { "item": "pebble", "count": [ 4, 8 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
     "id": "f_golden_monolith",
     "name": "golden monolith",
     "//": "The golden monolith produces mist that summons changelings, basically the equivalent of a tear in reality.",

--- a/data/mods/Xedra_Evolved/mapgen/map_extras.json
+++ b/data/mods/Xedra_Evolved/mapgen/map_extras.json
@@ -896,5 +896,133 @@
     "color": "dark_gray_red",
     "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "mx_ozma_statue",
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ],
+      "place_nested": [ { "chunks": [ "poppy_ring_chunk" ], "x": [ 2, 8 ], "y": [ 2, 8 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "poppy_ring_chunk",
+    "weight": 1000,
+    "object": {
+      "mapgensize": [ 5, 5 ],
+      "rows": [
+        " S,S ",
+        "S,,,S",
+        ",,@,,",
+        "S,,,S",
+        " S,S "
+      ],
+      "terrain": { ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_grass_dead", 25 ] ], " ": "t_null", "@": "t_statue_fae_ozymandius" },
+      "furniture": { "S": "f_ozma_poppy" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "poppy_ring_chunk",
+    "weight": 600,
+    "object": {
+      "mapgensize": [ 5, 5 ],
+      "rows": [
+        " S,S ",
+        "S,,,S",
+        ",,@,,",
+        "S,,,S",
+        " S,S "
+      ],
+      "terrain": { ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_grass_dead", 25 ] ], "@": "t_statue_fae_ozymandius", " ": "t_null" },
+      "furniture": { "S": "f_ozma_poppy" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "place_monster": [ { "group": "GROUP_CHANGELING_STRIKE_FORCE", "x": [ 0, 4 ], "y": [ 0, 4 ], "chance": 75, "repeat": [ 3, 5 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "poppy_ring_chunk",
+    "weight": 500,
+    "object": {
+      "mapgensize": [ 15, 15 ],
+      "rows": [
+        "      S,S      ",
+        "    S,,,,,S    ",
+        "  S,,,,,,,,,S  ",
+        "  ,,,,,,,,,,,  ",
+        " S,,,,,,,,,,,S ",
+        " ,,,,,,,,,,,,, ",
+        "S,,,,,,,,,,,,,S",
+        ",,,,,,,@,,,,,,,",
+        "S,,,,,,,,,,,,,S",
+        " ,,,,,,,,,,,,, ",
+        " S,,,,,,,,,,,S ",
+        "  ,,,,,,,,,,,  ",
+        "  S,,,,,,,,,S  ",
+        "    S,,,,,S    ",
+        "      S,S      "
+      ],
+      "terrain": { ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_grass_dead", 25 ] ], "@": "t_statue_fae_ozymandius", " ": "t_null" },
+      "furniture": { "S": "f_ozma_poppy" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "poppy_ring_chunk",
+    "weight": 200,
+    "object": {
+      "mapgensize": [ 15, 15 ],
+      "rows": [
+        "      S,S      ",
+        "    S,,,,,S    ",
+        "  S,,,,,,,,,S  ",
+        "  ,,,,,,,,,,,  ",
+        " S,,,,,,,,,,,S ",
+        " ,,,,,,,,,,,,, ",
+        "S,,,,,,,,,,,,,S",
+        ",,,,,,,@,,,,,,,",
+        "S,,,,,,,,,,,,,S",
+        " ,,,,,,,,,,,,, ",
+        " S,,,,,,,,,,,S ",
+        "  ,,,,,,,,,,,  ",
+        "  S,,,,,,,,,S  ",
+        "    S,,,,,S    ",
+        "      S,S      "
+      ],
+      "terrain": { ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_grass_dead", 25 ] ], "@": "t_statue_fae_ozymandius", " ": "t_null" },
+      "furniture": { "S": "f_ozma_poppy" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "place_monster": [ { "group": "GROUP_CHANGELING_STRIKE_FORCE", "x": [ 0, 14 ], "y": [ 0, 14 ], "chance": 75, "repeat": [ 7, 15 ] } ]
+    }
   }
 ]

--- a/data/mods/Xedra_Evolved/mapgen/map_extras.json
+++ b/data/mods/Xedra_Evolved/mapgen/map_extras.json
@@ -310,7 +310,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "E",
     "color": "light_green",
-    "autonote_visibility": "same_tile"
+    "autonote_visibility": "details"
   },
   {
     "type": "mapgen",
@@ -898,6 +898,18 @@
     "flags": [ "CLASSIC" ]
   },
   {
+    "id": "mx_ozma_statue",
+    "type": "map_extra",
+    "name": { "str": "a statue surrounded by emerald poppies" },
+    "description": "A ruined statue surrounded by emerald poppies.",
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_ozma_statue" },
+    "min_max_zlevel": [ 0, 0 ],
+    "sym": "m",
+    "color": "light_green",
+    "autonote_visibility": "none",
+    "flags": [ "CLASSIC" ]
+  },
+  {
     "type": "mapgen",
     "update_mapgen_id": "mx_ozma_statue",
     "object": {
@@ -944,8 +956,8 @@
         "S,,,S",
         " S,S "
       ],
-      "terrain": { ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_grass_dead", 25 ] ], " ": "t_null", "@": "t_statue_fae_ozymandius" },
-      "furniture": { "S": "f_ozma_poppy" },
+      "terrain": { ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_grass_dead", 25 ] ], " ": "t_null" },
+      "furniture": { "S": "f_ozma_poppy", "@": "t_statue_fae_ozymandius" },
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
@@ -962,8 +974,8 @@
         "S,,,S",
         " S,S "
       ],
-      "terrain": { ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_grass_dead", 25 ] ], "@": "t_statue_fae_ozymandius", " ": "t_null" },
-      "furniture": { "S": "f_ozma_poppy" },
+      "terrain": { ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_grass_dead", 25 ] ], " ": "t_null" },
+      "furniture": { "S": "f_ozma_poppy", "@": "t_statue_fae_ozymandius" },
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "place_monster": [ { "group": "GROUP_CHANGELING_STRIKE_FORCE", "x": [ 0, 4 ], "y": [ 0, 4 ], "chance": 75, "repeat": [ 3, 5 ] } ]
     }
@@ -991,8 +1003,8 @@
         "    S,,,,,S    ",
         "      S,S      "
       ],
-      "terrain": { ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_grass_dead", 25 ] ], "@": "t_statue_fae_ozymandius", " ": "t_null" },
-      "furniture": { "S": "f_ozma_poppy" },
+      "terrain": { ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_grass_dead", 25 ] ], " ": "t_null" },
+      "furniture": { "S": "f_ozma_poppy", "@": "t_statue_fae_ozymandius" },
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
@@ -1019,8 +1031,8 @@
         "    S,,,,,S    ",
         "      S,S      "
       ],
-      "terrain": { ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_grass_dead", 25 ] ], "@": "t_statue_fae_ozymandius", " ": "t_null" },
-      "furniture": { "S": "f_ozma_poppy" },
+      "terrain": { ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_grass_dead", 25 ] ], " ": "t_null" },
+      "furniture": { "S": "f_ozma_poppy", "@": "t_statue_fae_ozymandius" },
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "place_monster": [ { "group": "GROUP_CHANGELING_STRIKE_FORCE", "x": [ 0, 14 ], "y": [ 0, 14 ], "chance": 75, "repeat": [ 7, 15 ] } ]
     }

--- a/data/mods/Xedra_Evolved/regional_overlay.json
+++ b/data/mods/Xedra_Evolved/regional_overlay.json
@@ -15,13 +15,13 @@
     "type": "map_extra_collection",
     "id": "forest",
     "copy-from": "forest",
-    "extend": { "extras": [ [ "mx_goblin_fruits", 25 ], [ "mx_ring_of_mushrooms", 15 ] ] }
+    "extend": { "extras": [ [ "mx_goblin_fruits", 25 ], [ "mx_ozma_statue", 5 ], [ "mx_ring_of_mushrooms", 15 ] ] }
   },
   {
     "type": "map_extra_collection",
     "id": "forest_thick",
     "copy-from": "forest_thick",
-    "extend": { "extras": [ [ "mx_goblin_fruits", 30 ], [ "mx_ring_of_mushrooms", 20 ] ] }
+    "extend": { "extras": [ [ "mx_goblin_fruits", 30 ], [ "mx_ozma_statue", 5 ], [ "mx_ring_of_mushrooms", 20 ] ] }
   },
   {
     "type": "map_extra_collection",
@@ -47,6 +47,7 @@
         [ "mx_pond_forest_undine", 75 ],
         [ "mx_pond_forest_undine_ierde", 75 ],
         [ "mx_ring_of_mushrooms", 30 ],
+        [ "mx_ozma_statue", 5 ],
         [ "mx_goblin_fruits", 15 ]
       ]
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Add some extra content for Xedra Evolved via a map extra that is just a bunch of references to a faerie empire of auld.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds emerald poppies and some hints at deeper past of Fae.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Making a PR adding lots of poppy variants.  
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested and everything worked.  Well I'm not sure that monsters are impacted by the pollen?
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
