### PR TITLE
change bullet_forming and make it less absract

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -484,6 +484,7 @@
       [ "briefcase", 5 ],
       [ "puller", 5 ],
       [ "press", 5 ],
+      [ "arbor_press", 5 ],
       [ "vac_sealer", 10 ],
       [ "gasoline_lantern", 5 ],
       [ "electric_lantern", 8 ],

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -208,6 +208,7 @@
       { "item": "portable_generator", "prob": 5 },
       [ "jumper_cable_heavy", 2 ],
       [ "lug_wrench", 20 ],
+      [ "arbor_press", 20 ],
       [ "jerrycan", 10 ],
       [ "jerrycan_big", 10 ],
       [ "belt_grinder", 20 ],
@@ -633,7 +634,8 @@
       { "group": "tools_blacksmith", "prob": 50 },
       { "item": "large_repairkit", "prob": 50, "charges": [ 0, 500 ] },
       [ "puller", 100 ],
-      [ "press", 100 ]
+      [ "press", 100 ],
+      [ "arbor_press", 100 ]
     ]
   },
   {

--- a/data/json/items/tool/handloading.json
+++ b/data/json/items/tool/handloading.json
@@ -60,7 +60,7 @@
     "longest_side": "29 cm",
     "price": "300 USD",
     "price_postapoc": "10 USD",
-    "material": [ "cast_iron", "plastic" ],
+    "material": [ "iron", "plastic" ],
     "symbol": ";",
     "color": "dark_gray",
     "melee_damage": { "bash": 10 }

--- a/data/json/items/tool/handloading.json
+++ b/data/json/items/tool/handloading.json
@@ -54,7 +54,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "name": { "str": "arbor press", "str_pl": "arbor presses" },
-    "description": "A small hand operated press, it can be used for staking, rivetting, or various other small jobs. If you had a swage and die, you could use it to make copper jackets for handloading.",
+    "description": "A small hand operated press, it can be used for staking, rivetting, or various other small jobs.  If you had a swage and die, you could use it to make copper jackets for handloading.",
     "weight": "6350 g",
     "volume": "12000 ml",
     "longest_side": "29 cm",

--- a/data/json/items/tool/handloading.json
+++ b/data/json/items/tool/handloading.json
@@ -48,5 +48,21 @@
     "color": "green",
     "qualities": [ [ "PULL", 2 ] ],
     "melee_damage": { "bash": 5 }
+  },
+  {
+    "id": "arbor_press",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "arbor press", "str_pl": "arbor presses" },
+    "description": "A small hand operated press, it can be used for staking, rivetting, or various other small jobs. If you had a swage and die, you could use it to make copper jackets for handloading.",
+    "weight": "6350 g",
+    "volume": "12000 ml",
+    "longest_side": "29 cm",
+    "price": "300 USD",
+    "price_postapoc": "10 USD",
+    "material": [ "cast_iron", "plastic" ],
+    "symbol": ";",
+    "color": "dark_gray",
+    "melee_damage": { "bash": 10 }
   }
 ]

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -2,8 +2,9 @@
   {
     "id": "bullet_forming",
     "type": "requirement",
-    "//": "Forming of bullets from raw materials",
-    "tools": [ [ [ "press", -1 ] ], [ [ "fire", -1 ], [ "hotplate", 2 ], [ "integrated_welder", 2 ] ] ]
+    "//": "This is a mess in need of fixing. Forming bullets from raw materials.",
+    "tools": [ [ [ "press", -1 ] ], [ [ "fire", -1 ], [ "hotplate", 2 ], [ "integrated_welder", 2 ] ], [ [ "tongs", -1 ] ], [ [ "tape_measure", -1 ] ] ],
+    "qualities": [ { "id": "CONTAIN", "level": 1 } ]
   },
   {
     "id": "shot_forming",

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -9,7 +9,8 @@
       [ [ "tongs", -1 ] ],
       [ [ "tape_measure", -1 ] ],
       [ [ "swage", -1 ] ],
-      [ [ "arbor_press", -1 ] ]
+      [ [ "arbor_press", -1 ] ],
+      [ [ "ppe_gloves", -1 ] ]
     ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ]
   },

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -2,7 +2,7 @@
   {
     "id": "bullet_forming",
     "type": "requirement",
-    "//": "This is a mess in need of fixing. Forming bullets from raw materials.",
+    "//": "Forming bullets from raw materials.",
     "tools": [
       [ [ "press", -1 ] ],
       [ [ "fire", -1 ], [ "hotplate", 2 ], [ "integrated_welder", 2 ] ],
@@ -10,7 +10,7 @@
       [ [ "tape_measure", -1 ] ],
       [ [ "swage", -1 ] ],
       [ [ "arbor_press", -1 ] ],
-      [ [ "ppe_gloves", -1 ] ]
+      [ [ [ "gloves_medical", -1 ], [ "gloves_rubber", -1 ], [ "entry_suit", -1 ], [ "hazmat_suit", -1 ] ] ]
     ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ]
   },

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -8,7 +8,8 @@
       [ [ "fire", -1 ], [ "hotplate", 2 ], [ "integrated_welder", 2 ] ],
       [ [ "tongs", -1 ] ],
       [ [ "tape_measure", -1 ] ],
