### PR TITLE
Add non-book book nests

### DIFF
--- a/data/json/mapgen/nested/house_nested.json
+++ b/data/json/mapgen/nested/house_nested.json
@@ -2497,6 +2497,31 @@
   },
   {
     "type": "mapgen",
+    "nested_mapgen_id": "domestic_bookcase_nest_plant",
+    "//": "Replace bookshelf with plant instead",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rotation": [ 0, 3 ],
+      "rows": [ "R" ],
+      "furniture": { "R": "f_indoor_plant" },
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "domestic_bookcase_nest_table_book",
+    "//": "Replace bookshelf with table and book instead",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rotation": [ 0, 3 ],
+      "rows": [ "R" ],
+      "furniture": { "R": "f_table" },
+      "items": { "R": [ { "item": "novels", "chance": 100 } ] },
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
+    }
+  },
+  {
+    "type": "mapgen",
     "nested_mapgen_id": "domestic_bookcase_nest_fiction",
     "object": {
       "mapgensize": [ 1, 1 ],

--- a/data/json/mapgen/nested/house_nested.json
+++ b/data/json/mapgen/nested/house_nested.json
@@ -2522,6 +2522,19 @@
   },
   {
     "type": "mapgen",
+    "nested_mapgen_id": "domestic_bookcase_nest_table_book",
+    "//": "Replace bookshelf with armchair and book instead",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rotation": [ 0, 3 ],
+      "rows": [ "R" ],
+      "furniture": { "R": "f_armchair" },
+      "items": { "R": [ { "item": "novels", "chance": 100 } ] },
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
+    }
+  },
+  {
+    "type": "mapgen",
     "nested_mapgen_id": "domestic_bookcase_nest_fiction",
     "object": {
       "mapgensize": [ 1, 1 ],

--- a/data/json/mapgen_palettes/house_general_palette.json
+++ b/data/json/mapgen_palettes/house_general_palette.json
@@ -248,7 +248,9 @@
         "chunks": [
           [ "domestic_bookcase_nest_fiction", 1750 ],
           [ "domestic_bookcase_nest_fiction_and_nonfiction", 850 ],
+          [ "domestic_bookcase_nest_plant", 850 ],
           [ "domestic_bookcase_nest_literature_enthusiast", 500 ],
+          [ "domestic_bookcase_nest_table_book", 500 ],
           [ "domestic_bookcase_nest_cookbooks", 350 ],
           [ "domestic_bookcase_nest_manga", 100 ],
           [ "domestic_bookcase_nest_tailoring", 100 ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Add non-book book nests"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

A _lot_ of houses in this game have a row of three bookshelves all next to each other. Or more than one such row. Time for a bit of variety.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add two more bookshelf nests that don't have bookshelves in them. One has a potted plant and the other has two options: a table with book on it and an armchair with a book on it.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

The nests did spawn.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
