### PR TITLE
Fix personal autopickup rules not saved.

### DIFF
--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -896,7 +896,7 @@ bool player_settings::save( const bool bCharacter )
         const cata_path player_save = PATH_INFO::player_base_save_path() + ".sav";
         const cata_path player_save_zzip = player_save + zzip_suffix;
         //Character not saved yet.
-        if( !file_exist( player_save ) || !file_exist( player_save_zzip ) ) {
+        if( !file_exist( player_save ) && !file_exist( player_save_zzip ) ) {
             return true;
         }
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Preserve character-specific auto-pickup rules between sessions"

#### Purpose of change

Character-specific auto-pickup rules were not saved when the character used a compressed .sav.zzip save file.

#### Describe the solution

Corrected the save file existence check performed before writing character-specific auto-pickup rules.

The previous condition required both the uncompressed .sav file and the compressed .sav.zzip file to exist. Normally only one of these save formats exists, so the function returned without writing the character-specific auto-pickup rules.

The updated condition skips saving only when neither save file variant exists.

#### Describe alternatives you've considered

Character-specific auto-pickup rules could be stored directly in the main character save instead of a separate `.apu.json` file. However, this would be a larger and unrelated change. The existing persistence mechanism works correctly once the save file existence check is fixed.

#### Testing

Tested with a character using a compressed .sav.zzip save:

Added an auto-pickup rule from the advanced inventory.
Confirmed that it appeared in the character-specific section of the auto-pickup manager.
Saved and exited the game.
Loaded the same character.
Confirmed that the rule was still present.

Also confirmed that saving is skipped when neither the .sav nor .sav.zzip character save exists.

#### Additional context

The issue was caused by using a logical OR when checking whether the save files were missing. This caused saving to be skipped whenever either save format was absent, although a character normally has only one of the two save formats.
