### PR TITLE
Fix issue with SDL3 build mouse position not right

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -610,7 +610,8 @@ bool cataimgui::clear_pending()
     return clear_screen;
 }
 
-void cataimgui::client::process_input( void *input, int display_buffer_w, int display_buffer_h, int scaling_factor )
+void cataimgui::client::process_input( void *input, int display_buffer_w, int display_buffer_h,
+                                       int scaling_factor )
 {
     if( any_window_shown() ) {
         const SDL_Event *evt = static_cast<const SDL_Event *>( input );

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -1,4 +1,5 @@
 #include "cata_imgui.h"
+#include "cursesport.h" // Import ability to get the scale factor
 
 #include <cmath>
 
@@ -665,7 +666,22 @@ void cataimgui::client::process_input( void *input, int display_buffer_w, int di
         ( void )display_buffer_w;
         ( void )display_buffer_h;
 #if SDL_MAJOR_VERSION >= 3
-        ImGui_ImplSDL3_ProcessEvent( evt );
+        // Make use of the scale factor to make this part take input with consideration of scale
+        SDL_Event imgui_ev = *evt;
+        const int sf = get_scaling_factor();
+        if( sf > 1 ) {
+            if( imgui_ev.type == CATA_MOUSEMOTION ) {
+                imgui_ev.motion.x /= sf;
+                imgui_ev.motion.y /= sf;
+            } else if( imgui_ev.type == CATA_MOUSEBUTTONDOWN || imgui_ev.type == CATA_MOUSEBUTTONUP ) {
+                imgui_ev.button.x /= sf;
+                imgui_ev.button.y /= sf;
+            } else if( imgui_ev.type == CATA_MOUSEWHEEL ) {
+                imgui_ev.wheel.mouse_x /= sf;
+                imgui_ev.wheel.mouse_y /= sf;
+            }
+        }
+        ImGui_ImplSDL3_ProcessEvent( &imgui_ev );
 #else
         // Coordinates already converted to display_buffer space by
         // convert_event_to_display_buffer_coords in the event pump.

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1147,6 +1147,17 @@ SDL_Point window_to_display_buffer_coords( SDL_Point window_pt )
         static_cast<int>( static_cast<int64_t>( window_pt.y - dstrect.y ) * buf_h / dstrect.h )
     };
 #else
+#if SDL_MAJOR_VERSION >= 3
+    // Use the SDL provided translation of scaling and casting for SDL3 builds
+    if( renderer ) {
+        float rx = 0.0f;
+        float ry = 0.0f;
+        if( SDL_RenderCoordinatesFromWindow( renderer.get(),
+                static_cast<float>( window_pt.x ), static_cast<float>( window_pt.y ), &rx, &ry ) ) {
+            return SDL_Point{ static_cast<int>( rx ), static_cast<int>( ry ) };
+        }
+    }
+#endif    
     int win_w = 0;
     int win_h = 0;
     GetWindowSize( window.get(), &win_w, &win_h );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1153,11 +1153,11 @@ SDL_Point window_to_display_buffer_coords( SDL_Point window_pt )
         float rx = 0.0f;
         float ry = 0.0f;
         if( SDL_RenderCoordinatesFromWindow( renderer.get(),
-                static_cast<float>( window_pt.x ), static_cast<float>( window_pt.y ), &rx, &ry ) ) {
+                                             static_cast<float>( window_pt.x ), static_cast<float>( window_pt.y ), &rx, &ry ) ) {
             return SDL_Point{ static_cast<int>( rx ), static_cast<int>( ry ) };
         }
     }
-#endif    
+#endif
     int win_w = 0;
     int win_h = 0;
     GetWindowSize( window.get(), &win_w, &win_h );


### PR DESCRIPTION
When not using the Fullscreen, the mouse position not translated right fixes #87685

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix mouse position not translated right when not in fullscreen, and with scales not 1x"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When I using the game at windows mode, and on Windows computer, sometimes the mouse hovering position is not correct, click on tiles my not be the one I want.
The issue become way worse when I tries on a high DPI computer, and have to use the scale to 2x, it just have a massive misalign between the mouse position and the game's perceiving position.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
In function window_to_display_buffer_coords() in sdltiles.cpp, it seems in SDL3, due to SDL_LOGICAL_PRESENTATION_LETTERBOX will create letterboxes when scaling and resizing, the starting point may not at(0,0), which makes the original manual conversion create wrong result.
So add a block which when using the SDL3, it will use the SDL3's SDL_RenderCoordinatesFromWindow to get the coordinates, and return the result and end the function.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Maybe also check why the #87755 occurs, but clearly this fix won't going to affect this issue.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compile the game on windows with command:
```bash
make -j$(nproc) CCACHE=1 RELEASE=1 MSYS2=1 DYNAMIC_LINKING=1 SDL3=1 TILES=1 SOUND=1 LOCALIZE=1 LANGUAGES=all LINTJSON=0 ASTYLE=0 TESTS=1 WARNINGS="-Wall -Wextra -Wformat-signedness -Wlogical-op -Wmissing-declarations -Wmissing-noreturn -Wpedantic -Wunused-macros"
```

Then test the mouse position with a maximized window, and the scale is set to 2x. Hovering the mouse around the main menu to see the difference, it is indeed at correct position now. Before the change, I would move mouse all over the window without find any UI elements can be hovered.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
references #87685
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
