### PR TITLE
Add PAUSE_BODYPART_INFECTION flag, use in MoM

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2778,7 +2778,12 @@
   {
     "id": "PAUSE_INFECTIONS",
     "type": "json_flag",
-    "info": "If you're invisible, now you're not"
+    "info": "Prevents all infections from progressing to death, though does not relieve symptoms"
+  },
+  {
+    "id": "PAUSE_BODYPART_INFECTION",
+    "type": "json_flag",
+    "info": "Prevents infection on a bodypart with this flag from progressing to death, though does not relieve symptoms"
   },
   {
     "id": "ANIMALEMPATH2",

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -2639,7 +2639,8 @@
     "show_intensity": false,
     "max_duration": "7 days",
     "base_mods": { "healing_rate": [ 20 ], "healing_head": [ 100 ], "healing_torso": [ 100 ] },
-    "scaling_mods": { "healing_rate": [ 6 ] }
+    "scaling_mods": { "healing_rate": [ 6 ] },
+    "flags": [ "PAUSE_BODYPART_INFECTION" ]
   },
   {
     "type": "effect_type",

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -444,7 +444,8 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```ONE_STORY_FALL``` You can slow your fall, effectively reducing the height of it by 1 level.
 - ```PAIN_IMMUNE``` Character don't feel pain.
 - ```PARAIMMUNE``` You are immune to parasites.
-- ```PAUSE_INFECTIONS``` Infections cannot kill you while you have this flag
+- ```PAUSE_BODYPART_INFECTION``` Infections on the bodypart that has an effect with this flag cannot kill you
+- ```PAUSE_INFECTIONS``` Infections on any bodypart cannot kill you while you have this flag
 - ```PHASE_MOVEMENT``` DEBUG. Completely ignores all impassable tiles, gravity checks, etc. and forces movement anyway.
 - ```PLANTBLOOD``` Your body drip veggy blood if wounded.
 - ```PORTAL_PROOF``` You are immune to personal portal storm effects.

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -1559,7 +1559,6 @@ void Character::hardcoded_effects( effect &it )
             }
         }
         if( !recovered ) {
-          
             // PAUSE_INFECTIONS means you cannot die and you have plenty of time when it wears off
             // PAUSE_BODYPART_INFECTION is the same but only if it's on the same bodypart as the infection
             const bool paused_infections = has_flag( json_flag_PAUSE_INFECTIONS );

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -1562,7 +1562,7 @@ void Character::hardcoded_effects( effect &it )
             // PAUSE_INFECTIONS means you cannot die and you have plenty of time when it wears off
             // PAUSE_BODYPART_INFECTION is the same but only if it's on the same bodypart as the infection
             bool paused_infections = has_flag( json_flag_PAUSE_INFECTIONS );
-            if ( !paused_infections ) {
+            if( !paused_infections ) {
                 if( bp != bodypart_str_id::NULL_ID() ) {
                     for( const effect &eff : get_effects_from_bp( bp ) ) {
                         if( eff.has_flag( json_flag_PAUSE_BODYPART_INFECTION ) ) {

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -123,6 +123,7 @@ static const json_character_flag json_flag_ALARMCLOCK( "ALARMCLOCK" );
 static const json_character_flag json_flag_BIONIC_LIMB( "BIONIC_LIMB" );
 static const json_character_flag json_flag_CANNOT_TAKE_DAMAGE( "CANNOT_TAKE_DAMAGE" );
 static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
+static const json_character_flag json_flag_PAUSE_BODYPART_INFECTION( "PAUSE_BODYPART_INFECTION" );
 static const json_character_flag json_flag_PAUSE_INFECTIONS( "PAUSE_INFECTIONS" );
 static const json_character_flag json_flag_SEESLEEP( "SEESLEEP" );
 
@@ -1559,7 +1560,7 @@ void Character::hardcoded_effects( effect &it )
         }
         if( !recovered ) {
             // PAUSE_INFECTIONS means you cannot die and you have plenty of time when it wears off
-            if( has_flag( json_flag_PAUSE_INFECTIONS ) ) {
+            if( has_flag( json_flag_PAUSE_INFECTIONS ) || bp->has_flag( json_flag_PAUSE_BODYPART_INFECTION ) ) {
                 if( dur > 6_hours ) {
                     it.mod_duration( -1_turns );
                 }

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -1561,17 +1561,18 @@ void Character::hardcoded_effects( effect &it )
         if( !recovered ) {
             // PAUSE_INFECTIONS means you cannot die and you have plenty of time when it wears off
             // PAUSE_BODYPART_INFECTION is the same but only if it's on the same bodypart as the infection
-            const bool paused_infections = has_flag( json_flag_PAUSE_INFECTIONS );
-            bool bodypart_paused_infections = false;
-            if( bp != bodypart_str_id::NULL_ID() ) {
-                for( const effect &eff : get_effects_from_bp( bp ) ) {
-                    if( eff.has_flag( json_flag_PAUSE_BODYPART_INFECTION ) ) {
-                        bodypart_paused_infections = true;
-                        break;
+            bool paused_infections = has_flag( json_flag_PAUSE_INFECTIONS );
+            if ( !paused_infections ) {
+                if( bp != bodypart_str_id::NULL_ID() ) {
+                    for( const effect &eff : get_effects_from_bp( bp ) ) {
+                        if( eff.has_flag( json_flag_PAUSE_BODYPART_INFECTION ) ) {
+                            paused_infections = true;
+                            break;
+                        }
                     }
                 }
             }
-            if( paused_infections || bodypart_paused_infections ) {
+            if( paused_infections ) {
                 if( dur > 6_hours ) {
                     it.mod_duration( -1_turns );
                 }

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -1559,8 +1559,20 @@ void Character::hardcoded_effects( effect &it )
             }
         }
         if( !recovered ) {
+          
             // PAUSE_INFECTIONS means you cannot die and you have plenty of time when it wears off
-            if( has_flag( json_flag_PAUSE_INFECTIONS ) || bp->has_flag( json_flag_PAUSE_BODYPART_INFECTION ) ) {
+            // PAUSE_BODYPART_INFECTION is the same but only if it's on the same bodypart as the infection
+            const bool paused_infections = has_flag( json_flag_PAUSE_INFECTIONS );
+            bool bodypart_paused_infections = false;
+            if( bp != bodypart_str_id::NULL_ID() ) {
+                for( const effect &eff : get_effects_from_bp( bp ) ) {
+                    if( eff.has_flag( json_flag_PAUSE_BODYPART_INFECTION ) ) {
+                        bodypart_paused_infections = true;
+                        break;
+                    }
+                }
+            }
+            if( paused_infections || bodypart_paused_infections ) {
                 if( dur > 6_hours ) {
                     it.mod_duration( -1_turns );
                 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Add PAUSE_BODYPART_INFECTION flag, use in MoM"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Follow-up to #88088, thought a flag to pause infections on just one bodypart would be useful too. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the `PAUSE_BODYPART_INFECTION` flag and add it to the Leukocyte Accumulation Vitakinetic power in MoM, so you can channel that on your infected bodypart and halt the infection. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Game compiles, ~~it doesn't work.~~ It works. Made sure both left and right arms were infected, channeled Leukocyte Accumulation on the right arm. Right arm infection timer reversed (as appropriate), left did not. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Next up--hedge magic charm with this flag.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
