### PR TITLE
[alt-map-key] Add new overmap terrain

### DIFF
--- a/data/mods/alt_map_key/overmap_terrain_pink.json
+++ b/data/mods/alt_map_key/overmap_terrain_pink.json
@@ -607,6 +607,27 @@
   },
   {
     "type": "overmap_terrain",
+    "id": "exo_base_safehouse_stone_0",
+    "copy-from": "exo_base_safehouse_stone_0",
+    "sym": "U",
+    "color": "pink"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "exo_base_safehouse_stone_1",
+    "copy-from": "exo_base_safehouse_stone_1",
+    "sym": "U",
+    "color": "pink"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "exo_base_safehouse_stone_2",
+    "copy-from": "exo_base_safehouse_stone_2",
+    "sym": "U",
+    "color": "pink"
+  },
+  {
+    "type": "overmap_terrain",
     "id": "slimepit_z0",
     "copy-from": "slimepit_z0",
     "name": "slime pit",


### PR DESCRIPTION
#### Summary
Mods "[alt-map-key] Add new overmap terrain"


#### Purpose of change
Adding new overmap terrain

#### Describe the solution
Add new exodii warehouse from #87794

#### Describe alternatives you've considered


#### Testing
<img width="143" height="110" alt="image" src="https://github.com/user-attachments/assets/503bc516-7e46-4c61-afb0-fe0da65ec933" />

#### Additional context



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
