### PR TITLE
Slightly larger feather

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -704,8 +704,8 @@
     "description": "A feather from a bird.  Useful for fletching arrows.",
     "material": [ "cotton" ],
     "flags": [ "NO_SALVAGE" ],
-    "volume": "1 ml",
-    "weight": "10 mg"
+    "volume": "50 ml",
+    "weight": "500 mg"
   },
   {
     "type": "ITEM",


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Make the feather slightly larger because i feel like it could be a bit larger. Also somewhat reduces the feather amount gained when butchering feathered being.

#### Describe the solution

from `"volume": "1 ml", "weight": "10 mg"` to `"volume": "50 ml" and "weight": "500 mg"`

#### Describe alternatives you've considered
None.

#### Testing

<img width="613" height="250" alt="Screenshot_20260804_073436" src="https://github.com/user-attachments/assets/86a3cac2-3341-4de9-b579-d7d65e9f837f" />
<img width="448" height="228" alt="Screenshot_20260804_072548" src="https://github.com/user-attachments/assets/459e430a-6868-4cdd-98cf-7b19ceef91c0" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
