### PR TITLE
Update pits not to be killing machines

### DIFF
--- a/data/json/construction/terrain.json
+++ b/data/json/construction/terrain.json
@@ -242,6 +242,21 @@
   },
   {
     "type": "construction",
+    "id": "constr_pit_from_corpsefilled",
+    "skill": "survival",
+    "group": "dig_a_pit",
+    "category": "CONSTRUCT",
+    "difficulty": 0,
+    "time": "90m",
+    "on_display": true,
+    "qualities": [ { "id": "DIG", "level": 2 } ],
+    "pre_terrain": "t_pit_corpsed",
+    "post_terrain": "t_pit",
+    "activity_level": "ACTIVE_EXERCISE",
+    "do_turn_special": "do_turn_shovel"
+  },
+  {
+    "type": "construction",
     "id": "constr_pit_shallow_sand",
     "skill": "survival",
     "group": "dig_a_shallow_pit",

--- a/data/json/furniture_and_terrain/terrain-traps.json
+++ b/data/json/furniture_and_terrain/terrain-traps.json
@@ -33,9 +33,9 @@
     "symbol": "#",
     "color": "green",
     "move_cost": 5,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "PIT_FILLABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true },
-    "//": "left diggable to clean out corpses-KA101"
+    "//COMMENT": "The SEALED flag here is so that the corpse filled pit must be dug out to get the corpses out. The player can still pulp from adjacent squares, without removing the bodies.",
+    "flags": [ "TRANSPARENT", "DIGGABLE", "SEALED" ],
+    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",

--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -555,7 +555,7 @@
     "flags": [ "ECHOLOCATION_DETECTABLE", "PIT" ],
     "symbol": "0",
     "visibility": 0,
-    "avoidance": 8,
+    "avoidance": 99,
     "difficulty": 99,
     "action": "pit",
     "vehicle_data": { "damage": 500 }
@@ -601,7 +601,7 @@
     "flags": [ "ECHOLOCATION_DETECTABLE", "PIT" ],
     "symbol": "0",
     "visibility": 0,
-    "avoidance": 8,
+    "avoidance": 99,
     "difficulty": 99,
     "action": "pit_spikes",
     "vehicle_data": { "damage": 500 }
@@ -833,7 +833,7 @@
     "memorial_female": { "ctxt": "memorial_female", "str": "Fell into a pit filled with glass shards." },
     "symbol": "0",
     "visibility": 0,
-    "avoidance": 8,
+    "avoidance": 99,
     "difficulty": 99,
     "flags": [ "PIT", "ECHOLOCATION_DETECTABLE" ],
     "action": "pit_glass",

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -53,6 +53,7 @@ static const damage_type_id damage_bullet( "bullet" );
 static const damage_type_id damage_cut( "cut" );
 static const damage_type_id damage_heat( "heat" );
 static const damage_type_id damage_pure( "pure" );
+static const damage_type_id damage_stab( "stab" );
 
 static const efftype_id effect_beartrap( "beartrap" );
 static const efftype_id effect_downed( "downed" );
@@ -100,6 +101,7 @@ static const ter_str_id ter_t_floor_blue( "t_floor_blue" );
 static const ter_str_id ter_t_floor_green( "t_floor_green" );
 static const ter_str_id ter_t_floor_red( "t_floor_red" );
 static const ter_str_id ter_t_pit( "t_pit" );
+static const ter_str_id ter_t_pit_corpsed( "t_pit_corpsed" );
 static const ter_str_id ter_t_rock_blue( "t_rock_blue" );
 static const ter_str_id ter_t_rock_green( "t_rock_green" );
 static const ter_str_id ter_t_rock_red( "t_rock_red" );
@@ -111,7 +113,9 @@ static const trap_str_id tr_shotgun_1( "tr_shotgun_1" );
 static const trap_str_id tr_shotgun_2( "tr_shotgun_2" );
 static const trap_str_id tr_temple_flood( "tr_temple_flood" );
 
-// A pit becomes less effective as it fills with corpses.
+// A pit becomes less effective as it fills with corpses. Returned values are between 0.0 and 1.0.
+// 0.0 - totally ineffective pit, filled with corpses. Should become a corpse-filled pit.
+// 1.0 - totally empty pit, maximum effectiveness.
 static float pit_effectiveness( const tripoint_bub_ms &p )
 {
     units::volume corpse_volume = 0_ml;
@@ -121,10 +125,34 @@ static float pit_effectiveness( const tripoint_bub_ms &p )
         }
     }
 
