### PR TITLE
add 12.3ln ap 

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -2873,9 +2873,9 @@
     "subtype": "collection",
     "items": [
       { "item": "exodiiminimag", "count": [ 2, 20 ], "ammo-item": "123ln_ap", "charges": 10, "prob": 80 },
-      { "item": "exodiiBRmag", "count": [ 2, 20 ], "ammo-group": "123ln_loose", "charges": 60, "prob": 100 },
-      { "item": "exodiiBRmag_153", "count": [ 1, 5 ], "ammo-group": "123ln_loose", "charges": 153, "prob": 100 },
-      { "item": "exodiiBRmag_26", "count": [ 4, 30 ], "ammo-group": "123ln_loose", "charges": 26, "prob": 100 },
+      { "group": "full_exodiiBRmag", "count": [ 2, 20 ] },
+      { "group": "full_exodiiBRmag_153", "count": [ 1, 5 ] },
+      { "group": "full_exodiiBRmag_26", "count": [ 4, 30 ] },
       { "item": "grenade", "count": [ 1, 10 ], "prob": 20 }
     ]
   },

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -2873,9 +2873,9 @@
     "subtype": "collection",
     "items": [
       { "item": "exodiiminimag", "count": [ 2, 20 ], "ammo-item": "123ln_ap", "charges": 10, "prob": 80 },
-      { "item": "exodiiBRmag", "count": [ 2, 20 ], "ammo-item": "123ln_loose", "charges": 60, "prob": 100 },
-      { "item": "exodiiBRmag_153", "count": [ 1, 5 ], "ammo-item": "123ln_loose", "charges": 153, "prob": 100 },
-      { "item": "exodiiBRmag_26", "count": [ 4, 30 ], "ammo-item": "123ln_loose", "charges": 26, "prob": 100 },
+      { "item": "exodiiBRmag", "count": [ 2, 20 ], "ammo-group": "123ln_loose", "charges": 60, "prob": 100 },
+      { "item": "exodiiBRmag_153", "count": [ 1, 5 ], "ammo-group": "123ln_loose", "charges": 153, "prob": 100 },
+      { "item": "exodiiBRmag_26", "count": [ 4, 30 ], "ammo-group": "123ln_loose", "charges": 26, "prob": 100 },
       { "item": "grenade", "count": [ 1, 10 ], "prob": 20 }
     ]
   },

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -2872,10 +2872,10 @@
     "id": "exodii_ammo_crate",
     "subtype": "collection",
     "items": [
-      { "item": "exodiiminimag", "count": [ 2, 20 ], "ammo-item": "123ln", "charges": 10, "prob": 80 },
-      { "item": "exodiiBRmag", "count": [ 2, 20 ], "ammo-item": "123ln", "charges": 60, "prob": 100 },
-      { "item": "exodiiBRmag_153", "count": [ 1, 5 ], "ammo-item": "123ln", "charges": 153, "prob": 100 },
-      { "item": "exodiiBRmag_26", "count": [ 4, 30 ], "ammo-item": "123ln", "charges": 26, "prob": 100 },
+      { "item": "exodiiminimag", "count": [ 2, 20 ], "ammo-item": "123ln_ap", "charges": 10, "prob": 80 },
+      { "item": "exodiiBRmag", "count": [ 2, 20 ], "ammo-item": "123ln_loose", "charges": 60, "prob": 100 },
+      { "item": "exodiiBRmag_153", "count": [ 1, 5 ], "ammo-item": "123ln_loose", "charges": 153, "prob": 100 },
+      { "item": "exodiiBRmag_26", "count": [ 4, 30 ], "ammo-item": "123ln_loose", "charges": 26, "prob": 100 },
       { "item": "grenade", "count": [ 1, 10 ], "prob": 20 }
     ]
   },

--- a/data/json/itemgroups/SUS/alien.json
+++ b/data/json/itemgroups/SUS/alien.json
@@ -95,7 +95,8 @@
           { "item": "exodiiBRmag", "count": [ 1, 2 ] },
           { "item": "exodiiBRmag_153", "count": [ 0, 1 ] },
           { "item": "exodiiBRmag_26", "count": [ 2, 4 ] },
