### PR TITLE
fix copy-from of examine_actions

### DIFF
--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1232,6 +1232,11 @@ void map_data_common_t::load( const JsonObject &jo, const std::string &src )
     }
 
     // this certainly need some cleanup, leverage it to generic factory or something
+    if( jo.has_member( "examine_action" ) ) {
+        examine_func.clear();
+        examine_actor.clear();
+    }
+
     if( jo.has_string( "examine_action" ) ) {
         examine_func.emplace_back( iexamine_functions_from_string( jo.get_string( "examine_action" ) ) );
     } else if( jo.has_object( "examine_action" ) ) {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #88066
#### Describe the solution
#87934 made possible to use array notation for examine actions, but it doesn't use generic factory `optional()`, so copy-from always extends the vector, never resetting
Resetting variables when `examine_action` is detected solves it
#### Describe alternatives you've considered
Ideally it would be leveraged to `optional()`, but for this one need to refactor the code so there will be only one variable to store examine action, not two (legacy examine_func and modern examine_actor), which coincidentally requires refactor of how this json is used (i think dummy actor that checks the type of activity and then calls corresponding examine action will do the trick)
#### Testing
Save from 88066 has obelisk with only one use action, that is later used automatically