### PR TITLE
Fix NEED_FULL_MAGAZINE rejecting ordinary recipe components

### DIFF
--- a/data/mods/TEST_DATA/recipe_need_full_magazine_test.json
+++ b/data/mods/TEST_DATA/recipe_need_full_magazine_test.json
@@ -1,0 +1,42 @@
+[
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "test_rock",
+    "id_suffix": "ordinary_stick_and_battery",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 0,
+    "time": "1 s",
+    "autolearn": true,
+    "components": [ [ [ "stick", 1 ] ], [ [ "medium_battery_cell", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "test_rock",
+    "id_suffix": "ordinary_stick_and_rock",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 0,
+    "time": "1 s",
+    "autolearn": true,
+    "components": [ [ [ "stick", 1 ] ], [ [ "rock", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "test_rock",
+    "id_suffix": "need_full_magazine_mixed",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 0,
+    "time": "1 s",
+    "autolearn": true,
+    "flags": [ "NEED_FULL_MAGAZINE" ],
+    "components": [ [ [ "chest_freezer", 1 ] ], [ [ "medium_battery_cell", 1 ] ] ]
+  }
+]

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -515,9 +515,11 @@ class crafting_ui_impl : public cataimgui::window
                                   int batch_size );
         void draw_requirement_tools( const requirement_data &req, const inventory &inv,
                                      int batch_size, int group_offset );
-        void draw_components( const requirement_data &req, const inventory &inv,
+        void draw_components( const requirement_data &req,
+                              const inventory &inv,
                               const std::function<bool( const item & )> &filter,
-                              int batch_size );
+                              int batch_size,
+                              bool need_full_magazine );
         void draw_item_info_panel();
         void draw_status_header();
         void draw_hidden_count();
@@ -1307,7 +1309,8 @@ void crafting_ui_impl::draw_recipe_info_panel()
 
             // Components (always recipe-level)
             draw_components( recp.simple_requirements(), crafting_inv,
-                             recp.get_component_filter(), batch_size );
+                             recp.get_component_filter(), batch_size,
+                             recp.has_flag( "NEED_FULL_MAGAZINE" ) );
 
             // Byproducts
             if( recp.has_byproducts() ) {
@@ -1845,8 +1848,10 @@ void crafting_ui_impl::draw_modifier_table( const recipe &recp,
 
 // Lazy-built lookup: sorted item IDs of a tool group -> requirement display name.
 void crafting_ui_impl::draw_components( const requirement_data &req,
-                                        const inventory &crafting_inv, const std::function<bool( const item & )> &filter,
-                                        int batch_size )
+                                        const inventory &crafting_inv,
+                                        const std::function<bool( const item & )> &filter,
+                                        int batch_size,
+                                        bool need_full_magazine )
 {
     const requirement_data::alter_item_comp_vector &comp_groups = req.get_components();
     if( comp_groups.empty() ) {
@@ -1863,6 +1868,16 @@ void crafting_ui_impl::draw_components( const requirement_data &req,
             return crafting_inv.charges_of( ic.type, INT_MAX, filter );
         }
         return crafting_inv.amount_of( ic.type, false, INT_MAX, filter );
+    };
+
+    const auto component_text = [batch_size, need_full_magazine]
+    ( const item_comp & comp, const int available ) {
+        std::string text = comp.to_string( batch_size, available );
+        if( need_full_magazine && item( comp.type ).is_magazine() ) {
+            //~ Appended to the name of a battery or ammunition magazine in the crafting menu.  It means the component must be completely charged or loaded.
+            text += _( " (full)" );
+        }
+        return text;
     };
 
     ImGui::TextColored( cataimgui::imvec4_from_color( c_white ), "%s",
@@ -1914,7 +1929,7 @@ void crafting_ui_impl::draw_components( const requirement_data &req,
                 }
                 nc_color col = ic->get_color( any_available, crafting_inv, filter, batch_size );
                 ImGui::TextColored( cataimgui::imvec4_from_color( col ), "%s",
-                                    ic->to_string( batch_size, avail_count( *ic ) ).c_str() );
+                                    component_text( *ic, avail_count( *ic ) ).c_str() );
             }
             if( nav_clickable( _( "show less" ), c_dark_gray ) ) {
                 expanded_comp_groups.erase( gi );
@@ -1927,7 +1942,7 @@ void crafting_ui_impl::draw_components( const requirement_data &req,
 
             int fits = 0;
             for( size_t i = 0; i < sorted_alts.size(); ++i ) {
-                std::string text = sorted_alts[i]->to_string( batch_size, avail_count( *sorted_alts[i] ) );
+                std::string text = component_text( *sorted_alts[i], avail_count( *sorted_alts[i] ) );
                 float tw = ImGui::CalcTextSize( text.c_str() ).x;
                 float sep = ( i > 0 ) ? or_w : 0.f;
                 int rem = static_cast<int>( sorted_alts.size() ) - fits - 1;
@@ -1955,7 +1970,7 @@ void crafting_ui_impl::draw_components( const requirement_data &req,
                 }
                 nc_color col = sorted_alts[i]->get_color( any_available, crafting_inv, filter, batch_size );
                 ImGui::TextColored( cataimgui::imvec4_from_color( col ), "%s",
-                                    sorted_alts[i]->to_string( batch_size, avail_count( *sorted_alts[i] ) ).c_str() );
+                                    component_text( *sorted_alts[i], avail_count( *sorted_alts[i] ) ).c_str() );
             }
 
             int remaining = static_cast<int>( sorted_alts.size() ) - fits;

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1876,12 +1876,13 @@ std::function<bool( const item & )> recipe::get_component_filter(
     std::function<bool( const item & )> magazine_filter = return_true<item>;
     if( has_flag( "NEED_FULL_MAGAZINE" ) ) {
         magazine_filter = []( const item & component ) {
+            if( !component.is_magazine() ) {
+                return true;
+            }
             if( component.ammo_remaining( ) == 0 ) {
                 return false;
             }
-            return !component.is_magazine() ||
-                   ( component.ammo_remaining( ) >= component.ammo_capacity(
-                         component.ammo_data()->ammo->type ) );
+            return component.ammo_remaining() >= component.ammo_capacity( component.ammo_data()->ammo->type );
         };
     }
 

--- a/tests/recipe_need_full_magazine_test.cpp
+++ b/tests/recipe_need_full_magazine_test.cpp
@@ -1,4 +1,5 @@
-#include "avatar.h"
+#include <string>
+
 #include "cata_catch.h"
 #include "character.h"
 #include "item.h"

--- a/tests/recipe_need_full_magazine_test.cpp
+++ b/tests/recipe_need_full_magazine_test.cpp
@@ -15,9 +15,12 @@ static const itype_id itype_medium_battery_cell( "medium_battery_cell" );
 static const itype_id itype_rock( "rock" );
 static const itype_id itype_stick( "stick" );
 
-static const recipe_id recipe_ordinary_stick_and_battery( "test_rock_ordinary_stick_and_battery" );
-static const recipe_id recipe_ordinary_stick_and_rock( "test_rock_ordinary_stick_and_rock" );
-static const recipe_id recipe_need_full_magazine_mixed( "test_rock_need_full_magazine_mixed" );
+static const recipe_id
+recipe_test_rock_ordinary_stick_and_battery( "test_rock_ordinary_stick_and_battery" );
+static const recipe_id
+recipe_test_rock_ordinary_stick_and_rock( "test_rock_ordinary_stick_and_rock" );
+static const recipe_id
+recipe_test_rock_need_full_magazine_mixed( "test_rock_need_full_magazine_mixed" );
 
 static const skill_id skill_fabrication( "fabrication" );
 
@@ -50,7 +53,8 @@ TEST_CASE( "ordinary_recipes_do_not_require_full_magazines", "[recipe][component
         guy.i_add( battery );
         guy.invalidate_crafting_inventory();
 
-        CHECK( guy.can_start_craft( &recipe_ordinary_stick_and_battery.obj(), recipe_filter_flags::none,
+        CHECK( guy.can_start_craft( &recipe_test_rock_ordinary_stick_and_battery.obj(),
+                                    recipe_filter_flags::none,
                                     1 ) );
     }
 
@@ -60,7 +64,8 @@ TEST_CASE( "ordinary_recipes_do_not_require_full_magazines", "[recipe][component
         guy.i_add( item( itype_rock ) );
         guy.invalidate_crafting_inventory();
 
-        CHECK( guy.can_start_craft( &recipe_ordinary_stick_and_rock.obj(), recipe_filter_flags::none, 1 ) );
+        CHECK( guy.can_start_craft( &recipe_test_rock_ordinary_stick_and_rock.obj(),
+                                    recipe_filter_flags::none, 1 ) );
     }
 }
 
@@ -77,7 +82,7 @@ TEST_CASE( "NEED_FULL_MAGAZINE_only_filters_magazine_components", "[recipe][comp
         guy.i_add( battery_with_charge( capacity ) );
         guy.invalidate_crafting_inventory();
 
-        CHECK( guy.can_start_craft( &recipe_need_full_magazine_mixed.obj(),
+        CHECK( guy.can_start_craft( &recipe_test_rock_need_full_magazine_mixed.obj(),
                                     recipe_filter_flags::none, 1 ) );
     }
 
@@ -85,7 +90,7 @@ TEST_CASE( "NEED_FULL_MAGAZINE_only_filters_magazine_components", "[recipe][comp
         guy.i_add( battery_with_charge( capacity / 2 ) );
         guy.invalidate_crafting_inventory();
 
-        CHECK_FALSE( guy.can_start_craft( &recipe_need_full_magazine_mixed.obj(),
+        CHECK_FALSE( guy.can_start_craft( &recipe_test_rock_need_full_magazine_mixed.obj(),
                                           recipe_filter_flags::none, 1 ) );
     }
 
@@ -93,7 +98,7 @@ TEST_CASE( "NEED_FULL_MAGAZINE_only_filters_magazine_components", "[recipe][comp
         guy.i_add( battery_with_charge( 0 ) );
         guy.invalidate_crafting_inventory();
 
-        CHECK_FALSE( guy.can_start_craft( &recipe_need_full_magazine_mixed.obj(),
+        CHECK_FALSE( guy.can_start_craft( &recipe_test_rock_need_full_magazine_mixed.obj(),
                                           recipe_filter_flags::none, 1 ) );
     }
 }

--- a/tests/recipe_need_full_magazine_test.cpp
+++ b/tests/recipe_need_full_magazine_test.cpp
@@ -16,12 +16,11 @@ static const itype_id itype_rock( "rock" );
 static const itype_id itype_stick( "stick" );
 
 static const recipe_id
+recipe_test_rock_need_full_magazine_mixed( "test_rock_need_full_magazine_mixed" );
+static const recipe_id
 recipe_test_rock_ordinary_stick_and_battery( "test_rock_ordinary_stick_and_battery" );
 static const recipe_id
 recipe_test_rock_ordinary_stick_and_rock( "test_rock_ordinary_stick_and_rock" );
-static const recipe_id
-recipe_test_rock_need_full_magazine_mixed( "test_rock_need_full_magazine_mixed" );
-
 static const skill_id skill_fabrication( "fabrication" );
 
 static item battery_with_charge( const int charges )

--- a/tests/recipe_need_full_magazine_test.cpp
+++ b/tests/recipe_need_full_magazine_test.cpp
@@ -1,0 +1,98 @@
+#include "avatar.h"
+#include "cata_catch.h"
+#include "character.h"
+#include "item.h"
+#include "map_helpers.h"
+#include "player_helpers.h"
+#include "recipe.h"
+#include "type_id.h"
+
+static const ammotype ammo_battery( "battery" );
+
+static const itype_id itype_chest_freezer( "chest_freezer" );
+static const itype_id itype_medium_battery_cell( "medium_battery_cell" );
+static const itype_id itype_rock( "rock" );
+static const itype_id itype_stick( "stick" );
+
+static const recipe_id recipe_ordinary_stick_and_battery( "test_rock_ordinary_stick_and_battery" );
+static const recipe_id recipe_ordinary_stick_and_rock( "test_rock_ordinary_stick_and_rock" );
+static const recipe_id recipe_need_full_magazine_mixed( "test_rock_need_full_magazine_mixed" );
+
+static const skill_id skill_fabrication( "fabrication" );
+
+static item battery_with_charge( const int charges )
+{
+    item battery( itype_medium_battery_cell );
+    battery.ammo_set( battery.ammo_default(), charges );
+    return battery;
+}
+
+static Character &prepare_crafter()
+{
+    clear_avatar();
+    clear_map();
+    Character &guy = get_player_character();
+    guy.set_skill_level( skill_fabrication, 10 );
+    return guy;
+}
+
+TEST_CASE( "ordinary_recipes_do_not_require_full_magazines", "[recipe][components][magazine]" )
+{
+    SECTION( "an incomplete magazine is accepted without the flag" ) {
+        Character &guy = prepare_crafter();
+        item battery( itype_medium_battery_cell );
+        const int capacity = battery.ammo_capacity( ammo_battery );
+        REQUIRE( capacity > 1 );
+        battery.ammo_set( battery.ammo_default(), capacity / 2 );
+
+        guy.i_add( item( itype_stick ) );
+        guy.i_add( battery );
+        guy.invalidate_crafting_inventory();
+
+        CHECK( guy.can_start_craft( &recipe_ordinary_stick_and_battery.obj(), recipe_filter_flags::none,
+                                    1 ) );
+    }
+
+    SECTION( "ordinary non-magazine components are unaffected" ) {
+        Character &guy = prepare_crafter();
+        guy.i_add( item( itype_stick ) );
+        guy.i_add( item( itype_rock ) );
+        guy.invalidate_crafting_inventory();
+
+        CHECK( guy.can_start_craft( &recipe_ordinary_stick_and_rock.obj(), recipe_filter_flags::none, 1 ) );
+    }
+}
+
+TEST_CASE( "NEED_FULL_MAGAZINE_only_filters_magazine_components", "[recipe][components][magazine]" )
+{
+    Character &guy = prepare_crafter();
+    const item battery( itype_medium_battery_cell );
+    const int capacity = battery.ammo_capacity( ammo_battery );
+    REQUIRE( capacity > 1 );
+
+    guy.i_add( item( itype_chest_freezer ) );
+
+    SECTION( "a full magazine and an ordinary component satisfy the recipe" ) {
+        guy.i_add( battery_with_charge( capacity ) );
+        guy.invalidate_crafting_inventory();
+
+        CHECK( guy.can_start_craft( &recipe_need_full_magazine_mixed.obj(),
+                                    recipe_filter_flags::none, 1 ) );
+    }
+
+    SECTION( "a half-full magazine does not satisfy the recipe" ) {
+        guy.i_add( battery_with_charge( capacity / 2 ) );
+        guy.invalidate_crafting_inventory();
+
+        CHECK_FALSE( guy.can_start_craft( &recipe_need_full_magazine_mixed.obj(),
+                                          recipe_filter_flags::none, 1 ) );
+    }
+
+    SECTION( "an empty magazine does not satisfy the recipe" ) {
+        guy.i_add( battery_with_charge( 0 ) );
+        guy.invalidate_crafting_inventory();
+
+        CHECK_FALSE( guy.can_start_craft( &recipe_need_full_magazine_mixed.obj(),
+                                          recipe_filter_flags::none, 1 ) );
+    }
+}


### PR DESCRIPTION
#### Summary
Bugfixes "Fix NEED_FULL_MAGAZINE rejecting ordinary recipe components"

#### Purpose of change

Recipes using the `NEED_FULL_MAGAZINE` flag could incorrectly reject some ordinary non-magazine components.

For example, a recipe requiring both a `chest_freezer` and a fully charged battery did not recognize a nearby `chest_freezer` as a valid component. Removing `NEED_FULL_MAGAZINE` made the same freezer valid again.

This happened because the component filter checked whether an item had any remaining ammunition before checking whether that item was actually a magazine. Ordinary items such as `chest_freezer` report zero remaining ammunition and could therefore be rejected by recipes using this flag.

The crafting interface also did not indicate that a magazine component had to be fully charged or loaded, making recipes using this flag less clear to the player.

#### Describe the solution

Reorder the component filter so that the full-charge requirement is only applied to magazine components.

Non-magazine components now pass through the filter normally. Magazine components must still be fully loaded when the recipe has `NEED_FULL_MAGAZINE`.

In the crafting interface, magazine components affected by `NEED_FULL_MAGAZINE` now receive a ` (full)` suffix after their name. This indicates that the battery or ammunition magazine must be completely charged or loaded.

#### Describe alternatives you've considered

The affected recipes could avoid using `NEED_FULL_MAGAZINE`, or require the magazine and its ammunition as separate components. Neither approach preserves the intended meaning of the flag, and both would require content-side workarounds for a bug in the shared component filter.

A new per-component condition was also unnecessary because the existing flag already has the intended semantics once non-magazine components are excluded from the charge check.

A longer interface label such as ` (must be full)` was considered, but ` (full)` conveys the same requirement while using less horizontal space in the component list.

#### Testing

Added automated tests in `tests/recipe_need_full_magazine_test.cpp` with supporting recipes in `data/mods/TEST_DATA`.

Verified that:

- a recipe without `NEED_FULL_MAGAZINE` accepts a partially charged battery;
- a recipe without the flag accepts ordinary non-magazine components;
- a recipe with `NEED_FULL_MAGAZINE` accepts a `chest_freezer` together with a fully charged battery;
- the same flagged recipe rejects a half-charged battery.

Also tested in-game with a mod draft and confirmed that:

- the previously rejected `chest_freezer` is recognized while the flag is present;
- affected magazine components are marked with ` (full)` in the crafting interface;
- ordinary non-magazine components do not receive the suffix.

#### Additional context

The original failure was limited to recipes using `NEED_FULL_MAGAZINE` where ordinary components were passed through the same filter as magazines. It did not affect ordinary recipes without the flag.