-    // 10 zombies; see item::volume
-    const units::volume filled_volume = 10 * units::from_milliliter<float>( 62500 );
+    // Arbitrary value. A regular human body is about 70-75L. Our base zombified human size is 62.5L.
+    // This value allows one 'full kill' and then a second at seriously reduced effectiveness.
+    // A single large creature will instantly render the pit ineffective.
+    const units::volume filled_volume = 100_liter;
 
     return std::max( 0.0f, 1.0f - corpse_volume / filled_volume );
+}
+
+// Returns true if pit was completely filled, becoming corpse-filled pit
+static bool cleanup_after_pit( map &here, const tripoint_bub_ms &p, Creature *c )
+{
+    c->check_dead_state( &here );
+    // Pit filled with corpses? It becomes a corpse-filled pit.
+    if( pit_effectiveness( p ) <= 0.0f ) {
+        here.ter_set( p, ter_t_pit_corpsed );
+        return true;
+    }
+    return false;
+}
+
+static void pit_try_dismount( monster *z )
+{
+    // Note that it's possible for NPCs to ride horses or other mounts.
+    // FIXME: Only checks for/ejects player, need some way to match the rider and the mount
+    if( z->has_effect( effect_ridden ) && z->pos_abs() == get_player_character().pos_abs() ) {
+        add_msg( m_bad, _( "Your %s falls into a pit!" ), z->get_name() );
+        get_player_character().forced_dismount();
+    }
 }
 
 bool trapfunc::none( const tripoint_bub_ms &, Creature *, item * )
@@ -1049,43 +1077,45 @@ bool trapfunc::pit( const tripoint_bub_ms &p, Creature *c, item * )
     if( c->get_size() == creature_size::tiny ) {
         return false;
     }
-    const float eff = pit_effectiveness( p );
-    c->add_msg_player_or_npc( m_bad, _( "You fall in a pit!" ), _( "<npcname> falls in a pit!" ) );
+
+    // NOTE: This will be bash-type damage, and reduced by armor accordingly.
+    const int expected_dmg = pit_effectiveness( p ) * rng( 6, 12 );
+
+    const bool did_see = get_player_character().sees( here, p );
+
+    if( did_see ) {
+        c->add_msg_player_or_npc( m_bad, _( "You fall in a pit!" ), _( "<npcname> falls in a pit!" ) );
+    }
+
     c->add_effect( effect_in_pit, 1_turns, true );
