### PR TITLE
Fixes #88074: revert to calling play_music() rather than make_music().

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2640,7 +2640,8 @@ std::optional<int> musical_instrument_actor::use( Character *p, item &it,
     }
 
     // We already played the sounds, just handle applying effects now
-    iuse::make_music( p, p->pos_bub( *here ), volume, morale_effect, /*play_sounds=*/false );
+    // TODO: migrate back to make_music(), but avoid re-introducing #88074.
+    iuse::play_music( p, p->pos_bub( *here ), volume, morale_effect, /*play_sounds=*/false );
 
     return 0;
 }


### PR DESCRIPTION
#### Summary
None

In musical_instrument_actor::use(), revert to calling play_music() rather than make_music().

Fixes #88074 by reverting to the behavior before #84822. I left the make_music() function so that we can migrate back to it after fixing the bug that causes morale to increase by only 1, and I added a TODO to do so.