### PR TITLE
[XE] Remove leftover checks for obsoleted blotted sun weather.

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -1985,7 +1985,7 @@
     "//2": "This enchantment removes the effect if the vampire is outside at day.",
     "enchantments": [
       {
-        "condition": { "and": [ "is_day", "u_is_outside", { "not": { "is_weather": "blotted_sun " } } ] },
+        "condition": { "and": [ "is_day", "u_is_outside" ] },
         "ench_effects": [ { "effect": "effect_vampire_lose_invisible_in_dark", "intensity": 1 } ]
       }
     ]

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -675,7 +675,7 @@
         { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" },
         "is_day",
         "u_is_outside",
-        { "not": { "is_weather": "blotted_sun" } }
+        { "not": { "u_has_effect": "vampire_blind_the_sun" } }
       ]
     },
     "effect": [
@@ -694,7 +694,7 @@
     "condition": {
       "and": [
         { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" },
-        { "or": [ { "not": "is_day" }, { "not": "u_is_outside" }, { "is_weather": "blotted_sun" } ] }
+        { "or": [ { "not": "is_day" }, { "not": "u_is_outside" }, { "u_has_effect": "vampire_blind_the_sun" } ] }
       ]
     },
     "effect": [ { "u_lose_effect": "effect_slain_by_the_sun" }, { "u_lose_effect": "effect_slain_by_the_sun_limiter" } ]
@@ -737,7 +737,7 @@
         { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" },
         "is_day",
         "u_is_outside",
-        { "not": { "is_weather": "blotted_sun" } }
+        { "not": { "u_has_effect": "vampire_blind_the_sun" } }
       ]
     },
     "effect": [ { "run_eocs": "EOC_VAMPIRE_ANATHEMA_BURN_IN_SUNLIGHT_CONTINUAL" } ]
@@ -2935,7 +2935,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_INVISIBLE_IN_DARK",
-    "condition": { "not": { "and": [ "is_day", "u_is_outside", { "not": { "is_weather": "blotted_sun" } } ] } },
+    "condition": { "not": { "and": [ "is_day", "u_is_outside", { "not": { "u_has_effect": "vampire_blind_the_sun" } } ] } },
     "effect": [
       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "0.25" ] } },
       { "math": [ "u_vitamin('human_blood_vitamin') -= 300" ] },
@@ -2955,12 +2955,7 @@
     "id": "EOC_VAMPIRE_HEAL_IN_DARK",
     "//": "Heals and reduces bleeding and pain every minute while away from the sun if the player has the trait.",
     "recurrence": 60,
-    "condition": {
-      "and": [
-        { "u_has_trait": "VAMPIRE_HEAL_IN_DARK" },
-        { "not": { "and": [ "is_day", "u_is_outside", { "not": { "is_weather": "blotted_sun" } } ] } }
-      ]
-    },
+    "condition": { "and": [ { "u_has_trait": "VAMPIRE_HEAL_IN_DARK" }, { "not": { "and": [ "is_day", "u_is_outside" ] } } ] },
     "deactivate_condition": { "not": { "u_has_trait": "VAMPIRE_HEAL_IN_DARK" } },
     "effect": [
       { "if": { "math": [ "u_pain() >= 1" ] }, "then": { "math": [ "u_pain() -= 3" ] } },


### PR DESCRIPTION
#### Summary
Mods "[XE] Remove leftover checks for obsoleted blotted sun weather."

#### Purpose of change

I changed Blind the Sun from a weather to an effect in #83753, but some checks were missed. 
This PR changes or removes all such checks.

#### Describe the solution

Checks for vampire burning under the sun now check for the effect and not for the weather.
The checks for being in the dark no longer check for this power as it no longer causes darkness.

#### Describe alternatives you've considered


#### Testing
Debugged in vampire trait & anathema weakness to sun
-Without blind the sun active: caught fire in seconds
-With it active: stood under the sun unharmed until my inner blood ran out

#### Additional context
Being on fire is still exceedingly lethal with the head or torso being on fire causing certain death from full health in below 30 seconds of waiting in place, but fixing that is out of scope.