### PR TITLE
Aftershock: Project Sobek Genetech

### DIFF
--- a/data/mods/aftershock_exoplanet/effects.json
+++ b/data/mods/aftershock_exoplanet/effects.json
@@ -178,6 +178,15 @@
   },
   {
     "type": "effect_type",
+    "id": "afs_remove_stun_biological",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "//": "Empty name and description to hide effect",
+    "rating": "good",
+    "removes_effects": [ "stunned", "dazed" ]
+  },
+  {
+    "type": "effect_type",
     "id": "afs_generic_speed_bonus",
     "name": [ "Movement Optimization (1)", "Movement Optimization (2)", "Movement Optimization (3)", "Movement Optimization (4)" ],
     "desc": [ "You move with machine-guided precision." ],

--- a/data/mods/aftershock_exoplanet/itemgroups/software.json
+++ b/data/mods/aftershock_exoplanet/itemgroups/software.json
@@ -12,7 +12,8 @@
       { "item": "ruin_data_space_currents", "prob": 5 },
       { "item": "ruin_data_holo", "prob": 2 },
       { "item": "ruin_data_geoengineering", "prob": 2 },
-      { "item": "ruin_data_mercurial_id", "prob": 1 }
+      { "item": "ruin_data_mercurial_id", "prob": 1 },
+      { "item": "afs_gene_template_combat_brute", "prob": 1 }
     ]
   }
 ]

--- a/data/mods/aftershock_exoplanet/items/armor/integrated.json
+++ b/data/mods/aftershock_exoplanet/items/armor/integrated.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "integrated_cranial_padding",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "category": "armor",
+    "name": { "str_sp": "cranial padding" },
+    "description": "Internal bladders of cerebrospinal fluid better protect your brain from trauma and concussions.",
+    "weight": "300 g",
+    "volume": "200 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "afs_plastic_armor" ],
+    "symbol": ";",
+    "color": "brown",
+    "warmth": 2,
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "WATER_FRIENDLY", "PADDED" ],
+    "armor": [
+      {
+        "material": [ { "type": "afs_plastic_armor", "covered_by_mat": 100, "thickness": 1 } ],
+        "covers": [ "head" ],
+        "coverage": 60,
+        "encumbrance": 5
+      }
+    ]
+  }
+]

