### PR TITLE
[Magiclysm] Make Magical Bracers into Bracers

### DIFF
--- a/data/mods/Magiclysm/items/enchanted_bracers.json
+++ b/data/mods/Magiclysm/items/enchanted_bracers.json
@@ -15,8 +15,14 @@
     "color": "light_gray",
     "warmth": 10,
     "material_thickness": 5,
-    "flags": [ "BELTED", "STURDY", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ],
-    "armor": [ { "encumbrance": 10, "coverage": 45, "covers": [ "arm_l", "arm_r" ] } ]
+    "flags": [ "OUTER", "STURDY", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ],
+    "armor": [ { "covers": [ "arm_l", "arm_r" ],
+        "encumbrance": 3,
+        "coverage": 95,
+        "cover_melee": 95,
+        "cover_ranged": 90,
+        "cover_vitals": 70,
+        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ] } ]
   },
   {
     "copy-from": "mbracer_steel_pair",
@@ -37,7 +43,7 @@
     "price_postapoc": "950 USD",
     "description": "A light but extremely sturdy steel bracer with an ornate shield engraved on the top, silver accentuates the intricate design.  It protects your body with a light aura to reduce damage you take.",
     "material_thickness": 6,
-    "flags": [ "BELTED", "STURDY", "BLOCK_WHILE_WORN" ],
+    "flags": [ "OUTER", "STURDY", "BLOCK_WHILE_WORN" ],
     "passive_effects": [
       {
         "has": "WORN",
@@ -60,7 +66,7 @@
     "name": { "str": "bracer of greater defense", "str_pl": "bracers of greater defense" },
     "description": "A light but extremely sturdy steel bracer with an ornate shield engraved on the top, gold accentuates the intricate design.  It protects your body with a strong aura to reduce damage you take.",
     "material_thickness": 6,
-    "flags": [ "BELTED", "STURDY", "BLOCK_WHILE_WORN" ],
+    "flags": [ "OUTER", "STURDY", "BLOCK_WHILE_WORN" ],
     "passive_effects": [
       {
         "has": "WORN",
@@ -84,7 +90,7 @@
     "description": "A light but extremely sturdy steel bracer with an ornate bundle of lightning bolts engraved on the top, silver accentuates the intricate design.  It protects your body with a light aura to reduce electrical damage you take, as well as being able to release a Jolt spell 3 times a day.",
     "charges_per_use": 1,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "holster": true, "ammo_restriction": { "crystallized_mana": 3 } } ],
-    "flags": [ "BELTED", "STURDY", "BLOCK_WHILE_WORN", "NO_UNLOAD", "NO_RELOAD" ],
+    "flags": [ "OUTER", "STURDY", "BLOCK_WHILE_WORN", "NO_UNLOAD", "NO_RELOAD" ],
     "use_action": { "type": "cast_spell", "spell_id": "jolt", "no_fail": true, "level": 15, "need_worn": true },
     "charge_info": { "recharge_type": "periodic", "time": "24 h", "regenerate_ammo": true },
     "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "incoming_damage_mod": [ { "type": "electric", "add": -5 } ] } ]
@@ -99,13 +105,13 @@
     "description": "A light but extremely sturdy steel bracer with an ornate bundle of lightning bolts engraved on the top, gold accentuates the intricate design.  It protects your body with a strong aura to reduce electrical damage you take, as well as being able to release a Lightning Bolt spell 3 times a day.",
     "charges_per_use": 1,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "holster": true, "ammo_restriction": { "crystallized_mana": 3 } } ],
-    "flags": [ "BELTED", "STURDY", "BLOCK_WHILE_WORN", "NO_UNLOAD", "NO_RELOAD" ],
+    "flags": [ "OUTER", "STURDY", "BLOCK_WHILE_WORN", "NO_UNLOAD", "NO_RELOAD" ],
     "use_action": { "type": "cast_spell", "spell_id": "lightning_bolt", "no_fail": true, "level": 15, "need_worn": true },
     "charge_info": { "recharge_type": "periodic", "time": "24 h", "regenerate_ammo": true },
     "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "incoming_damage_mod": [ { "type": "electric", "add": -10 } ] } ]
   },
   {
-    "copy-from": "armguard_larmor",
+    "copy-from": "vambrace_larmor",
     "type": "ITEM",
     "subtypes": [ "ARMOR", "ARTIFACT" ],
     "id": "mbracer_archery",
@@ -122,7 +128,7 @@
     ]
   },
   {
-    "copy-from": "armguard_larmor",
+    "copy-from": "vambrace_larmor",
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "id": "mbracer_blinding_strike",

--- a/data/mods/Magiclysm/items/enchanted_bracers.json
+++ b/data/mods/Magiclysm/items/enchanted_bracers.json
@@ -16,8 +16,8 @@
     "warmth": 10,
     "material_thickness": 5,
     "flags": [ "OUTER", "STURDY", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ],
-    "armor": [ 
-      { 
+    "armor": [
+      {
         "covers": [ "arm_l", "arm_r" ],
         "encumbrance": 3,
         "coverage": 95,

--- a/data/mods/Magiclysm/items/enchanted_bracers.json
+++ b/data/mods/Magiclysm/items/enchanted_bracers.json
@@ -16,13 +16,17 @@
     "warmth": 10,
     "material_thickness": 5,
     "flags": [ "OUTER", "STURDY", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ],
-    "armor": [ { "covers": [ "arm_l", "arm_r" ],
+    "armor": [ 
+      { 
+        "covers": [ "arm_l", "arm_r" ],
         "encumbrance": 3,
         "coverage": 95,
         "cover_melee": 95,
         "cover_ranged": 90,
         "cover_vitals": 70,
-        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ] } ]
+        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ] 
+      } 
+    ]
   },
   {
     "copy-from": "mbracer_steel_pair",

--- a/data/mods/Magiclysm/items/enchanted_bracers.json
+++ b/data/mods/Magiclysm/items/enchanted_bracers.json
@@ -24,8 +24,8 @@
         "cover_melee": 95,
         "cover_ranged": 90,
         "cover_vitals": 70,
-        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ] 
-      } 
+        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ]
+      }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Magiclysm] Update Magical Bracers"

#### Purpose of change

When the bracers where made in Magiclysm we didn't even have sub-locations yet, so they were given a 45% chance of being hit to simulate this. We now have sub-locations so this is obsolete. 

#### Describe the solution

Gave the Bracers the same coverage as the Sheet Steel Vambraces and the same encumbrance as they have (10 was way too high) Also, the Magical Leather Bracers used Leather Arm Guards as their basis - this is a full arm harness, not a vambrace so I changed them to use Leather Vambraces instead.

Also, Bracers were on the Belted layer, like the older armor was, changed that to the Outer layer to be in line with pretty much all other hard armor.

#### Describe alternatives you've considered

Leaving them the way they are or creating an issue to let someone else do it, but I wasn't feeling lazy. ;)

#### Testing

Made the changes locally, Bracers work as intended.

#### Additional context

I'm not married to the 3 encumbrance, but that's what the crudely banged out sheet steel ones have. I figure magical bracers are fairly unencumbering, certainly no more than some sheet steel banged into shape.

Also, some kinds or Bracers IRL do cover the elbows (Bazubands come to mind) so if it is desired they could cover that location as well. Typically, though, they just cover the forearms.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
