### PR TITLE
Exodii traders dont accept currencies

### DIFF
--- a/data/json/npcs/exodii/exodii_merchant_definitions.json
+++ b/data/json/npcs/exodii/exodii_merchant_definitions.json
@@ -66,6 +66,7 @@
     "type": "shopkeeper_blacklist",
     "id": "rubik_shopkeep_blacklist",
     "entries": [
+      { "item": "RobofacCoin", "message": "Will not accept Hub 01 currency" },
       { "group": "exodii_do_not_buy_ammo_blacklist" },
       { "category": "clothing" },
       { "group": "SUS_bathroom_sink" },

--- a/data/json/npcs/exodii/exodii_merchant_definitions.json
+++ b/data/json/npcs/exodii/exodii_merchant_definitions.json
@@ -66,7 +66,7 @@
     "type": "shopkeeper_blacklist",
     "id": "rubik_shopkeep_blacklist",
     "entries": [
-      { "item": "RobofacCoin", "message": "Will not accept Hub 01 currency" },
+      { "group": "exodii_do_not_buy_currency_blacklist", "message": "Will not accept currency" },
       { "group": "exodii_do_not_buy_ammo_blacklist" },
       { "category": "clothing" },
       { "group": "SUS_bathroom_sink" },

--- a/data/json/npcs/exodii/exodii_merchant_itemlist.json
+++ b/data/json/npcs/exodii/exodii_merchant_itemlist.json
@@ -814,5 +814,21 @@
       { "item": "bp_shot_scrap", "prob": 1 },
       { "item": "wax_slug", "prob": 1 }
     ]
+  },
+  {
+    "id": "exodii_do_not_buy_currency_blacklist",
+    "type": "item_group",
+    "subtype": "collection",
+    "//": "Due to jumps making currency from the last world worthless, the Exodii prefers to directly barter for what they want or need.",
+    "//2": "This should include all currencies used by post-cataclysm groups.",
+    "entries": [
+      { "item": "FMCNote", "prob": 1 },
+      { "item": "money_strap_FMCNote", "prob": 1 },
+      { "item": "money_bundle_FMCNote", "prob": 1 },
+      { "item": "RobofacCoin", "prob": 1 },
+      { "item": "FlatCoin", "prob": 1 },
+      { "item": "signed_chit", "prob": 1 },
+      { "item": "icon", "prob": 1 }
+    ]
   }
 ]

--- a/data/json/npcs/exodii/exodii_weaponmaster.json
+++ b/data/json/npcs/exodii/exodii_weaponmaster.json
@@ -66,7 +66,7 @@
     "type": "shopkeeper_blacklist",
     "id": "cyborg_type_9_shopkeep_blacklist",
     "entries": [
-      { "item": "RobofacCoin", "message": "Will not accept Hub 01 currency" },
+      { "group": "exodii_do_not_buy_currency_blacklist", "message": "Will not accept currency" },
       { "group": "exodii_do_not_buy_ammo_blacklist" },
       { "category": "clothing" },
       { "group": "SUS_bathroom_sink" },

--- a/data/json/npcs/exodii/exodii_weaponmaster.json
+++ b/data/json/npcs/exodii/exodii_weaponmaster.json
@@ -66,6 +66,7 @@
     "type": "shopkeeper_blacklist",
     "id": "cyborg_type_9_shopkeep_blacklist",
     "entries": [
+      { "item": "RobofacCoin", "message": "Will not accept Hub 01 currency" },
       { "group": "exodii_do_not_buy_ammo_blacklist" },
       { "category": "clothing" },
       { "group": "SUS_bathroom_sink" },


### PR DESCRIPTION
#### Summary
Balance "Exodii traders dont accept currencies"

#### Purpose of change
I planned to make Rubik and other Exodii traders not accept Hub 01 coins, like they become hostile to players with Hub 01 bionics.
After discussion on the discord it has been decided to extend that to all currencies, as coins and paper aren't useful for the Exodii just like how they won't buy whisks and ladles.

#### Describe the solution
Exodii traders have a blacklist including all post-cataclysm currencies.

#### Describe alternatives you've considered
Only make the Hub coins unusable with the Exodii due to the conflict between them.

#### Testing
Teleported to Rubik with coins, merch and ingots.
Rubik refused the coins and merch but accepted the ingots

#### Additional context
The Exodii have to prepare to perform jumps as soon as needed. A valuable currency becomes nothing more than a small piece of metal after a jump.
They also have little knowledge of local factions, as seen by their missions about scouting other factions and locating lost items.
This combines into you having a hard time convincing them why that particular small metal disk is totally worth a bionic implant.