-    monster *z = dynamic_cast<monster *>( c );
-    Character *you = dynamic_cast<Character *>( c );
+    monster *z = c->as_monster();
+    Character *you = c->as_character();
     if( you != nullptr ) {
         if( you->can_fly() ) {
-            you->add_msg_player_or_npc( _( "You spread your wings to slow your fall." ),
-                                        _( "<npcname> spreads their wings to slow their fall." ) );
+            if( did_see ) {
+                you->add_msg_player_or_npc( _( "You spread your wings to slow your fall." ),
+                                            _( "<npcname> spreads their wings to slow their fall." ) );
+            }
         } else if( you->has_active_bionic( bio_shock_absorber ) ) {
             you->add_msg_if_player( m_info,
                                     _( "You hit the ground hard, but your grav chute handles the impact admirably!" ) );
         } else {
-            int dodge = you->get_dodge();
-            ///\EFFECT_DODGE reduces damage taken falling into a pit
-            int damage = eff * rng( 10, 20 ) - rng( dodge, dodge * 5 );
-            if( damage > 0 ) {
-                you->add_msg_if_player( m_bad, _( "You hurt yourself!" ) );
-                // like the message says \-:
-                you->hurtall( rng( static_cast<int>( damage / 2 ), damage ), you );
-                you->deal_damage( nullptr, bodypart_id( "leg_l" ), damage_instance( damage_bash, damage ) );
-                you->deal_damage( nullptr, bodypart_id( "leg_r" ), damage_instance( damage_bash, damage ) );
-            } else {
-                you->add_msg_if_player( _( "You land nimbly." ) );
+            you->add_msg_if_player( m_bad, _( "You are hurt from falling into a pit!" ) );
+            for( const bodypart_id &bp : you->get_all_body_parts( get_body_part_flags::only_main ) ) {
+                if( bp->primary_limb_type() == bp_type::leg ) {
+                    // Extra damage to legs or your tentacles, whatever you've got
+                    you->deal_damage( nullptr, bp, damage_instance( damage_bash, expected_dmg * 2 ) );
+                } else {
+                    you->deal_damage( nullptr, bp, damage_instance( damage_bash, expected_dmg ) );
+                }
             }
         }
     } else if( z != nullptr ) {
-        if( z->has_effect( effect_ridden ) ) {
-            add_msg( m_bad, _( "Your %s falls into a pit!" ), z->get_name() );
-            get_player_character().forced_dismount();
-        }
-        z->deal_damage( nullptr, bodypart_id( "leg_l" ), damage_instance( damage_bash, eff * rng( 10,
-                        20 ) ) );
-        z->deal_damage( nullptr, bodypart_id( "leg_r" ), damage_instance( damage_bash, eff * rng( 10,
-                        20 ) ) );
+        pit_try_dismount( z );
+        z->deal_damage( nullptr, z->get_random_body_part_of_type( bp_type::leg ),
+                        damage_instance( damage_bash, expected_dmg ) );
     }
-    c->check_dead_state( &here );
+    cleanup_after_pit( here, p, c );
     return true;
 }
 
@@ -1100,54 +1130,57 @@ bool trapfunc::pit_spikes( const tripoint_bub_ms &p, Creature *c, item * )
     if( c->get_size() == creature_size::tiny ) {
         return false;
     }
-    c->add_msg_player_or_npc( m_bad, _( "You fall in a spiked pit!" ),
-                              _( "<npcname> falls in a spiked pit!" ) );
+
+    // NOTE: This will be pierce-type damage, and reduced by armor accordingly. (Spike 'misses' will be bash damage at half this value)
+    // pit_effectiveness() intentionally does not change the damage - instead, partially-filled pits have a higher chance to miss the spikes.
+    const int expected_dmg = rng( 10, 20 );
+
+    const float pit_eff = pit_effectiveness( p );
+    // +20% chance to serendipitiously avoid spikes even in an empty pit. NOTE: Chances rolled separately for each main limb.
+    const float miss_chance = 0.2f;
+    const float total_pit_eff = std::max( 0.0f, pit_eff - miss_chance );
+
+    const bool did_see = get_player_character().sees( here, p );
+
+    if( did_see ) {
+        c->add_msg_player_or_npc( m_bad, _( "You fall in a spiked pit!" ),
+                                  _( "<npcname> falls in a spiked pit!" ) );
+    }
+
     c->add_effect( effect_in_pit, 1_turns, true );
