### PR TITLE
NPCs default to allow_sleep ally rule

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -4067,7 +4067,7 @@ npc_follower_rules::npc_follower_rules()
 
     clear_flag( ally_rule::allow_pick_up );
     clear_flag( ally_rule::allow_bash );
-    clear_flag( ally_rule::allow_sleep );
+    set_flag( ally_rule::allow_sleep );
     set_flag( ally_rule::allow_complain );
     set_flag( ally_rule::allow_pulp );
     set_flag( ally_rule::close_doors );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -533,8 +533,8 @@ void talk_function::stop_guard( npc &p )
 
 void talk_function::wake_up( npc &p )
 {
-    p.rules.clear_override( ally_rule::allow_sleep );
     p.rules.enable_override( ally_rule::allow_sleep );
+    p.rules.set_override( ally_rule::allow_sleep );
     p.remove_effect( effect_allow_sleep );
     p.remove_effect( effect_lying_down );
     p.remove_effect( effect_npc_suspend );


### PR DESCRIPTION

#### Summary
Bugfixes "NPCs default to allow_sleep ally rule"


#### Purpose of change
There are two primary motivations for this change:
1: Prevent weird NPC behavior. Currently, as allow_sleep is defaulted to off, NPCs will try and stay awake as long as possible. This applies to when they are stationed in a work camp during free time (over 1000 sleepiness is required to make them sleep, where tired is considered 191). As a result, they acquire a lot of sleepiness, and when assigned to a task they go to sleep, interrupting it with no warning. Allow_sleep can be enabled in NPC ally rules, however it resets each time the NPC wakes up. This means that if a player wants to have their NPC sleep when tired at a basecamp, they need to manually adjust this rule for each NPC in the camp each sleep cycle.
2: It doesn't really make sense for an NPC to always try to stay awake as long as possible (unless they are a college student). It makes more sense that they sleep when tired unless told otherwise.


#### Describe the solution

Have NPCs default to the allow_sleep ally rule. Reset to allow_sleep every sleep cycle if the player changes it.

Currently, allow sleep is disabled whenever an NPC wakes up. I think it makes sense that NPC will default to some sleeping behavior naturally, so I decided to keep this, but instead default to allow_sleep instead of disabling it.

#### Describe alternatives you've considered

NPCs default to allow_sleep as off, but do not reset the override when waking up.
Do not override the value at all when waking up.

#### Testing

Created a new world, spawned an NPC follower. Looked at ally rules and saw that allow_sleep was enabled. Made them sleep, and when they woke up, allow_sleep was still enabled. Disabled allow_sleep, made them sleep, and saw enable_sleep was enabled when they woke up.

#### Additional context
See additional context of PR #88097 

