### PR TITLE
Scared npcs are no longer guaranteed_hostile.

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2737,7 +2737,7 @@ bool npc::is_minion() const
 
 bool npc::guaranteed_hostile() const
 {
-    return attitude_to( get_player_character() ) == Attitude::HOSTILE || is_enemy() ||
+    return (attitude_to( get_player_character() ) == Attitude::HOSTILE && !is_player_ally()) || is_enemy() ||
            ( my_fac && my_fac->likes_u < -10 );
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2737,7 +2737,7 @@ bool npc::is_minion() const
 
 bool npc::guaranteed_hostile() const
 {
-    return ( attitude_to( get_player_character() ) == Attitude::HOSTILE && !is_player_ally() ) ||
+    return ( attitude_to( get_player_character() ) == Attitude::HOSTILE ) ||
            is_enemy() ||
            ( my_fac && my_fac->likes_u < -10 );
 }
@@ -2787,7 +2787,7 @@ bool npc::is_leader() const
 
 bool npc::is_enemy() const
 {
-    return attitude == NPCATT_KILL || attitude == NPCATT_FLEE || attitude == NPCATT_FLEE_TEMP;
+    return attitude == NPCATT_KILL || attitude == NPCATT_FLEE;
 }
 
 bool npc::is_stationary( bool include_guards ) const

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2737,7 +2737,8 @@ bool npc::is_minion() const
 
 bool npc::guaranteed_hostile() const
 {
-    return (attitude_to( get_player_character() ) == Attitude::HOSTILE && !is_player_ally()) || is_enemy() ||
+    return ( attitude_to( get_player_character() ) == Attitude::HOSTILE && !is_player_ally() ) ||
+           is_enemy() ||
            ( my_fac && my_fac->likes_u < -10 );
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Scared NPCs don't turn hostile"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

The implementation of the guaranteed_hostile function effectively flagged fleeing neutral npcs as bandits, reviving an old bug. 

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

I stuck the same function call that was used to fix this problem when it came up a few years ago into the logic that turns hostile all NPCs that are currently in combat.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

none. This was readily available and worked with minimal code changes.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Spawned 3 mi-gos in the default scenario. Checked that the terrified resident of my bunker was still willing to talk to me and also did not show as hostile when highlighted with 'x'.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
