### PR TITLE
Adding binder+paper disassemble recipe for books that uses a binder

### DIFF
--- a/data/json/items/book/cooking.json
+++ b/data/json/items/book/cooking.json
@@ -289,7 +289,7 @@
     "volume": "1400 ml",
     "price": "19 USD 50 cent",
     "price_postapoc": "5 USD",
-    "material": [ { "type": "leather", "portion": 10 }, { "type": "paper", "portion": 90 } ],
+    "material": [ { "type": "plastic", "portion": 10 }, { "type": "paper", "portion": 90 } ],
     "symbol": "?",
     "color": "light_gray",
     "looks_like": "cookbook",

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -8059,5 +8059,13 @@
     "time": "4 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "meat_tainted", 6 ] ], [ [ "bone_tainted", 3 ] ], [ [ "sinew", 2 ] ] ]
-  }
+  },
+  {
+    "result": "family_cookbook",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "time": "5 s",
+    "components": [ [ [ "book_binder", 1 ] ], [ [ "paper", 400 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
 ]

--- a/data/mods/TEST_DATA/known_bad_uncrafts.json
+++ b/data/mods/TEST_DATA/known_bad_uncrafts.json
@@ -675,6 +675,7 @@
       "exodii_wire_kit",
       "extension_cable",
       "extinguisher",
+      "family_cookbook",
       "fancy_ordinance_cartridge_necklace",
       "fancy_pistol_cartridge_necklace",
       "fancy_rifle_cartridge_necklace",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Teaching everyone in New England how to remove papers from binder- like what normal people would do.

#### Describe the solution
Adding disassemble recipe for books that uses a binder:

- Family Cookbook (_"A big **binder** full of..."_)
- Standpipe Maintenance Log (_"This **binder** details..."_)
- Chemical Reference-CLASSIFIED (_"This somewhat technical **binder** has..."_)
- PE023 "Medical": Application and Findings (_"This **binder** of..."_)
- Lab Journal-Herrera (_"This hefty **binder** contains..."_)
- 2XI design **binder**-CLASSIFIED
- Trifacet Handling Procedures (_"A heavy and disparate **binder** detailing..."_)
- Rivtech design **binder**

#### Describe alternatives you've considered
*brutally destroy the plasitc binder to get paper*

#### Testing
TBD

#### Additional context
Family Cookbook supposedly uses leather binder ("type": "leather", "portion": 10), not sure if I should exclude it from the list or not.