### PR TITLE
Swap cash card with credit card in basegame itemgroup

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/wallets.json
+++ b/data/json/itemgroups/Clothing_Gear/wallets.json
@@ -37,7 +37,7 @@
     "subtype": "collection",
     "container-item": "wallet",
     "items": [
-      { "item": "cash_card", "prob": 100, "charges": [ 0, 50000 ] },
+      { "item": "credit_card", "prob": 100 },
       { "group": "banknotes", "prob": 80, "count": [ 1, 20 ] },
       { "group": "coins", "prob": 80, "count": [ 1, 10 ] },
       { "group": "discount_cards", "prob": 40, "count": [ 1, 3 ] },
@@ -53,7 +53,7 @@
     "container-item": "wallet_leather",
     "//": "copy-from: wallet_full ",
     "items": [
-      { "item": "cash_card", "prob": 100, "charges": [ 0, 50000 ] },
+      { "item": "credit_card", "prob": 100 },
       { "group": "banknotes", "prob": 80, "count": [ 1, 20 ] },
       { "group": "coins", "prob": 80, "count": [ 1, 10 ] },
       { "group": "discount_cards", "prob": 40, "count": [ 1, 3 ] },
@@ -69,7 +69,7 @@
     "//": "copy-from: wallet_full ",
     "container-item": "wallet_large",
     "items": [
-      { "item": "cash_card", "prob": 100, "charges": [ 0, 50000 ] },
+      { "item": "credit_card", "prob": 100 },
       { "group": "banknotes", "prob": 80, "count": [ 1, 20 ] },
       { "group": "coins", "prob": 80, "count": [ 1, 10 ] },
       { "group": "discount_cards", "prob": 40, "count": [ 1, 3 ] },
@@ -84,7 +84,7 @@
     "id": "wallet_duct_tape_full",
     "container-item": "wallet_duct_tape",
     "items": [
-      { "item": "cash_card", "prob": 50, "charges": [ 0, 500 ] },
+      { "item": "credit_card", "prob": 50 },
       { "group": "banknotes", "prob": 50, "count": [ 1, 20 ] },
       { "group": "coins", "prob": 80, "count": [ 1, 10 ] },
       { "group": "discount_cards", "prob": 10 },
@@ -99,7 +99,7 @@
     "subtype": "collection",
     "container-item": "wallet_stylish",
     "items": [
-      { "item": "cash_card", "prob": 100, "charges": [ 10000, 50000 ] },
+      { "item": "credit_card", "prob": 100 },
       { "group": "banknotes", "prob": 80, "count": [ 1, 20 ] },
       { "group": "coins", "prob": 80, "count": [ 1, 10 ] },
       { "group": "discount_cards", "prob": 60, "count": [ 2, 5 ] },
@@ -116,7 +116,7 @@
     "//": "copy-from: wallet_leather_full ",
     "container-item": "wallet_leather",
     "items": [
-      { "item": "cash_card", "prob": 100, "charges": [ 0, 50000 ] },
+      { "item": "credit_card", "prob": 100 },
       { "item": "id_military", "prob": 100 },
       { "group": "banknotes", "prob": 80, "count": [ 1, 20 ] },
       { "group": "coins", "prob": 80, "count": [ 1, 10 ] },
@@ -133,7 +133,7 @@
     "//": "copy-from: wallet_full ",
     "container-item": "wallet",
     "items": [
-      { "item": "cash_card", "prob": 100, "charges": [ 0, 50000 ] },
+      { "item": "credit_card", "prob": 100 },
       { "item": "id_military", "prob": 100 },
       { "group": "banknotes", "prob": 80, "count": [ 1, 20 ] },
       { "group": "coins", "prob": 80, "count": [ 1, 10 ] },
@@ -151,7 +151,7 @@
     "container-item": "wallet_leather",
     "on_overflow": "discard",
     "items": [
-      { "item": "cash_card", "prob": 100, "charges": [ 0, 50000 ] },
+      { "item": "credit_card", "prob": 100 },
       { "group": "banknotes", "prob": 80, "count": [ 1, 20 ] },
       { "group": "coins", "prob": 80, "count": [ 1, 10 ] },
       { "item": "id_science", "prob": 100 },
@@ -171,7 +171,7 @@
     "container-item": "wallet",
     "on_overflow": "discard",
     "items": [
-      { "item": "cash_card", "prob": 100, "charges": [ 0, 50000 ] },
+      { "item": "credit_card", "prob": 100 },
       { "item": "id_science", "prob": 100 },
       { "item": "id_science_visitor_1", "prob": 100 },
       { "group": "banknotes", "prob": 80, "count": [ 1, 20 ] },
@@ -193,7 +193,7 @@
     "items": [
       { "item": "id_science", "prob": 100 },
       { "item": "id_science_visitor_1", "prob": 100 },
-      { "item": "cash_card", "prob": 100, "charges": [ 10000, 50000 ] },
+      { "item": "credit_card", "prob": 100 },
       { "group": "banknotes", "prob": 80, "count": [ 1, 20 ] },
       { "group": "coins", "prob": 80, "count": [ 1, 10 ] },
       { "group": "discount_cards", "prob": 60, "count": [ 2, 5 ] },
@@ -228,7 +228,7 @@
     "//": "copy-from: wallet_leather_full ",
     "container-item": "wallet_leather",
     "items": [
-      { "item": "cash_card", "prob": 100, "charges": [ 0, 50000 ] },
+      { "item": "credit_card", "prob": 100 },
       { "item": "id_industrial", "prob": 100 },
       { "group": "banknotes", "prob": 80, "count": [ 1, 20 ] },
       { "group": "coins", "prob": 80, "count": [ 1, 10 ] },
@@ -245,7 +245,7 @@
     "//": "copy-from: wallet_full ",
     "container-item": "wallet",
     "items": [
-      { "item": "cash_card", "prob": 100, "charges": [ 0, 50000 ] },
+      { "item": "credit_card", "prob": 100 },
       { "item": "id_industrial", "prob": 100 },
       { "group": "banknotes", "prob": 80, "count": [ 1, 20 ] },
       { "group": "coins", "prob": 80, "count": [ 1, 10 ] },
@@ -261,7 +261,7 @@
     "subtype": "collection",
     "container-item": "wallet",
     "items": [
-      { "item": "cash_card", "prob": 100, "charges": [ 0, 1000 ] },
+      { "item": "credit_card", "prob": 100 },
       { "group": "banknotes", "prob": 80, "count": [ 1, 2 ] },
       { "group": "coins", "prob": 80, "count": [ 1, 5 ] }
     ]
@@ -272,7 +272,7 @@
     "subtype": "collection",
     "container-item": "wallet_stylish",
     "items": [
-      { "item": "cash_card", "prob": 100, "charges": [ 8000, 12000 ] },
+      { "item": "credit_card", "prob": 100 },
       { "group": "banknotes", "prob": 80, "count": [ 1, 2 ] },
       { "group": "coins", "prob": 80, "count": [ 1, 5 ] }
     ]

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -699,7 +699,7 @@
       [ "bubblewrap", 30 ],
       [ "syringe", 35 ],
       [ "glowstick_dead", 15 ],
-      { "item": "cash_card", "prob": 5, "charges": [ 5, 5000 ] },
+      { "item": "credit_card", "prob": 5 },
       [ "id_science", 3 ],
       [ "sandbox_kit", 5 ],
       [ "ear_spool", 15 ],

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -168,8 +168,7 @@
     "//2": "This group is for a messy junk drawer.  The idea is that it should be filled with random crud, much of it obvious trash.  Like you might find in the home of someone with a small hoarding problem.",
     "subtype": "collection",
     "entries": [
-      { "item": "cash_card", "count": [ 1, 3 ], "charges": [ 1, 1150 ] },
-      { "item": "cash_card", "count": [ 1, 4 ], "charges": 0 },
+      { "item": "credit_card", "count": [ 1, 4 ] },
       { "item": "lighter", "prob": 90, "charges": [ 0, 2 ] },
       { "group": "bag_garbage_box_part", "prob": 95 },
       { "item": "bottle_opener", "prob": 90 },

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -2962,6 +2962,19 @@
     "tool_ammo": [ "money" ]
   },
   {
+    "id": "credit_card",
+    "type": "ITEM",
+    "category": "currency",
+    "copy-from": "card_plastic_abstract",
+    "symbol": "$",
+    "color": "yellow",
+    "name": { "str": "credit card" },
+    "ascii_picture": "cashcard",
+    "description": "A plastic card used to purchase goods and services.  It's useless now",
+    "price": "10 USD",
+    "extend": { "flags": [ "TRADER_AVOID" ] }
+  },
+  {
     "id": "robofac_test_data",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/data/json/monsterdrops/zombie_survivor.json
+++ b/data/json/monsterdrops/zombie_survivor.json
@@ -28,7 +28,7 @@
       { "group": "mil_surplus", "prob": 15 },
       { "group": "default_zombie_items_bags", "prob": 15 },
       { "group": "default_zombie_items_pockets", "prob": 15 },
-      { "item": "cash_card", "charges": [ 25000, 100000 ] },
+      { "item": "credit_card" },
       {
         "distribution": [ { "group": "full_survival_kit", "damage": [ 1, 4 ] }, { "group": "used_survival_kit", "damage": [ 1, 4 ] } ],
         "prob": 5
@@ -180,7 +180,7 @@
           { "group": "mil_surplus", "prob": 6 }
         ]
       },
-      { "item": "cash_card", "charges": [ 50000, 150000 ] }
+      { "item": "credit_card" }
     ]
   },
   {

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -601,7 +601,8 @@
         [ "bottle_plastic_small", 1 ],
         [ "plastic_chunk", 1 ],
         [ "aluminum_foil", 40 ],
-        [ "cash_card", 2 ]
+        [ "cash_card", 2 ],
+        [ "credit_card", 2 ]
       ]
     ]
   },


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Since the ATM is unusuable in basegame, i thought it'd be prudent to swap out the cash card itemspawn with credit card. The cash card item itself wont be obsoleted due to them being used in some other in repo mods like Aftershock.

#### Describe the solution

Make credit card item and replace the basegame cashcard reference with credit card.

#### Describe alternatives you've considered

Nah

#### Testing
Shows up in fletching requirement.
<img width="598" height="748" alt="Screenshot_20260724_203634" src="https://github.com/user-attachments/assets/94c6a393-6646-4dce-9a78-29370a822569" />

The credit card item.
<img width="789" height="895" alt="Screenshot_20260724_203300" src="https://github.com/user-attachments/assets/0ea23c2a-d736-40bb-b6e9-4af003c5d4ab" />

Spawn in zombie's wallet
<img width="559" height="346" alt="Screenshot_20260724_203244" src="https://github.com/user-attachments/assets/0372d490-6ffd-43a4-a5b1-785c33861e07" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