--- a/data/mods/aftershock_exoplanet/items/genetech.json
+++ b/data/mods/aftershock_exoplanet/items/genetech.json
@@ -36,6 +36,16 @@
     "flags": [ "GENE_TECH" ]
   },
   {
+    "id": "afs_gene_template_combat_brute",
+    "name": "Project Sobek Genetech",
+    "copy-from": "afs_gene_disp",
+    "description": "A genetic treatment from Project Sobek, part of Mercurial's own military augmentation program.  The whole treatment is designed for general combat enhancement, without the xenobiology-derived traits that are rumored to exist in more secretive programs.",
+    "type": "ITEM",
+    "price": "75 kUSD",
+    "subtypes": [ "TOOL" ],
+    "trait_group": "GENETECH_COMBAT_BRUTE_TRAITS"
+  },
+  {
     "id": "afs_gene_disp_low_tier",
     "name": "Mercurial Genetech",
     "copy-from": "afs_gene_disp",
@@ -146,9 +156,32 @@
       { "trait": "MUT_TOUGH2", "prob": 100 },
       { "trait": "NOPAIN", "prob": 100 },
       { "trait": "PRED1", "prob": 100 },
-      { "trait": "STR_UP", "prob": 100 },
       { "trait": "LARGE_OK", "prob": 100 },
       { "trait": "FLEET2", "prob": 100 }
+    ]
+  },
+  {
+    "type": "trait_group",
+    "id": "GENETECH_COMBAT_BRUTE_TRAITS",
+    "subtype": "distribution",
+    "traits": [
+      { "trait": "AFS_QUICK", "prob": 15 },
+      { "trait": "INFRESIST", "prob": 15 },
+      { "trait": "AFS_INFIMMUNE", "prob": 15 },
+      { "trait": "AFS_GOODCARDIO", "prob": 15 },
+      { "trait": "AFS_PAINRESIST", "prob": 15 },
+      { "trait": "AFS_UNCARING", "prob": 15 },
+      { "trait": "DISIMMUNE", "prob": 15 },
+      { "trait": "DISRESISTANT", "prob": 15 },
+      { "trait": "AFS_NIGHTVISION", "prob": 15 },
+      { "trait": "AFS_COMBAT_DRUG_PRODUCTION", "prob": 50 },
+      { "trait": "AFS_HYPERMETABOLISM", "prob": 50 },
+      { "trait": "AFS_FAST_BLOOD_PRODUCTION", "prob": 50 },
+      { "trait": "AFS_REDUNDANT_ORGANS", "prob": 50 },
+      { "trait": "AFS_WAR_BUILD", "prob": 100 },
+      { "trait": "AFS_THROWING_STRENGTH", "prob": 100 },
+      { "trait": "AFS_STRONG", "prob": 100 },
+      { "trait": "AFS_GOOD_HEAD", "prob": 100 }
     ]
   },
   {
@@ -160,9 +193,9 @@
       { "trait": "ACIDPROOF", "prob": 50 },
       { "trait": "TOUGH_MEDICAL", "prob": 100 },
       { "trait": "STRONGER_RESISTCHILL", "prob": 50 },
-      { "trait": "GOODCARDIO", "prob": 100 },
+      { "trait": "AFS_GOODCARDIO", "prob": 100 },
       { "trait": "LIGHTEATER", "prob": 100 },
-      { "trait": "PAINRESIST", "prob": 100 },
+      { "trait": "AFS_PAINRESIST", "prob": 100 },
       { "trait": "BOVINE_BULK2", "prob": 50 },
       { "trait": "THICKSKIN", "prob": 100 },
       { "trait": "TOLERANCE", "prob": 100 },

--- a/data/mods/aftershock_exoplanet/mutations/combat_brute.json
+++ b/data/mods/aftershock_exoplanet/mutations/combat_brute.json
@@ -54,7 +54,7 @@
     "type": "mutation",
     "id": "AFS_GOOD_HEAD",
     "name": { "str": "Intra-Cranial Padding" },
-    "description": "Internal bladders of cerebrospinal fluid better protect your brain from trauma and concussions.  You cannot be stunned in melee, and your head is more resistant than normal.  The reduced brain volume has slight effects on your intelligence and learning ability.",
+    "description": "Internal bladders of cerebrospinal fluid better protect your brain from trauma and concussions.  You cannot be stunned in melee, and your head is more resistant than normal.  The reduced brain volume has slightly deleterious effects on your intelligence and learning ability.",
     "category": [ "COMBAT_BRUTE" ],
     "points": 1,
     "integrated_armor": [ "integrated_cranial_padding" ],

--- a/data/mods/aftershock_exoplanet/mutations/combat_brute.json
+++ b/data/mods/aftershock_exoplanet/mutations/combat_brute.json
@@ -1,0 +1,188 @@
+[
+  {
+    "type": "mutation_category",
+    "id": "COMBAT_BRUTE",
+    "name": "Perfect Warrior",
+    "threshold_mut": "THRESH_COMBAT_BRUTE",
+    "mutagen_message": "You feel like a trillion bucks.",
+    "memorial_message": "Was reborn as the perfect warrior."
+  },
+  {
+    "type": "mutation",
+    "id": "THRESH_COMBAT_BRUTE",
+    "name": "Perfect Warrior",
+    "points": 1,
+    "description": "None around you could best you in a fight.",
+    "valid": false,
+    "purifiable": false,
+    "threshold": true
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_THROWING_STRENGTH",
+    "name": { "str": "All-Star Pitch" },
+    "description": "If you throw a grenade at someone, it will first cave their skull in.",
+    "category": [ "COMBAT_BRUTE" ],
+    "points": 2,
+    "changes_to": [ "GOODCARDIO2" ],
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [ { "value": "THROW_STR", "multiply": 2 }, { "value": "THROW_DAMAGE", "multiply": 1.25 } ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_STRONG",
+    "name": { "str": "Bio-Sculpted Musculature" },
+    "description": "Your arms and legs are finely threaded pieces of living machinery, greatly increasing your strength and capacity to lift and carry heavy objects.  Unfortunately, the complex tissue heals at a slower rate than normal.",
+    "category": [ "COMBAT_BRUTE" ],
+    "points": 4,
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "STRENGTH", "add": 2 },
+          { "value": "MENDING_MODIFIER", "multiply": -0.25 },
+          { "value": "REGEN_HP", "multiply": -0.25 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_GOOD_HEAD",
+    "name": { "str": "Intra-Cranial Padding" },
+    "description": "Internal bladders of cerebrospinal fluid better protect your brain from trauma and concussions.  You cannot be stunned in melee, and your head is more resistant than normal.  The reduced brain volume has slight effects on your intelligence and learning ability.",
+    "category": [ "COMBAT_BRUTE" ],
+    "points": 1,
+    "integrated_armor": [ "integrated_cranial_padding" ],
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [ { "value": "INTELLIGENCE", "add": -2 }, { "value": "LEARNING_FOCUS", "multiply": -0.15 } ],
+        "ench_effects": [ { "effect": "afs_remove_stun_biological", "intensity": 1 } ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_WAR_BUILD",
+    "name": { "str": "Superhuman Physique" },
+    "description": "Your augmented body dwarfs anything ordinary humans can achieve.  You are stronger, faster, and more durable than any unaugmented human could ever hope to be.",
+    "threshreq": [ "THRESH_COMBAT_BRUTE" ],
+    "points": 15,
+    "category": [ "COMBAT_BRUTE" ],
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "STRENGTH", "add": 2 },
+          { "value": "DEXTERITY", "add": 2 },
+          { "value": "PERCEPTION", "add": 2 },
+          { "value": "SPEED", "add": 10 },
+          { "value": "THROW_STR", "multiply": 1 },
+          { "value": "METABOLISM", "multiply": 1 },
+          { "value": "THROW_DAMAGE", "multiply": 0.25 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_COMBAT_DRUG_PRODUCTION",
+    "name": { "str": "Stimulant biosynthesis" },
+    "description": "You naturally produce combat-enhancing substances, and you might consciously trigger their release as you see fit.",
+    "vitamin_cost": 350,
+    "points": 15,
+    "active": true,
+    "cost": 800,
+    "kcal": true,
+    "activation_msg": "You release the flood of combat-enhancing substances into your bloodstream.",
+    "activated_eocs": [
+      {
+        "id": "_EOC_AFS_COMBAT_DRUG_MUTATION",
+        "effect": [ { "u_add_effect": "afs_combat_stims", "duration": "10 minutes" } ]
+      }
+    ],
+    "category": [ "COMBAT_BRUTE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_HYPERMETABOLISM",
+    "name": { "str": "Hypermetabolism" },
+    "description": "Your particular metabolism allows you to burn calories at a prodigious rate to regenerate tissues in a matter of minutes; this is, however, a very wasteful process.  Activate to start healing.",
+    "threshreq": [ "THRESH_COMBAT_BRUTE" ],
+    "category": [ "COMBAT_BRUTE" ],
+    "types": [ "METABOLISM" ],
+    "points": 15,
+    "active": true,
+    "vitamin_cost": 350,
+    "transform": {
+      "target": "AFS_HYPERMETABOLISM_active",
+      "msg_transform": "Your hyper-metabolism starts burning up calories.",
+      "active": true,
+      "moves": 0
+    }
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_HYPERMETABOLISM_active",
+    "copy-from": "AFS_HYPERMETABOLISM",
+    "name": { "str": "Hyper-Metabolism: burning" },
+    "description": "You're burning calories like crazy to heal your wounds.",
+    "valid": false,
+    "time": "1 s",
+    "cost": 9,
+    "kcal": true,
+    "transform": { "target": "AFS_HYPERMETABOLISM", "msg_transform": "Your hyper-metabolism slows down.", "active": false, "moves": 0 },
+    "enchantments": [ { "values": [ { "value": "REGEN_HP", "multiply": 349 }, { "value": "REGEN_HP_AWAKE", "multiply": 0.85 } ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_FAST_BLOOD_PRODUCTION",
+    "recurrence": "5 minutes",
+    "condition": { "u_has_trait": "AFS_FAST_BLOOD_PRODUCTION" },
+    "deactivate_condition": { "not": { "u_has_trait": "AFS_FAST_BLOOD_PRODUCTION" } },
+    "effect": [
+      { "math": [ "u_vitamin('blood') = min(0, u_vitamin('blood') + 50)" ] },
+      { "math": [ "u_vitamin('redcells') = min(0, u_vitamin('redcells') + 50)" ] }
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_FAST_BLOOD_PRODUCTION",
+    "name": { "str": "Accelerated Hematopoiesis" },
+    "description": "Your body produces blood at a prodigious rate, allowing you to recover from injuries that would be fatal to any ordinary human.",
+    "points": 15,
+    "enchantments": [ { "values": [ { "value": "THIRST", "multiply": 0.5 } ] } ],
+    "threshreq": [ "THRESH_COMBAT_BRUTE" ],
+    "category": [ "COMBAT_BRUTE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_REDUNDANT_ORGANS",
+    "name": { "str": "Distributed Physiology" },
+    "description": "Your vital organs have been restructured, split and distributed all across your body.  Anyone lucky enough to hit you is unlikely to deal a fatal blow.",
+    "threshreq": [ "THRESH_COMBAT_BRUTE" ],
+    "points": 15,
+    "category": [ "COMBAT_BRUTE" ],
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "incoming_damage_mod_post_absorbed": [
+          { "type": "bash", "multiply": -0.25 },
+          { "type": "cut", "multiply": -0.25 },
+          { "type": "bullet", "multiply": -0.5 },
+          { "type": "pierce", "multiply": -0.5 },
+          { "type": "afs_laser", "multiply": -0.15 },
+          { "type": "afs_plasma", "multiply": -0.15 },
+          { "type": "afs_toxin_bullet", "multiply": -0.5 },
+          { "type": "afs_toxin_pierce", "multiply": -0.5 },
+          { "type": "psi_telekinetic_damage", "multiply": -0.15 }
+        ]
+      }
+    ]
+  }
+]

--- a/data/mods/aftershock_exoplanet/mutations/mutations.json
+++ b/data/mods/aftershock_exoplanet/mutations/mutations.json
@@ -913,30 +913,6 @@
   },
   {
     "type": "mutation",
-    "id": "DISRESISTANT",
-    "copy-from": "DISRESISTANT",
-    "extend": { "category": [ "MIGO" ] }
-  },
-  {
-    "type": "mutation",
-    "id": "DISIMMUNE",
-    "copy-from": "DISIMMUNE",
-    "extend": { "category": [ "MIGO" ] }
-  },
-  {
-    "type": "mutation",
-    "id": "INFRESIST",
-    "copy-from": "INFRESIST",
-    "extend": { "category": [ "MIGO" ] }
-  },
-  {
-    "type": "mutation",
-    "id": "INFIMMUNE",
-    "copy-from": "INFIMMUNE",
-    "extend": { "category": [ "MIGO" ] }
-  },
-  {
-    "type": "mutation",
     "id": "PARAIMMUNE",
     "copy-from": "PARAIMMUNE",
     "extend": { "category": [ "MIGO" ] }

--- a/data/mods/aftershock_exoplanet/mutations/vanilla_overrides.json
+++ b/data/mods/aftershock_exoplanet/mutations/vanilla_overrides.json
@@ -1,0 +1,62 @@
+[
+  {
+    "type": "mutation",
+    "id": "AFS_NIGHTVISION",
+    "name": { "str": "High Night Vision" },
+    "points": 2,
+    "description": "You can see incredibly well in the dark!  Activate to toggle NV-visible areas on or off.",
+    "enchantments": [ { "values": [ { "value": "NIGHT_VIS", "add": { "math": [ "u_val('perception') * 0.8" ] } } ] } ],
+    "category": [ "COMBAT_BRUTE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "DISRESISTANT",
+    "copy-from": "DISRESISTANT",
+    "extend": { "category": [ "COMBAT_BRUTE", "MIGO" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "DISIMMUNE",
+    "copy-from": "DISIMMUNE",
+    "extend": { "category": [ "COMBAT_BRUTE", "MIGO" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_UNCARING",
+    "name": { "str": "Uncaring" },
+    "points": 1,
+    "description": "The suffering of others does not affect you, they either serve a purpose or they do not.  It's pragmatism, nothing more.",
+    "flags": [ "PSYCHOPATH" ],
+    "category": [ "COMBAT_BRUTE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_QUICK",
+    "copy-from": "QUICK",
+    "category": [ "COMBAT_BRUTE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "INFRESIST",
+    "copy-from": "INFRESIST",
+    "extend": { "category": [ "COMBAT_BRUTE", "MIGO" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_INFIMMUNE",
+    "copy-from": "INFIMMUNE",
+    "category": [ "COMBAT_BRUTE", "MIGO" ]
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_PAINRESIST",
+    "copy-from": "PAINRESIST",
+    "category": [ "COMBAT_BRUTE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_GOODCARDIO",
+    "copy-from": "GOODCARDIO",
+    "category": [ "COMBAT_BRUTE" ]
+  }
+]


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Project Sobek Genetech"

#### Purpose of change
The genetech system needs some more content, especially since the way it function requires that traits be neither fully positive nor fully negative like in the base game (otherwise they are no-brainer picks or avoids).

Based on that consideration, I'm adding a new "mutation tree" here that is oriented towards basic combat ability. Its very practical, like the CBMs of mutations.

#### Describe the solution
These are straightforward combat augmentations without any fancy animal/alien traits. Mostly related to making you more durable and dangerous in a fight, without involving special abilities. The exclusive traits are:

- All-Star Pitch: Increases throwning range and increases thrown damage by x0.25.
- Bio-Sculpted Musculature: 2 strength but makes you slower to heal.
- Intra-Cranial Padding: Makes you immune to stuns/dazes and gives light armor to your head (ballistic damage excluded) it also reduces int by 2.
- Stimulant Biosynthesis: Lets you make your own combat stims at a kcal cost.
- Accelerated Hematopoiesis: A post threshold trait for the line, you regen 50 blood every 5 minutes. Is this enough to prevent Hypovolemic shock? sometimes.
- Hpermetabolism: Post threshold, like the vanilla variant.
- Superhuman Physique: Post threshold it gives: 10 quickness, 2 of strength perception and dexterity, and x0.25 thrownig strength. It also doubles your metabolism.
- Distributed Physiology: The big post threshold trait for the line, it reduces all post armor damage you receive by 50% to 5% Energy damage types are less affected with ballistic and pierce getting the greatest reduction.

#### Describe alternatives you've considered
Making the initial traitlist a bit larger.

#### Testing

Used enough of the templates to make sure the Threshold can apply. It can.