### PR TITLE
Double map range and hint for 🌹 Alonso mission 🌹

### DIFF
--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Alonso_Lautrec.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Alonso_Lautrec.json
@@ -345,7 +345,7 @@
     "value": 1000,
     "item": "pants_leather",
     "start": {
-      "assign_mission_target": { "om_terrain": "cs_sex_shop", "reveal_radius": 1, "random": true, "search_range": 120 },
+      "assign_mission_target": { "om_terrain": "cs_sex_shop", "reveal_radius": 1, "random": true, "search_range": 240 },
       "update_mapgen": { "om_terrain": "cs_sex_shop", "place_item": [ { "item": "pants_leather", "x": 19, "y": 20 } ] },
       "effect": { "u_add_var": "mission_flag_Alonso_pants", "value": "in_progress" }
     },
@@ -363,7 +363,7 @@
       "offer": "This clown was into some of the different things, not the vanilla, you understand me?  Yes.  I think you will find my valuables in a toy shop not so far.",
       "accepted": "You make me so happy I could give you little kisses, and some big kisses, and then something else maybe.",
       "rejected": "I know that you cannot resist me long.  I will wait, and perhaps some other pretty thing will help me instead?",
-      "advice": "It may be crowded no?  A popular place before, maybe is better to visit at night.  Sounds like Alonso's apartment no?",
+      "advice": "It may be crowded no?  A popular place before, maybe is better to visit at night.  Sounds like Alonso's apartment no?  Ah, and if something strange grabs you and another pair of leather pants comes to you, maybe Alonso is even happier?",
       "inquire": "Have you found what it is that you seek?  There may be something in it for you no?  Something big, but we take it slow yes?",
       "success": "This is the best news since those lonely teachers asked me to be a nude model at the college for the blind.  Alas, the special condoms have all been used.  This is not a surprise, few could resist this seductive clown.  You find a condom, I find a use for it.  Safety, she was never more important than now, in *so* many ways.",
       "success_lie": "You give me confidence.  I trust you.  I do not know why this is.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Double map range and hint for Alonso mission"

#### Purpose of change

Fix #48029

#### Describe the solution

Doubles search radius as suggested, also suggests a hint in game that the player try different leather pants if something strange happens

#### Describe alternatives you've considered

I like @stubkan 's idea laid out there in the comments but the intent of this mission was to highlight this map special. That may be a fun idea for a follow up quest

#### Testing

Simple JSON edit 

#### Additional context

N/A