### PR TITLE
Display multiple like items in car part removal on the same line with a count

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1809,20 +1809,21 @@ bool veh_interact::can_remove_part( map &here, int idx, const Character &you )
                     _( "<color_white>Removing the %1$s will yield:</color>\n> %2$s\n" ),
                     sel_vehicle_part->name(), result_of_removal.display_name() );
 
-        std::map<item, int> unique_salvageable_items;
+        std::map<itype_id, int> unique_salvageable_items;
         for( const item &it : sel_vehicle_part->get_salvageable() ) {
-            unique_salvageable_items[ it ] += 1;
+            unique_salvageable_items[ it.typeId() ] += 1;
         }
 
-        std::map<item, int>::iterator it;
+        std::map<itype_id, int>::iterator it;
         for( it = unique_salvageable_items.begin(); it != unique_salvageable_items.end(); it++ ) {
+            const itype *type = item::find_type( it->first );
             nmsg += "> ";
 
             if( it->second > 1 ) {
-                nmsg += std::to_string( it->second ) + " ";
+                nmsg += type->item_measure_prefix( it->second ) + " ";
             }
 
-            nmsg += it->first.display_name( it->second ) + "\n";
+            nmsg += type->nname( it->second ) + "\n";
         }
     }
 

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1808,8 +1808,21 @@ bool veh_interact::can_remove_part( map &here, int idx, const Character &you )
         nmsg += string_format(
                     _( "<color_white>Removing the %1$s will yield:</color>\n> %2$s\n" ),
                     sel_vehicle_part->name(), result_of_removal.display_name() );
+
+        std::map<item, int> unique_salvageable_items;
         for( const item &it : sel_vehicle_part->get_salvageable() ) {
-            nmsg += "> " + it.display_name() + "\n";
+            unique_salvageable_items[ it ] += 1;
+        }
+
+        std::map<item, int>::iterator it;
+        for( it = unique_salvageable_items.begin(); it != unique_salvageable_items.end(); it++ ) {
+            nmsg += "> ";
+
+            if( it->second > 1 ) {
+                nmsg += std::to_string( it->second ) + " ";
+            }
+
+            nmsg += it->first.display_name( it->second ) + "\n";
         }
     }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Display multiple like items in car part removal on the same line with a count"

#### Purpose of change

Fixes #87399

#### Describe the solution

Store a map of salvageable parts and display the count with the item instead of each individual item.

#### Describe alternatives you've considered

Display as "item x40" instead of "40 item"

#### Testing

Created a fresh world.
Debug spawned in a car.
Tried removing various parts and looked at the descriptions.

#### Additional context

NOTE: C++ is not my normal programming language, so if there's anything that should be done differently in my approach, please let me know and I will try to fix it.

Result:
<img width="817" height="308" alt="image" src="https://github.com/user-attachments/assets/d66f2493-5e20-48d3-b756-1208ea7eb14d" />
