### PR TITLE
Add faults to all melee weapons

### DIFF
--- a/data/json/faults/fault_groups_melee.json
+++ b/data/json/faults/fault_groups_melee.json
@@ -110,5 +110,16 @@
       { "fault": "fault_aluminum_bat_bent_heavy", "weight": 50 },
       { "fault": "fault_aluminum_bat_handle_broken", "weight": 10 }
     ]
+  },
+  {
+    "type": "fault_group",
+    "id": "batons",
+    "//": "Mechanical damage of a baton",
+    "group": [
+      { "fault": "fault_baton_bent", "weight": 60 },
+      { "fault": "fault_baton_bent_tip", "weight": 100 },
+      { "fault": "fault_baton_broken_tip", "weight": 30 },
+      { "fault": "fault_baton_handle_broken", "weight": 10 }
+    ]
   }
 ]

--- a/data/json/faults/fault_groups_melee.json
+++ b/data/json/faults/fault_groups_melee.json
@@ -121,5 +121,11 @@
       { "fault": "fault_baton_broken_tip", "weight": 30 },
       { "fault": "fault_baton_handle_broken", "weight": 10 }
     ]
+  },
+  {
+    "type": "fault_group",
+    "id": "tonfas",
+    "//": "Mechanical damage of a tonfa",
+    "group": [ { "fault": "fault_tonfa_handle_broken", "weight": 70 }, { "fault": "fault_tonfa_broken", "weight": 30 } ]
   }
 ]

--- a/data/json/faults/fault_groups_melee.json
+++ b/data/json/faults/fault_groups_melee.json
@@ -100,5 +100,15 @@
       { "fault": "fault_staff_long_broken_half", "weight": 25 },
       { "fault": "fault_staff_long_broken", "weight": 5 }
     ]
+  },
+  {
+    "type": "fault_group",
+    "id": "aluminum_bat",
+    "//": "Mechanical damage of an aluminum bat",
+    "group": [
+      { "fault": "fault_aluminum_bat_bent", "weight": 100 },
+      { "fault": "fault_aluminum_bat_bent_heavy", "weight": 50 },
+      { "fault": "fault_aluminum_bat_handle_broken", "weight": 10 }
+    ]
   }
 ]

--- a/data/json/faults/faults_melee.json
+++ b/data/json/faults/faults_melee.json
@@ -304,6 +304,7 @@
     "//": "This fault is meant for batons.",
     "//1": "Ideally this would make it so you can't retract it anymore, this is not possible currently.",
     "fault_type": "mechanical_damage",
+    "name": { "str": "Broken handle" },
     "description": "The handle of the %s has seperated from the shaft, rendering it nigh unusable."
   },
   {
@@ -312,8 +313,9 @@
     "copy-from": "fault_handle_broken",
     "//": "This fault is meant for tonfas.",
     "fault_type": "mechanical_damage",
+    "name": { "str": "Broken handle" },
     "description": "The handle of the %s has broken off.",
-    "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.4 } ]
+    "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.6 } ]
   },
   {
     "type": "fault",
@@ -321,7 +323,7 @@
     "//": "This fault is meant for tonfas.",
     "fault_type": "mechanical_damage",
     "name": { "str": "Broken" },
-    "description": "The %s is completely broken.",
-    "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.2 } ]
+    "description": "The %s is broken in half.",
+    "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.1 } ]
   }
 ]

--- a/data/json/faults/faults_melee.json
+++ b/data/json/faults/faults_melee.json
@@ -250,7 +250,7 @@
     "name": { "str": "Collapsed" },
     "degradation_mod": 50,
     "description": "The %s has collapsed, a part of the once hollow bat is now touching inside of it due to heavy bending.  It is usable still but significantly less effective.",