-      [ [ "swage", -1 ] ]
+      [ [ "swage", -1 ] ],
+      [ [ "arbor_press", -1 ] ]
     ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ]
   },

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -3,7 +3,12 @@
     "id": "bullet_forming",
     "type": "requirement",
     "//": "This is a mess in need of fixing. Forming bullets from raw materials.",
-    "tools": [ [ [ "press", -1 ] ], [ [ "fire", -1 ], [ "hotplate", 2 ], [ "integrated_welder", 2 ] ], [ [ "tongs", -1 ] ], [ [ "tape_measure", -1 ] ] ],
+    "tools": [
+      [ [ "press", -1 ] ],
+      [ [ "fire", -1 ], [ "hotplate", 2 ], [ "integrated_welder", 2 ] ],
+      [ [ "tongs", -1 ] ],
+      [ [ "tape_measure", -1 ] ]
+    ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ]
   },
   {

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -10,7 +10,7 @@
       [ [ "tape_measure", -1 ] ],
       [ [ "swage", -1 ] ],
       [ [ "arbor_press", -1 ] ],
-      [ [ [ "gloves_medical", -1 ], [ "gloves_rubber", -1 ], [ "entry_suit", -1 ], [ "hazmat_suit", -1 ] ] ]
+      [ [ "gloves_medical", -1 ], [ "gloves_rubber", -1 ], [ "entry_suit", -1 ], [ "hazmat_suit", -1 ] ]
     ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ]
   },

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -10,9 +10,16 @@
       [ [ "tape_measure", -1 ] ],
       [ [ "swage", -1 ] ],
       [ [ "arbor_press", -1 ] ],
-      [ [ "gloves_medical", -1 ], [ "gloves_rubber", -1 ], [ "entry_suit", -1 ], [ "hazmat_suit", -1 ] ]
-    ],
-    "qualities": [ { "id": "CONTAIN", "level": 1 } ]
+      [ [ "gloves_medical", -1 ], [ "gloves_rubber", -1 ], [ "entry_suit", -1 ], [ "hazmat_suit", -1 ] ],
+      [
+        [ "crucible", -1 ],
+        [ "crucible_clay", -1 ],
+        [ "iron_pot", -1 ],
+        [ "pan", -1 ],
+        [ "pot_makeshift", -1 ],
+        [ "pressure_cooker", -1 ]
+      ]
+    ]
   },
   {
     "id": "shot_forming",

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -7,7 +7,8 @@
       [ [ "press", -1 ] ],
       [ [ "fire", -1 ], [ "hotplate", 2 ], [ "integrated_welder", 2 ] ],
       [ [ "tongs", -1 ] ],
-      [ [ "tape_measure", -1 ] ]
+      [ [ "tape_measure", -1 ] ],
+      [ [ "swage", -1 ] ]
     ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Add more tools and requirements to reloading ammo"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The current reloading recipe is extremely abstract, this would make it less so and would increase the difficulty of it to some degree without cluttering the game with a different def for each bullet or calibre.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change bullet_forming, possibly add a second requirement similar to it that's for jacketed ammunition if deemed neccesary (most ammo you make is jacketed though so probably not)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
discussions still on going on how this will be changed. ideally we would do change this without adding new items (but if we end up doing that it's whatever). 

- [x] make the requirement actually make sense.
- [x] figure out how the pc is even making the bullet in the first place, the main hurdle is jacketed ammo, simple lead core ammo is much more simple. this needs to be done before the requirement is "finalized"

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
