### PR TITLE
Stop unattended crafts stalling when their crafter is unreachable

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1674,18 +1674,31 @@ static void craft_actualize_ready( item &craft, time_point now, const item_locat
     // Stamp consecutive unattended step at the just-consumed ready_at so a
     // chain catches up without losing wall-clock between them.
     const time_point step_end = craft.get_ready_at();
-    advance_passive_step( craft );
-    const int new_idx = craft.get_current_step();
-    bool wakeups_rebuilt = false;
-    if( new_idx < static_cast<int>( rec.steps().size() ) &&
-        rec.steps()[new_idx].attention == step_attention::unattended ) {
-        Character *next_crafter = resolve_crafter( craft.get_crafter_id() );
-        if( next_crafter != nullptr ) {
-            craft_stamp_passive_entry( craft, *next_crafter, step_end, loc );
-            wakeups_rebuilt = true;
+    // Resolve the next step's crafter before advancing: advance_passive_step
+    // clears every deadline and counter bound, so advancing into a passive step
+    // that cannot be stamped strands the craft with nothing left to wake it.
+    const int next_idx = step_idx + 1;
+    const bool next_is_passive = next_idx < static_cast<int>( rec.steps().size() ) &&
+                                 rec.steps()[next_idx].attention == step_attention::unattended;
+    Character *next_crafter = nullptr;
+    if( next_is_passive ) {
+        next_crafter = resolve_crafter( craft.get_crafter_id() );
+        if( next_crafter == nullptr && !craft.get_crafter_id().is_valid() ) {
+            // A craft with no crafter recorded can only be the avatar's.
+            next_crafter = &get_avatar();
+            craft.set_crafter_id( next_crafter->getID() );
+        }
+        if( next_crafter == nullptr ) {
+            // An NPC crafter outside the bubble: poll until they are reachable.
+            craft.set_ready_at( now + 1_minutes );
+            get_item_wakeups().rebuild_for_item( loc );
+            return;
         }
     }
-    if( !wakeups_rebuilt ) {
+    advance_passive_step( craft );
+    if( next_is_passive ) {
+        craft_stamp_passive_entry( craft, *next_crafter, step_end, loc );
+    } else {
         get_item_wakeups().rebuild_for_item( loc );
         fire_step_complete_distraction( completion_msg, flavor_msg, loc );
     }

--- a/tests/craft_attention_test.cpp
+++ b/tests/craft_attention_test.cpp
@@ -1355,6 +1355,110 @@ TEST_CASE( "craft_resolve_overdue_passive_chains_preserve_wall_time",
     }
 }
 
+TEST_CASE( "chained_unattended_step_stays_live_without_resolvable_crafter",
+           "[craft][attention][overdue][chain]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_consecutive_unattended.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+
+    // Cure A (idx 1) in flight with Cure B (idx 2) unattended behind it, so
+    // closing Cure A has to chain into another passive step.
+    on_map.set_current_step( 1 );
+    on_map.set_passive_started_at( calendar::turn );
+    on_map.set_ready_at( calendar::turn + 10_minutes );
+    on_map.set_passive_start_counter( 2500000 );
+    on_map.set_passive_end_counter( 5000000 );
+    on_map.set_step_plans( std::vector<attention_plan>( 4 ) );
+    // Crafter cannot be looked up: an NPC that left the bubble, or a craft
+    // that never got a crafter stamped onto it.
+    on_map.set_crafter_id( character_id() );
+    REQUIRE_FALSE( on_map.get_crafter_id().is_valid() );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+
+    GIVEN( "an overdue unattended step whose crafter cannot be resolved" ) {
+        WHEN( "the ready dispatch runs" ) {
+            craft_actualize_scheduled( on_map, item_wakeup_kind::ready_check,
+                                       calendar::turn + 10_minutes, loc );
+            REQUIRE( loc.get_item() != nullptr );
+
+            THEN( "the craft still carries a completion deadline" ) {
+                CAPTURE( on_map.get_current_step() );
+                CHECK( on_map.get_ready_at() != calendar::before_time_starts );
+            }
+
+            // Equal bounds switch the tname projection off, which pins the
+            // displayed percentage to the step that just closed.
+            THEN( "progress bounds still span a range" ) {
+                CAPTURE( on_map.get_current_step() );
+                CAPTURE( on_map.get_passive_start_counter() );
+                CAPTURE( on_map.get_passive_end_counter() );
+                CHECK( on_map.get_passive_end_counter() >
+                       on_map.get_passive_start_counter() );
+            }
+
+            THEN( "waiting out the remaining passive time reaches the active step" ) {
+                craft_resolve_overdue_passive( on_map, calendar::turn + 3_hours, loc );
+                REQUIRE( loc.get_item() != nullptr );
+                CHECK( on_map.get_current_step() == 3 );
+            }
+        }
+    }
+}
+
+TEST_CASE( "chained_unattended_step_holds_for_absent_npc_crafter",
+           "[craft][attention][overdue][chain]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    item ingredient( itype_2x4, calendar::turn );
+    item placed( &recipe_cudgel_test_consecutive_unattended.obj(), 1, ingredient );
+    item &on_map = here.add_item( origin, placed );
+    REQUIRE( on_map.is_craft() );
+
+    on_map.set_current_step( 1 );
+    on_map.set_passive_started_at( calendar::turn );
+    on_map.set_ready_at( calendar::turn + 10_minutes );
+    on_map.set_passive_start_counter( 2500000 );
+    on_map.set_passive_end_counter( 5000000 );
+    on_map.set_step_plans( std::vector<attention_plan>( 4 ) );
+    // A recorded crafter who is not the avatar and is not a loaded NPC: an
+    // NPC that walked out of the reality bubble mid-craft.
+    const character_id absent_npc( u.getID().get_value() + 1000 );
+    on_map.set_crafter_id( absent_npc );
+    REQUIRE( on_map.get_crafter_id().is_valid() );
+
+    item_location loc( map_cursor( here.get_abs( origin ) ), &on_map );
+
+    GIVEN( "an overdue unattended step whose crafter is an absent NPC" ) {
+        WHEN( "the ready dispatch runs" ) {
+            craft_actualize_scheduled( on_map, item_wakeup_kind::ready_check,
+                                       calendar::turn + 10_minutes, loc );
+            REQUIRE( loc.get_item() != nullptr );
+
+            THEN( "the step is held rather than advanced" ) {
+                CHECK( on_map.get_current_step() == 1 );
+            }
+
+            THEN( "a retry deadline keeps the craft reachable" ) {
+                CHECK( on_map.get_ready_at() == calendar::turn + 11_minutes );
+            }
+        }
+    }
+}
+
 TEST_CASE( "craft_actualize_ready_fail_at_precedes_ready",
            "[craft][attention][overdue][fail]" )
 {


### PR DESCRIPTION
#### Summary
Bugfixes "Unattended crafts no longer stall forever when their crafter is unreachable"

#### Purpose of change

An unattended step that finishes while its crafter cannot be looked up leaves the craft dead. Advancing the step wipes every deadline and both progress bounds, and the next step only gets stamped if the crafter resolves. When it doesn't, nothing is left to wake the craft: the wakeup queue rebuilds from item state, and an item with no deadlines asks for nothing.

The craft then sits at whatever percentage the previous step ended on and never moves again. Walking over and resuming it manually is the only way back.

Only hits unattended into unattended chains, so the broths, cheese powder, and a few modded recipes. Fixes #88114.

#### Describe the solution

Resolve the crafter before advancing rather than after. No crafter id recorded at all means the craft can only be the avatar's, so use that. A recorded NPC who left the bubble means hold the step and re-check in a minute, instead of advancing into a step nothing can finish.

#### Describe alternatives you've considered

Stamping the next step with whoever happens to be standing nearby. Cheap, and then step timing and tool access quietly come from the wrong character.

#### Testing

Two new tests, one per branch. Existing crafting tests pass. Verified in-game.

#### Additional context

There is a second route to the same frozen state: loading a save whose recipe changed step count makes `craft_data::deserialize` drop the passive timing and bounds, with the same no-wakeup result. Not touched yet, needs more thinkin.