### PR TITLE
Feature: character stat requirements in recipes

### DIFF
--- a/data/json/recipes/other/medical.json
+++ b/data/json/recipes/other/medical.json
@@ -31,10 +31,11 @@
     "time": "16 s",
     "autolearn": true,
     "flags": [ "BLIND_EASY" ],
-    "//": "using brute force, so not very precise, but still relatively fast;  can't make str requirement for the recipe; so assume relatively weak character tries to rip it",
     "//2": "Too simple to learn any tailoring or healthcare.",
     "result_mult": 2,
-    "components": [ [ [ "sheet_cotton", 1 ], [ "sheet_cotton_patchwork", 1 ] ] ]
+    "components": [ [ [ "sheet_cotton", 1 ], [ "sheet_cotton_patchwork", 1 ] ] ],
+    "//": "Ripping the sheet uses brute force rather than precision, so relatively weak characters cannot do it.",
+    "character_requirements": { "str": 9 }
   },
   {
     "result": "bandages_makeshift",

--- a/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
+++ b/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
@@ -40,6 +40,12 @@ Crafting recipes are defined as a JSON object with the following fields:
 "delete_flags": [ "CANNIBALISM" ], // Optional (default: empty list). Flags specified here will be removed from the resultant item upon crafting. This will override flag inheritance, but *will not* delete flags that are part of the item type itself.
 "skill_used": "fabrication", // Skill trained and used for success checks
 "skills_required": [["survival", 1], ["throw", 2]], // Skills required to unlock recipe
+"character_requirements": { // Optional final character stat values required to craft the recipe.
+  "str": 9, // Integer is an alias for { "min": 9 }
+  "dex": { "min": 6 },
+  "int": { "min": 4, "max": 10 },
+  "per": { "max": 12 }
+},
 "book_learn": {	             // (optional) Books that this recipe can be learned from.
     "textbook_anarch" : {    // ID of the book the recipe can be learned from
         "skill_level" : 7,   // Skill level at which it can be learned
@@ -119,9 +125,28 @@ Crafting recipes are defined as a JSON object with the following fields:
 ]
 ```
 
+#### `character_requirements`
+
+`character_requirements` optionally restricts a recipe to characters whose current final primary stat values satisfy the configured bounds. The supported members are `str`, `dex`, `int`, and `per`. Final values include all modifiers currently affecting the character.
+
+Each member can be written as an integer or as an object containing `min`, `max`, or both:
+
+```jsonc
+"character_requirements": {
+  "str": 9,                         // Equivalent to { "min": 9 }.
+  "dex": { "min": 6 },
+  "int": { "min": 4, "max": 10 }, // Both bounds are inclusive.
+  "per": { "max": 12 }             // The maximum is inclusive.
+}
+```
+
+A bound of `0` is valid but has no effect. A stat entry whose configured bounds are all zero is ignored. The recipe cannot be started while any effective bound is unmet.
+
+When a recipe with `copy-from` defines `character_requirements`, the entire inherited object is replaced. Members omitted from the child object are not inherited individually.
+
 #### `batch_time_factors`
 
-`batch_time_factors supports several formats, with two different scaling functions.
+`batch_time_factors` supports several formats, with two different scaling functions.
 
 Logistic scaling provides savings of some percent once the batch reaches a certain size.
 ```jsonc

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -17,6 +17,7 @@
 #include "activity_actor.h"
 #include "activity_actor_definitions.h"
 #include "addiction.h"
+#include "bonuses.h"
 #include "clone_ptr.h"
 #include "anatomy.h"
 #include "avatar.h"
@@ -3280,6 +3281,22 @@ int Character::get_per_bonus() const
 int Character::get_int_bonus() const
 {
     return int_bonus;
+}
+
+int Character::get_primary_stat_value( const scaling_stat stat ) const
+{
+    switch( stat ) {
+        case STAT_STR:
+            return get_str();
+        case STAT_DEX:
+            return get_dex();
+        case STAT_INT:
+            return get_int();
+        case STAT_PER:
+            return get_per();
+        default:
+            cata_fatal( "Invalid primary character stat" );
+    }
 }
 
 int Character::get_enchantment_speed_bonus() const

--- a/src/character.h
+++ b/src/character.h
@@ -24,6 +24,7 @@
 #include "activity_tracker.h"
 #include "body_part_set.h"
 #include "bodypart.h"
+#include "bonuses.h"
 #include "calendar.h"
 #include "cata_utility.h"
 #include "character_attire.h"
@@ -592,6 +593,9 @@ class Character : public Creature, public visitable
         int get_dex_bonus() const;
         int get_per_bonus() const;
         int get_int_bonus() const;
+
+        // Returns the current value of one of the four primary character stats: str, dex, int, or per.
+        int get_primary_stat_value( scaling_stat stat ) const;
 
         /** Cache variables to store stamina use info
         *   these will be updated when the player's limb makeup changes

--- a/src/character.h
+++ b/src/character.h
@@ -86,6 +86,8 @@ class ui_adaptor;
 class vehicle;
 class vpart_reference;
 
+enum scaling_stat : int;
+
 namespace catacurses
 {
 class window;

--- a/src/character.h
+++ b/src/character.h
@@ -24,7 +24,6 @@
 #include "activity_tracker.h"
 #include "body_part_set.h"
 #include "bodypart.h"
-#include "bonuses.h"
 #include "calendar.h"
 #include "cata_utility.h"
 #include "character_attire.h"

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -628,7 +628,8 @@ bool Character::can_make( const recipe *r, int batch_size ) const
         return false;
     }
 
-    if( !r->character_has_required_proficiencies( *this ) ) {
+    if( !r->character_has_required_proficiencies( *this ) ||
+        !r->character_meets_requirements( *this ) ) {
         return false;
     }
 
@@ -643,7 +644,8 @@ bool Character::can_start_craft( const recipe *rec, recipe_filter_flags flags,
         return false;
     }
 
-    if( !rec->character_has_required_proficiencies( *this ) ) {
+    if( !rec->character_has_required_proficiencies( *this ) ||
+        !rec->character_meets_requirements( *this ) ) {
         return false;
     }
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+#include "bonuses.h"
 #include "calendar.h"
 #include "cata_imgui.h"
 #include "cata_utility.h"
@@ -76,6 +77,47 @@ namespace
 {
 
 generic_factory<crafting_category> craft_cat_list( "recipe_category" );
+
+constexpr std::array character_requirement_display_order = { STAT_STR, STAT_DEX, STAT_INT, STAT_PER };
+
+std::string character_stat_name( const scaling_stat stat )
+{
+    switch( stat ) {
+        case STAT_STR:
+            return _( "strength" );
+        case STAT_DEX:
+            return _( "dexterity" );
+        case STAT_INT:
+            return _( "intelligence" );
+        case STAT_PER:
+            return _( "perception" );
+        default:
+            return "<-error->";
+    }
+}
+
+std::string character_requirement_text( const scaling_stat stat,
+                                        const character_stat_requirement &requirement,
+                                        int current,
+                                        const bool is_met )
+{
+    const std::string name = character_stat_name( stat );
+    std::string text;
+    if( requirement.min && requirement.max ) {
+        text = string_format( "%s %d..%d", name, *requirement.min, *requirement.max );
+    } else if( requirement.min ) {
+        text = string_format( "%s %d", name, *requirement.min );
+    } else {
+        text = string_format( "%s ≤%d", name, *requirement.max );
+    }
+
+    if( !is_met ) {
+        //~ Shown after an unmet crafting stat requirement. %1$s: stat name, %2$d: current stat value
+        text += string_format( _( " (current %1$s %2$d)" ), name, current );
+    }
+
+    return text;
+}
 
 } // namespace
 
@@ -1279,8 +1321,10 @@ void crafting_ui_impl::draw_recipe_info_panel()
         }
 
         // --- Recipe ---
-        const bool has_recipe_content = !recp.is_nested() &&
-                                        ( !recp.simple_requirements().is_empty() || recp.has_steps() );
+        const bool has_recipe_content = !recp.is_nested() && (
+                                            recp.has_character_requirements() ||
+                                            !recp.simple_requirements().is_empty() ||
+                                            recp.has_steps() );
         if( has_recipe_content ) {
             ImGui::NewLine();
             {
@@ -1303,6 +1347,25 @@ void crafting_ui_impl::draw_recipe_info_panel()
                 ImGui::TextColored( cataimgui::imvec4_from_color( c_white ),
                                     "%s", step.name.translated().c_str() );
                 ImGui::NewLine();
+            }
+
+            if( recp.has_character_requirements() ) {
+                //~ Header shown above a recipe's required primary character stats.
+                ImGui::TextColored( cataimgui::imvec4_from_color( c_white ), "%s", _( "Character requirements:" ) );
+                const auto &requirements = recp.get_character_requirements();
+                for( const scaling_stat stat : character_requirement_display_order ) {
+                    const auto found = requirements.find( stat );
+                    if( found == requirements.end() ) {
+                        continue;
+                    }
+                    const character_stat_requirement &requirement = found->second;
+                    const int value = crafter->get_primary_stat_value( stat );
+                    const bool is_met = requirement.is_met( value );
+                    const nc_color color = is_met ? c_green : c_red;
+                    const std::string text = character_requirement_text( stat, requirement, value, is_met );
+                    ImGui::TextColored( cataimgui::imvec4_from_color( color ), "\u2022  %s", text.c_str() );
+                }
+                ImGui::Spacing();
             }
 
             // Components (always recipe-level)

--- a/src/crafting_gui_helpers.cpp
+++ b/src/crafting_gui_helpers.cpp
@@ -115,6 +115,7 @@ availability::availability( Character &_crafter, const recipe *r, int batch_size
                                 || crafter.get_knowledge_level( rec->skill_used )
                                 >= static_cast<int>( rec->get_difficulty( crafter ) * 0.8f );
     has_proficiencies = r->character_has_required_proficiencies( crafter );
+    const bool meets_character_requirements = r->character_meets_requirements( crafter );
     std::string reason;
     craft_flags flag = camp_crafting ? craft_flags::none : craft_flags::start_only;
 
@@ -124,6 +125,7 @@ availability::availability( Character &_crafter, const recipe *r, int batch_size
         can_craft = check_can_craft_nested( _crafter, *r );
     } else {
         can_craft = ( !r->is_practice() || has_all_skills ) && has_proficiencies &&
+                    meets_character_requirements &&
                     req.can_make_with_inventory( inv, all_items_filter, batch_size, flag );
     }
     would_use_rotten = !req.can_make_with_inventory( inv, no_rotten_filter, batch_size,
@@ -134,6 +136,7 @@ availability::availability( Character &_crafter, const recipe *r, int batch_size
     is_nested_category = r->is_nested();
     const requirement_data &simple_req = r->simple_requirements();
     apparently_craftable = ( !r->is_practice() || has_all_skills ) && has_proficiencies &&
+                           meets_character_requirements &&
                            simple_req.can_make_with_inventory( inv, all_items_filter, batch_size, flag );
     for( const auto &[skill, skill_lvl] : r->required_skills ) {
         if( crafter.get_skill_level( skill ) < skill_lvl ) {

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1,6 +1,7 @@
 #include "recipe.h"
 
 #include <algorithm>
+#include <array>
 #include <climits>
 #include <cmath>
 #include <initializer_list>
@@ -10,6 +11,7 @@
 #include <sstream>
 #include <unordered_map>
 
+#include "bonuses.h"
 #include "cached_options.h"
 #include "calendar.h"
 #include "cartesian_product.h"
@@ -60,6 +62,20 @@ static const morale_type morale_fun_craft( "morale_fun_craft" );
 static const morale_type morale_shitty_craft( "morale_shitty_craft" );
 
 static const std::string flag_FULL_MAGAZINE( "FULL_MAGAZINE" );
+
+namespace
+{
+
+constexpr std::array<std::pair<std::string_view, scaling_stat>, 4> character_requirement_members
+= { {
+        { "str", STAT_STR },
+        { "dex", STAT_DEX },
+        { "int", STAT_INT },
+        { "per", STAT_PER }
+    }
+};
+
+} // namespace
 
 
 std::string recipe::get_description( const Character &crafter ) const
@@ -233,6 +249,42 @@ bool recipe::has_flag( const std::string &flag_name ) const
     return flags.count( flag_name );
 }
 
+static character_stat_requirement load_character_stat_requirement( const JsonObject &parent,
+        const std::string_view &member )
+{
+    const JsonValue value = parent.get_member( member );
+    character_stat_requirement requirement;
+    if( value.test_int() ) {
+        requirement.min = value.get_int();
+    } else {
+        if( !value.test_object() ) {
+            parent.throw_error_at( member, "character requirement must be an integer or an object" );
+        }
+
+        const JsonObject range = value.get_object();
+        if( !range.has_member( "min" ) && !range.has_member( "max" ) ) {
+            range.throw_error( "character requirement object must contain min or max" );
+        }
+        if( range.has_member( "min" ) ) {
+            requirement.min = range.get_int( "min" );
+        }
+        if( range.has_member( "max" ) ) {
+            requirement.max = range.get_int( "max" );
+        }
+    }
+
+    if( requirement.min && *requirement.min == 0 ) {
+        requirement.min.reset();
+    }
+    if( requirement.max && *requirement.max == 0 ) {
+        requirement.max.reset();
+    }
+    if( requirement.min && requirement.max && *requirement.min > *requirement.max ) {
+        parent.throw_error_at( member, "character requirement min cannot exceed max" );
+    }
+    return requirement;
+}
+
 void recipe::load( const JsonObject &jo, const std::string_view src )
 {
     abstract = jo.has_string( "abstract" );
@@ -391,6 +443,20 @@ void recipe::load( const JsonObject &jo, const std::string_view src )
         } else {
             // single requirement
             required_skills[skill_id( sk.get_string( 0 ) )] = sk.get_int( 1 );
+        }
+    }
+
+    if( jo.has_member( "character_requirements" ) ) {
+        character_requirements_.clear();
+        JsonObject requirements = jo.get_object( "character_requirements" );
+        for( const auto &[member, stat] : character_requirement_members ) {
+            if( !requirements.has_member( member ) ) {
+                continue;
+            }
+            character_stat_requirement requirement = load_character_stat_requirement( requirements, member );
+            if( requirement.min || requirement.max ) {
+                character_requirements_.emplace( stat, requirement );
+            }
         }
     }
 
@@ -1728,6 +1794,26 @@ static std::string required_skills_as_string( const std::vector<std::pair<skill_
     [&]( const std::pair<skill_id, int> &skill ) {
         return string_format( "<color_white>%s (%d)</color>", skill.first->name(), skill.second );
     } );
+}
+
+bool recipe::character_meets_requirements( const Character &character ) const
+{
+    for( const auto &[stat, requirement] : character_requirements_ ) {
+        if( !requirement.is_met( character.get_primary_stat_value( stat ) ) ) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool recipe::has_character_requirements() const
+{
+    return !character_requirements_.empty();
+}
+
+const std::map<scaling_stat, character_stat_requirement> &recipe::get_character_requirements() const
+{
+    return character_requirements_;
 }
 
 std::string recipe::primary_skill_string( const Character &c ) const

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "build_reqs.h"
+#include "bonuses.h"
 #include "calendar.h"
 #include "crafting_enums.h"
 #include "proficiency.h"
@@ -52,6 +53,19 @@ struct enum_traits<recipe_time_flag> {
 template<>
 struct enum_traits<recipe_filter_flags> {
     static constexpr bool is_flag_enum = true;
+};
+
+
+// Inclusive minimum and maximum values for one character stat requirement.
+struct character_stat_requirement {
+    // Inclusive minimum value, or no lower bound when unset.
+    std::optional<int> min;
+    // Inclusive maximum value, or no upper bound when unset.
+    std::optional<int> max;
+    // Returns true if the supplied value satisfies both configured bounds.
+    bool is_met( int value ) const {
+        return ( !min || value >= *min ) && ( !max || value <= *max );
+    }
 };
 
 struct recipe_proficiency {
@@ -286,6 +300,13 @@ class recipe
 
         std::set<flag_id> flags_to_delete; // Flags to delete from the resultant item.
 
+        // Returns true if the character satisfies all configured stat requirements.
+        bool character_meets_requirements( const Character &character ) const;
+        // Returns true if the recipe has any character stat requirements.
+        bool has_character_requirements() const;
+        // Returns the character stat requirements configured for this recipe.
+        const std::map<scaling_stat, character_stat_requirement> &get_character_requirements() const;
+
         // Create a string list to describe the skill requirements for this recipe
         // Format: skill_name(level/amount), skill_name(level/amount)
         // Character object (if provided) used to color levels
@@ -461,6 +482,9 @@ class recipe
 
         /** Requires specified inline with the recipe (and replaced upon inheritance) */
         std::vector<std::pair<requirement_id, int>> reqs_internal;
+
+        /** Character stat requirements. */
+        std::map<scaling_stat, character_stat_requirement> character_requirements_;
 
         /** Combined requirements cached when recipe finalized */
         requirement_data requirements_;

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -15,7 +15,6 @@
 #include <vector>
 
 #include "build_reqs.h"
-#include "bonuses.h"
 #include "calendar.h"
 #include "crafting_enums.h"
 #include "proficiency.h"

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -33,6 +33,8 @@ class read_only_visitable;
 class recipe;
 template <typename E> struct enum_traits;
 
+enum scaling_stat : int;
+
 enum class recipe_filter_flags : int {
     none = 0,
     no_rotten = 1,

--- a/tests/recipe_character_requirements_test.cpp
+++ b/tests/recipe_character_requirements_test.cpp
@@ -37,7 +37,7 @@ static void set_primary_stats( Character &character, const int str, const int de
     character.set_per_bonus( 0 );
 }
 
-TEST_CASE( "recipe character requirements load as minimum stat values",
+TEST_CASE( "recipe_character_requirements_load_as_minimum_stat_values",
            "[recipe][character_requirements][json]" )
 {
     const recipe &result = recipe_cudgel_character_requirements_all_stats.obj();
@@ -52,7 +52,7 @@ TEST_CASE( "recipe character requirements load as minimum stat values",
     CHECK( requirements.at( STAT_PER ) == 12 );
 }
 
-TEST_CASE( "zero character requirements have no effect",
+TEST_CASE( "zero_character_requirements_have_no_effect",
            "[recipe][character_requirements][json]" )
 {
     const recipe &result = recipe_cudgel_character_requirements_zero_entries.obj();
@@ -61,7 +61,7 @@ TEST_CASE( "zero character requirements have no effect",
     CHECK( result.get_character_requirements().empty() );
 }
 
-TEST_CASE( "recipe character requirements inheritance",
+TEST_CASE( "recipe_character_requirements_inheritance",
            "[recipe][character_requirements][json][copy-from]" )
 {
     SECTION( "omitting the field preserves inherited requirements" ) {
@@ -91,7 +91,7 @@ TEST_CASE( "recipe character requirements inheritance",
     }
 }
 
-TEST_CASE( "recipe character requirements use final primary stat values",
+TEST_CASE( "recipe_character_requirements_use_final_primary_stat_values",
            "[recipe][character_requirements][character]" )
 {
     avatar &character = get_avatar();
@@ -118,7 +118,7 @@ TEST_CASE( "recipe character requirements use final primary stat values",
     }
 }
 
-TEST_CASE( "character requirements affect craft start availability",
+TEST_CASE( "character_requirements_affect_craft_start_availability",
            "[recipe][character_requirements][crafting]" )
 {
     avatar &character = get_avatar();

--- a/tests/recipe_character_requirements_test.cpp
+++ b/tests/recipe_character_requirements_test.cpp
@@ -1,0 +1,315 @@
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "avatar.h"
+#include "bonuses.h"
+#include "cata_catch.h"
+#include "character.h"
+#include "json_loader.h"
+#include "player_helpers.h"
+#include "recipe.h"
+#include "string_formatter.h"
+
+namespace
+{
+
+recipe load_test_recipe( const std::string_view character_requirements,
+                         const std::string_view id_suffix = "character_requirements_test" )
+{
+    const std::string json = string_format( R"({
+        "type": "recipe",
+        "result": "cudgel",
+        "id_suffix": "%s",
+        "category": "CC_WEAPON",
+        "subcategory": "CSC_WEAPON_BASHING",
+        "skill_used": "fabrication",
+        "difficulty": 0,
+        "time": "1 s",
+        "activity_level": "LIGHT_EXERCISE",
+        "character_requirements": %s
+    })", std::string( id_suffix ), std::string( character_requirements ) );
+
+    const JsonObject jo = json_loader::from_string( json );
+    recipe result;
+    result.load( jo, "dda" );
+    return result;
+}
+
+recipe load_test_recipe_without_character_requirements(
+    const std::string_view id_suffix = "no_character_requirements_test" )
+{
+    const std::string json = string_format( R"({
+        "type": "recipe",
+        "result": "cudgel",
+        "id_suffix": "%s",
+        "category": "CC_WEAPON",
+        "subcategory": "CSC_WEAPON_BASHING",
+        "skill_used": "fabrication",
+        "difficulty": 0,
+        "activity_level": "LIGHT_EXERCISE",
+        "time": "1 s"
+    })", std::string( id_suffix ) );
+
+    const JsonObject jo = json_loader::from_string( json );
+    recipe result;
+    result.load( jo, "dda" );
+    return result;
+}
+
+// Simulate copy-from by loading the base and child JSON onto the same object.
+// This matches recipe_dictionary::load() behavior.
+recipe load_base_then_child( const std::string_view base_requirements,
+                             const std::optional<std::string_view> &child_requirements )
+{
+    recipe result = load_test_recipe( base_requirements, "character_requirements_base_test" );
+    result.was_loaded = true;
+
+    std::string child_json = R"({
+        "type": "recipe",
+        "result": "cudgel",
+        "id_suffix": "character_requirements_child_test",
+        "copy-from": "cudgel_character_requirements_base_test"
+    )";
+    if( child_requirements ) {
+        child_json += string_format( R"(, "character_requirements": %s)",
+                                     std::string( *child_requirements ) );
+    }
+    child_json += '}';
+
+    const JsonObject jo = json_loader::from_string( child_json );
+    jo.allow_omitted_members();
+    result.load( jo, "dda" );
+    return result;
+}
+
+void set_primary_stats( Character &character, const int str, const int dex, const int intel,
+                        const int per )
+{
+    character.set_str_base( str );
+    character.set_dex_base( dex );
+    character.set_int_base( intel );
+    character.set_per_base( per );
+    character.set_str_bonus( 0 );
+    character.set_dex_bonus( 0 );
+    character.set_int_bonus( 0 );
+    character.set_per_bonus( 0 );
+}
+
+} // namespace
+
+TEST_CASE( "character stat requirement bounds are inclusive",
+           "[recipe][character_requirements]" )
+{
+    character_stat_requirement requirement;
+
+    SECTION( "no bounds" ) {
+        CHECK( requirement.is_met( 0 ) );
+        CHECK( requirement.is_met( 10 ) );
+    }
+
+    SECTION( "minimum only" ) {
+        requirement.min = 5;
+
+        CHECK_FALSE( requirement.is_met( 4 ) );
+        CHECK( requirement.is_met( 5 ) );
+        CHECK( requirement.is_met( 6 ) );
+    }
+
+    SECTION( "maximum only" ) {
+        requirement.max = 10;
+
+        CHECK( requirement.is_met( 9 ) );
+        CHECK( requirement.is_met( 10 ) );
+        CHECK_FALSE( requirement.is_met( 11 ) );
+    }
+
+    SECTION( "minimum and maximum" ) {
+        requirement.min = 5;
+        requirement.max = 10;
+
+        CHECK_FALSE( requirement.is_met( 4 ) );
+        CHECK( requirement.is_met( 5 ) );
+        CHECK( requirement.is_met( 10 ) );
+        CHECK_FALSE( requirement.is_met( 11 ) );
+    }
+}
+
+TEST_CASE( "recipe character requirements load from supported JSON forms",
+           "[recipe][character_requirements][json]" )
+{
+    const recipe result = load_test_recipe( R"({
+        "str": 9,
+        "dex": { "min": 6 },
+        "int": { "min": 4, "max": 10 },
+        "per": { "max": 12 }
+    })" );
+
+    REQUIRE( result.has_character_requirements() );
+    const std::map<scaling_stat, character_stat_requirement> &requirements =
+        result.get_character_requirements();
+    REQUIRE( requirements.size() == 4 );
+
+    CHECK( requirements.at( STAT_STR ).min == 9 );
+    CHECK_FALSE( requirements.at( STAT_STR ).max );
+
+    CHECK( requirements.at( STAT_DEX ).min == 6 );
+    CHECK_FALSE( requirements.at( STAT_DEX ).max );
+
+    CHECK( requirements.at( STAT_INT ).min == 4 );
+    CHECK( requirements.at( STAT_INT ).max == 10 );
+
+    CHECK_FALSE( requirements.at( STAT_PER ).min );
+    CHECK( requirements.at( STAT_PER ).max == 12 );
+}
+
+TEST_CASE( "zero character requirement bounds have no effect",
+           "[recipe][character_requirements][json]" )
+{
+    SECTION( "all zero entries are discarded" ) {
+        const recipe result = load_test_recipe( R"({
+            "str": 0,
+            "dex": { "min": 0 },
+            "int": { "max": 0 },
+            "per": { "min": 0, "max": 0 }
+        })" );
+
+        CHECK_FALSE( result.has_character_requirements() );
+        CHECK( result.get_character_requirements().empty() );
+    }
+
+    SECTION( "zero removes only its own bound" ) {
+        const recipe result = load_test_recipe( R"({
+            "str": { "min": 0, "max": 10 },
+            "dex": { "min": 5, "max": 0 }
+        })" );
+
+        const auto &requirements = result.get_character_requirements();
+        REQUIRE( requirements.size() == 2 );
+
+        CHECK_FALSE( requirements.at( STAT_STR ).min );
+        CHECK( requirements.at( STAT_STR ).max == 10 );
+        CHECK( requirements.at( STAT_DEX ).min == 5 );
+        CHECK_FALSE( requirements.at( STAT_DEX ).max );
+    }
+}
+
+TEST_CASE( "recipe character requirements inheritance",
+           "[recipe][character_requirements][json][copy-from]" )
+{
+    SECTION( "omitting the field preserves inherited requirements" ) {
+        const recipe result = load_base_then_child(
+                                  R"({ "str": 9, "dex": 6 })", std::nullopt );
+
+        const auto &requirements = result.get_character_requirements();
+        REQUIRE( requirements.size() == 2 );
+        CHECK( requirements.at( STAT_STR ).min == 9 );
+        CHECK( requirements.at( STAT_DEX ).min == 6 );
+    }
+
+    SECTION( "defining the field replaces all inherited requirements" ) {
+        const recipe result = load_base_then_child(
+                                  R"({ "str": 9, "dex": 6 })",
+                                  R"({ "per": 12 })" );
+
+        const auto &requirements = result.get_character_requirements();
+        REQUIRE( requirements.size() == 1 );
+        CHECK( requirements.count( STAT_STR ) == 0 );
+        CHECK( requirements.count( STAT_DEX ) == 0 );
+        CHECK( requirements.at( STAT_PER ).min == 12 );
+    }
+
+    SECTION( "an empty object clears all inherited requirements" ) {
+        const recipe result = load_base_then_child(
+                                  R"({ "str": 9, "dex": 6 })", R"({})" );
+
+        CHECK_FALSE( result.has_character_requirements() );
+        CHECK( result.get_character_requirements().empty() );
+    }
+}
+
+TEST_CASE( "invalid recipe character requirements are rejected",
+           "[recipe][character_requirements][json]" )
+{
+    SECTION( "minimum exceeds maximum" ) {
+        CHECK_THROWS_AS(
+            load_test_recipe( R"({ "str": { "min": 10, "max": 5 } })" ),
+            JsonError );
+    }
+
+    SECTION( "range object has no bounds" ) {
+        CHECK_THROWS_AS( load_test_recipe( R"({ "str": {} })" ), JsonError );
+    }
+
+    SECTION( "stat requirement has unsupported type" ) {
+        CHECK_THROWS_AS( load_test_recipe( R"({ "str": "high" })" ), JsonError );
+    }
+
+    SECTION( "character requirements field is not an object" ) {
+        CHECK_THROWS_AS( load_test_recipe( R"([])" ), JsonError );
+    }
+}
+
+TEST_CASE( "recipe character requirements use final primary stat values",
+           "[recipe][character_requirements][character]" )
+{
+    avatar &character = get_avatar();
+    clear_character( character );
+    set_primary_stats( character, 8, 6, 10, 12 );
+
+    const recipe result = load_test_recipe( R"({
+        "str": 9,
+        "dex": { "min": 6 },
+        "int": { "min": 4, "max": 10 },
+        "per": { "max": 12 }
+    })" );
+
+    SECTION( "an unmet minimum rejects the character" ) {
+        CHECK_FALSE( result.character_meets_requirements( character ) );
+    }
+
+    SECTION( "bonuses contribute to the final value" ) {
+        character.set_str_bonus( 1 );
+
+        REQUIRE( character.get_str() == 9 );
+        CHECK( result.character_meets_requirements( character ) );
+    }
+
+    SECTION( "an exceeded maximum rejects the character" ) {
+        character.set_str_base( 9 );
+        character.set_int_base( 11 );
+
+        CHECK_FALSE( result.character_meets_requirements( character ) );
+    }
+
+    SECTION( "inclusive maximum accepts an equal value" ) {
+        character.set_str_base( 9 );
+
+        REQUIRE( character.get_int() == 10 );
+        REQUIRE( character.get_per() == 12 );
+        CHECK( result.character_meets_requirements( character ) );
+    }
+}
+
+TEST_CASE( "character requirements affect craft start availability",
+           "[recipe][character_requirements][crafting]" )
+{
+    avatar &character = get_avatar();
+    clear_character( character );
+    set_primary_stats( character, 8, 8, 8, 8 );
+
+    recipe control = load_test_recipe_without_character_requirements();
+    recipe restricted = load_test_recipe( R"({ "str": 9 })" );
+    control.finalize();
+    restricted.finalize();
+
+    // Verify that the synthetic recipe itself is otherwise startable.  This keeps a failure
+    // in unrelated crafting prerequisites separate from the character requirement assertion.
+    REQUIRE( character.can_start_craft( &control, recipe_filter_flags::none ) );
+
+    CHECK_FALSE( character.can_start_craft( &restricted, recipe_filter_flags::none ) );
+
+    character.set_str_base( 9 );
+    CHECK( character.can_start_craft( &restricted, recipe_filter_flags::none ) );
+}

--- a/tests/recipe_character_requirements_test.cpp
+++ b/tests/recipe_character_requirements_test.cpp
@@ -7,6 +7,7 @@
 #include "bonuses.h"
 #include "cata_catch.h"
 #include "character.h"
+#include "flexbuffer_json.h"
 #include "json_loader.h"
 #include "player_helpers.h"
 #include "recipe.h"


### PR DESCRIPTION
#### Summary
Features "Add character stat requirements to crafting recipes"

#### Purpose of change

Some crafting actions should only be possible for characters whose current physical or mental capabilities meet the recipe's needs. This is required, for example, for recipes that represent forceful manual actions rather than skill-based work.

#### Describe the solution

Adds an optional `character_requirements` object to recipes with support for `str`, `dex`, `int`, and `per`.

Each stat can be defined either as a number, which acts as a minimum, or as an object with optional inclusive `min` and `max` bounds. Zero-valued bounds are accepted but ignored.

The requirements use the character's current final stat values, including active modifiers. Recipes that do not meet the requirements are shown as unavailable, cannot be started, and display the required values in the crafting interface. Child recipes that define `character_requirements` replace the inherited object rather than merging individual stats.

#### Describe alternatives you've considered

None.

#### Testing

Added automated tests covering:

- numeric minimum requirements;
- minimum-only, maximum-only, and bounded ranges;
- inclusive range boundaries;
- zero-bound normalization;
- inheritance, replacement, and clearing through `copy-from`;
- invalid JSON forms and invalid ranges;
- use of final modified character stats;
- integration with craft start availability.

All character requirement tests pass: 52 assertions in 7 test cases.

Also tested manually in the crafting interface to verify availability coloring, displayed requirements, and craft blocking.

#### Additional context

The initial use case is ripping a sheet by brute force, which now requires sufficient strength.
