### PR TITLE
[Sky Island] Obsolete some talk topic in the island statue re: portal storm

### DIFF
--- a/data/mods/Sky_Island/dialog_statue.json
+++ b/data/mods/Sky_Island/dialog_statue.json
@@ -53,7 +53,7 @@
   {
     "type": "talk_topic",
     "id": "SKYISLAND_EXPLAIN5",
-    "dynamic_line": "This statue offers a variety of services.  You can be instantly healed, dispel an ongoing portal storm, check your current statistics and progress, and tweak your expedition difficulty settings.\n\nHealing is free until you have survived 10 expeditions.  After this point, healing costs 4 warp shards per treatment.\n\nExpedition difficulty is set to default when you start a new game, but here you can change many finer details to suit your own playstyle.",
+    "dynamic_line": "This statue offers a variety of services.  You can be instantly healed, check your current statistics and progress, and tweak your expedition difficulty settings.\n\nHealing is free until you have survived 10 expeditions.  After this point, healing costs 4 warp shards per treatment.\n\nExpedition difficulty is set to default when you start a new game, but here you can change many finer details to suit your own playstyle.",
     "responses": [ { "text": "Interesting…", "topic": "SKYISLAND_QUESTIONS" } ]
   },
   {
@@ -98,14 +98,6 @@
         "text": "Heal me.  (Costs 4 Warp Shards)",
         "condition": { "math": [ "islandrank != 0" ] },
         "effect": [ { "run_eocs": [ "EOC_HEAL_NEWBIE" ] } ],
-        "topic": "SKYISLAND_SERVICES"
-      },
-      {
-        "text": "End an active portal storm.",
-        "effect": [
-          { "run_eocs": [ "EOC_CANCEL_PORTAL_STORM" ] },
-          { "u_message": "The air crackles with static electricity, then stabilizes.", "popup": true }
-        ],
         "topic": "SKYISLAND_SERVICES"
       },
       {


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Considering the fact that the portal storm had been blocked off from the sky island dimension, it is prudent to remove the mention and a talk topic for cancelling ongoing portal storm.
#### Describe the solution

Yote the bits.

#### Describe alternatives you've considered

Re-enable the portal storm? nah, it is a risk.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
<img width="541" height="300" alt="Screenshot_20260803_175243" src="https://github.com/user-attachments/assets/c5d8528a-e783-4216-b59b-33b157611b58" />
<img width="1042" height="331" alt="Screenshot_20260803_175226" src="https://github.com/user-attachments/assets/6d59c38f-ca2d-4583-b1e1-2165e6f0b60f" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
