### PR TITLE
[XEDRA Evolved] Ozymandias fae statue from terrain to furniture

### DIFF
--- a/data/mods/Xedra_Evolved/furniture_and_terrain/furniture.json
+++ b/data/mods/Xedra_Evolved/furniture_and_terrain/furniture.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "furniture",
-    "id": "t_statue_fae_ozymandius",
+    "id": "f_statue_fae_ozymandius",
     "name": "broken statue",
     "description": "All that remains of this previously grand statue are a pair of feet and a set of broken wings.",
     "looks_like": "f_statue",

--- a/data/mods/Xedra_Evolved/mapgen/map_extras.json
+++ b/data/mods/Xedra_Evolved/mapgen/map_extras.json
@@ -957,7 +957,7 @@
         " S,S "
       ],
       "terrain": { ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_grass_dead", 25 ] ], " ": "t_null" },
-      "furniture": { "S": "f_ozma_poppy", "@": "t_statue_fae_ozymandius" },
+      "furniture": { "S": "f_ozma_poppy", "@": "f_statue_fae_ozymandius" },
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
@@ -975,7 +975,7 @@
         " S,S "
       ],
       "terrain": { ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_grass_dead", 25 ] ], " ": "t_null" },
-      "furniture": { "S": "f_ozma_poppy", "@": "t_statue_fae_ozymandius" },
+      "furniture": { "S": "f_ozma_poppy", "@": "f_statue_fae_ozymandius" },
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "place_monster": [ { "group": "GROUP_CHANGELING_STRIKE_FORCE", "x": [ 0, 4 ], "y": [ 0, 4 ], "chance": 75, "repeat": [ 3, 5 ] } ]
     }
@@ -1004,7 +1004,7 @@
         "      S,S      "
       ],
       "terrain": { ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_grass_dead", 25 ] ], " ": "t_null" },
-      "furniture": { "S": "f_ozma_poppy", "@": "t_statue_fae_ozymandius" },
+      "furniture": { "S": "f_ozma_poppy", "@": "f_statue_fae_ozymandius" },
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },

--- a/data/mods/Xedra_Evolved/mapgen/map_extras.json
+++ b/data/mods/Xedra_Evolved/mapgen/map_extras.json
@@ -1032,7 +1032,7 @@
         "      S,S      "
       ],
       "terrain": { ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_grass_dead", 25 ] ], " ": "t_null" },
-      "furniture": { "S": "f_ozma_poppy", "@": "t_statue_fae_ozymandius" },
+      "furniture": { "S": "f_ozma_poppy", "@": "f_statue_fae_ozymandius" },
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "place_monster": [ { "group": "GROUP_CHANGELING_STRIKE_FORCE", "x": [ 0, 14 ], "y": [ 0, 14 ], "chance": 75, "repeat": [ 7, 15 ] } ]
     }

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/terrain.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/terrain.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "ter_furn_migration",
+    "from_ter": "t_statue_fae_ozymandius",
+    "to_ter": "t_railroad_rubble"
+  }
+]


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
No reason for the ozymandias statue to be a terrain, so i changed it to furniture. Makes spriting it easier because then i dont have to hassle myself with the terrain background.
#### Describe the solution
change the id from (t)errain to (f)urniture

change the ozmandias map extra's statue id to the one mentioned above

migrate terrain ozymandias statue to gravel

#### Describe alternatives you've considered
No.

#### Testing
The game didnt error on me.
<img width="586" height="530" alt="Screenshot_20260725_004954" src="https://github.com/user-attachments/assets/6857a687-4f95-41c9-ad8a-78d82f3548c0" />
<img width="681" height="625" alt="Screenshot_20260725_005107" src="https://github.com/user-attachments/assets/28ed26f1-c25f-4350-8ceb-b6c23c99e769" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
