### PR TITLE
Make it easier to partially decouple combat attack times from weariness maluses

### DIFF
--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -172,8 +172,9 @@ const std::map<float, std::string> activity_levels_str_map = {
  * Works multiplicatively.
  * Does not decrease weariness gains, and doesn't
  * allow faster-than-usual actions under any circumstances.
+ * .8 approximately decreases the light and extra maluses by one level.
  */
-   constexpr float FORGET_UR_TIRED = 0.6f;
+   constexpr float FORGET_UR_TIRED = 1.0f;
 
 
 // these are the lower bounds of each of the weight classes, determined by the amount of BMI coming from stored calories (fat)

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -168,6 +168,14 @@ const std::map<float, std::string> activity_levels_str_map = {
     { EXTRA_EXERCISE, "EXTRA_EXERCISE" }
 };
 
+/* Decreases the effect of weary maluses on combat actions.
+ * Works multiplicatively.
+ * Does not decrease weariness gains, and doesn't
+ * allow faster-than-usual actions under any circumstances.
+ */
+   constexpr float FORGET_UR_TIRED = 0.6f;
+
+
 // these are the lower bounds of each of the weight classes, determined by the amount of BMI coming from stored calories (fat)
 namespace character_weight_category
 {

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -174,7 +174,7 @@ const std::map<float, std::string> activity_levels_str_map = {
  * allow faster-than-usual actions under any circumstances.
  * .8 approximately decreases the light and extra maluses by one level.
  */
-   constexpr float FORGET_UR_TIRED = 1.0f;
+   constexpr float ADRENALINE = 1.0f;
 
 
 // these are the lower bounds of each of the weight classes, determined by the amount of BMI coming from stored calories (fat)

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -173,7 +173,7 @@ const std::map<float, std::string> activity_levels_str_map = {
  * Does not decrease weariness gains, and doesn't
  * allow faster-than-usual actions under any circumstances.
  */
-   constexpr float FORGET_UR_TIRED = 0.6f;
+constexpr float FORGET_UR_TIRED = 0.6f;
 
 
 // these are the lower bounds of each of the weight classes, determined by the amount of BMI coming from stored calories (fat)

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -981,7 +981,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
     add_msg_debug( debugmode::DF_MELEE, "Stamina burn base/total (capped at -50): %d/%d", base_stam,
                    total_stam + deft_bonus );
     // Weariness handling - 1 / the value, because it returns what % of the normal speed
-    const float weary_mult = exertion_adjusted_move_multiplier( EXTRA_EXERCISE );
+    const float weary_mult = STD::max( FORGET_UR_TIRED * exertion_adjusted_move_multiplier( EXTRA_EXERCISE ), 1 );
     mod_moves( forced_movecost >= 0 ? -forced_movecost : -move_cost * ( 1 / weary_mult ) );
     // trigger martial arts on-attack effects
     martial_arts_data->ma_onattack_effects( *this );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -982,7 +982,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
                    total_stam + deft_bonus );
     // Weariness handling - 1 / the value, because it returns what % of the normal speed
     // FORGET_UR_TIRED is defined in game_constants.h
-    const float weary_mult = std::max( FORGET_UR_TIRED * exertion_adjusted_move_multiplier( EXTRA_EXERCISE ), 1.0f );
+    const float weary_mult = std::max( ADRENALINE * exertion_adjusted_move_multiplier( EXTRA_EXERCISE ), 1.0f );
     mod_moves( forced_movecost >= 0 ? -forced_movecost : -move_cost * ( 1 / weary_mult ) );
     // trigger martial arts on-attack effects
     martial_arts_data->ma_onattack_effects( *this );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -981,7 +981,8 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
     add_msg_debug( debugmode::DF_MELEE, "Stamina burn base/total (capped at -50): %d/%d", base_stam,
                    total_stam + deft_bonus );
     // Weariness handling - 1 / the value, because it returns what % of the normal speed
-    const float weary_mult = STD::max( FORGET_UR_TIRED * exertion_adjusted_move_multiplier( EXTRA_EXERCISE ), 1 );
+    // FORGET_UR_TIRED is defined in game_constants.h
+    const float weary_mult = std::max( FORGET_UR_TIRED * exertion_adjusted_move_multiplier( EXTRA_EXERCISE ), 1.0f );
     mod_moves( forced_movecost >= 0 ? -forced_movecost : -move_cost * ( 1 / weary_mult ) );
     // trigger martial arts on-attack effects
     martial_arts_data->ma_onattack_effects( *this );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Allow future contributors to easily tune weary maluses in combat"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

As per I-am-Erk in [the comments of #85333](https://github.com/CleverRaven/Cataclysm-DDA/pull/85333#issuecomment-3955077027), weary maluses were never intended to apply to combat actions, and that they do was an oversight from the initial implementation of weariness. I-am-Erk also suggested in the same comment somewhat decreasing the effects of minor and extreme weary maluses on combat. While weary maluses applying to combat do have some positive gameplay effects (such as preventing players from taking a nice relaxing break from their tiresome farming by going toe-to-toe with the living dead), with #85333 likely to finish implementing soon (and with bug #59139 still open, which will likely change the weariness calculus again once it gets resolved), I anticipate that in the near future, balance questions are likely to arise surrounding the impact of weariness on combat attacks. The purpose of this PR is not to preemptively solve a problem that may or may not exist, but rather to simplify the process (when the time comes) of deciding to what degree weariness ought to affect attack speed, especially if that degree changes as the game is developed.

The other benefit to including such infrastructure now is that when #59864 gets finished, rebalancing will be easier.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Add a constant, 'ADRENALINE', that acts as a numerical multiplier on attack time-after-incorporating-weariness, to a minimum of 1x the normal speed.

It's currently set to 1, and therefore does nothing. When decreased to 0.8, it effectively decreases the weary malus when computing combat time by about one step (exactly one step if your weariness is light or extreme), to a minimum of Fresh. 

This is less a feature on the player side, but rather an additional lever that could be used to balance a mechanic that's seeing a number of changes on the way.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

I also worked out an implementation that effectively just reserved a separate weariness calculation for attacks to allow for more granular control, but threw it out because it created a LOT of overhead and magic numbers. It also would have conflicted somewhat with #85333, whereas the implementation I settled on here should not.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I made a couple of characters after compiling with different ADRENALINE values and had them punch things after working out. A value of 0.6 almost entirely negated weary maluses for moderate weariness, and 0.8 decreased the penalties by about a step, as expected.



#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
