### PR TITLE
Shallow pit can contain fire

### DIFF
--- a/data/json/furniture_and_terrain/terrain-traps.json
+++ b/data/json/furniture_and_terrain/terrain-traps.json
@@ -8,7 +8,8 @@
     "color": "yellow",
     "move_cost": 8,
     "flags": [ "TRANSPARENT", "DIGGABLE", "DIGGABLE_CAN_DEEPEN", "FIRE_CONTAINER" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true },
+    "examine_action": "fireplace"
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-traps.json
+++ b/data/json/furniture_and_terrain/terrain-traps.json
@@ -3,11 +3,11 @@
     "type": "terrain",
     "id": "t_pit_shallow",
     "name": "shallow pit",
-    "description": "A pit that could be dug even deeper or filled up.  Also useful as a starting foundation for some constructions.",
+    "description": "A pit that could be dug even deeper or filled up.  Also useful as a starting foundation for some constructions.  You can also use it to contain a fire.",
     "symbol": "0",
     "color": "yellow",
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "DIGGABLE_CAN_DEEPEN" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "DIGGABLE_CAN_DEEPEN", "FIRE_CONTAINER" ],
     "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Surely some shallow dug up pit can contain a fire, not like the park rangers are alive to complain to you about it.

#### Describe the solution
Give the shallow pit FIRE_CONTAINER flag and examine_action that brazier and the like got.

#### Describe alternatives you've considered

Extend it to pit? nah, too risky.

#### Testing
<img width="341" height="449" alt="Screenshot_20260804_182407" src="https://github.com/user-attachments/assets/d9b19fca-cfa5-4bdf-9edb-b8431a9e8486" />
<img width="804" height="785" alt="Screenshot_20260804_182400" src="https://github.com/user-attachments/assets/ee35842e-4f81-48f6-8178-889d16969ddb" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