-          { "item": "123ln", "count": [ 0, 100 ] }
+          { "item": "123ln", "count": [ 0, 100 ] },
+          { "item": "123ln_ap", "count": [ 0, 50 ] }
         ],
         "prob": 5
       },

--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo/loose_ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo/loose_ammo.json
@@ -67,12 +67,6 @@
   {
     "type": "item_group",
     "subtype": "distribution",
-    "id": "123ln_loose",
-    "items": [ { "item": "123ln", "charges": [ 1, 10 ], "prob": 7 }, { "item": "123ln_ap", "charges": [ 1, 10 ], "prob": 3 } ]
-  },
-  {
-    "type": "item_group",
-    "subtype": "distribution",
     "id": "308_loose",
     "items": [ { "item": "308", "charges": [ 1, 10 ], "prob": 7 }, { "item": "762_51", "charges": [ 1, 10 ], "prob": 3 } ]
   },

--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo/loose_ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo/loose_ammo.json
@@ -67,6 +67,12 @@
   {
     "type": "item_group",
     "subtype": "distribution",
+    "id": "123ln_loose",
+    "items": [ { "item": "123ln", "charges": [ 1, 10 ], "prob": 7 }, { "item": "123ln_ap", "charges": [ 1, 10 ], "prob": 3 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
     "id": "308_loose",
     "items": [ { "item": "308", "charges": [ 1, 10 ], "prob": 7 }, { "item": "762_51", "charges": [ 1, 10 ], "prob": 3 } ]
   },

--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/exodii_full_mags.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/exodii_full_mags.json
@@ -1,0 +1,23 @@
+[
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "full_exodiiBRmag",
+    "container-item": "exodiiBRmag",
+    "items": [ { "item": "123ln", "charges": 60, "prob": 7 }, { "item": "123ln_ap", "charges": 60, "prob": 3 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "full_exodiiBRmag_153",
+    "container-item": "exodiiBRmag_153",
+    "items": [ { "item": "123ln", "charges": 153, "prob": 7 }, { "item": "123ln_ap", "charges": 153, "prob": 3 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "full_exodiiBRmag_26",
+    "container-item": "exodiiBRmag_26",
+    "items": [ { "item": "123ln", "charges": 26, "prob": 3 }, { "item": "123ln_ap", "charges": 26, "prob": 7 } ]
+  }
+]

--- a/data/json/items/ammo/exodii.json
+++ b/data/json/items/ammo/exodii.json
@@ -62,6 +62,7 @@
     "type": "ITEM",
     "subtypes": [ "AMMO" ],
     "name": { "str_sp": "12.3ln AP, black powder" },
+    "weight": "27 g",
     "proportional": {
       "price": 0.3,
       "damage": { "damage_type": "bullet", "amount": 0.76, "armor_penetration": 0.5 },

--- a/data/json/items/ammo/exodii.json
+++ b/data/json/items/ammo/exodii.json
@@ -41,7 +41,7 @@
     "subtypes": [ "AMMO" ],
     "copy-from": "3006fmj",
     "name": { "str_sp": "12.3ln AP" },
-    "description": "Placeholder",
+    "description": "In some alternate universe, the 12.3ln cartridge was introduced in Romania in the wake of the second Carpathian conflict.  This is the armor piercing variant, and it is the ammo that is preferred by exodii snipers or individuals using the PS md. 71z.",
     "ammo_type": "123ln",
     "relative": { "damage": { "damage_type": "bullet", "amount": -4 } },
     "casing": "123ln_casing"

--- a/data/json/items/ammo/exodii.json
+++ b/data/json/items/ammo/exodii.json
@@ -41,7 +41,7 @@
     "subtypes": [ "AMMO" ],
     "copy-from": "3006fmj",
     "name": { "str_sp": "12.3ln AP" },
-    "description": "Placeholder"
+    "description": "Placeholder",
     "ammo_type": "123ln",
     "relative": { "damage": { "damage_type": "bullet", "amount": -4 } },
     "casing": "123ln_casing"

--- a/data/json/items/ammo/exodii.json
+++ b/data/json/items/ammo/exodii.json
@@ -36,6 +36,42 @@
     "delete": { "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }
   },
   {
+    "id": "123ln_ap",
+    "type": "ITEM",
+    "subtypes": [ "AMMO" ],
+    "copy-from": "3006fmj",
+    "name": { "str_sp": "12.3ln AP" },
+    "description": "In some alternate universe, the 12.3ln cartridge was introduced in Romania in the wake of the second Carpathian conflict.  Then used to defeat modern body armour, now it is the preffered ammunition for exodii snipers, combined with the PS md. 71z. ",
+    "ammo_type": "123ln",
+    "relative": { "damage": { "damage_type": "bullet", "amount": -4 } },
+    "casing": "123ln_casing"
+  },
+  {
+    "id": "reloaded_123ln_ap",
+    "copy-from": "123ln_ap",
+    "type": "ITEM",
+    "subtypes": [ "AMMO" ],
+    "name": { "str_sp": "12.3ln AP, reloaded" },
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
+    "extend": { "effects": [ "RECYCLED" ] },
+    "delete": { "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }
+  },
+  {
+    "id": "bp_123ln_ap",
+    "copy-from": "123ln_ap",
+    "type": "ITEM",
+    "subtypes": [ "AMMO" ],
+    "name": { "str_sp": "12.3ln AP, black powder" },
+    "proportional": {
+      "price": 0.3,
+      "damage": { "damage_type": "bullet", "amount": 0.76, "armor_penetration": 0.5 },
+      "recoil": 0.76,
+      "dispersion": 1.2
+    },
+    "extend": { "effects": [ "RECYCLED", "BLACKPOWDER", "MUZZLE_SMOKE" ] },
+    "delete": { "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }
+  },
+  {
     "abstract": "273x110abstract",
     "type": "ITEM",
     "subtypes": [ "AMMO" ],

--- a/data/json/items/ammo/exodii.json
+++ b/data/json/items/ammo/exodii.json
@@ -41,7 +41,7 @@
     "subtypes": [ "AMMO" ],
     "copy-from": "3006fmj",
     "name": { "str_sp": "12.3ln AP" },
-    "description": "In some alternate universe, the 12.3ln cartridge was introduced in Romania in the wake of the second Carpathian conflict.  Then used to defeat modern body armour, now it is the preferred ammunition for exodii snipers, combined with the PS md. 71z. ",
+    "description": "In some alternate universe, the 12.3ln cartridge was introduced in Romania in the wake of the second Carpathian conflict. Then used to defeat modern body armour, now it is the preferred ammunition for exodii snipers, combined with the PS md. 71z.",
     "ammo_type": "123ln",
     "relative": { "damage": { "damage_type": "bullet", "amount": -4 } },
     "casing": "123ln_casing"

--- a/data/json/items/ammo/exodii.json
+++ b/data/json/items/ammo/exodii.json
@@ -41,7 +41,7 @@
     "subtypes": [ "AMMO" ],
     "copy-from": "3006fmj",
     "name": { "str_sp": "12.3ln AP" },
-    "description": "In some alternate universe, the 12.3ln cartridge was introduced in Romania in the wake of the second Carpathian conflict.  Then used to defeat modern body armour, now it is the preffered ammunition for exodii snipers, combined with the PS md. 71z. ",
+    "description": "In some alternate universe, the 12.3ln cartridge was introduced in Romania in the wake of the second Carpathian conflict.  Then used to defeat modern body armour, now it is the preferred ammunition for exodii snipers, combined with the PS md. 71z. ",
     "ammo_type": "123ln",
     "relative": { "damage": { "damage_type": "bullet", "amount": -4 } },
     "casing": "123ln_casing"

--- a/data/json/items/ammo/exodii.json
+++ b/data/json/items/ammo/exodii.json
@@ -41,7 +41,7 @@
     "subtypes": [ "AMMO" ],
     "copy-from": "3006fmj",
     "name": { "str_sp": "12.3ln AP" },
-    "description": "In some alternate universe, the 12.3ln cartridge was introduced in Romania in the wake of the second Carpathian conflict. Then used to defeat modern body armour, now it is the preferred ammunition for exodii snipers, combined with the PS md. 71z.",
+    "description": "Placeholder"
     "ammo_type": "123ln",
     "relative": { "damage": { "damage_type": "bullet", "amount": -4 } },
     "casing": "123ln_casing"

--- a/data/json/monsters/drones.json
+++ b/data/json/monsters/drones.json
@@ -125,7 +125,7 @@
     "aggro_character": false,
     "vision_day": 50,
     "vision_night": 20,
-    "starting_ammo": { "123ln": 10 },
+    "starting_ammo": { "123ln_ap": 10 },
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT" ],
     "special_attacks": [
       {

--- a/data/json/npcs/exodii/exodii_merchant_itemlist.json
+++ b/data/json/npcs/exodii/exodii_merchant_itemlist.json
@@ -158,6 +158,7 @@
         ]
       },
       { "item": "123ln", "container-item": "box_small", "prob": 60, "count": [ 2, 4 ], "sealed": true },
+      { "item": "123ln_ap", "container-item": "box_small", "prob": 30, "count": [ 2, 4 ], "sealed": true },
       { "item": "273x110sluglight", "container-item": "box_small", "prob": 40, "count": [ 3, 4 ], "sealed": true },
       { "item": "273x44trainer", "container-item": "box_small", "prob": 30, "count": [ 3, 5 ], "sealed": true },
       { "item": "273x110flock", "container-item": "box_small", "prob": 10, "count": [ 1, 2 ], "sealed": true },

--- a/data/json/recipes/ammo/rifle.json
+++ b/data/json/recipes/ammo/rifle.json
@@ -1660,7 +1660,7 @@
     "//": "This is an alien cartridge, so it'd require a bit of guesswork on the load data, hence the higher skill req for crafting + book.",
     "charges": 1,
     "reversible": { "time": "5 s" },
-    "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 3 ] ],
+    "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 2 ] ],
     "//1": "3200 mg gunpowder rounded to 32 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "components": [
@@ -1685,7 +1685,7 @@
     "book_learn": [ [ "recipe_bullets", 2 ] ],
     "charges": 1,
     "reversible": { "time": "5 s" },
-    "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 4 ] ],
+    "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "components": [
       [ [ "unprimed_123ln_casing", 1 ] ],

--- a/data/json/recipes/ammo/rifle.json
+++ b/data/json/recipes/ammo/rifle.json
@@ -1660,7 +1660,7 @@
     "//": "Skill level bumped up cause its armour piercing, recipe needs some fixing but ap uncrafts/recipies are kinda broken currently.",
     "charges": 1,
     "reversible": { "time": "5 s" },
-    "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 2 ] ],
+    "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 1 ] ],
     "//1": "3200 mg gunpowder rounded to 32 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "components": [

--- a/data/json/recipes/ammo/rifle.json
+++ b/data/json/recipes/ammo/rifle.json
@@ -1657,7 +1657,7 @@
     "time": "2 m",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_bullets", 2 ] ],
-    "//": "This is an alien cartridge, so it'd require a bit of guesswork on the load data, hence the higher skill req for crafting + book.",
+    "//": "Skill level bumped up cause its armour piercing, recipe needs some fixing but ap uncrafts/recipies are kinda broken currently.",
     "charges": 1,
     "reversible": { "time": "5 s" },
     "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 2 ] ],
@@ -1667,8 +1667,7 @@
       [ [ "unprimed_123ln_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
       [ [ "gunpowder_rifle", 32 ], [ "gunpowder_large_rifle", 32 ] ],
-      [ [ "copper", 2 ] ],
-      [ [ "scrap", 1 ] ]
+      [ [ "copper", 2 ] ]
     ]
   },
   {
@@ -1685,14 +1684,13 @@
     "book_learn": [ [ "recipe_bullets", 2 ] ],
     "charges": 1,
     "reversible": { "time": "5 s" },
-    "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 3 ] ],
+    "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 2 ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "components": [
       [ [ "unprimed_123ln_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
       [ [ "chem_black_powder", 32 ] ],
-      [ [ "copper", 2 ] ],
-      [ [ "scrap", 1 ] ]
+      [ [ "copper", 2 ] ]
     ]
   },
   {

--- a/data/json/recipes/ammo/rifle.json
+++ b/data/json/recipes/ammo/rifle.json
@@ -1667,7 +1667,7 @@
       [ [ "unprimed_123ln_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
       [ [ "gunpowder_rifle", 32 ], [ "gunpowder_large_rifle", 32 ] ],
-      [ [ "copper", 2 ] ]
+      [ [ "copper", 2 ] ],
       [ [ "scrap", 1 ] ]
     ]
   },
@@ -1691,7 +1691,7 @@
       [ [ "unprimed_123ln_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
       [ [ "chem_black_powder", 32 ] ],
-      [ [ "copper", 2 ] ]
+      [ [ "copper", 2 ] ],
       [ [ "scrap", 1 ] ]
     ]
   },

--- a/data/json/recipes/ammo/rifle.json
+++ b/data/json/recipes/ammo/rifle.json
@@ -1684,7 +1684,7 @@
     "book_learn": [ [ "recipe_bullets", 2 ] ],
     "charges": 1,
     "reversible": { "time": "5 s" },
-    "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 2 ] ],
+    "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "components": [
       [ [ "unprimed_123ln_casing", 1 ] ],

--- a/data/json/recipes/ammo/rifle.json
+++ b/data/json/recipes/ammo/rifle.json
@@ -1646,6 +1646,56 @@
     ]
   },
   {
+    "result": "reloaded_123ln_ap",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "skills_required": [ "gun", 4 ],
+    "time": "2 m",
+    "batch_time_factors": [ 60, 5 ],
+    "book_learn": [ [ "recipe_bullets", 2 ] ],
+    "//": "This is an alien cartridge, so it'd require a bit of guesswork on the load data, hence the higher skill req for crafting + book.",
+    "charges": 1,
+    "reversible": { "time": "5 s" },
+    "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 3 ] ],
+    "//1": "3200 mg gunpowder rounded to 32 100 mg 'pieces'",
+    "proficiencies": [ { "proficiency": "prof_handloading" } ],
+    "components": [
+      [ [ "unprimed_123ln_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder_rifle", 32 ], [ "gunpowder_large_rifle", 32 ] ],
+      [ [ "copper", 2 ] ]
+      [ [ "scrap", 1 ] ]
+    ]
+  },
+  {
+    "result": "bp_123ln_ap",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "skills_required": [ "gun", 4 ],
+    "time": "2 m",
+    "batch_time_factors": [ 60, 5 ],
+    "book_learn": [ [ "recipe_bullets", 2 ] ],
+    "charges": 1,
+    "reversible": { "time": "5 s" },
+    "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 4 ] ],
+    "proficiencies": [ { "proficiency": "prof_handloading" } ],
+    "components": [
+      [ [ "unprimed_123ln_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 32 ] ],
+      [ [ "copper", 2 ] ]
+      [ [ "scrap", 1 ] ]
+    ]
+  },
+  {
     "result": "reloaded_50beowulf_xtp",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -6891,7 +6891,7 @@
     "subcategory": "CSC_AMMO_RIFLE",
     "name": "12.3ln ammo",
     "description": "Recipes related to reloading 12.3ln ammo.",
-    "nested_category_data": [ "reloaded_123ln", "bp_123ln" ]
+    "nested_category_data": [ "reloaded_123ln", "bp_123ln", "reloaded_123ln_ap", "bp_123ln_ap" ]
   },
   {
     "id": "nested_50beowulf",

--- a/data/json/uncraft/ammo/exodii.json
+++ b/data/json/uncraft/ammo/exodii.json
@@ -32,7 +32,6 @@
     "type": "uncraft",
     "activity_level": "MODERATE_EXERCISE",
     "time": "5 s",
-    "//": "delete this when the ap uncrafts are fixed",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [
       [ [ "lead", 1 ] ],

--- a/data/json/uncraft/ammo/exodii.json
+++ b/data/json/uncraft/ammo/exodii.json
@@ -28,20 +28,6 @@
     ]
   },
   {
-    "result": "bp_123ln_ap",
-    "type": "uncraft",
-    "activity_level": "MODERATE_EXERCISE",
-    "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
-    "components": [
-      [ [ "lead", 1 ] ],
-      [ [ "unprimed_123ln_casing", 1 ] ],
-      [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder_large_rifle", 32 ] ],
-      [ [ "copper", 1 ] ]
-    ]
-  },
-  {
     "result": "123ln_casing",
     "type": "uncraft",
     "activity_level": "MODERATE_EXERCISE",

--- a/data/json/uncraft/ammo/exodii.json
+++ b/data/json/uncraft/ammo/exodii.json
@@ -13,15 +13,7 @@
       [ [ "copper", 2 ] ]
     ]
   },
-  {
-    "result": "123ln_casing",
-    "type": "uncraft",
-    "activity_level": "MODERATE_EXERCISE",
-    "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
-    "components": [ [ [ "unprimed_123ln_casing", 1 ] ], [ [ "spent_lgrifle_primer", 1 ] ] ]
-  },
-  {
+   {
     "result": "123ln_ap",
     "type": "uncraft",
     "activity_level": "MODERATE_EXERCISE",
@@ -34,5 +26,28 @@
       [ [ "gunpowder_large_rifle", 32 ] ],
       [ [ "copper", 2 ] ]
     ]
+  },
+  {
+    "result": "bp_123ln_ap",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "time": "5 s",
+    "//": "delete this when the ap uncrafts are fixed"
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 1 ] ],
+      [ [ "unprimed_123ln_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder_large_rifle", 32 ] ],
+      [ [ "copper", 1 ] ]
+    ]
+  },
+  {
+    "result": "123ln_casing",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "unprimed_123ln_casing", 1 ] ], [ [ "spent_lgrifle_primer", 1 ] ] ]
   }
 ]

--- a/data/json/uncraft/ammo/exodii.json
+++ b/data/json/uncraft/ammo/exodii.json
@@ -28,7 +28,7 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [
-      [ [ "lead", 2 ] ],
+      [ [ "lead", 1 ] ],
       [ [ "unprimed_123ln_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
       [ [ "gunpowder_large_rifle", 32 ] ],

--- a/data/json/uncraft/ammo/exodii.json
+++ b/data/json/uncraft/ammo/exodii.json
@@ -32,7 +32,7 @@
       [ [ "unprimed_123ln_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
       [ [ "gunpowder_large_rifle", 32 ] ],
-      [ [ "copper", 2 ] ]
+      [ [ "copper", 2 ] ],
       [ [ "scrap", 1 ] ]
     ]
   }

--- a/data/json/uncraft/ammo/exodii.json
+++ b/data/json/uncraft/ammo/exodii.json
@@ -22,7 +22,7 @@
     "components": [ [ [ "unprimed_123ln_casing", 1 ] ], [ [ "spent_lgrifle_primer", 1 ] ] ]
   },
   {
-    "result": "123ln",
+    "result": "123ln_ap",
     "type": "uncraft",
     "activity_level": "MODERATE_EXERCISE",
     "time": "5 s",

--- a/data/json/uncraft/ammo/exodii.json
+++ b/data/json/uncraft/ammo/exodii.json
@@ -20,5 +20,20 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "unprimed_123ln_casing", 1 ] ], [ [ "spent_lgrifle_primer", 1 ] ] ]
+  },
+  {
+    "result": "123ln",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 2 ] ],
+      [ [ "unprimed_123ln_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder_large_rifle", 32 ] ],
+      [ [ "copper", 2 ] ]
+      [ [ "scrap", 1 ] ]
+    ]
   }
 ]

