### PR TITLE
You drop it; they own it

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -21,6 +21,7 @@
 #include "activity_actor_definitions.h"
 #include "activity_type.h"
 #include "avatar.h"
+#include "basecamp.h"
 #include "butchery.h"
 #include "calendar.h"
 #include "cata_utility.h"
@@ -568,6 +569,24 @@ void put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
         try_to_put_into_vehicle( you, reason, items, *vp );
         return;
     }
+
+    // If dropping on the ground and it's on purpose, then it's now property of whoever owns this place.
+    if( reason == item_drop_reason::deliberate ) {
+        std::optional<basecamp *> bcp = overmap_buffer.find_camp( you.pos_abs_omt().xy() );
+        if( bcp ) {
+            if( basecamp *actual_camp = *bcp; actual_camp ) {
+                if( actual_camp->get_owner() != you.get_faction()->id ) {
+                    std::list<item> copy_items = items;
+                    for( item &copy : copy_items ) {
+                        copy.set_owner( actual_camp->get_owner() );
+                    }
+                    drop_on_map( you, reason, copy_items, here, where );
+                    return;
+                }
+            }
+        }
+    }
+
     drop_on_map( you, reason, items, here, where );
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Can't use faction bases as your own personal storage"

#### Purpose of change
You could store all sorts of crap at the refugee center, and nobody would bat an eye.

#### Describe the solution
You intentionally throw something out on another faction's territory - it's theirs now. 


#### Describe alternatives you've considered
Garbagetron 9000 the cleaning robot just shoots you for littering

#### Testing
Dropped some stuff at the door to the refugee center. Confirmed they owned it. Backed up until I was outside of their territory, dropped more stuff. Confirmed I still owned the newly dropped stuff.

#### Additional context
