### PR TITLE
Fix advanced smartphone recovery with active laptop screen

### DIFF
--- a/data/json/effects_on_condition/computer_eocs.json
+++ b/data/json/effects_on_condition/computer_eocs.json
@@ -96,7 +96,12 @@
     "id": "EOC_SMARTPHONE_RECOVERY_ADVANCED",
     "condition": {
       "and": [
-        { "u_has_software": { "item": "software_hacking", "charges": 20, "device": "laptop" } },
+        {
+          "or": [
+            { "u_has_software": { "item": "software_hacking", "charges": 20, "device": "laptop" } },
+            { "u_has_software": { "item": "software_hacking", "charges": 20, "device": "laptop_screen_lit" } }
+          ]
+        },
         { "math": [ "u_skill('computer') >= 4" ] }
       ]
     },


### PR DESCRIPTION
#### Summary
Bugfixes "Recognize screen-lit laptops during advanced smartphone recovery"

#### Purpose of change

Advanced recovery on locked smartphones only detected laptops with their screen turned off.

With the screen active, the laptop changes to `laptop_screen_lit`, so a powered laptop containing Hacking PRO was incorrectly rejected.

Closes #88158

#### Describe the solution

Allow the advanced recovery condition to accept either `laptop` or `laptop_screen_lit`.

#### Describe alternatives you've considered

Removing the device restriction would also avoid the issue, but would allow Hacking PRO on unrelated devices. Keeping explicit checks for both laptop states preserves the intended requirement.

#### Testing

Tested with a laptop containing Hacking PRO and sufficient power:

- Advanced recovery is available with the laptop screen off.
- Advanced recovery is available with the laptop screen on.
- The recovery option remains unavailable without the required software or skill.

#### Additional context

None.