--- a/data/json/uncraft/ammo/exodii.json
+++ b/data/json/uncraft/ammo/exodii.json
@@ -32,7 +32,7 @@
     "type": "uncraft",
     "activity_level": "MODERATE_EXERCISE",
     "time": "5 s",
-    "//": "delete this when the ap uncrafts are fixed"
+    "//": "delete this when the ap uncrafts are fixed",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [
       [ [ "lead", 1 ] ],

--- a/data/json/uncraft/ammo/exodii.json
+++ b/data/json/uncraft/ammo/exodii.json
@@ -32,8 +32,7 @@
       [ [ "unprimed_123ln_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
       [ [ "gunpowder_large_rifle", 32 ] ],
-      [ [ "copper", 2 ] ],
-      [ [ "scrap", 1 ] ]
+      [ [ "copper", 2 ] ]
     ]
   }
 ]

--- a/data/json/uncraft/ammo/exodii.json
+++ b/data/json/uncraft/ammo/exodii.json
@@ -13,7 +13,7 @@
       [ [ "copper", 2 ] ]
     ]
   },
-   {
+  {
     "result": "123ln_ap",
     "type": "uncraft",
     "activity_level": "MODERATE_EXERCISE",

--- a/data/mods/Generic_Guns/ammo/gg_ammo_migration.json
+++ b/data/mods/Generic_Guns/ammo/gg_ammo_migration.json
@@ -295,7 +295,8 @@
     "type": "MIGRATION",
     "replace": "bp_rifle_ball_foreign"
   },
-  {"id": [ "123ln_ap" ],
+  {
+    "id": [ "123ln_ap" ],
     "type": "MIGRATION",
     "replace": "rifle_AP_foreign"
   },

--- a/data/mods/Generic_Guns/ammo/gg_ammo_migration.json
+++ b/data/mods/Generic_Guns/ammo/gg_ammo_migration.json
@@ -295,6 +295,21 @@
     "type": "MIGRATION",
     "replace": "bp_rifle_ball_foreign"
   },
+  
+    "id": [ "123ln_ap" ],
+    "type": "MIGRATION",
+    "replace": "rifle_AP_foreign"
+  },
+  {
+    "id": [ "reloaded_123ln_ap" ],
+    "type": "MIGRATION",
+    "replace": "reloaded_rifle_AP_foreign"
+  },
+  {
+    "id": [ "bp_123ln_ap" ],
+    "type": "MIGRATION",
+    "replace": "bp_rifle_AP_foreign"
+  },
   {
     "id": [
       "reloaded_223",

--- a/data/mods/Generic_Guns/ammo/gg_ammo_migration.json
+++ b/data/mods/Generic_Guns/ammo/gg_ammo_migration.json
@@ -295,7 +295,6 @@
     "type": "MIGRATION",
     "replace": "bp_rifle_ball_foreign"
   },
-  
     "id": [ "123ln_ap" ],
     "type": "MIGRATION",
     "replace": "rifle_AP_foreign"

--- a/data/mods/Generic_Guns/ammo/gg_ammo_migration.json
+++ b/data/mods/Generic_Guns/ammo/gg_ammo_migration.json
@@ -295,7 +295,7 @@
     "type": "MIGRATION",
     "replace": "bp_rifle_ball_foreign"
   },