-    monster *z = dynamic_cast<monster *>( c );
-    Character *you = dynamic_cast<Character *>( c );
-    Character &player_character = get_player_character();
+    monster *z = c->as_monster();
+    Character *you = c->as_character();
     if( you != nullptr ) {
-        int dodge = you->get_dodge();
-        int damage = pit_effectiveness( p ) * rng( 20, 50 );
         if( you->can_fly() ) {
-            you->add_msg_player_or_npc( _( "You spread your wings to slow your fall." ),
-                                        _( "<npcname> spreads their wings to slow their fall." ) );
+            // Gliding bullshit allows maneuvering to avoid spikes
+            if( did_see ) {
+                you->add_msg_player_or_npc( _( "You spread your wings to slow your fall." ),
+                                            _( "<npcname> spreads their wings to slow their fall." ) );
+            }
         } else if( you->has_active_bionic( bio_shock_absorber ) ) {
+            // Not sure this should really work vs spikes, but whatever
             you->add_msg_if_player( m_info,
                                     _( "You hit the ground hard, but your grav chute handles the impact admirably!" ) );
-            ///\EFFECT_DODGE reduces chance of landing on spikes in spiked pit
-        } else if( 0 == damage || rng( 5, 30 ) < dodge ) {
-            you->add_msg_if_player( _( "You avoid the spikes within." ) );
         } else {
-            bodypart_id hit = bodypart_str_id::NULL_ID();
-            switch( rng( 1, 10 ) ) {
-                case  1:
-                    hit = bodypart_id( "leg_l" );
-                    break;
-                case  2:
-                    hit = bodypart_id( "leg_r" );
-                    break;
-                case  3:
-                    hit = bodypart_id( "arm_l" );
-                    break;
-                case  4:
-                    hit = bodypart_id( "arm_r" );
-                    break;
-                case  5:
-                case  6:
-                case  7:
-                case  8:
-                case  9:
-                case 10:
-                    hit = bodypart_id( "torso" );
-                    break;
+            bool did_any_stab_dmg = false;
+            for( const bodypart_id &bp : you->get_all_body_parts( get_body_part_flags::only_main ) ) {
+                if( total_pit_eff > 0.0 && total_pit_eff >= rng_float( 0.0, 1.0 ) ) {
+                    you->add_msg_if_player( m_bad, _( "The spikes impale your %s!" ),
+                                            body_part_name_accusative( bp ) );
+                    dealt_damage_instance dealt_dmg =
+                        you->deal_damage( nullptr, bp, damage_instance( damage_stab, expected_dmg ) );
+                    if( dealt_dmg.type_damage( damage_stab ) > 0 ) {
+                        did_any_stab_dmg = true;
+                    }
+                } else {
+                    you->add_msg_if_player( m_bad, _( "Your %s hits the ground, missing the spikes!" ),
+                                            body_part_name_accusative( bp ) );
+                    you->deal_damage( nullptr, bp, damage_instance( damage_bash,
+                                      static_cast<int>( expected_dmg / 2 ) ) );
+                }
             }
-            you->add_msg_if_player( m_bad, _( "The spikes impale your %s!" ),
-                                    body_part_name_accusative( hit ) );
-            dealt_damage_instance dealt_dmg = you->deal_damage( nullptr, hit, damage_instance( damage_cut,
-                                              damage ) );
-            if( !you->has_flag( json_flag_INFECTION_IMMUNE ) &&
-                dealt_dmg.type_damage( damage_cut ) > 0 ) {
+
+            if( !you->has_flag( json_flag_INFECTION_IMMUNE ) && did_any_stab_dmg ) {
                 const int chance_in = you->has_trait( trait_INFRESIST ) ? 256 : 35;
                 if( one_in( chance_in ) ) {
                     you->add_effect( effect_tetanus, 1_turns, true );
@@ -1155,14 +1188,12 @@ bool trapfunc::pit_spikes( const tripoint_bub_ms &p, Creature *c, item * )
             }
         }
     } else if( z != nullptr ) {
-        if( z->has_effect( effect_ridden ) ) {
-            add_msg( m_bad, _( "Your %s falls into a pit!" ), z->get_name() );
-            player_character.forced_dismount();
-        }
-        z->deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_cut, rng( 20, 50 ) ) );
+        pit_try_dismount( z );
+        z->deal_damage( nullptr, z->get_random_body_part_of_type( bp_type::torso ),
+                        damage_instance( damage_stab, expected_dmg ) );
     }
-    c->check_dead_state( &here );
-    if( one_in( 4 ) ) {
+    const bool filled_up = cleanup_after_pit( here, p, c );
+    if( !filled_up && one_in( 4 ) ) {
         add_msg_if_player_sees( p, _( "The spears break!" ) );
         map &here = get_map();
         here.ter_set( p, ter_t_pit );
@@ -1187,58 +1218,55 @@ bool trapfunc::pit_glass( const tripoint_bub_ms &p, Creature *c, item * )
     if( c->get_size() == creature_size::tiny ) {
         return false;
     }
-    c->add_msg_player_or_npc( m_bad, _( "You fall in a pit filled with glass shards!" ),
-                              _( "<npcname> falls in pit filled with glass shards!" ) );
+
+    // NOTE: This will be cut-type damage, and reduced by armor accordingly. (Glass 'misses' will be bash damage at 100% of this value)
+    // pit_effectiveness() intentionally does not change the damage - instead, partially-filled pits have a higher chance to miss the glass.
+    const int expected_dmg = pit_effectiveness( p ) * rng( 6, 12 );
+
+    const float pit_eff = pit_effectiveness( p );
+    // +50% chance to avoid glass even in an empty pit. NOTE: Chances rolled separately for each main limb.
+    // Random scattered glass is not very effective.
+    const float miss_chance = 0.5f;
+    const float total_pit_eff = std::max( 0.0f, pit_eff - miss_chance );
+
+    const bool did_see = get_player_character().sees( here, p );
+
+    if( did_see ) {
+        c->add_msg_player_or_npc( m_bad, _( "You fall in a pit filled with glass shards!" ),
+                                  _( "<npcname> falls in pit filled with glass shards!" ) );
+    }
+
     c->add_effect( effect_in_pit, 1_turns, true );
-    monster *z = dynamic_cast<monster *>( c );
-    Character *you = dynamic_cast<Character *>( c );
-    Character &player_character = get_player_character();
+    monster *z = c->as_monster();
+    Character *you = c->as_character();
     if( you != nullptr ) {
-        int dodge = you->get_dodge();
-        int damage = pit_effectiveness( p ) * rng( 15, 35 );
         if( you->can_fly() ) {
-            you->add_msg_player_or_npc( _( "You spread your wings to slow your fall." ),
-                                        _( "<npcname> spreads their wings to slow their fall." ) );
+            if( did_see ) {
+                you->add_msg_player_or_npc( _( "You spread your wings to slow your fall." ),
+                                            _( "<npcname> spreads their wings to slow their fall." ) );
+            }
         } else if( you->has_active_bionic( bio_shock_absorber ) ) {
             you->add_msg_if_player( m_info,
                                     _( "You hit the ground hard, but your grav chute handles the impact admirably!" ) );
-            ///\EFFECT_DODGE reduces chance of landing on glass in glass pit
-        } else if( 0 == damage || rng( 5, 30 ) < dodge ) {
-            you->add_msg_if_player( _( "You avoid the glass shards within." ) );
         } else {
-            bodypart_id hit = bodypart_str_id::NULL_ID();
-            switch( rng( 1, 10 ) ) {
-                case  1:
-                    hit = bodypart_id( "leg_l" );
-                    break;
-                case  2:
-                    hit = bodypart_id( "leg_r" );
-                    break;
-                case  3:
-                    hit = bodypart_id( "arm_l" );
-                    break;
-                case  4:
-                    hit = bodypart_id( "arm_r" );
-                    break;
-                case  5:
-                    hit = bodypart_id( "foot_l" );
-                    break;
-                case  6:
-                    hit = bodypart_id( "foot_r" );
-                    break;
-                case  7:
-                case  8:
-                case  9:
-                case 10:
-                    hit = bodypart_id( "torso" );
-                    break;
+            bool did_any_cut_dmg = false;
+            for( const bodypart_id &bp : you->get_all_body_parts( get_body_part_flags::only_main ) ) {
+                if( total_pit_eff > 0.0 && total_pit_eff >= rng_float( 0.0, 1.0 ) ) {
+                    you->add_msg_if_player( m_bad, _( "The glass shards slash your %s!" ),
+                                            body_part_name_accusative( bp ) );
+                    dealt_damage_instance dealt_dmg =
+                        you->deal_damage( nullptr, bp, damage_instance( damage_cut, expected_dmg ) );
+                    if( dealt_dmg.type_damage( damage_cut ) > 0 ) {
+                        did_any_cut_dmg = true;
+                    }
+                } else {
+                    you->add_msg_if_player( m_bad, _( "Your %s hits the ground, missing the glass!" ),
+                                            body_part_name_accusative( bp ) );
+                    you->deal_damage( nullptr, bp, damage_instance( damage_bash, expected_dmg ) );
+                }
             }
-            you->add_msg_if_player( m_bad, _( "The glass shards slash your %s!" ),
-                                    body_part_name_accusative( hit ) );
-            dealt_damage_instance dealt_dmg = you->deal_damage( nullptr, hit, damage_instance( damage_cut,
-                                              damage ) );
-            if( !you->has_flag( json_flag_INFECTION_IMMUNE ) &&
-                dealt_dmg.type_damage( damage_cut ) > 0 ) {
+
+            if( !you->has_flag( json_flag_INFECTION_IMMUNE ) && did_any_cut_dmg ) {
                 const int chance_in = you->has_trait( trait_INFRESIST ) ? 256 : 35;
                 if( one_in( chance_in ) ) {
                     you->add_effect( effect_tetanus, 1_turns, true );
@@ -1246,15 +1274,12 @@ bool trapfunc::pit_glass( const tripoint_bub_ms &p, Creature *c, item * )
             }
         }
     } else if( z != nullptr ) {
-        if( z->has_effect( effect_ridden ) ) {
-            add_msg( m_bad, _( "Your %s falls into a pit!" ), z->get_name() );
-            player_character.forced_dismount();
-        }
-        z->deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_cut, rng( 20,
-                        50 ) ) );
+        pit_try_dismount( z );
+        z->deal_damage( nullptr, z->get_random_body_part_of_type( bp_type::torso ),
+                        damage_instance( damage_cut, expected_dmg ) );
     }
-    c->check_dead_state( &here );
-    if( one_in( 5 ) ) {
+    const bool filled_up = cleanup_after_pit( here, p, c );
+    if( !filled_up && one_in( 5 ) ) {
         add_msg_if_player_sees( p, _( "The shards shatter!" ) );
         map &here = get_map();
         here.ter_set( p, ter_t_pit );


### PR DESCRIPTION
#### Summary
Balance "Update pits not to be killing machines"

#### Purpose of change
Traps are not supposed to be infinite killing machines. Any trap that lets you do one thing and wait for everything in a city to be dead is *badly designed*. Nailboards, caltrops, blade traps, and others have all been brought to heel. Now I'm coming for pits.

#### Describe the solution

Cleaned up some cases where the player would gain ESP knowledge of creatures falling into pits

Fixed cases where the player would be thrown off a horse because an NPC rode their mount into a pit

dynamic_casts updated to use our `as_monster()`/`as_character()` virtuals

Pit traps of any type which kill monsters will eventually become corpse-filled pits. These must be dug out to retrieve the corpses, though they can still be smashed to prevent revival without digging out the corpses.

Corpse-filled pits said things could be dug out of them, they could not. Updated the corpse-filled pit terrain to actually be SEALED (you cannot simply take the corpses out, they must be dug out). You can still see and smash corpses, if present.

*Seriously* nerfed the ability for pits to actually kill things. A deep pit with some glass shards scattered about could deal upwards of 50 damage. That's absurd. Now the spiked pit has roughly(slightly more) the same damage as a fire-hardened spear. Glass pit is just a regular pit, but the damage type switches to cut which can cause bleeding. Regular pit used `hurtall` which effectively gave it pure damage, this has been changed to properly hit only main limbs and use bash damage (affected by armor etc).

Players could somehow contort themselves in mid-air to avoid dozens of glass shards if they were just *really good* at dodging. Also absurd, but completely removed. Dodge has no effect when you're *falling into a pit*.

Spiked/glass pits would only hit one bodypart despite literally falling into the pit. This was clearly wrong, and now all your main bodyparts roll a chance to get hit. Parts which don't get impaled/cut on glass instead slam into the ground, dealing regular pit bash damage.

Updated the spiked pits to actually use stab(piercing) damage. At the time these functions were written piercing damage was just cut with some special-casing applied. Now that we have real piercing and armor values that are bad/good against it, it properly uses piercing.

Pits did not have a 100% chance to trigger when entering their tile - A player or monster or animal could walk right over a pit with only a mild inconvenience. The `avoidance` has been changed to 99 to make this essentially impossible. Entering a tile with a pit WILL pit you.

#### Describe alternatives you've considered


#### Testing
Threw myself into some pits
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/bcaf0c3e-d356-4920-9a57-72d8a593a1dc" />

Lured some zombies into pits, making sure they turned into corpse-filled pits when the bodies piled up

#### Additional context

KNOWN ISSUES:

Now that the corpse-filled pits are diggable this makes the mass grave extra weirder - you can actually dig the (many, many) corpse-filled pits there, but there's nothing in them.