### PR TITLE
fix skirt env protection

### DIFF
--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -1980,8 +1980,8 @@
           "tentacle_lower_middle_middle_l",
           "tentacle_lower_rear_base_l",
           "tentacle_lower_rear_middle_l",
-          "tentacle_lower_middle_base_r",
-          "tentacle_lower_middle_middle_r",
+          "tentacle_lower_front_base_r",
+          "tentacle_lower_front_middle_r",
           "tentacle_lower_middle_base_r",
           "tentacle_lower_middle_middle_r",
           "tentacle_lower_rear_base_r",
@@ -2199,7 +2199,7 @@
           "tentacle_lower_middle_tip_l",
           "tentacle_lower_rear_tip_l",
           "tentacle_lower_middle_tip_r",
-          "tentacle_lower_middle_tip_r",
+          "tentacle_lower_front_tip_r",
           "tentacle_lower_rear_tip_r"
         ]
       },
@@ -2267,7 +2267,7 @@
           "tentacle_lower_middle_middle_l",
           "tentacle_lower_rear_middle_l",
           "tentacle_lower_middle_middle_r",
-          "tentacle_lower_middle_middle_r",
+          "tentacle_lower_front_middle_r",
           "tentacle_lower_rear_middle_r"
         ]
       },
@@ -2340,7 +2340,7 @@
           "tentacle_lower_middle_middle_l",
           "tentacle_lower_rear_middle_l",
           "tentacle_lower_middle_middle_r",
-          "tentacle_lower_middle_middle_r",
+          "tentacle_lower_front_middle_r",
           "tentacle_lower_rear_middle_r"
         ]
       },


### PR DESCRIPTION
#### Summary
Bugfixes "Skirts have overflowing env protection"

#### Purpose of change

Bug

#### Describe the solution

Some tentacle body subparts erroneously appeared 2x, most likely simple copy paste mistake

#### Describe alternatives you've considered

N/A

#### Testing

UI doesnt crash out.

#### Additional context

<img width="1178" height="335" alt="image" src="https://github.com/user-attachments/assets/dab784a7-0e48-47dc-b300-77fca6a4c056" />

Current:
<img width="1364" height="554" alt="image" src="https://github.com/user-attachments/assets/fcd126e4-4e6f-40ec-a2f7-efe76f8e60ca" />
