### PR TITLE
add sound effect calls for lockpick break, damage, and success 

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3491,8 +3491,8 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
         here.furn_set( target, furn_f_gunsafe_mj );
     } else if( lock_roll > ( 1.5 * pick_roll ) ) {
         if( it->inc_damage() ) {
-        sounds::sound( target, 5, sounds::sound_t::combat, _( "Snap!" ),
-                    true, "tool", "lockpick_break" );
+            sounds::sound( target, 5, sounds::sound_t::combat, _( "Snap!" ),
+                           true, "tool", "lockpick_break" );
             who.add_msg_if_player( m_bad,
                                    _( "The lock stumps your efforts to pick it, and you destroy your tool." ) );
             destroy = true;

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3483,16 +3483,22 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
         } else {
             here.ter_set( target, new_ter_type );
         }
+        sounds::sound( target, 5, sounds::sound_t::combat, _( "Click!" ),
+                   true, "tool", "lockpick_success" );
         who.add_msg_if_player( m_good, open_message );
     } else if( furn_type == furn_f_gunsafe_ml && lock_roll > ( 3 * pick_roll ) ) {
         who.add_msg_if_player( m_bad, _( "Your clumsy attempt jams the lock!" ) );
         here.furn_set( target, furn_f_gunsafe_mj );
     } else if( lock_roll > ( 1.5 * pick_roll ) ) {
         if( it->inc_damage() ) {
+        sounds::sound( target, 5, sounds::sound_t::combat, _( "Snap!" ),
+                    true, "tool", "lockpick_break" );
             who.add_msg_if_player( m_bad,
                                    _( "The lock stumps your efforts to pick it, and you destroy your tool." ) );
             destroy = true;
         } else {
+        sounds::sound( target, 5, sounds::sound_t::combat, _( "Crrk!" ),
+                                true, "tool", "lockpick_damage" );
             who.add_msg_if_player( m_bad,
                                    _( "The lock stumps your efforts to pick it, and you damage your tool." ) );
         }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3497,8 +3497,8 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
                                    _( "The lock stumps your efforts to pick it, and you destroy your tool." ) );
             destroy = true;
         } else {
-        sounds::sound( target, 5, sounds::sound_t::combat, _( "Crrk!" ),
-                    true, "tool", "lockpick_damage" );
+            sounds::sound( target, 5, sounds::sound_t::combat, _( "Crrk!" ),
+                           true, "tool", "lockpick_damage" );
             who.add_msg_if_player( m_bad,
                                    _( "The lock stumps your efforts to pick it, and you damage your tool." ) );
         }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3484,7 +3484,7 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
             here.ter_set( target, new_ter_type );
         }
         sounds::sound( target, 5, sounds::sound_t::combat, _( "Click!" ),
-                   true, "tool", "lockpick_success" );
+                    true, "tool", "lockpick_success" );
         who.add_msg_if_player( m_good, open_message );
     } else if( furn_type == furn_f_gunsafe_ml && lock_roll > ( 3 * pick_roll ) ) {
         who.add_msg_if_player( m_bad, _( "Your clumsy attempt jams the lock!" ) );
@@ -3498,7 +3498,7 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
             destroy = true;
         } else {
         sounds::sound( target, 5, sounds::sound_t::combat, _( "Crrk!" ),
-                                true, "tool", "lockpick_damage" );
+                    true, "tool", "lockpick_damage" );
             who.add_msg_if_player( m_bad,
                                    _( "The lock stumps your efforts to pick it, and you damage your tool." ) );
         }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3484,7 +3484,7 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
             here.ter_set( target, new_ter_type );
         }
         sounds::sound( target, 5, sounds::sound_t::combat, _( "Click!" ),
-                    true, "tool", "lockpick_success" );
+                       true, "tool", "lockpick_success" );
         who.add_msg_if_player( m_good, open_message );
     } else if( furn_type == furn_f_gunsafe_ml && lock_roll > ( 3 * pick_roll ) ) {
         who.add_msg_if_player( m_bad, _( "Your clumsy attempt jams the lock!" ) );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I recalled hearing the satisfying click of a lock being picked successfully, but after loading up every soundpack I could find and every stable release within reason, I could not find that satisfying click anywhere. Maybe it was just a memory, but it shouldn't be just a memory.

#### Describe the solution
I added sound effect calls for lockpicking. 

#### Describe alternatives you've considered


#### Testing
1. I added some placeholder lockpick_break.ogg, lockpick_attempt, lockpick_success.ogg sounds to their respective tools folder.
2. I added all three to the effects json like so
```
"type": "sound_effect",
"id" : "tool",
"variant" : "lockpick_success",
"volume" : 70,
"files" : [
"effects/tools/lockpick_success.ogg"
```
3. loaded into game and listened with keen ears

https://github.com/user-attachments/assets/588732dd-5f67-4759-9d84-99f51689ae55

