### PR TITLE
Fixed 'weigth' typo in zed_acid.json

### DIFF
--- a/data/json/monsters/zed_acid.json
+++ b/data/json/monsters/zed_acid.json
@@ -187,7 +187,7 @@
       [ "ACID_BARF", 10 ]
     ],
     "bleed_rate": 50,
-    "proportional": { "hp": 1.8, "speed": 1.3, "volume": 1.4, "weigth": 1.1 },
+    "proportional": { "hp": 1.8, "speed": 1.3, "volume": 1.4, "weight": 1.1 },
     "special_when_hit": [ "ACIDSPLASH", 100 ]
   }
 ]


### PR DESCRIPTION
#### Summary
Bugfixes "Fixed field typo in zed_acid.json file"

#### Purpose of change

Bug fixing.

#### Describe the solution

`proportional` operation should use defined fields.

#### Describe alternatives you've considered

#### Testing

Checking weight of `mon_zombie_dog_brute_acidic` monster.

#### Additional context

None.