-    "item_suffix": "bent",
+    "item_suffix": "collapsed",
     "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.5 } ]
   },
   {
@@ -263,5 +263,46 @@
     "description": "The handle of the %s has completely broken and seperated from the %s.",
     "item_suffix": "no handle",
     "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.1 } ]
+  },
+  {
+    "type": "fault",
+    "copy-from": "fault_aluminum_bat_bent",
+    "id": "fault_baton_bent",
+    "//0": "This fault is meant for batons.",
+    "//1": "Ideally this would make it so you can't retract it anymore, this is not possible currently.",
+    "fault_type": "mechanical_damage",
+    "description": "The shaft of the %s has been bent.",
+    "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.7 } ]
+  },
+  {
+    "type": "fault",
+    "id": "fault_baton_bent_tip",
+    "//": "This fault is meant for batons.",
+    "//1": "Ideally this would make it so you can't retract it anymore, maybe, this is not possible currently.",
+    "fault_type": "mechanical_damage",
+    "name": { "str": "Bent tip" },
+    "degradation_mod": 50,
+    "description": "The tip of the %s has been bent.",
+    "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.7 } ]
+  },
+  {
+    "type": "fault",
+    "id": "fault_baton_broken_tip",
+    "//": "This fault is meant for batons.",
+    "fault_type": "mechanical_damage",
+    "name": { "str": "Broken tip" },
+    "degradation_mod": 50,
+    "description": "The tip of the %s has broken off",
+    "block_faults": [ "fault_baton_bent_tip" ],
+    "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.5 } ]
+  },
+  {
+    "type": "fault",
+    "id": "fault_baton_handle_broken",
+    "copy-from": "fault_handle_broken",
+    "//": "This fault is meant for batons.",
+    "//1": "Ideally this would make it so you can't retract it anymore, this is not possible currently.",
+    "fault_type": "mechanical_damage",
+    "description": "The handle of the %s has seperated from the shaft, rendering it nigh unusable."
   }
 ]

--- a/data/json/faults/faults_melee.json
+++ b/data/json/faults/faults_melee.json
@@ -334,7 +334,7 @@
     "fault_type": "mechanical_damage",
     "name": { "str": "Broken shaft" },
     "degradation_mod": 100,
-    "description": "The pipe shaft of the %1$s has broken in half, you can still weild by holding onto the second pipe though, albeit it's very awkward and unwealdy.",
+    "description": "The pipe shaft of the %1$s has broken in half, you can still wield by holding onto the second pipe though, albeit it's very awkward and unwieldy.",
     "item_suffix": "broken shaft",
     "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.4 }, { "damage_id": "cut", "multiply": 0.4 } ]
   },

--- a/data/json/faults/faults_melee.json
+++ b/data/json/faults/faults_melee.json
@@ -304,5 +304,23 @@
     "//1": "Ideally this would make it so you can't retract it anymore, this is not possible currently.",
     "fault_type": "mechanical_damage",
     "description": "The handle of the %s has seperated from the shaft, rendering it nigh unusable."
+  },
+  {
+    "type": "fault",
+    "id": "fault_tonfa_handle_broken",
+    "copy-from": "fault_handle_broken",
+    "//": "This fault is meant for tonfas.",
+    "fault_type": "mechanical_damage",
+    "description": "The handle of the %s has broken off.",
+    "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.4 } ]
+  },
+  {
+    "type": "fault",
+    "id": "fault_tonfa_broken",
+    "//": "This fault is meant for tonfas.",
+    "fault_type": "mechanical_damage",
+    "name": { "str": "Broken" },
+    "description": "The %s is completely broken.",
+    "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.2 } ]
   }
 ]

--- a/data/json/faults/faults_melee.json
+++ b/data/json/faults/faults_melee.json
@@ -260,7 +260,7 @@
     "fault_type": "mechanical_damage",
     "name": { "str": "Broken handle" },
     "degradation_mod": 50,
-    "description": "The handle of the %s has completely broken and seperated from the %s.",
+    "description": "The handle of the %s has completely broken and separated from the %s.",
     "item_suffix": "no handle",
     "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.1 } ]
   },
@@ -305,7 +305,7 @@
     "//1": "Ideally this would make it so you can't retract it anymore, this is not possible currently.",
     "fault_type": "mechanical_damage",
     "name": { "str": "Broken handle" },
-    "description": "The handle of the %s has seperated from the shaft, rendering it nigh unusable."
+    "description": "The handle of the %s has separated from the shaft, rendering it nigh unusable."
   },
   {
     "type": "fault",

--- a/data/json/faults/faults_melee.json
+++ b/data/json/faults/faults_melee.json
@@ -271,6 +271,7 @@
     "//0": "This fault is meant for batons.",
     "//1": "Ideally this would make it so you can't retract it anymore, this is not possible currently.",
     "fault_type": "mechanical_damage",
+    "name": { "str": "Bent" },
     "description": "The shaft of the %s has been bent.",
     "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.7 } ]
   },

