### PR TITLE
Allow NPCs to sleep during downtime

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1909,7 +1909,6 @@ void npc::move()
                     action = address_needs();
                 }
             } else if( is_executor_goal( new_goal ) ) {
-                add_msg_debug( debugmode::DF_NPC_NEEDS, "executor function triggered=%s", new_goal );
                 const need_result result = execute_need_goal( new_goal );
                 if( result == need_result::progressed && activity ) {
                     // Undo attitude/mission change from assign_activity.

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1883,7 +1883,10 @@ void npc::move()
                 }
                 action = npc_goto_destination;
             } else if( new_goal == "free_time" ) {
-                action = npc_worker_downtime;
+                action = address_needs();
+                if( action == npc_undecided ) {
+                    action = npc_worker_downtime;
+                }
             } else if( new_goal == "idle" ) {
                 if( guard_pos && is_guarding() ) {
                     // Persistent duty post: stay put, tend minor needs.
@@ -1906,6 +1909,7 @@ void npc::move()
                     action = address_needs();
                 }
             } else if( is_executor_goal( new_goal ) ) {
+                add_msg_debug( debugmode::DF_NPC_NEEDS, "executor function triggered=%s", new_goal );
                 const need_result result = execute_need_goal( new_goal );
                 if( result == need_result::progressed && activity ) {
                     // Undo attitude/mission change from assign_activity.


### PR DESCRIPTION


#### Summary
Bugfixes "Allow NPCs to sleep during free_time"


#### Purpose of change
Resolves #86915 

#### Describe the solution
The behavior tree in npcmove would select free_time when the NPC is able too. When this is triggered, the npc is stuck in the free_time action, with no way to address needs like sleep. This resulted in NPCs stationed at a basecamp not being able to sleep when idle. When an activity is called, the behavior tree would see that the NPC needs to sleep and sends go_to_sleep. This in turn causes the npc to sleep, seemingly interrupting its work cycle to sleep.

The solution in the PR makes it so if an NPC is in free_time, it checks to see if any needs need to be evaluated. If true, it changes the action to address_needs(). Otherwise, it lets the NPCs go into npc_worker_downtime.

#### Describe alternatives you've considered

Another possible solution is adjusting the behavior tree so that it returns go_to_sleep instead of free_time when the NPC is tired when tick() is called.

#### Testing

Created a world with an NPCs stationed at a basecamp. Made sure they were in free_time and set their sleepiness above tired. They did not go to sleep. Made the changes and compiled. The NPC went to sleep when in free_time instead of remaining awake.

#### Additional context

A few things to note:
1. Due to the way address_needs() works, the NPC will try to still prefer to stay awake indefinitely according to rules. The player setting for NPC rules needs to be changed to "will sleep when tired", otherwise the NPC will still try to stay awake.
2. Another thing I discovered when testing this is that the rule for "will sleep when tired" will automatically reset to the default of "will stay awake as long as possible" every time the NPC goes to sleep. This will cause the NPC to still try and stay awake and the behavior will repeat unless this is enabled every sleep cycle. I am not sure if this is intentional or not, however this persisted before and after the code change.


