### PR TITLE
fix two too-small notebooks

### DIFF
--- a/data/json/items/book/maps.json
+++ b/data/json/items/book/maps.json
@@ -572,9 +572,8 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": [ "paper" ],
-    "flags": [ "PAPER_SHAPED" ],
-    "weight": "5 g",
-    "volume": "5 ml",
+    "weight": "90 g",
+    "volume": "150 ml",
     "use_action": {
       "type": "effect_on_conditions",
       "menu_text": "Study the notebook",
@@ -620,9 +619,8 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": [ "paper" ],
-    "flags": [ "PAPER_SHAPED" ],
-    "weight": "5 g",
-    "volume": "5 ml"
+    "weight": "90 g",
+    "volume": "150 ml"
   },
   {
     "type": "ITEM",
@@ -634,10 +632,9 @@
     "description": "An absolutely ancient-looking, leather-bound journal.  The pages are gilded at the edges.",
     "price": "0 cent",
     "price_postapoc": "0 cent",
-    "material": [ "paper" ],
-    "flags": [ "PAPER_SHAPED" ],
-    "weight": "5 g",
-    "volume": "5 ml",
+    "material": [ "paper", "leather" ],
+    "weight": "750 g",
+    "volume": "1200 ml",
     "use_action": {
       "type": "effect_on_conditions",
       "menu_text": "Study the journal",
@@ -683,7 +680,6 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": [ "paper" ],
-    "flags": [ "PAPER_SHAPED" ],
     "weight": "5 g",
     "volume": "5 ml"
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Old item on my to-do list: a couple of notebooks were way too small:

<img width="882" height="121" alt="image" src="https://github.com/user-attachments/assets/602f9b52-9e38-4ee2-a9d2-d62ea76f03ab" />

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

`xedra_field_notes` and `xedra_field_notes_used` (field notebook): 5ml/5g -> 150ml/90g (based on https://www.riteintherain.com/4x6-top-spiral-notebook#146)

`inner_cabins_depths_note` and `inner_cabins_depths_note_used` (leather notebook): 5ml/5g -> 1200ml/750g (based on seeming reasonable)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Other sizes

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Has correct values
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
