### PR TITLE
Fix Crafting GUI text wrapping & don't offscreen recipe detail selection (`SPACE`)

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1055,8 +1055,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
                     if( text_w < region_w ) {
                         ImGui::SetCursorPosX( ImGui::GetCursorPosX() + ( region_w - text_w ) / 2.f );
                     }
-                    ImGui::TextColored( cataimgui::imvec4_from_color( c_dark_gray ), "%s",
-                                        source_text.c_str() );
+                    cataimgui::draw_colored_text( source_text, c_dark_gray, region_w );
                 }
             }
 
@@ -1146,7 +1145,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
                 if( line_w < region_w ) {
                     ImGui::SetCursorPosX( ImGui::GetCursorPosX() + ( region_w - line_w ) / 2.f );
                 }
-                cataimgui::draw_colored_text( colored, c_light_gray );
+                cataimgui::draw_colored_text( colored, c_light_gray, region_w );
             }
         }
 
@@ -1157,7 +1156,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
             if( line_w < region_w ) {
                 ImGui::SetCursorPosX( ImGui::GetCursorPosX() + ( region_w - line_w ) / 2.f );
             }
-            cataimgui::draw_colored_text( lighting_str, c_red );
+            cataimgui::draw_colored_text( lighting_str, c_red, region_w );
         }
         ImGui::Separator();
 
@@ -1216,7 +1215,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
             if( !savings.empty() ) {
                 cataimgui::draw_colored_text(
                     string_format( _( "Batch time savings: %s" ),
-                                   colorize( savings, c_cyan ) ), c_light_gray );
+                                   colorize( savings, c_cyan ) ), c_light_gray, region_w );
             }
         }
 
@@ -1996,21 +1995,16 @@ void crafting_ui_impl::draw_requirement_tools( const requirement_data &req,
         }
         ImGui::TextColored( cataimgui::imvec4_from_color( c_white ), "  \u2022 " );
         ImGui::SameLine( 0, 0 );
-        bool first = true;
+        std::vector<std::string> req;
         for( const quality_requirement &qr : qual_alts ) {
-            if( !first ) {
-                ImGui::SameLine( 0, 0 );
-                ImGui::TextColored( cataimgui::imvec4_from_color( c_white ), " %s ",
-                                    _( "OR" ) );
-                ImGui::SameLine( 0, 0 );
-            }
-            first = false;
             nc_color col = qr.has( crafting_inv, return_true<item>, 1 ) ? c_green :
                            ( any_has ? c_dark_gray : c_red );
-            ImGui::TextColored( cataimgui::imvec4_from_color( col ), "%s",
-                                qr.to_string( 1 ).c_str() );
+            req.emplace_back( colorize( qr.to_string( 1 ), col ) );
         }
-        ImGui::Dummy( ImVec2( 0, 0 ) );
+        const float avail_width = ImGui::GetContentRegionAvail().x;
+        ImGui::BeginGroup();
+        cataimgui::draw_colored_text( string_join( req, _( " OR " ) ), avail_width );
+        ImGui::EndGroup();
     }
 
     // Tool groups -- bullet per group, with named req labels and expand/collapse

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -461,6 +461,7 @@ class crafting_ui_impl : public cataimgui::window
         bool pending_enter_batch = false;
         bool pending_exit_batch = false;
         bool need_scroll_to_selected = false;
+        bool need_scroll_to_selected_recipe_details = false;
 
         // One-frame flags: force ImGui to select a specific tab, then clear.
         // Set on programmatic tab changes (PREV_TAB/NEXT_TAB/LEFT/RIGHT).
@@ -925,6 +926,10 @@ bool crafting_ui_impl::nav_clickable( const char *label, nc_color col )
 {
     int idx = info_nav_active ? info_nav_count : -1;
     info_nav_count++;
+    if( need_scroll_to_selected_recipe_details && info_nav_cursor == idx ) {
+        ImGui::SetScrollHereY();
+        need_scroll_to_selected_recipe_details = false;
+    }
     return clickable_text( label, col, idx,
                            info_nav_active ? info_nav_cursor : -1,
                            info_nav_active ? info_nav_activated : -1 );
@@ -2491,8 +2496,10 @@ void crafting_ui_impl::process_action( const std::string &action_in,
         if( action == "DOWN" ) {
             info_nav_cursor = std::min( info_nav_cursor + 1,
                                         std::max( 0, info_nav_count - 1 ) );
+            need_scroll_to_selected_recipe_details = true;
         } else if( action == "UP" ) {
             info_nav_cursor = std::max( info_nav_cursor - 1, 0 );
+            need_scroll_to_selected_recipe_details = true;
         } else if( action == "CONFIRM" ) {
             info_nav_activated = info_nav_cursor;
         } else if( action == "TOGGLE_INFO_NAV" || action == "QUIT" ) {


### PR DESCRIPTION
#### Summary
Interface "Fix Crafting GUI text wrapping & don't offscreen recipe detail selection (`SPACE`)"

#### Purpose of change

Text or selection is going off screen.

#### Describe the solution

(1st, 2nd commit)
1. When navigating details in the recipe result (`SPACE`), jump to the newly selected thing, rather than the selection going off-screen.
2. Lots of overflow, or possible overflow (if translation is longer than English) for small screens.

#### Describe alternatives you've considered

Overflow - do `…` to cut off the message; it would save space, but hide part of the text. Anyway, currently it is wrong.

#### Testing

<img width="644" height="389" alt="image" src="https://github.com/user-attachments/assets/fa3e3a00-f34a-438f-a18f-cb6db1322edb" />

<img width="641" height="420" alt="image" src="https://github.com/user-attachments/assets/4f0fd724-f98b-4f16-915f-f829af20b140" />

Resize a ton in crafting menu. Make the texts such as "Batch crafting:" longer, recompile, and check that it wraps.

#### Additional context

Reference:
 - #86044

The hint probably shouldn't display for small screens, it takes up 5 lines, which would gain 55.5% extra space:

<img width="644" height="421" alt="image" src="https://github.com/user-attachments/assets/3e6ad998-cca9-42c6-91ea-b9c6b4bd9330" />

Existing regression: The mouse cannot be used since the migration #86044. Code still registers the events, but it doesn't handle them. We used to be able to hover over the 3 lists presented and scroll, and it would scroll the correct one. It was cool.

Filter menu doesn't fit:
<img width="645" height="415" alt="image" src="https://github.com/user-attachments/assets/18b58ed0-e6db-4a93-a3e1-7298a3bafd2a" />
