### PR TITLE
Handful of down feathers

### DIFF
--- a/data/json/furniture_and_terrain/furniture-sleep.json
+++ b/data/json/furniture_and_terrain/furniture-sleep.json
@@ -93,7 +93,7 @@
         { "item": "splinter", "count": [ 3, 6 ] },
         { "item": "sheet_cotton", "count": [ 1, 2 ] },
         { "item": "cotton_patchwork", "count": [ 10, 15 ] },
-        { "item": "down_feather", "count": [ 45, 55 ] },
+        { "item": "down_feather", "count": [ 5, 9 ] },
         { "item": "scrap", "count": [ 10, 20 ] }
       ],
       "hit_field": [ "fd_dust", 2 ],
@@ -129,7 +129,7 @@
         { "item": "splinter", "count": [ 8, 15 ] },
         { "item": "sheet_cotton", "count": [ 2, 3 ] },
         { "item": "cotton_patchwork", "count": [ 12, 14 ] },
-        { "item": "down_feather", "count": [ 90, 110 ] },
+        { "item": "down_feather", "count": [ 10, 13 ] },
         { "item": "scrap", "count": [ 20, 40 ] }
       ],
       "hit_field": [ "fd_dust", 2 ],

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -713,14 +713,14 @@
     "category": "spare_parts",
     "price": "0 cent",
     "price_postapoc": "0 cent",
-    "name": { "str": "down feather" },
+    "name": { "str": "handful of down feathers", "str_pl": "handfuls of down feather" },
     "symbol": "=",
     "color": "brown",
-    "description": "A fluffy down feather from a bird.  Useful for making cozy bedclothes.",
+    "description": "A handful of fluffy down feather from a bird.  Useful for making cozy bedclothes.",
     "material": [ "down_feathers" ],
     "flags": [ "NO_SALVAGE" ],
-    "volume": "1 ml",
-    "weight": "1 mg"
+    "volume": "102 ml",
+    "weight": "102 mg"
   },
   {
     "type": "ITEM",

--- a/data/json/recipes/armor/other.json
+++ b/data/json/recipes/armor/other.json
@@ -133,7 +133,7 @@
     "time": "85 m",
     "autolearn": true,
     "using": [ [ "tailoring_cotton_patchwork_simple", 33 ] ],
-    "components": [ [ [ "down_feather", 160 ] ] ],
+    "components": [ [ [ "down_feather", 10 ] ] ],
     "byproducts": [ [ "scrap_cotton", 2 ] ]
   },
   {

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -26,7 +26,7 @@
     "reversible": true,
     "autolearn": true,
     "using": [ [ "sewing_standard", 12 ] ],
-    "components": [ [ [ "cotton_patchwork", 6 ] ], [ [ "down_feather", 40 ] ] ]
+    "components": [ [ [ "cotton_patchwork", 6 ] ], [ [ "down_feather", 5 ] ] ]
   },
   {
     "type": "recipe",
@@ -40,7 +40,7 @@
     "reversible": true,
     "autolearn": true,
     "using": [ [ "sewing_standard", 12 ] ],
-    "components": [ [ [ "cotton_patchwork", 60 ] ], [ [ "down_feather", 1160 ] ] ]
+    "components": [ [ [ "cotton_patchwork", 60 ] ], [ [ "down_feather", 15 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/uncraft/armor.json
+++ b/data/json/uncraft/armor.json
@@ -117,7 +117,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "time": "20 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "sheet_cotton", 33 ] ], [ [ "down_feather", 160 ] ] ]
+    "components": [ [ [ "sheet_cotton", 33 ] ], [ [ "down_feather", 10 ] ] ]
   },
   {
     "result": "under_armor_shorts",

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -310,7 +310,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "time": "2 m",
     "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-    "components": [ [ [ "sheet_cotton", 2 ] ], [ [ "cotton_patchwork", 4 ] ], [ [ "down_feather", 50 ] ] ]
+    "components": [ [ [ "sheet_cotton", 2 ] ], [ [ "cotton_patchwork", 4 ] ], [ [ "down_feather", 5 ] ] ]
   },
   {
     "result": "well_pump",

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -2423,7 +2423,7 @@
     "activity_level": "NO_EXERCISE",
     "time": "1 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "cotton_patchwork", 6 ] ], [ [ "down_feather", 40 ] ] ]
+    "components": [ [ [ "cotton_patchwork", 6 ] ], [ [ "down_feather", 5 ] ] ]
   },
   {
     "result": "sheet",


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Feels like the down feather dont have to be represented individually due to the fact that down feather is not useful in fletching, so i group it into handful of down feathers

#### Describe the solution
Adjust the volume and weight to be the equivalent of 100-ish down feathers and adjust the stuff that uses it.
#### Describe alternatives you've considered

No.

#### Testing
skinning up goose yield me 50 handfuls of down feathers now.
<img width="422" height="302" alt="Screenshot_20260731_132011" src="https://github.com/user-attachments/assets/c9a36c01-67f4-4276-9ba2-abeb21619390" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
