### PR TITLE
Slime has reduntant omnicellular parts

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2521,6 +2521,11 @@
     "info": "You burn in the sunlight like a vampire, but not quite as badly."
   },
   {
+    "id": "DISTRIBUTED_DAMAGE",
+    "type": "json_flag",
+    "info": "Damage you take is split evenly between your limbs"
+  },
+  {
     "id": "SHREDDED",
     "type": "json_flag",
     "info": "This is a small fragment."

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6907,7 +6907,8 @@
     "thirst": true,
     "visibility": 10,
     "ugliness": 10,
-    "enchantments": [ { "values": [ { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 2 } ] } ]
+    "enchantments": [ { "values": [ { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 2 } ] } ],
+    "flags": [ "DISTRIBUTED_DAMAGE" ]
   },
   {
     "type": "mutation",

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -167,6 +167,7 @@ static const json_character_flag json_flag_CANNIBAL( "CANNIBAL" );
 static const json_character_flag json_flag_CANNOT_GAIN_WEARINESS( "CANNOT_GAIN_WEARINESS" );
 static const json_character_flag json_flag_CANNOT_TAKE_DAMAGE( "CANNOT_TAKE_DAMAGE" );
 static const json_character_flag json_flag_DEAF( "DEAF" );
+static const json_character_flag json_flag_DISTRIBUTED_DAMAGE( "DISTRIBUTED_DAMAGE" );
 static const json_character_flag json_flag_GRAB( "GRAB" );
 static const json_character_flag json_flag_HEAL_OVERRIDE( "HEAL_OVERRIDE" );
 static const json_character_flag json_flag_NO_BODY_HEAT( "NO_BODY_HEAT" );
@@ -2590,7 +2591,25 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam,
 
     const int dam_to_bodypart = std::min( dam, get_part_hp_cur( part_to_damage ) );
 
-    mod_part_hp_cur( part_to_damage, - dam_to_bodypart );
+    if( has_flag( json_flag_DISTRIBUTED_DAMAGE ) ) {
+        int num_limbs = 0; // number of limbs
+        for( const std::pair<const bodypart_str_id, bodypart> &elem : get_body() ) {
+            if( elem.first == bodypart_str_id::NULL_ID() ) {
+                continue;
+            }
+            num_limbs++;
+        }
+        const int dam_per_part = dam / num_limbs;
+        for ( const bodypart_id &bp : get_all_body_parts() ) {
+            if( bp->main_part ) {
+                mod_part_hp_cur( bp, -dam_per_part);
+            }
+        }
+        
+    } else { 
+        mod_part_hp_cur( part_to_damage, - dam_to_bodypart );
+    }
+    
     if( source ) {
         cata::event e = cata::event::make<event_type::character_takes_damage>( getID(), dam_to_bodypart,
                         part_to_damage.id(), pain );

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -2600,16 +2600,16 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam,
             num_limbs++;
         }
         const int dam_per_part = dam / num_limbs;
-        for ( const bodypart_id &bp : get_all_body_parts() ) {
+        for( const bodypart_id &bp : get_all_body_parts() ) {
             if( bp->main_part ) {
-                mod_part_hp_cur( bp, -dam_per_part);
+                mod_part_hp_cur( bp, -dam_per_part );
             }
         }
-        
-    } else { 
+
+    } else {
         mod_part_hp_cur( part_to_damage, - dam_to_bodypart );
     }
-    
+
     if( source ) {
         cata::event e = cata::event::make<event_type::character_takes_damage>( getID(), dam_to_bodypart,
                         part_to_damage.id(), pain );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1288,7 +1288,7 @@ void Creature::messaging_projectile_attack( const Creature *source,
         } else if( is_avatar() ) {
             //monster hits player ranged
             //~ Hit message. 1$s is bodypart name in accusative. 2$d is damage value.  If you have DISTRIBUTED_DAMAGE, don't print bodypart--you're hit everywhere
-            if( has_flag (json_flag_DISTRIBUTED_DAMAGE) ) {
+            if( has_flag( json_flag_DISTRIBUTED_DAMAGE ) ) {
                 add_msg_if_player( m_bad, _( "You were hit for %2$d total damage." ) );
             } else {
                 add_msg_if_player( m_bad, _( "You were hit in the %1$s for %2$d damage." ),

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1289,7 +1289,7 @@ void Creature::messaging_projectile_attack( const Creature *source,
             //monster hits player ranged
             //~ Hit message. 1$s is bodypart name in accusative. 2$d is damage value.  If you have DISTRIBUTED_DAMAGE, don't print bodypart--you're hit everywhere
             if( has_flag (json_flag_DISTRIBUTED_DAMAGE) ) {
-                add_msg_if_player( m_bad, _( "You were hit for %2$d damage." ) );
+                add_msg_if_player( m_bad, _( "You were hit for %2$d total damage." ) );
             } else {
                 add_msg_if_player( m_bad, _( "You were hit in the %1$s for %2$d damage." ),
                                                body_part_name_accusative( hit_selection.bp_hit ),

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1292,8 +1292,8 @@ void Creature::messaging_projectile_attack( const Creature *source,
                 add_msg_if_player( m_bad, _( "You were hit for %2$d total damage." ) );
             } else {
                 add_msg_if_player( m_bad, _( "You were hit in the %1$s for %2$d damage." ),
-                                               body_part_name_accusative( hit_selection.bp_hit ),
-                                               total_damage );
+                                   body_part_name_accusative( hit_selection.bp_hit ),
+                                   total_damage );
             }
             add_msg_if_player( m_bad, _( "You were hit in the %1$s for %2$d damage." ) );
         } else if( source != nullptr ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -134,6 +134,7 @@ static const json_character_flag json_flag_BIONIC_LIMB( "BIONIC_LIMB" );
 static const json_character_flag json_flag_CANNOT_GAIN_EFFECTS( "CANNOT_GAIN_EFFECTS" );
 static const json_character_flag json_flag_CANNOT_MOVE( "CANNOT_MOVE" );
 static const json_character_flag json_flag_CANNOT_TAKE_DAMAGE( "CANNOT_TAKE_DAMAGE" );
+static const json_character_flag json_flag_DISTRIBUTED_DAMAGE( "DISTRIBUTED_DAMAGE" );
 static const json_character_flag json_flag_FREEZE_EFFECTS( "FREEZE_EFFECTS" );
 static const json_character_flag json_flag_IGNORE_TEMP( "IGNORE_TEMP" );
 static const json_character_flag json_flag_INVISIBLE( "INVISIBLE" );
@@ -1286,10 +1287,15 @@ void Creature::messaging_projectile_attack( const Creature *source,
             }
         } else if( is_avatar() ) {
             //monster hits player ranged
-            //~ Hit message. 1$s is bodypart name in accusative. 2$d is damage value.
-            add_msg_if_player( m_bad, _( "You were hit in the %1$s for %2$d damage." ),
-                               body_part_name_accusative( hit_selection.bp_hit ),
-                               total_damage );
+            //~ Hit message. 1$s is bodypart name in accusative. 2$d is damage value.  If you have DISTRIBUTED_DAMAGE, don't print bodypart--you're hit everywhere
+            if( has_flag (json_flag_DISTRIBUTED_DAMAGE) ) {
+                add_msg_if_player( m_bad, _( "You were hit for %2$d damage." ) );
+            } else {
+                add_msg_if_player( m_bad, _( "You were hit in the %1$s for %2$d damage." ),
+                                               body_part_name_accusative( hit_selection.bp_hit ),
+                                               total_damage );
+            }
+            add_msg_if_player( m_bad, _( "You were hit in the %1$s for %2$d damage." ) );
         } else if( source != nullptr ) {
             if( source->is_avatar() ) {
                 //player hits monster ranged


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Slime has reduntant omnicellular parts"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Rework of #85205, which proved untenable due to body part and armor issues. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Rework Omnicellular. It now replaces your entire body with equivalent parts--a `Core` and five `Pseudopods`. These are all equivalent to the head, arms, etc, but they share HP--whenever you take damage, the total is summed up and applied equally to all your bodyparts. Only when you reach 0 `Core` HP do you die. 

This is done using a `DISTRIBUTED_DAMAGE` flag, for easy modding. 

~~If you drop below 25% HP, you "lose cohesion" and drop all of your items. You can't pick anything up again until you regain some HP. You can still open doors and smash things.~~ Will do this in another PR due to all the bodyparts I'll need to make for this one. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

WIP

Flag works. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