-    "id": [ "123ln_ap" ],
+  {"id": [ "123ln_ap" ],
     "type": "MIGRATION",
     "replace": "rifle_AP_foreign"
   },

--- a/data/mods/Generic_Guns/ammo/rifle.json
+++ b/data/mods/Generic_Guns/ammo/rifle.json
@@ -74,6 +74,15 @@
     "ammo_type": "ammo_rifle_foreign"
   },
   {
+    "id": "rifle_AP_foreign",
+    "copy-from": "rifle_AP",
+    "type": "ITEM",
+    "subtypes": [ "AMMO" ],
+    "name": { "str_sp": "foreign rifle ammo, AP" },
+    "description": "Foreign armour piercing rifle ammo brought by the Exodii, common amongst them.",
+    "ammo_type": "ammo_rifle_foreign"
+  },
+  {
     "id": "reloaded_rifle_ball_foreign",
     "type": "ITEM",
     "subtypes": [ "AMMO" ],
@@ -83,8 +92,31 @@
     "extend": { "effects": [ "RECYCLED" ] }
   },
   {
+    "id": "reloaded_rifle_AP_foreign",
+    "type": "ITEM",
+    "subtypes": [ "AMMO" ],
+    "copy-from": "rifle_AP_foreign",
+    "name": { "str_sp": "foreign rifle ammo, AP (reloaded)" },
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
+    "extend": { "effects": [ "RECYCLED" ] }
+  },
+  {
     "id": "bp_rifle_ball_foreign",
     "copy-from": "rifle_ball_foreign",
+    "type": "ITEM",
+    "subtypes": [ "AMMO" ],
+    "name": { "str_sp": "foreign rifle ammo, ball (black powder)" },
+    "proportional": {
+      "price": 0.3,
+      "damage": { "damage_type": "bullet", "amount": 0.57, "armor_penetration": 0.5 },
+      "recoil": 0.57,
+      "dispersion": 1.2
+    },
+    "extend": { "effects": [ "RECYCLED", "BLACKPOWDER", "MUZZLE_SMOKE" ] }
+  },
+  {
+    "id": "bp_rifle_AP_foreign",
+    "copy-from": "rifle_AP_foreign",
     "type": "ITEM",
     "subtypes": [ "AMMO" ],
     "name": { "str_sp": "foreign rifle ammo, ball (black powder)" },

--- a/data/mods/Generic_Guns/recipes/recipes_rifle.json
+++ b/data/mods/Generic_Guns/recipes/recipes_rifle.json
@@ -88,7 +88,7 @@
     "result": "reloaded_rifle_AP_foreign",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "copy-from": "reloaded_rifle_ap",
+    "copy-from": "reloaded_rifle_AP",
     "components": [
       [ [ "gunpowder", 12 ], [ "gunpowder_magnum_pistol", 12 ], [ "gunpowder_rifle", 12 ], [ "gunpowder_large_rifle", 12 ] ]
     ]
@@ -97,7 +97,7 @@
     "result": "bp_rifle_AP_foreign",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "copy-from": "bp_rifle_ap",
+    "copy-from": "bp_rifle_AP",
     "components": [ [ [ [ "chem_black_powder", 12 ] ] ] ]
   },
   {

--- a/data/mods/Generic_Guns/recipes/recipes_rifle.json
+++ b/data/mods/Generic_Guns/recipes/recipes_rifle.json
@@ -98,7 +98,7 @@
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "copy-from": "bp_rifle_AP",
-    "components": [ [ [ [ "chem_black_powder", 12 ] ] ] ]
+    "components": [ [ [ "chem_black_powder", 12 ] ] ]
   },
   {
     "result": "bp_rifle_ball",

--- a/data/mods/Generic_Guns/recipes/recipes_rifle.json
+++ b/data/mods/Generic_Guns/recipes/recipes_rifle.json
@@ -85,6 +85,22 @@
     "components": [ [ [ "chem_black_powder", 12 ] ] ]
   },
   {
+    "result": "reloaded_rifle_AP_foreign",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "copy-from": "reloaded_rifle_ap",
+    "components": [
+      [ [ "gunpowder", 12 ], [ "gunpowder_magnum_pistol", 12 ], [ "gunpowder_rifle", 12 ], [ "gunpowder_large_rifle", 12 ] ]
+    ]
+  },
+  {
+    "result": "bp_rifle_AP_foreign",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "copy-from": "bp_rifle_ap",
+    "components": [ [ [ [ "chem_black_powder", 12 ] ] ] ]
+  },
+  {
     "result": "bp_rifle_ball",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Add 12.3ln AP"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently 12.3 ln only has an fmj variant, even though the exodii have a sniper that uses it. Many monsters since the cataclysm are significantly armoured, including against ballistic weapons. Aditionally, one would assume the world it was developed in, which was more technologically advanced than current year, would have still used body armour? Currently m855a1 has more armour penetrarion (because it is not an fmj bullet) and it is a much smaller calibre. This also just makes 12.3 ln a better caliber for overall usage by the player. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add an ap bullet to the 12.3 ln calibre, make it spawn naturally with 12.ln, maybe change the name of 12.3 ln to fmj. Aditionally, maybe also add an incendiary armour piercing variant to 12.3. One as preferrebly used by snipers (at least exodii snipers/used by exodii to eliminate high priority targets), which would be the incendiary variant, and the armour piercing variant would be used by infantry (assuming in the second carpathian war the description mentions, body armour was still being used, it does not make sense for infantry to largely use only fmj rounds).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
changing the 12.3ln round to a variant with a steel penetrator (undesiarable)

only implimenting the armour piercing incendiary variant.

not doing this
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
they spawn
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
may take a while (esentially have no coding experience besides current/prior pr's in this repo and editing rimworld mods and writing a single patch)

advice from @I-am-Erk on weather or not this round (and/or the incendiary variant) should exist (as they handle exodii lore) would be nice but this will continue even if they don't respond

this will largely be constrained by how much time it takes us to figure out how to make it actually spawn (probably something to do with item groups?) and wether or nor we have to modify much else to make them spawn.


To do:

- [x] dissasembly and reload recipies (done?)
- [x] Make them spawn naturally somehow
- [x] add compatibility with generic guns (untested, probably works)
- [x] give it an actual good description 
- [x] depending on the description (and presumed construction of the bullet) see if it should be craftable or not (input from others is heavily encouraged and wanted, see https://github.com/CleverRaven/Cataclysm-DDA/pull/88131 )

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
