### PR TITLE
Pocket options: allow interacting with a pocket with hidden contents (fixes crashes too)

### DIFF
--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -157,11 +157,6 @@ void pocket_favorite_callback::add_pockets( item_location il,
     pocket_selector.addentry( -1, false, '\0', string_format( "%s%s", depth, i.display_name() ) );
     // pad list with empty entries for the items themselves
     saved_pockets.emplace_back( nullptr, 0, nullptr, item_location() );
-    if( ( i.is_collapsed() && to_organize.size() != 1 ) || i.all_pockets_sealed() ) {
-        //is collapsed, or all pockets are sealed skip its nested pockets
-        // only skip collapsed items if doing multi menu, for a single item this wouldn't make sense
-        return;
-    }
 
     uilist_entry *item_entry = &pocket_selector.entries.back();
     int pocket_num = 1;


### PR DESCRIPTION
#### Summary
Bugfixes "Pocket options: allow interacting with a pocket with hidden contents (fixes crashes too)"

#### Purpose of change
 - Fixes #86060
 - Resolves #59308
 - Fixes #88049 (duplicate?)

#### Describe the solution

 - Partially revert #58612.

It did two things:
1. Skip over containers without pockets. (Kept by this PR.)
2. Special case which pockets not to show. Further refined by #59370. Reverted by this PR.

#58612 stated that uilist cannot handle changing the number of entries. I don't get it, since we can move items with pockets around and that works.

#### Describe alternatives you've considered

 - Find a way to keep the behaviour but prevent crashes.
 - Toggle to show items, not just pockets.

#### Testing

See the issues.

#### Additional context

Bug: We can move items in & out of a sealed pocket. The reverted PR provided a special case check, but both AIM & pocket options menus allow moving items in & out of sealed containers.