### PR TITLE
Generalize the threshold requirement for quadrupedal movement.

### DIFF
--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -314,7 +314,7 @@
     "condition": {
       "and": [
         { "u_has_flag": "QUADRUPED_CROUCH" },
-        { "u_has_any_trait": [ "THRESH_RABBIT", "THRESH_BEAST", "THRESH_LUPINE", "THRESH_FELINE" ] },
+        { "u_has_flag": "THRESH_ALLOWS_QUADRUPEDAL_MOVEMENT" },
         { "u_has_flag": "QUADRUPED_RUN" },
         { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "run" } ] },
         { "not": "u_can_drop_weapon" }
@@ -330,7 +330,7 @@
     "condition": {
       "and": [
         { "u_has_flag": "QUADRUPED_CROUCH" },
-        { "u_has_any_trait": [ "THRESH_RABBIT", "THRESH_BEAST", "THRESH_LUPINE", "THRESH_FELINE" ] },
+        { "u_has_flag": "THRESH_ALLOWS_QUADRUPEDAL_MOVEMENT" },
         { "not": { "u_has_flag": "QUADRUPED_RUN" } },
         { "u_has_move_mode": "crouch" },
         { "not": "u_can_drop_weapon" }

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2827,6 +2827,11 @@
     "//": "This character goes down on all fours when they crouch, if their hands are free.  Used for paw mutations."
   },
   {
+    "id": "THRESH_ALLOWS_QUADRUPEDAL_MOVEMENT",
+    "type": "json_flag",
+    "//": "Wether your threshold mutation enables quadrupedal movement."
+  },
+  {
     "id": "QUADRUPED_RUN",
     "type": "json_flag",
     "//": "This character can run or crouch on all fours if they have QUADRUPED_CROUCH, and gains the natural_stance effect.  Used for paw mutations."

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2337,7 +2337,8 @@
     "threshold_substitutes": [ "THRESH_CHIMERA" ],
     "points": 1,
     "purifiable": false,
-    "valid": false
+    "valid": false,
+    "flags": [ "THRESH_ALLOWS_QUADRUPEDAL_MOVEMENT" ]
   },
   {
     "type": "mutation",
@@ -2427,7 +2428,8 @@
     "threshold_substitutes": [ "THRESH_CHIMERA" ],
     "points": 1,
     "purifiable": false,
-    "valid": false
+    "valid": false,
+    "flags": [ "THRESH_ALLOWS_QUADRUPEDAL_MOVEMENT" ]
   },
   {
     "type": "mutation",
@@ -2471,7 +2473,8 @@
     "threshold": true,
     "points": 1,
     "purifiable": false,
-    "valid": false
+    "valid": false,
+    "flags": [ "THRESH_ALLOWS_QUADRUPEDAL_MOVEMENT" ]
   },
   {
     "type": "mutation",
@@ -2556,7 +2559,8 @@
     "threshold_substitutes": [ "THRESH_CHIMERA" ],
     "points": 1,
     "purifiable": false,
-    "valid": false
+    "valid": false,
+    "flags": [ "THRESH_ALLOWS_QUADRUPEDAL_MOVEMENT" ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
#### Summary
Mods ""Generalize the threshold requirement for quadrupedal movement.h"

#### Purpose of change
Allows for better mod support, since you no longer have to override the enchantments. I need this for aftershock uplifts

#### Describe the solution
Check for  threshold flag `THRESH_ALLOWS_QUADRUPEDAL_MOVEMENT` instead of specific threshold ids.

#### Testing
Loads