### PR TITLE
[XEDRA Evolved] Humaniform Mi-Go diplomacy

### DIFF
--- a/data/mods/Xedra_Evolved/snippets/migo_speech.json
+++ b/data/mods/Xedra_Evolved/snippets/migo_speech.json
@@ -1,70 +1,70 @@
 [
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon", "mon_mi_go_humanoid" ],
     "sound": "\"We negotiated salvage rights to any biological matter remaining in the event of civilizational collapse.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon", "mon_mi_go_humanoid" ],
     "sound": "\"Come with us if you want to live!\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon", "mon_mi_go_humanoid" ],
     "sound": "\"Cease opposition.  Our rights here are guaranteed by treaty M-A-J-I-K-1-2.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon", "mon_mi_go_humanoid" ],
     "sound": "\"Your government no longer exists, we will adopt you.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon", "mon_mi_go_humanoid" ],
     "sound": "\"Welcome to the Mi-go family, children of Earth!  Soon our biologies will mingle unto the death of the stars!\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon", "mon_mi_go_humanoid" ],
     "//": "Mi-go xys/zys words should be pronounced as one single combined word.",
     "sound": "\"We were so pleased/honored to be chosen as the inheritors of your species, so close to it's death that you must have felt it coming and sought us out.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon", "mon_mi_go_humanoid" ],
     "sound": "\"Let us commingle humans!  We can make use of your genetics and your species will live on as part of us!\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon", "mon_mi_go_humanoid" ],
     "sound": "\"In one of it's last acts your government gave us responsibility for the remainder of you.  That number shrinks by the hour.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon", "mon_mi_go_humanoid" ],
     "//": "Mi-go xys/zys words should be pronounced as one single combined word.",
     "sound": "\"Good night Human/Earthlings!\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon", "mon_mi_go_humanoid" ],
     "//": "Mi-go is not their name for themselves and Yuggoth is not their name for their planet.  But the humans they knew liked to pretend so the mi-go continue pretending for their racial memory.",
     "sound": "\"We're off to see the Wizard, the wonderful wizard of Yuggoth.  Come humans we have watched your legends, we know your culture.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon", "mon_mi_go_humanoid" ],
     "sound": "\"Have you considered ceasing to break the laws granting us rights and responsibility over the remains of human civilization and it's peoples?\"",
     "volume": 20
   }


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Just realized the humaniform migo i added dont parrot at all because i forgot to put their id in the migo speech snippet. So i added it.

#### Describe the solution

Add the humaniform migo id to the snippet speaker array thing.

#### Describe alternatives you've considered

No
#### Testing

<img width="869" height="243" alt="Screenshot_20260726_161638" src="https://github.com/user-attachments/assets/eaa0a136-9362-4171-9ec9-de66d63210a1" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
