### PR TITLE
Auto drink using faucets in a vehicle bound auto drink zone

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -4395,7 +4395,7 @@ int get_auto_consume_moves( Character &you, const bool food )
 
                 // checks for any installed fluid tanks on the whole car with liquid in them
                 for( const vpart_reference &vp_fluid_tank :
-                    vp->vehicle().get_avail_parts( "FLUIDTANK" ) ) {
+                     vp->vehicle().get_avail_parts( "FLUIDTANK" ) ) {
                     item_location i_loc =
                         vp->vehicle().part_base( vp_fluid_tank.part_index() );
                     visit_item_contents( i_loc, visit );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -140,6 +140,8 @@ static const trait_id trait_SAPROVORE( "SAPROVORE" );
 
 static const trap_str_id tr_firewood_source( "tr_firewood_source" );
 
+static const itype_id itype_water_faucet( "water_faucet" );
+
 static const zone_type_id zone_type_( "" );
 static const zone_type_id zone_type_AUTO_DRINK( "AUTO_DRINK" );
 static const zone_type_id zone_type_AUTO_EAT( "AUTO_EAT" );
@@ -4387,6 +4389,18 @@ int get_auto_consume_moves( Character &you, const bool food )
                     visit_item_contents( i_loc, visit );
                 }
             }
+
+            // checks if we have a faucet we can drink from on the tile
+            if( vp.part_with_tool( here, itype_water_faucet ) ) {
+
+                // checks for any installed fluid tanks on the whole car with liquid in them
+                for( const vpart_reference &vp_fluid_tank :
+                    vp->vehicle().get_avail_parts( "FLUIDTANK" ) ) {
+                    item_location i_loc =
+                        vp->vehicle().part_base( vp_fluid_tank.part_index() );
+                    visit_item_contents( i_loc, visit );
+                    }
+                }
         } else {
             for( item &it : here.i_at( here.get_bub( loc ) ) ) {
                 item_location i_loc( map_cursor( loc ), &it );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -4399,8 +4399,8 @@ int get_auto_consume_moves( Character &you, const bool food )
                     item_location i_loc =
                         vp->vehicle().part_base( vp_fluid_tank.part_index() );
                     visit_item_contents( i_loc, visit );
-                    }
                 }
+            }
         } else {
             for( item &it : here.i_at( here.get_bub( loc ) ) ) {
                 item_location i_loc( map_cursor( loc ), &it );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -110,6 +110,7 @@ static const itype_id itype_battery( "battery" );
 static const itype_id itype_disassembly( "disassembly" );
 static const itype_id itype_log( "log" );
 static const itype_id itype_soldering_iron( "soldering_iron" );
+static const itype_id itype_water_faucet( "water_faucet" );
 static const itype_id itype_welder( "welder" );
 
 static const quality_id qual_AXE( "AXE" );
@@ -139,8 +140,6 @@ static const trait_id trait_SAPROPHAGE( "SAPROPHAGE" );
 static const trait_id trait_SAPROVORE( "SAPROVORE" );
 
 static const trap_str_id tr_firewood_source( "tr_firewood_source" );
-
-static const itype_id itype_water_faucet( "water_faucet" );
 
 static const zone_type_id zone_type_( "" );
 static const zone_type_id zone_type_AUTO_DRINK( "AUTO_DRINK" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Makes it so that if an auto drink zone is placed on a faucet, it will enable you to auto drink form it"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This enables drinking liquids from vehicle tanks as one can do normally with a faucet trough both interaction and eating menu, this should also be able to done by auto drink zone.  Before you would need to fill up a container and then have that in the drinking zone, while not a terrible ting it is nevertheless something taking up volume in your precious cargo space.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Allow drinking liquids in vehicle tanks if there is a faucet on the auto drink tile. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Doing nothing. Also considered enabling auto drink from vehicle tanks if you have a hose (as done with eat menu in #86632 ) as you can siphon it from any tile as long as you can examine the car there, however it felt a bit out of scope for what an auto drink zone would be.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Tested with and observed nothing anomalous;
Normal non car auto drink zone with and without liquid in it.
0 tanks in car.
Multiple tanks with only 1 with water. With and without faucet on auto drink tile.
Multiple tanks with more than one with water. With and without faucet on auto drink tile.
1 tank in car with and without water. With and without faucet on auto drink tile.

#### Additional context
Drinking from the tanks still has the universal auto drink problem of possibly drinking other things than clean water if its available.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
