### PR TITLE
Fix Megacity mod lag and recursion issue

### DIFF
--- a/data/mods/Megacity/modinfo.json
+++ b/data/mods/Megacity/modinfo.json
@@ -12,7 +12,7 @@
   },
   {
     "type": "dimension",
-    "id": "Default",
+    "id": "default",
     "region_layout": "default"
   },
   {
@@ -32,6 +32,10 @@
     "id": "Evac Shelter",
     "copy-from": "Evac Shelter",
     "//COMMENT": "Oops! Not so unused now, are you? Well we need to spawn somewhere, so this will have to do. For now.",
+    "occurrences": [ 0, 1 ],
+    "locations": [ "land" ],
+    "city_distance": [ 0, 10 ],
+    "city_sizes": [ 0, -1 ],
     "extend": { "flags": [ "FAKE_UNUSED_FLAG" ] }
   },
   {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix Megacity mod lag and worldgen recursion"

#### Purpose of change
This pull request resolves a critical performance freeze and lag issue occurring when loading a save or crossing overmap boundaries with the Megacity mod active. 

The freeze was caused by two main issues:
1. The Megacity mod defined the default dimension with `"id": "Default"` (uppercase "D"), which created a duplicate unused dimension instead of correctly overwriting `"default"` (lowercase "d").
2. The `"mega_mega_city"` region layout only allowed `Evac Shelter` to spawn. However, `Evac Shelter` inherited vanilla constraints requiring it to spawn in `"wilderness"` locations and with a minimum of 2 occurrences. In a continuous megacity, there are no wilderness locations. Since the game could never place the mandatory minimum, it repeatedly triggered recursive generation of adjacent overmaps in an infinite loop, freezing the game.

Resolves #88167

#### Describe the solution
In [data/mods/Megacity/modinfo.json](file:///Users/akul/Desktop/github%20pull/data/mods/Megacity/modinfo.json):
1. Corrected `"id": "Default"` to `"id": "default"` for the dimension definition to properly override the default dimension.
2. Overrode the `Evac Shelter` overmap special's placement constraints to allow it to spawn within a city context:
   - Changed `"locations"` to `[ "land" ]` and set `"city_distance"` to `[ 0, 10 ]` and `"city_sizes"` to `[ 0, -1 ]`.
   - Set `"occurrences"` to `[ 0, 1 ]` (minimum 0). This prevents the game from initiating a cascade of recursive overmap generations if the shelter cannot be placed.

#### Describe alternatives you've considered
- We considered setting `occurrences` to exactly 0 to completely disable Evac Shelter spawns. However, setting it to `[ 0, 1 ]` allows players a chance to spawn in/find an evac shelter on land while safely preventing the worldgen cascade.

#### Testing
- Verified that the modified `modinfo.json` is syntax-compliant and valid JSON.
- Confirmed that the occurrences, locations, and city_distance overrides satisfy the overmap placement criteria without triggering recursive generation.

#### Additional context
None.
