### PR TITLE
Add INFECTION_RECOVERY flag, use in XE

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2731,6 +2731,11 @@
     "info": "You are immune to gaseous toxins"
   },
   {
+    "id": "INFECTION_RECOVERY",
+    "type": "json_flag",
+    "info": "You have greater odds to recover from infections (equivalent to taking antibiotics)"
+  },
+  {
     "id": "TREE_COMMUNION_PLUS",
     "type": "json_flag",
     "info": "You gain greatly enhanced effects from the Mycorrhizal Communion mutation"

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -3236,6 +3236,14 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_lilin_resist_infections",
+    "name": [ "Make Thy Plagues Wonderful" ],
+    "desc": [ "You are immune to minor diseases and any infections you have are recovering more easily." ],
+    "removes_effects": [ "common_cold", "pre_common_cold", "flu", "pre_flu" ],
+    "flags": [ "PAUSE_INFECTIONS", "INFECTION_RECOVERY" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_lilin_attack_warning_cooldown",
     "//": "Hidden effect, used as a blocker",
     "name": [ "" ],

--- a/data/mods/Xedra_Evolved/mutations/xe_lilin.json
+++ b/data/mods/Xedra_Evolved/mutations/xe_lilin.json
@@ -281,6 +281,20 @@
   },
   {
     "type": "mutation",
+    "id": "LILIN_RESIST_INFECTIONS_CURE_DISEASE",
+    "name": {
+      "//~": "This is a reference to Deuteronomy 28:59.  Note that it's not a positive statement in context",
+      "str": "Make Thy Plagues Wonderful"
+    },
+    "points": 4,
+    "purifiable": false,
+    "description": "With your power over plague comes the ability to alleviate sickness as well.  You may touch a target and cure minor illnesses as well as pause any infections they have in their tracks.  While this power is in effect, the target gains a bonus to their chance of recovery.",
+    "prereqs": [ "LILIN_AOE_LINE_DISEASE" ],
+    "category": [ "LILIN" ],
+    "spells_learned": [ [ "lilin_resist_infections_spell", 1 ] ]
+  },
+  {
+    "type": "mutation",
     "id": "LILIN_DISEASE_ENHANCEMENT_DAMAGE",
     "name": { "str": "Devoured by Pestilence" },
     "points": 6,

--- a/data/mods/Xedra_Evolved/spells/lilin_spells.json
+++ b/data/mods/Xedra_Evolved/spells/lilin_spells.json
@@ -158,26 +158,43 @@
     "magic_type": "xedra_magic_generic",
     "max_level": 1,
     "caster_condition": { "not": "is_day" },
+    "caster_condition_fail_message": "You cannot use Dwelling in Deep Darkness during the day.",
     "skill": "deduction",
     "effect": "effect_on_condition",
     "effect_str": "EOC_LILIN_BLINDING_TARGET",
     "shape": "blast",
     "min_range": { "math": [ "(u_vitamin('lilin_ruach_vitamin') / 600) + 5" ] },
     "max_range": { "math": [ "(u_vitamin('lilin_ruach_vitamin') / 600) + 5" ] },
-    "min_duration": {
-      "math": [
-        "(u_vitamin('lilin_ruach_vitamin') * 800) * (u_vitamin('lilin_ruach_vitamin') * 3) * (u_has_trait('THRESH_LILIN') + 1)"
-      ]
-    },
-    "max_duration": {
-      "math": [
-        "(u_vitamin('lilin_ruach_vitamin') * 2400) * (u_vitamin('lilin_ruach_vitamin') * 7.5) * (u_has_trait('THRESH_LILIN') + 1)"
-      ]
-    },
+    "min_duration": { "math": [ "(u_vitamin('lilin_ruach_vitamin') * 800) * (u_has_trait('THRESH_LILIN') + 1)" ] },
+    "max_duration": { "math": [ "(u_vitamin('lilin_ruach_vitamin') * 2400) * (u_has_trait('THRESH_LILIN') + 1)" ] },
     "energy_source": { "type": "VITAMIN", "vitamin": "lilin_ruach_vitamin" },
     "base_energy_cost": { "math": [ "120 * lilin_has_ruach_efficiency()" ] },
     "base_casting_time": 85,
     "ignored_monster_species": [ "ROBOT", "ROBOT_FLYING", "NETHER_EMANATION", "SLIME" ]
+  },
+  {
+    "id": "lilin_resist_infections_spell",
+    "type": "SPELL",
+    "name": "Make Thy Plagues Wonderful",
+    "description": "Touch a target and cure minor illnesses as well as pause any infections they have in their tracks.  While this power is in effect, the target gains a bonus to their chance of recovery.",
+    "message": "",
+    "teachable": false,
+    "valid_targets": [ "ally", "self", "hostile" ],
+    "flags": [ "SILENT", "NO_FAIL", "RANDOM_DURATION", "NO_EXPLOSION_SFX" ],
+    "spell_class": "LILIN_TRAITS",
+    "magic_type": "xedra_magic_generic",
+    "max_level": 1,
+    "skill": "deduction",
+    "effect": "attack",
+    "effect_str": "effect_lilin_resist_infections",
+    "shape": "blast",
+    "min_range": 1,
+    "max_range": 1,
+    "min_duration": { "math": [ "(u_vitamin('lilin_ruach_vitamin') * 2400) * (u_has_trait('THRESH_LILIN') + 1)" ] },
+    "max_duration": { "math": [ "(u_vitamin('lilin_ruach_vitamin') * 5100) * (u_has_trait('THRESH_LILIN') + 1)" ] },
+    "energy_source": { "type": "VITAMIN", "vitamin": "lilin_ruach_vitamin" },
+    "base_energy_cost": { "math": [ "240 * lilin_has_ruach_efficiency()" ] },
+    "base_casting_time": 250
   },
   {
     "id": "lilin_mesmerize_target_spell",
@@ -315,6 +332,7 @@
     "magic_type": "xedra_magic_generic",
     "max_level": 1,
     "caster_condition": { "math": [ "u_val('sleepiness') > 200" ] },
+    "caster_condition_fail_message": "You aren't sleepy",
     "skill": "deduction",
     "effect": "effect_on_condition",
     "effect_str": "EOC_LILIN_AVOID_SLEEP",

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -122,6 +122,7 @@ static const furn_str_id furn_f_rubble_rock( "f_rubble_rock" );
 static const json_character_flag json_flag_ALARMCLOCK( "ALARMCLOCK" );
 static const json_character_flag json_flag_BIONIC_LIMB( "BIONIC_LIMB" );
 static const json_character_flag json_flag_CANNOT_TAKE_DAMAGE( "CANNOT_TAKE_DAMAGE" );
+static const json_character_flag json_flag_INFECTION_RECOVERY( "INFECTION_RECOVERY" );
 static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
 static const json_character_flag json_flag_PAUSE_BODYPART_INFECTION( "PAUSE_BODYPART_INFECTION" );
 static const json_character_flag json_flag_PAUSE_INFECTIONS( "PAUSE_INFECTIONS" );
@@ -1535,6 +1536,9 @@ void Character::hardcoded_effects( effect &it )
                 recover_factor -= get_effect_dur( effect_recover ) / 1_hours;
             }
             if( has_trait( trait_INFRESIST ) ) {
+                recover_factor += 200;
+            }
+            if( has_flag( json_flag_INFECTION_RECOVERY ) ) {
                 recover_factor += 200;
             }
             if( has_effect( effect_panacea ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Add INFECTION_RECOVERY flag, use in XE"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I want supernatural means of curing or resisting infections in XedraWood but most infection resistances are hardcoded to particular effects (e.g. `else if( has_effect( effect_strong_antibiotic ) )` ), so this is adding a flag for more flexibility. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the `INFECTION_RECOVERY` flag, which provides the same bonus (and stacks with) the Infection Resistant trait and with normal antibiotics for the purposes of recovering from infections. Add a trait for Lilin in XE called Make Thy Plagues Wonderful (requires Unleash the Night-Wind), which lets the lilit enchant a target to cure cold or flu as well as halt the progression of an infection in its tracks and provide a bonus to recovery from it. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Trait exists, effect works (as near as I can tell with a bonus based on randomness).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Technically `wonderful` in Deuteronomy 28:59 means "a sign, a wonder, a marvel" and not something that's really neat--like, the next verse is "And He will bring back upon thee all the diseases of Egypt, which thou wast in dread of; and they shall cleave unto thee"--but the snippet fits for the ability name. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