--- a/data/json/faults/faults_melee.json
+++ b/data/json/faults/faults_melee.json
@@ -230,5 +230,38 @@
       { "damage_id": "bash", "multiply": 0.2 }
     ],
     "affected_by_degradation": true
+  },
+  {
+    "type": "fault",
+    "id": "fault_aluminum_bat_bent",
+    "//": "This fault is meant for aluminum bats.",
+    "fault_type": "mechanical_damage",
+    "name": { "str": "Bent" },
+    "degradation_mod": 20,
+    "description": "The %s has been bent.",
+    "item_suffix": "bent",
+    "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.8 } ]
+  },
+  {
+    "type": "fault",
+    "id": "fault_aluminum_bat_bent_heavy",
+    "//": "This fault is meant for aluminum bats.",
+    "fault_type": "mechanical_damage",
+    "name": { "str": "Collapsed" },
+    "degradation_mod": 50,
+    "description": "The %s has collapsed, a part of the once hollow bat is now touching inside of it due to heavy bending.  It is usable still but significantly less effective.",
+    "item_suffix": "bent",
+    "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.5 } ]
+  },
+  {
+    "type": "fault",
+    "id": "fault_aluminum_bat_handle_broken",
+    "//": "This fault is meant for aluminum bats.",
+    "fault_type": "mechanical_damage",
+    "name": { "str": "Broken handle" },
+    "degradation_mod": 50,
+    "description": "The handle of the %s has completely broken and seperated from the %s.",
+    "item_suffix": "no handle",
+    "melee_damage_mod": [ { "damage_id": "bash", "multiply": 0.1 } ]
   }
 ]

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -1860,6 +1860,7 @@
       }
     ],
     "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "BELT_CLIP" ],
+    "faults": [ { "fault_group": "tonfas" } ],
     "weapon_category": [ "BATONS" ],
     "pocket_data": [
       {
@@ -1909,6 +1910,7 @@
     "material": [ "plastic" ],
     "techniques": [ "WBLOCK_2", "RAPID", "PRECISE" ],
     "flags": [ "DURABLE_MELEE", "BELT_CLIP" ],
+    "faults": [ { "fault_group": "tonfas" } ],
     "weapon_category": [ "BATONS" ],
     "volume": "2 L",
     "to_hit": { "grip": "weapon", "length": "short", "surface": "any", "balance": "good" },

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -166,7 +166,8 @@
     "use_action": { "menu_text": "Expand", "type": "transform", "target": "baton-extended", "msg": "You snap open your baton." },
     "to_hit": { "grip": "weapon", "length": "hand", "surface": "any", "balance": "neutral" },
     "price": "229 USD",
-    "melee_damage": { "bash": 4 }
+    "melee_damage": { "bash": 4 },
+    "faults": [ { "fault_group": "batons" } ]
   },
   {
     "type": "ITEM",
@@ -1627,7 +1628,8 @@
     "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "good" },
     "price": "300 USD",
     "price_postapoc": "7 USD 50 cent",
-    "melee_damage": { "bash": 14 }
+    "melee_damage": { "bash": 14 },
+    "faults": [ { "fault_group": "batons" } ]
   },
   {
     "type": "ITEM",
@@ -1647,7 +1649,8 @@
     "to_hit": { "grip": "weapon", "length": "short", "surface": "any", "balance": "neutral" },
     "price": "300 USD",
     "price_postapoc": "7 USD 50 cent",
-    "melee_damage": { "bash": 5 }
+    "melee_damage": { "bash": 5 },
+    "faults": [ { "fault_group": "batons" } ]
   },
   {
     "type": "ITEM",

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -120,6 +120,7 @@
     "volume": "1750 ml",
     "price": "160 USD",
     "melee_damage": { "bash": 22 },
+    "faults": [ { "fault_group": "aluminum_bat" } ],
     "weapon_category": [ "MACES" ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Add faults to melee weapons lacking them"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adding faults to melee weapons that don't have them 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Creating faults and fault groups and assigning them
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
creating more general faults and fault groups
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
faults happen when using the weapons over an over
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
- [x] aluminum bat, batons, tonfas
- [x] welded battle axe
- [x] check the other melees that aren't in bludgeons
- [x] add faults to unarmed_weapons
- [x] misc weapons
- [x] refine knuckle faults, check over everything (didn't make changes to knuckle faults)
- [x] fix typos
- [ ] final test

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
