### PR TITLE
Pull pipe and umbrellas off the fencing weapon category

### DIFF
--- a/data/json/items/resources/metal.json
+++ b/data/json/items/resources/metal.json
@@ -13,7 +13,7 @@
     "material": [ "steel" ],
     "qualities": [ [ "HAMMER", 1 ] ],
     "techniques": [ "WBLOCK_2", "RAPID", "PRECISE" ],
-    "weapon_category": [ "BATONS", "FENCING_WEAPONRY" ],
+    "weapon_category": [ "BATONS" ],
     "faults": [ { "fault_group": "steel_pipe_short", "weight_mult": 2 } ],
     "volume": "370 ml",
     "price": "38 USD",

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -842,7 +842,6 @@
     "color": "dark_gray",
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "RAIN_PROTECT", "SHEATH_SWORD", "FRAGILE_MELEE" ],
-    "weapon_category": [ "FENCING_WEAPONRY" ],
     "use_action": { "menu_text": "Collapse", "type": "transform", "target": "teleumbrella", "msg": "You collapse your umbrella." },
     "melee_damage": { "bash": 6, "stab": 4 }
   },
@@ -946,7 +945,6 @@
     "color": "magenta",
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "RAIN_PROTECT", "SHEATH_SWORD", "FRAGILE_MELEE" ],
-    "weapon_category": [ "FENCING_WEAPONRY" ],
     "melee_damage": { "bash": 6, "stab": 4 }
   },
   {


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
While i was looking at the fencing weapon category, seeing pipe, umbrella, and telescopic umbrella being in there is just plain odd. So im removing it unless there's a very good reason not to.
#### Describe the solution
Delete `"FENCING_WEAPONRY"` off them.

#### Describe alternatives you've considered
Nah.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
cant fence with pipe anymore
<img width="346" height="134" alt="Screenshot_20260718_192002" src="https://github.com/user-attachments/assets/12312f1a-0d77-4e08-b526-156aee6a7e54" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
